### PR TITLE
Textbook: Update JavaScript to replace window.load event

### DIFF
--- a/textbook/assets/js/functions.js
+++ b/textbook/assets/js/functions.js
@@ -39,7 +39,7 @@
 	$( '.entry-footer' ).after( jQuery( '#jp-post-flair, .geo-post, .entry-content > .sharedaddy' ).detach() );
 
 	// On Load
-	$window.load( function() {
+	$( document ).ready( function() {
 
 		// Init Testimonials Carousel
 		testimonials.flexslider({
@@ -52,11 +52,6 @@
 			prevText: '<span class="screen-reader-text">Previous</span><svg version="1.1" id="previous-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 16" xml:space="preserve"><polygon points="8,12.7 1.3,6 2.7,4.6 8,9.9 13.3,4.6 14.7,6 "/></svg>',
 			nextText: '<span class="screen-reader-text">Next</span><svg version="1.1" id="next-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 16" xml:space="preserve"><polygon points="8,12.7 1.3,6 2.7,4.6 8,9.9 13.3,4.6 14.7,6 "/></svg>'
 		});
-
-		// Fade in body
-		wrapper.animate({
-			opacity: 1,
-		}, 30);
 
 		// Triggers resize event to make sure video widgets in the footer maintain the correct aspect ratio
 		setTimeout( function(){

--- a/textbook/style.css
+++ b/textbook/style.css
@@ -1597,11 +1597,6 @@ body {
   /* Fallback for when there is no custom background color defined. */
 }
 
-/* Fade in page after js loads */
-.js body {
-  opacity: 0;
-}
-
 /*--------------------------------------------------------------
 ## Content
 --------------------------------------------------------------*/


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This update replaces `$(window).load()` with `$(document).ready()` to work around an issue with the ads JavaScript.

I also removed the styles/function that hides then show the theme's `body` once the page is finished loading, since it doesn't seem like the page changes a lot as it loads (unlike, say, a page that uses masonry/isotope for layout). I'm open to going without that change, though.

#### Related issue(s):
See #108.
