### PR TITLE
Illustratr: Fix two small issues in Gutenberg support

### DIFF
--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -99,7 +99,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-gallery {
 	margin-bottom: 40px;
-	margin-left: auto;
+	margin-left: inherit;
 }
 
 /* Quote */

--- a/illustratr/editor-blocks.css
+++ b/illustratr/editor-blocks.css
@@ -445,6 +445,8 @@
 
 .wp-block-code {
 	background: #f1f2f3;
+	border: 0;
+	border-radius: 0;
 	letter-spacing: -0.05em;
 	padding: 20px;
 	position: relative;


### PR DESCRIPTION
When testing on WP.com before merging this update, I noticed two small issues that are fixed in this PR:

* The Code block had a light border and rounded corners in the editor, which doesn't match the front end.
* The Gallery block had some unneeded margins that were interfering with the wide alignment. 