### PR TITLE
Independent Publisher : Changes to author box CSS in rtl.css

### DIFF
--- a/independent-publisher-2/rtl.css
+++ b/independent-publisher-2/rtl.css
@@ -601,8 +601,8 @@ ol.comment-list .trackback {
 	}
 
 	.site-posted-on {
-		left: auto;
-		right: 0;
+		left: 0;
+		right: auto;
 		margin-right: 0;
 		text-align: left;
 		margin-left: auto;

--- a/independent-publisher-2/rtl.css
+++ b/independent-publisher-2/rtl.css
@@ -586,6 +586,7 @@ ol.comment-list .trackback {
 
 	.entry-author .author-avatar {
 		margin-right: 0;
+		margin-top: 60px;
 	}
 
 	.entry-author .author-avatar,
@@ -600,8 +601,8 @@ ol.comment-list .trackback {
 	}
 
 	.site-posted-on {
-		left: 0;
-		right: auto;
+		left: auto;
+		right: 0;
 		margin-right: 0;
 		text-align: left;
 		margin-left: auto;


### PR DESCRIPTION
Correcting the Avataar and site-posted-on div margins and alignment for RTL languages.

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Edited the rtl.css to move .site-posted-on info to the left and give a margin to the Avataar. This is a suggested fix for the overlap within the author box noted in the issue for RTL languages.

#### Related issue(s):
#330 