### PR TITLE
Apostrophe 2: Add check for is_paged for "Featured" on sticky posts

### DIFF
--- a/apostrophe-2/inc/template-tags.php
+++ b/apostrophe-2/inc/template-tags.php
@@ -33,7 +33,7 @@ function apostrophe_2_posted_on() {
 		esc_html_x( '%s', 'post author', 'apostrope-2' ),
 		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
 	);
-	if ( is_sticky() && ! is_single() && ! is_archive() ) {
+	if ( is_sticky() && ! is_single() && ! is_archive() && ! is_paged() ) {
 		echo '<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . esc_html__( 'Featured', 'apostrophe-2' ) . '</a><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.
 	} else {
 		echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.


### PR DESCRIPTION
Add check for is_paged for "Featured" on sticky posts so it's only output when they're "stuck" on the front page, not when they appear on other pages. 

See #170.

