### PR TITLE
Intergalactic 2: Update Custom Colours so background colour will be applied

### DIFF
--- a/intergalactic-2/inc/wpcom.php
+++ b/intergalactic-2/inc/wpcom.php
@@ -66,3 +66,17 @@ function intergalactic_2_wpcom_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'intergalactic_2_wpcom_body_classes' );
+
+/**
+* Make sure background colours work for users without Custom Colours.
+*
+*/
+function intergalactic_2_background_fix() {
+	$background_color = get_theme_mod( 'background_color','ffffff' );
+	$background_styles = '.entry-content-wrapper {';
+	$background_styles .= 'background-color: #' . $background_color . '; ';
+	$background_styles .= '}';
+
+	wp_add_inline_style( 'intergalactic-2-style', $background_styles );
+}
+add_action( 'wp_enqueue_scripts', 'intergalactic_2_background_fix' );

--- a/intergalactic-2/js/customizer.js
+++ b/intergalactic-2/js/customizer.js
@@ -39,4 +39,19 @@
 			}
 		} );
 	} );
+
+	// Background Colour
+	wp.customize( 'background_color', function( value ) {
+		value.bind( function( to ) {
+			if ( '' === to ) {
+				$( '.entry-content-wrapper' ).css( {
+					'background-color' : '#ffffff',
+				} );
+			} else {
+				$( '.entry-content-wrapper' ).css( {
+					'background-color' : to,
+				} );
+			}
+		} );
+	} );
 } )( jQuery );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This update makes sure the background colour will be applied to the content area in Intergalatic 2 when the user doesn't have custom colours. 

Intergalactic 2 by default has a white background covering most of the content area; due to this, the preview for custom colours and the reality was not the same.

#### Related issue(s):
See #103.