### PR TITLE
Illustratr: Replace window.load event with document.ready

### DIFF
--- a/illustratr/js/portfolio.js
+++ b/illustratr/js/portfolio.js
@@ -28,11 +28,9 @@
 				} );
 			}
 		} );
-
 	}
 
 	$( window ).load( function() {
-
 		/*
 		 * Wrap portfolio-featured-image in a div.
 		 */
@@ -41,6 +39,10 @@
 		} );
 
 		calc();
+
+	} );
+
+	$( document ).ready( function() {
 
 		var portfolio_wrapper = $( '.portfolio-wrapper, .jetpack-portfolio-shortcode' );
 


### PR DESCRIPTION
Replace `$(window).load()` event with `$(document).ready()` for functions that show hidden elements on the page, to help work around ads issue. 

#### Related issue(s):
See #108