### PR TITLE
Radcliffe 2: Fix 404 error coming from default.css

### DIFF
--- a/radcliffe-2/inc/style-packs-core.php
+++ b/radcliffe-2/inc/style-packs-core.php
@@ -66,6 +66,9 @@ class Style_Packs_Core {
 
 	public function enqueue_style() {
 		if ( array_key_exists( $this->style, $this->config['styles'] ) ) {
+			if ( 'default' === $this->style ) {
+				return;
+			}
 			$stylesheet = $this->get_stylesheet_uri( $this->style );
 			wp_enqueue_style( $this->get_style_pack_id( $this->style ), $stylesheet, array(), $this->theme_version );
 		}
@@ -182,7 +185,7 @@ class Style_Packs_Core {
 			'styles'            => $style_pack_stylesheets,
 			'fonts'             => $style_pack_fonts,
 		);
-		
+
 		wp_localize_script( 'style-packs-customizer', 'stylePacksData', $style_packs_data );
 	}
 
@@ -236,7 +239,7 @@ class Style_Packs_Core {
 		}
 		register_default_headers( $headers );
 	}
-	
+
 	static function get_description( $style ) {
 		if ( array_key_exists( $style, self::$instance->config['style_descriptions'] ) ) {
 			return self::$instance->config['style_descriptions'][ $style ];


### PR DESCRIPTION
Right now Radcliffe 2 attempts to load a default.css file when you're using the default style pack.

There isn't such a file -- all the default styles live in the style.css.

This PR adds a check for whether the site is using the default style pack before attempting to enqueue the style pack files; if the site is using the default style pack, it will skip this step. 

Related discussion: p1542402289609400-slack-themes.

Related ticket: 1567702-zen

