### PR TITLE
Shoreditch: Add colour to select dropdowns in widget area

### DIFF
--- a/shoreditch/inc/wpcom-colors.php
+++ b/shoreditch/inc/wpcom-colors.php
@@ -187,6 +187,10 @@ add_color_rule( 'bg', '#ffffff', array(
 		#comments #respond .comment-form-fields div.comment-form-input', 'color', 'bg', '1.1'
 	),
 
+	array(
+		'.widget-footer-top-area select option', 'color', 'fg2'
+	),
+
 ), __( 'Background' ) );
 
 add_color_rule( 'txt', '#7a7c84', array(

--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -313,6 +313,10 @@ textarea {
 	color: #fff;
 }
 
+.widget-footer-top-area select option {
+	color: #333;
+}
+
 .entry-footer,
 .entry-meta,
 .site-info {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The select dropdowns in the Top Widget area have a semi-transparent white background, with white text, which works well against the widget area's blue background. On a few Windows browsers, these styles carry over to the open select dropdown as well, leading to white text on a white background. This update applies a text colour to the options when the dropdown is open.

#### Related issue(s):
See #58.