### PR TITLE
Altofocus: Replace window.load event with document.ready

### DIFF
--- a/altofocus/assets/js/scripts.js
+++ b/altofocus/assets/js/scripts.js
@@ -115,17 +115,13 @@
 	$( document )
 		.ready( initColumnLists )
 		.ready( initGallerySlider )
+		.ready( fadeInPage )
 		.ready( function() {
 
 			body = $( document.body );
 
 			window.addEventListener( 'scroll', altofocus_debounce( stickyPageHeader, 20, 1 ) );
 
-			/**
-			 * Window calls
-			 */
-			$( window )
-				.load( fadeInPage );
 		} );
 
 })(jQuery);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This update replaces $(window).load() with $(document).ready() to work around an issue with the ads JavaScript.

#### Related issue(s):
See #108.
