### PR TITLE
Shoreditch: Fix main stylesheet when using child themes

### DIFF
--- a/shoreditch/functions.php
+++ b/shoreditch/functions.php
@@ -179,7 +179,7 @@ function shoreditch_scripts() {
 
 	wp_enqueue_style( 'shoreditch-fonts', shoreditch_fonts_url(), array(), null );
 
-	wp_enqueue_style( 'shoreditch-style', get_stylesheet_uri() );
+	wp_enqueue_style( 'shoreditch-style', get_template_directory_uri() . '/style.css' );
 
 	wp_enqueue_script( 'shoreditch-back-top', get_template_directory_uri() . '/js/back-top.js', array(), '20120206', true );
 


### PR DESCRIPTION
When trying to extend Shoreditch using a child theme the parent style.css isn't loaded correctly. 
Instead it loads the style.css of the child theme twice.
The reason for that is when using a child theme `get_stylesheet_uri()` returns the URI of the **current** theme stylesheet:
https://codex.wordpress.org/Function_Reference/get_stylesheet_uri
In this case it returns the stylesheet of the child theme.

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Change the way that the parent stylesheet is enqueued so that child themes can load it correctly instead of loading their own stylesheet twice.

#### Related issue(s):

I couldn't find any but the issue is kind of obvious.