### PR TITLE
Radcliffe 2: Make hover transparency more consistent

### DIFF
--- a/radcliffe-2/inc/wpcom-colors.php
+++ b/radcliffe-2/inc/wpcom-colors.php
@@ -356,11 +356,11 @@ add_color_rule( 'extra', '#000000', array(
 			.blog:not(.style-pack-vintage) article:nth-of-type(even) .entry-header,
 			.search-results:not(.style-pack-vintage) article:nth-of-type(even) .entry-header', 'background-color', 0.4 ),
 
-	array( '.archive .entry-header:hover,
+	array( '.archive article .entry-header:hover,
 			.archive article:nth-of-type(even) .entry-header:hover,
-			.blog .entry-header:hover,
+			.blog article .entry-header:hover,
 			.blog  article:nth-of-type(even) .entry-header:hover,
-			.search-results .entry-header:hover,
+			.search-results article .entry-header:hover,
 			.search-results  article:nth-of-type(even) .entry-header:hover', 'background-color', 0.75 ),
 
 	array( '.comments-area,

--- a/radcliffe-2/style.css
+++ b/radcliffe-2/style.css
@@ -908,7 +908,7 @@ textarea {
 	color: #666;
 	border: 1px solid #ccc;
 	border-radius: 3px;
-	padding: 3px 7px;
+	padding: 3px;
 	max-width: 100%;
 }
 
@@ -1487,9 +1487,9 @@ textarea {
 	background: rgba(0, 0, 0, 0.6);
 }
 
-.archive .entry-header:hover,
-.blog .entry-header:hover,
-.search-results .entry-header:hover {
+.archive article .entry-header:hover,
+.blog article .entry-header:hover,
+.search-results article .entry-header:hover {
 	background: rgba(0, 0, 0, 0.75);
 }
 


### PR DESCRIPTION
This update makes the hover transparency on posts on the blog, archive and search pages more consistent.

Also syncs up padding on form inputs with how they display in SVN. 

Fixes #140 