### PR TITLE
Independent Publisher 2: Correct JavaScript error

### DIFF
--- a/independent-publisher-2/js/independent-publisher-2.js
+++ b/independent-publisher-2/js/independent-publisher-2.js
@@ -32,7 +32,7 @@
 
                     if ( img_width >= 1100
                         && img.parents( '.tiled-gallery-item-large' ).length === 0
-                        && img.parents().attr( ['class^="wp-block-"'] ).length === 0 ) {
+                        && img.parents( '[class^="wp-block-"]' ).length === 0 ) {
                             $( img ).addClass( 'size-big' );
                      }
 


### PR DESCRIPTION
This update fixes a JavaScript error I introduced in the theme's Gutenberg support. 