### PR TITLE
Radcliffe 2: fix fatal error when query categories and tags

### DIFF
--- a/radcliffe-2/inc/template-tags.php
+++ b/radcliffe-2/inc/template-tags.php
@@ -66,14 +66,14 @@ function radcliffe_2_entry_footer() {
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( esc_html__( ', ', 'radcliffe-2' ) );
-		if ( $categories_list ) {
+		if ( $categories_list && ! is_wp_error( $categories_list ) ) {
 			/* translators: 1: list of categories. */
 			echo '<span class="cat-links">' . radcliffe_2_get_svg( array( 'icon' => 'category', 'title' => esc_html__( 'Categories', 'radcliffe-2' ) ) ) . $categories_list . '</span>';
 		}
 
 		/* translators: used between list items, there is a space after the comma */
 		$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'radcliffe-2' ) );
-		if ( $tags_list ) {
+		if ( $tags_list && ! is_wp_error( $tags_list ) ) {
 			/* translators: 1: list of tags. */
 			echo '<span class="tags-links">' . radcliffe_2_get_svg( array( 'icon' => 'tag', 'title' => esc_html__( 'Tags', 'radcliffe-2' ) ) ) . $tags_list . '</span>';
 		}


### PR DESCRIPTION
Sometimes WordPress returns a `WP_Error` object and not a string when querying for terms like tags and categories. The PHP fatal error in the server logs looks like this:

```
Catchable fatal error for wp-content/themes/pub/radcliffe-2/inc/template-tags.php:78 - Object of class WP_Error could not be converted to string #theme
```

This change applies a safety check to both `get_the_tag_list()` and `get_the_category_list()` for Radcliffe 2 — checking for the error before attempting to display the result as a string.
