### PR TITLE
Radcliffe 2: Clean up Gutenberg support

### DIFF
--- a/radcliffe-2/assets/css/blocks-vintage.css
+++ b/radcliffe-2/assets/css/blocks-vintage.css
@@ -1,8 +1,24 @@
-.style-pack-vintage .alignwide,
-.style-pack-vintage .alignfull,
-.style-pack-vintage ul.wp-block-gallery.alignwide,
-.style-pack-vintage ul.wp-block-gallery.alignfull,
-.style-pack-vintage .wp-block-cover-image {
+/*
+Theme Name: Radcliffe 2 - Vintage
+Description: Used to style Gutenberg Blocks.
+*/
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Block Alignments
+2.0 General Block Styles
+3.0 Blocks - Common
+4.0 Blocks - Formatting
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+1.0 General Block Alignments
+--------------------------------------------------------------*/
+
+.style-pack-vintage .alignwide:not(.wp-block-cover):not(.wp-block-cover-image),
+.style-pack-vintage .alignfull:not(.wp-block-cover):not(.wp-block-cover-image) {
 	background-color: rgba(255,255,255,0.7);
 	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,ffffff+100&0.8+0,1+20,1+80,0.8+100 */
 	background: -moz-linear-gradient(top, rgba(255,255,255,0.6) 0%, rgba(255,255,255,1) 15%, rgba(255,255,255,1) 85%, rgba(255,255,255,0.6) 100%); /* FF3.6-15 */
@@ -13,10 +29,23 @@
 }
 
 .style-pack-vintage .wp-block-cover-image.alignleft,
-.style-pack-vintage .wp-block-cover-image.alignright {
+.style-pack-vintage .wp-block-cover.alignleft,
+.style-pack-vintage .wp-block-cover-image.alignright,
+.style-pack-vintage .wp-block-cover.alignright {
 	left: auto;
-	/*margin-left: 0;
-	margin-right: 0;*/
+}
+
+.style-pack-vintage .wp-block-cover-image.alignwide,
+.style-pack-vintage .wp-block-cover-image.alignfull,
+.style-pack-vintage .wp-block-cover.alignwide,
+.style-pack-vintage .wp-block-cover.alignfull {
+	border: 4px double #c7c4b4;
+	padding: 0;
+}
+
+.style-pack-vintage ul.wp-block-gallery.alignwide,
+.style-pack-vintage ul.wp-block-gallery.alignfull {
+	padding-bottom: 0;
 }
 
 @media (min-width: 750px) {
@@ -31,7 +60,6 @@
 	.style-pack-vintage .wp-block-categories.alignfull,
 	.style-pack-vintage .wp-block-verse.alignfull,
 	.style-pack-vintage p.alignfull,
-	.style-pack-vintage .wp-block-cover-image:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright),
 	.style-pack-vintage .wp-block-cover-image.alignfull {
 		margin-left: calc(30% - 30vw);
 		margin-right: calc(30% - 30vw);
@@ -60,4 +88,86 @@
 		width: auto;
 		max-width: 1000%;
 	}
+}
+
+/*--------------------------------------------------------------
+2.0 General Block Styles
+--------------------------------------------------------------*/
+
+
+.style-pack-vintage .alignfull .jetpack-video-wrapper,
+.style-pack-vintage .alignwide .jetpack-video-wrapper {
+	margin-bottom: 0;
+}
+
+/*--------------------------------------------------------------
+3.0 Blocks - Common
+--------------------------------------------------------------*/
+
+/* File */
+
+.style-pack-vintage .wp-block-file .wp-block-file__button {
+	border-radius: 0;
+	border: 3px double #c7c4b4;
+	font-family: inherit;
+}
+
+.style-pack-vintage .wp-block-file .wp-block-file__button:hover,
+.style-pack-vintage .wp-block-file .wp-block-file__button:focus {
+	background-color: #2b6e9d;
+	opacity: 1.0;
+}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
+--------------------------------------------------------------*/
+
+/* Pullquote */
+
+.style-pack-vintage .wp-block-pullquote {
+	border-color: #c5c3bf;
+}
+
+/* Table */
+
+.style-pack-vintage .wp-block-table {
+	width: 100%;
+}
+
+@media (min-width: 750px) {
+	.style-pack-vintage .wp-block-table.alignwide {
+		width: 88vw;
+	}
+
+	.style-pack-vintage .wp-block-table.alignfull {
+		width: 92vw;
+	}
+}
+
+@media (min-width: 900px) {
+	.style-pack-vintage .wp-block-table.alignwide {
+		width: calc( 740px + 40vw - 40% );
+	}
+
+	.style-pack-vintage .wp-block-table.alignfull {
+		width: calc( 740px + 60vw - 60% );
+	}
+}
+
+/*--------------------------------------------------------------
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/* Latest Comments */
+
+.style-pack-vintage .wp-block-latest-comments__comment-meta {
+	font-family: inherit;
+}
+
+.style-pack-vintage.single-post .wp-block-latest-comments article,
+.style-pack-vintage.page .wp-block-latest-comments article {
+	border: 0;
+	background: transparent;
+	max-width: 100%;
+	padding: 0;
 }

--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -50,17 +50,19 @@ p.alignfull {
 	margin-right: auto;
 }
 
+@media (min-width: 1160px) {
+	.alignwide {
+		margin-left: -25%;
+		margin-right: -25%;
+		width: auto;
+		max-width: 1000%;
+	}
+}
+
 @media (min-width: 750px) {
 	.alignfull {
 		margin-left: calc(50% - 50vw);
 		margin-right: calc(50% - 50vw);
-		width: auto;
-		max-width: 1000%;
-	}
-
-	.alignwide {
-		margin-left: calc(25% - 25vw);
-		margin-right: calc(25% - 25vw);
 		width: auto;
 		max-width: 1000%;
 	}
@@ -80,20 +82,6 @@ p.alignfull {
 	p.alignfull {
 		margin-left: calc(50% - 48vw);
 		margin-right: calc(50% - 48vw);
-	}
-
-	.wp-block-text-columns.alignwide,
-	.wp-block-columns.alignwide,
-	.wp-block-table.alignwide,
-	.wp-block-preformatted.alignwide,
-	.wp-block-button.alignwide,
-	.wp-block-pullquote.alignwide,
-	.wp-block-latest-posts.alignwide,
-	.wp-block-latest-comments.alignwide,
-	.wp-block-categories.alignwide,
-	p.alignwide {
-		margin-left: calc(25% - 23vw);
-		margin-right: calc(25% - 23vw);
 	}
 
 	.wp-block-embed.is-type-video.alignwide iframe,
@@ -254,15 +242,23 @@ ul.wp-block-gallery li {
 	padding: 9px 18px;
 }
 
+.style-pack-colorful .wp-block-file .wp-block-file__button,
+.style-pack-modern .wp-block-file .wp-block-file__button {
+	font-family: inherit;
+}
+
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-file .wp-block-file__button:focus {
 	background: #ca2017;
 	opacity: 1.0;
 }
 
-/* Video */
+.rtl .wp-block-file * + .wp-block-file__button {
+	margin-left: 0.75em;
+	margin-right: 0;
+}
 
-.wp-block-video {}
+/* Video */
 
 .wp-block-video video,
 .wp-block-video iframe {
@@ -277,7 +273,7 @@ ul.wp-block-gallery li {
 
 .wp-block-verse {
 	background-color: transparent;
-	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	font-family: inherit;
 	font-size: 1.1em;
 	font-style: italic;
 	line-height: 1.8;
@@ -295,15 +291,20 @@ ul.wp-block-gallery li {
 /* Pullquotes */
 
 .wp-block-pullquote {
-	border: none;
+	border-bottom: 2px solid #ddd;
+	border-top: 3px solid #ddd;
 	color: #666;
-	padding: 0;
 	margin-bottom: 0;
 }
 
 .wp-block-pullquote cite {
 	color: inherit;
 	opacity: 0.8;
+}
+
+.wp-block-pullquote blockquote::before,
+.wp-block-pullquote blockquote::after {
+	display: none;
 }
 
 /* Tables */
@@ -317,8 +318,19 @@ ul.wp-block-gallery li {
 	border: none;
 }
 
+.wp-block-table.alignwide,
 .wp-block-table.alignfull {
 	width: 96vw;
+}
+
+.wp-block-table.alignwide {
+	width: 100%;
+}
+
+@media (min-width: 1160px) {
+	.wp-block-table.alignwide {
+		width: 1110px;
+	}
 }
 
 /*--------------------------------------------------------------
@@ -334,6 +346,11 @@ ul.wp-block-gallery li {
 	font-size: 14px;
 	line-height: 1.29;
 	padding: 9px 18px;
+}
+
+.style-pack-colorful .wp-block-file .wp-block-file__button,
+.style-pack-modern .wp-block-file .wp-block-file__button {
+	font-family: inherit;
 }
 
 .wp-block-button__link {
@@ -356,8 +373,6 @@ ul.wp-block-gallery li {
 .wp-block-button.aligncenter {
 	display: block;
 }
-
-/* Columns */
 
 /* Separator */
 
@@ -446,7 +461,8 @@ ul.wp-block-gallery li {
 
 /* Latest Comments */
 
-.wp-block-latest-comments {
+.wp-block-latest-comments.not(.alignwide),
+.wp-block-latest-comments.not(.alignfull) {
 	margin-left: 0;
 	margin-right: 0;
 }
@@ -463,6 +479,11 @@ ul.wp-block-gallery li {
 	margin-bottom: 0;
 }
 
+.style-pack-colorful .wp-block-latest-comments__comment-meta,
+.style-pack-modern .wp-block-latest-comments__comment-meta {
+	font-family: inherit;
+}
+
 .wp-block-latest-comments__comment-excerpt p {
 	font-size: 90%;
 }
@@ -475,6 +496,8 @@ ul.wp-block-gallery li {
 /*--------------------------------------------------------------
 7.0 Blocks - Colors
 --------------------------------------------------------------*/
+
+/* Default */
 
 .has-white-color,
 .has-white-color:hover,
@@ -538,4 +561,168 @@ ul.wp-block-gallery li {
 .has-red-background-color:focus,
 .has-red-background-color:visited {
 	background-color: #ca2017;
+}
+
+/* Modern */
+
+.has-modern-white-color,
+.has-modern-white-color:hover,
+.has-modern-white-color:active,
+.has-modern-white-color:focus,
+.has-modern-white-color:visited {
+	color: #fff;
+}
+
+.has-modern-white-background-color,
+.has-modern-white-background-color:hover,
+.has-modern-white-background-color:active,
+.has-modern-white-background-color:focus,
+.has-modern-white-background-color:visited {
+	background-color: #fff
+}
+
+.has-modern-light-gray-color,
+.has-modern-light-gray-color:hover,
+.has-modern-light-gray-color:active,
+.has-modern-light-gray-color:focus,
+.has-modern-light-gray-color:visited {
+	color: #f1f1f1;
+}
+
+.has-modern-light-gray-background-color,
+.has-modern-light-gray-background-color:hover,
+.has-modern-light-gray-background-color:active,
+.has-modern-light-gray-background-color:focus,
+.has-modern-light-gray-background-color:visited {
+	background-color: #f1f1f1
+}
+
+.has-modern-medium-gray-color,
+.has-modern-medium-gray-color:hover,
+.has-modern-medium-gray-color:active,
+.has-modern-medium-gray-color:focus,
+.has-modern-medium-gray-color:visited {
+	color: #aaa;
+}
+
+.has-modern-medium-gray-background-color,
+.has-modern-medium-gray-background-color:hover,
+.has-modern-medium-gray-background-color:active,
+.has-modern-medium-gray-background-color:focus,
+.has-modern-medium-gray-background-color:visited {
+	background-color: #aaa
+}
+
+.has-modern-dark-gray-color,
+.has-modern-dark-gray-color:hover,
+.has-modern-dark-gray-color:active,
+.has-modern-dark-gray-color:focus,
+.has-modern-dark-gray-color:visited {
+	color: #222;
+}
+
+.has-modern-dark-gray-background-color,
+.has-modern-dark-gray-background-color:hover,
+.has-modern-dark-gray-background-color:active,
+.has-modern-dark-gray-background-color:focus,
+.has-modern-dark-gray-background-color:visited {
+	background-color: #222
+}
+
+/* Colorful */
+
+.has-colorful-white-color,
+.has-colorful-white-color:hover,
+.has-colorful-white-color:active,
+.has-colorful-white-color:focus,
+.has-colorful-white-color:visited {
+	color: #fff;
+}
+
+.has-colorful-white-background-color,
+.has-colorful-white-background-color:hover,
+.has-colorful-white-background-color:active,
+.has-colorful-white-background-color:focus,
+.has-colorful-white-background-color:visited {
+	background-color: #fff
+}
+
+.has-colorful-light-gray-color,
+.has-colorful-light-gray-color:hover,
+.has-colorful-light-gray-color:active,
+.has-colorful-light-gray-color:focus,
+.has-colorful-light-gray-color:visited {
+	color: #e5e5e5;
+}
+
+.has-colorful-light-gray-background-color,
+.has-colorful-light-gray-background-color:hover,
+.has-colorful-light-gray-background-color:active,
+.has-colorful-light-gray-background-color:focus,
+.has-colorful-light-gray-background-color:visited {
+	background-color: #e5e5e5
+}
+
+.has-colorful-dark-gray-color,
+.has-colorful-dark-gray-color:hover,
+.has-colorful-dark-gray-color:active,
+.has-colorful-dark-gray-color:focus,
+.has-colorful-dark-gray-color:visited {
+	color: #222;
+}
+
+.has-colorful-dark-gray-background-color,
+.has-colorful-dark-gray-background-color:hover,
+.has-colorful-dark-gray-background-color:active,
+.has-colorful-dark-gray-background-color:focus,
+.has-colorful-dark-gray-background-color:visited {
+	background-color: #222
+}
+
+.has-colorful-blue-color,
+.has-colorful-blue-color:hover,
+.has-colorful-blue-color:active,
+.has-colorful-blue-color:focus,
+.has-colorful-blue-color:visited {
+	color: #4ba3c3;
+}
+
+.has-colorful-blue-background-color,
+.has-colorful-blue-background-color:hover,
+.has-colorful-blue-background-color:active,
+.has-colorful-blue-background-color:focus,
+.has-colorful-blue-background-color:visited {
+	background-color: #4ba3c3
+}
+
+.has-colorful-green-color,
+.has-colorful-green-color:hover,
+.has-colorful-green-color:active,
+.has-colorful-green-color:focus,
+.has-colorful-green-color:visited {
+	color: #71db9d;
+}
+
+.has-colorful-green-background-color,
+.has-colorful-green-background-color:hover,
+.has-colorful-green-background-color:active,
+.has-colorful-green-background-color:focus,
+.has-colorful-green-background-color:visited {
+	background-color: #71db9d
+}
+
+.has-colorful-orange-color,
+.has-colorful-orange-color:hover,
+.has-colorful-orange-color:active,
+.has-colorful-orange-color:focus,
+.has-colorful-orange-color:visited {
+	color: #d97059;
+}
+
+.has-colorful-orange-background-color,
+.has-colorful-orange-background-color:hover,
+.has-colorful-orange-background-color:active,
+.has-colorful-orange-background-color:focus,
+.has-colorful-orange-background-color:visited {
+	background-color: #d97059
 }

--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -1,12 +1,29 @@
+/*
+Theme Name: Radcliffe 2
+Description: Used to style Gutenberg Blocks.
+*/
+
 /*--------------------------------------------------------------
-## Gutenberg Styles
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Block Alignments
+2.0 General Block Styles
+3.0 Blocks - Common Blocks
+4.0 Blocks - Formatting
+5.0 Blocks - Layout Elements
+6.0 Blocks - Widgets
+7.0 Blocks - Colors
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+1.0 General Block Alignments
 --------------------------------------------------------------*/
 
 #page {
 	overflow-x: hidden;
 }
 
-*[class^="wp-block-"] {
+.entry-content > *[class^="wp-block-"] {
 	margin-bottom: 1.5em;
 }
 
@@ -17,13 +34,17 @@
 }
 
 /* Text-based blocks with alignfull */
+
 .wp-block-text-columns.alignfull,
+.wp-block-columns.alignfull,
 .wp-block-preformatted.alignfull,
 .wp-block-button.alignfull,
 .wp-block-pullquote.alignfull,
 .wp-block-latest-posts.alignfull,
 .wp-block-categories.alignfull,
+.wp-block-latest-comments.alignfull,
 .wp-block-verse.alignfull,
+.wp-block-audio.alignfull,
 p.alignfull {
 	margin-left: auto;
 	margin-right: auto;
@@ -46,28 +67,39 @@ p.alignfull {
 
 	/* Let's reduce this a bit for blocks with text */
 	.wp-block-text-columns.alignfull,
+	.wp-block-columns.alignfull,
 	.wp-block-table.alignfull,
 	.wp-block-preformatted.alignfull,
 	.wp-block-button.alignfull,
 	.wp-block-pullquote.alignfull,
 	.wp-block-latest-posts.alignfull,
 	.wp-block-categories.alignfull,
+	.wp-block-latest-comments.alignfull,
 	.wp-block-verse.alignfull,
+	.wp-block-audio.alignfull,
 	p.alignfull {
 		margin-left: calc(50% - 48vw);
 		margin-right: calc(50% - 48vw);
 	}
 
 	.wp-block-text-columns.alignwide,
+	.wp-block-columns.alignwide,
 	.wp-block-table.alignwide,
 	.wp-block-preformatted.alignwide,
 	.wp-block-button.alignwide,
 	.wp-block-pullquote.alignwide,
 	.wp-block-latest-posts.alignwide,
+	.wp-block-latest-comments.alignwide,
 	.wp-block-categories.alignwide,
 	p.alignwide {
 		margin-left: calc(25% - 23vw);
 		margin-right: calc(25% - 23vw);
+	}
+
+	.wp-block-embed.is-type-video.alignwide iframe,
+	.wp-block-embed.is-type-video.alignfull iframe {
+		width: 100% !important;
+		height: 100% !important;
 	}
 }
 
@@ -92,10 +124,45 @@ p.alignfull {
 	margin-right: auto !important;
 }
 
-/* Dropcaps */
-.has-drop-cap {}
+/* Video */
 
-/* Images */
+.wp-block-embed.is-type-video iframe {
+	max-height: 100%;
+}
+
+/*--------------------------------------------------------------
+2.0 General Block Styles
+--------------------------------------------------------------*/
+
+/* Caption */
+
+[class^="wp-block-"] figcaption {
+	font-size: 80%;
+}
+
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
+	opacity: 0.8;
+}
+
+/* Video */
+
+.wp-block-embed.is-type-video iframe {
+	max-height: 100%;
+}
+
+/*--------------------------------------------------------------
+3.0 Blocks - Common Blocks
+--------------------------------------------------------------*/
+
+/* Paragraph */
+
+p.has-drop-cap:not(:focus)::first-letter {
+	font-size: 5em;
+	margin-top: 0.15em;
+}
+
+/* Image */
+
 .wp-block-image {}
 
 .wp-block-image figure {
@@ -114,7 +181,6 @@ p.alignfull {
 	margin-left: 1.6em;
 }
 
-.wp-block-image.alignwide {}
 .wp-block-image.alignfull {
 	width: 100vw;
 	max-width: 100vw;
@@ -126,20 +192,28 @@ p.alignfull {
 	opacity: 0.8;
 }
 
-/* Galleries */
+/* Gallery */
+
 ul.wp-block-gallery,
 ul.wp-block-gallery li {
 	padding: 0;
 }
 
-/* Blockquotes*/
-.wp-block-quote {}
+/* Quote */
 
-.wp-block-quote.blocks-quote-style-1 {}
-.wp-block-quote.blocks-quote-style-2 {}
 .wp-block-quote cite {
 	color: inherit;
 	opacity: 0.8;
+}
+
+.wp-block-quote.is-large p,
+.wp-block-quote.is-style-large p {
+	font-size: 28px;
+}
+
+.wp-block-quote.is-large cite,
+.wp-block-quote.is-style-large cite {
+	font-size: 22px;
 }
 
 @media (min-width: 600px) {
@@ -149,33 +223,8 @@ ul.wp-block-gallery li {
 	}
 }
 
-/* Cover Images */
-@media (min-width: 750px) {
-	.wp-block-cover-image:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright) {
-		left: 50%;
-		margin-left: -50vw;
-		position: relative;
-		width: 100vw;
-	}
-}
-
-.wp-block-cover-image {
-	height: 75vh;
-	min-height: 400px;
-}
-
-.wp-block-cover-image.has-background-dim {}
-.wp-block-cover-image.has-parallax {}
-
-/* Video */
-.wp-block-video {}
-
-.wp-block-video video,
-.wp-block-video iframe {
-	max-width: 100%;
-}
-
 /* Audio */
+
 .wp-block-audio {}
 
 .wp-block-audio audio {
@@ -184,10 +233,67 @@ ul.wp-block-gallery li {
 	width: 100%;
 }
 
-/* Embed */
-.wp-block-embed {}
+/* Cover */
+
+.wp-block-cover-image.alignwide,
+.wp-block-cover.alignwide,
+.wp-block-cover-image.alignfull,
+.wp-block-cover.alignfull {
+	height: 75vh;
+}
+
+/* File */
+
+.wp-block-file .wp-block-file__button {
+	background: #222;
+	border-radius: 3px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 1.4rem;
+	font-size: 14px;
+	line-height: 1.29;
+	padding: 9px 18px;
+}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus {
+	background: #ca2017;
+	opacity: 1.0;
+}
+
+/* Video */
+
+.wp-block-video {}
+
+.wp-block-video video,
+.wp-block-video iframe {
+	max-width: 100%;
+}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
+--------------------------------------------------------------*/
+
+/* Verse */
+
+.wp-block-verse {
+	background-color: transparent;
+	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	font-size: 1.1em;
+	font-style: italic;
+	line-height: 1.8;
+	padding: 0;
+}
+
+/* Code */
+
+.wp-block-code {}
+
+/* Preformatted */
+
+.wp-block-preformatted {}
 
 /* Pullquotes */
+
 .wp-block-pullquote {
 	border: none;
 	color: #666;
@@ -201,6 +307,7 @@ ul.wp-block-gallery li {
 }
 
 /* Tables */
+
 .wp-block-table {
 	display: table;
 }
@@ -214,37 +321,13 @@ ul.wp-block-gallery li {
 	width: 96vw;
 }
 
-/* Preformatted */
-.wp-block-preformatted {}
-
-/* Code */
-.wp-block-code {}
-
-/* Verse */
-.wp-block-verse {
-	background-color: transparent;
-	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
-	font-size: 1.1em;
-	font-style: italic;
-	line-height: 1.8;
-	padding: 0;
-}
-
-/* Separator */
-.wp-block-separator {
-	border: none;
-	max-width: 100px;
-	margin: 1.6em auto;
-}
-
-.wp-block-separator.is-style-wide {
-	max-width: 100%;
-}
+/*--------------------------------------------------------------
+5.0 Blocks - Layout Elements
+--------------------------------------------------------------*/
 
 /* Buttons */
-.wp-block-file .wp-block-file__button,
+
 .wp-block-button .wp-block-button__link {
-	background: #222;
 	border-radius: 3px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 	font-size: 1.4rem;
@@ -253,26 +336,16 @@ ul.wp-block-gallery li {
 	padding: 9px 18px;
 }
 
-.wp-block-file a:hover,
-.wp-block-file a:focus,
-.wp-block-button a:hover,
-.wp-block-button a:focus {
+.wp-block-button__link {
+	background: #222;
+	color: #fff;
+}
+
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
 	opacity: 1.0;
 }
 
-.wp-block-button a:not([style]) {
-	border: 0;
-	color: #fff;
-}
-
-.wp-block-button:not([style]) a:hover,
-.wp-block-button:not([style]) a:focus {
-	color: #fff;
-	text-decoration: none;
-}
-
-.wp-block-file__button:hover,
-.wp-block-file__button:focus,
 .wp-block-button__link:not(.has-background):hover,
 .wp-block-button__link:not(.has-background):focus {
 	background: #ca2017;
@@ -284,54 +357,45 @@ ul.wp-block-gallery li {
 	display: block;
 }
 
-/* Text Columns */
-@media only screen and ( max-width: 32em ) {
-	.wp-block-text-columns,
-	.wp-block-text-columns.aligncenter {
-		display: block;
-	}
+/* Columns */
 
-	.wp-block-text-columns.columns-2 .wp-block-column,
-	.wp-block-text-columns.columns-3 .wp-block-column,
-	.wp-block-text-columns.columns-4 .wp-block-column {
-		float: none;
-		margin-left: 0;
-		margin-right: 0;
-		width: 100%;
-	}
+/* Separator */
+
+.wp-block-separator {
+	border: none;
+	max-width: 100px;
+	margin: 1.6em auto;
 }
 
-/* Latest Posts */
-.wp-block-latest-posts__post-date {
-	color: inherit;
+.wp-block-separator.is-style-wide {
+	max-width: 100%;
+}
+
+/* Media & Text */
+
+.wp-block-media-text *:last-child {
 	margin-bottom: 0;
-	opacity: 0.8;
 }
 
-.wp-block-latest-posts,
-.wp-block-latest-posts li {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-}
+/*--------------------------------------------------------------
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
 
-.wp-block-latest-posts li {
-	padding: 0.25em 0;
-}
+/* Categories, Latest Posts & Archives */
 
-.wp-block-latest-posts li:not(:last-child) {
-	border-bottom: 1px solid rgba(0,0,0,0.2);
+.wp-block-categories.aligncenter,
+.wp-block-categories.aligncenter ul,
+.wp-block-latest-posts.aligncenter,
+.wp-block-archives.aligncenter {
+	list-style-position: inside;
+	margin-left: 0;
+	margin-right: 0;
+	text-align: center;
 }
-
-.wp-block-latest-posts.is-grid li {
-	border: 0;
-}
-
-/* Widget blocks */
-.wp-block-categories {}
 
 .wp-block-archives,
 .wp-block-latest-comments,
+.wp-block-latest-posts,
 .wp-block-categories-list {
 	list-style: none;
 	padding: 0;
@@ -355,38 +419,123 @@ ul.wp-block-gallery li {
 	padding-bottom: 0;
 }
 
-.wp-block-categories-dropdown {}
+/* Latest Posts */
 
-/* Colours */
+.wp-block-latest-posts__post-date {
+	color: inherit;
+	margin-bottom: 0;
+	opacity: 0.8;
+}
 
-.has-white-color {
+.wp-block-latest-posts,
+.wp-block-latest-posts li {
+	list-style: none;
+}
+
+.wp-block-latest-posts li {
+	padding: 0.25em 0;
+}
+
+.wp-block-latest-posts li:not(:last-child) {
+	border-bottom: 1px solid rgba(0,0,0,0.2);
+}
+
+.wp-block-latest-posts.is-grid li {
+	border: 0;
+}
+
+/* Latest Comments */
+
+.wp-block-latest-comments {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.wp-block-latest-comments__comment,
+.wp-block-latest-comments__comment-date {
+	font-size: inherit;
+}
+
+.wp-block-latest-comments__comment-meta {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 80%;
+	font-weight: bold;
+	margin-bottom: 0;
+}
+
+.wp-block-latest-comments__comment-excerpt p {
+	font-size: 90%;
+}
+
+.wp-block-latest-comments__comment-date {
+	color: #707070;
+	font-size: 80%;
+}
+
+/*--------------------------------------------------------------
+7.0 Blocks - Colors
+--------------------------------------------------------------*/
+
+.has-white-color,
+.has-white-color:hover,
+.has-white-color:active,
+.has-white-color:focus,
+.has-white-color:visited {
 	color: #fff;
 }
 
-.has-dark-grey-color {
-	color: #222;
-}
-
-.has-light-grey-color {
-	color: #666;
-}
-
-.has-red-color {
-	color: #ca2017;
-}
-
-.has-white-background-color {
+.has-white-background-color,
+.has-white-background-color:hover,
+.has-white-background-color:active,
+.has-white-background-color:focus,
+.has-white-background-color:visited {
 	background-color: #fff
 }
 
-.has-dark-grey-background-color {
+.has-dark-gray-color,
+.has-dark-gray-color:hover,
+.has-dark-gray-color:active,
+.has-dark-gray-color:focus,
+.has-dark-gray-color:visited {
+	color: #222;
+}
+
+.has-dark-gray-background-color,
+.has-dark-gray-background-color:hover,
+.has-dark-gray-background-color:active,
+.has-dark-gray-background-color:focus,
+.has-dark-gray-background-color:visited {
 	background-color: #222;
 }
 
-.has-light-grey-background-color {
+.has-light-gray-color,
+.has-light-gray-color:hover,
+.has-light-gray-color:active,
+.has-light-gray-color:focus,
+.has-light-gray-color:visited {
+	color: #666;
+}
+
+.has-light-gray-background-color,
+.has-light-gray-background-color:hover,
+.has-light-gray-background-color:active,
+.has-light-gray-background-color:focus,
+.has-light-gray-background-color:visited {
 	background-color: #666;
 }
 
-.has-red-background-color {
+.has-red-color,
+.has-red-color:hover,
+.has-red-color:active,
+.has-red-color:focus,
+.has-red-color:visited {
+	color: #ca2017;
+}
+
+.has-red-background-color,
+.has-red-background-color:hover,
+.has-red-background-color:active,
+.has-red-background-color:focus,
+.has-red-background-color:visited {
 	background-color: #ca2017;
 }

--- a/radcliffe-2/assets/css/editor-style-colorful.css
+++ b/radcliffe-2/assets/css/editor-style-colorful.css
@@ -1,10 +1,43 @@
-/*!
-Editor Styles for Radcliffe 2: Colorful Style Pack
+/*
+Theme Name: Radcliffe 2 - Colorful Style Pack
+Description: Used to style Gutenberg Blocks in the editor.
+*/
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Typography
+2.0 General Block Settings
+3.0 Blocks - Common
+4.0 Blocks - Formatting
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+1.0 General Typography
 --------------------------------------------------------------*/
 
 /* Temporary method to include Google Fonts */
 @import url( "https://fonts.googleapis.com/css?family=Karla:400,400italic,700,700italic" );
 @import url( "https://fonts.googleapis.com/css?family=Inconsolata:400,700" );
+
+.edit-post-visual-editor .editor-block-list__block,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+	font-family: Inconsolata, monospace;
+}
+
+/* Color */
+
+.edit-post-visual-editor .editor-block-list__block {
+	color: #222;
+}
+
+/* Post title */
+
+.editor-post-title__block .editor-post-title__input {
+	color: #4ba3c3;
+	font-family: 'Karla', 'Helvetica Neue', Helvetica, arial, sans-serif;
+}
 
 /* Widths */
 @media screen and (min-width: 768px) {
@@ -13,83 +46,62 @@ Editor Styles for Radcliffe 2: Colorful Style Pack
 		margin-right: auto;
 		padding: 0 0 72px;
 		max-width: 92%;
-		width: 1040px;
+		width: 1070px;
 	}
 }
 
-/*--------------------------------------------------------------
-# Typography
---------------------------------------------------------------*/
+/* Headings */
 
-.edit-post-visual-editor,
-.edit-post-visual-editor p,
-.edit-post-visual-editor button,
-.edit-post-visual-editor input,
-.edit-post-visual-editor select,
-.edit-post-visual-editor optgroup,
-.edit-post-visual-editor textarea {
-	color: #222;
-	font-family: Inconsolata, monospace;
-}
-
-h1.mce-content-body,
-h2.mce-content-body,
-h3.mce-content-body,
-h4.mce-content-body,
-h5.mce-content-body,
-h6.mce-content-body,
-.mce-content-body h1,
-.mce-content-body h2,
-.mce-content-body h3,
-.mce-content-body h4,
-.mce-content-body h5,
-.mce-content-body h6,
-#poststuff h1,
-#poststuff h2,
-#poststuff h3,
-#poststuff h4,
-#poststuff h5,
-#poststuff h6 {
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
 	color: #71db9d;
 	font-family: 'Karla', 'Helvetica Neue', Helvetica, arial, sans-serif;
-}
-
-/* Post/Page title */
-.edit-post-visual-editor textarea.editor-post-title__input {
-	color: #4ba3c3;
-	font-family: 'Karla', 'Helvetica Neue', Helvetica, arial, sans-serif;
+	text-transform: none;
 }
 
 /*--------------------------------------------------------------
-# Navigation
+2.0 General Block Settings
 --------------------------------------------------------------*/
-/*--------------------------------------------------------------
-## Links
---------------------------------------------------------------*/
-.mce-content-body a,
-.wp-block-freeform.core-blocks-rich-text__tinymce a,
-.wp-block-categories a,
-.wp-block-latest-posts a {
+
+/* Links */
+
+.edit-post-visual-editor a,
+.editor-block-list__block a,
+.wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #d97059;
 }
 
-.mce-content-body a:hover,
-.mce-content-body a:focus,
-.mce-content-body a:active,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:hover,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:focus,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:active,
-.wp-block-categories a:hover,
-.wp-block-categories a:focus,
-.wp-block-categories a:active,
-.wp-block-latest-posts a:hover,
-.wp-block-latest-posts a:focus,
-.wp-block-latest-posts a:active {
-	color: #e43a31;
+/*--------------------------------------------------------------
+3.0 Blocks - Common
+--------------------------------------------------------------*/
+
+/* File */
+
+.wp-block-file__textlink {
+	color: #d97059;
+}
+
+.wp-block-file .wp-block-file__button {
+	font-family: Inconsolata, monospace;
+}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus {
+	background-color: #d97059;
 }
 
 /*--------------------------------------------------------------
-## Gutenberg Styles
+4.0 Blocks - Formatting
 --------------------------------------------------------------*/
 
 /* Buttons */
@@ -98,7 +110,17 @@ h6.mce-content-body,
 	font-family: Inconsolata, monospace;
 }
 
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus {
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
 	background-color: #d97059;
+}
+
+/*--------------------------------------------------------------
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/* Latest Comments */
+
+.wp-block-latest-comments__comment-meta {
+	font-family: inherit;
 }

--- a/radcliffe-2/assets/css/editor-style-modern.css
+++ b/radcliffe-2/assets/css/editor-style-modern.css
@@ -1,83 +1,119 @@
-/*!
-Editor Styles for Radcliffe 2: Modern Style Pack
+/*
+Theme Name: Radcliffe 2 - Modern Style Pack
+Description: Used to style Gutenberg Blocks in the editor.
+*/
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Typography
+2.0 General Block Settings
+3.0 Blocks - Common
+4.0 Blocks - Formatting
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+1.0 General Typography
 --------------------------------------------------------------*/
 
 /* Temporary method to include Google Fonts */
+
 @import url( "https://fonts.googleapis.com/css?family=Montserrat:400,400italic,700,700italic" );
 @import url( "https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,700,700italic" );
 
-/* Widths */
+.edit-post-visual-editor .editor-block-list__block,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+	font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, arial, sans-serif;
+}
+
+/* Color */
+
+.edit-post-visual-editor .editor-block-list__block {
+	color: #222;
+}
+
+/* Post title */
+
+.editor-post-title__block .editor-post-title__input {
+	font-family: 'Montserrat', 'Helvetica Neue', Helvetica, arial, sans-serif;
+	text-align: left;
+}
+
+.rtl .editor-post-title__block .editor-post-title__input {
+	text-align: right;
+}
+
 @media screen and (min-width: 768px) {
-	/* Post/Page title */
 	.edit-post-visual-editor textarea.editor-post-title__input {
-		max-width: 740px;
+		max-width: 770px;
 		margin-left: auto;
 		margin-right: auto;
 	}
 }
 
-/*--------------------------------------------------------------
-# Typography
---------------------------------------------------------------*/
+/* Headings */
 
-.edit-post-visual-editor,
-.edit-post-visual-editor p,
-.edit-post-visual-editor button,
-.edit-post-visual-editor input,
-.edit-post-visual-editor select,
-.edit-post-visual-editor optgroup,
-.edit-post-visual-editor textarea {
-	font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, arial, sans-serif;
-}
-
-h1.mce-content-body,
-h2.mce-content-body,
-h3.mce-content-body,
-h4.mce-content-body,
-h5.mce-content-body,
-h6.mce-content-body,
-.edit-post-visual-editor textarea.editor-post-title__input,
-.mce-content-body h1,
-.mce-content-body h2,
-.mce-content-body h3,
-.mce-content-body h4,
-.mce-content-body h5,
-.mce-content-body h6,
-#poststuff h1,
-#poststuff h2,
-#poststuff h3,
-#poststuff h4,
-#poststuff h5,
-#poststuff h6 {
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-family: 'Montserrat', 'Helvetica Neue', Helvetica, arial, sans-serif;
-}
-
-/* Post/Page title */
-.edit-post-visual-editor textarea.editor-post-title__input {
-	padding: 0 0 72px;
-	text-align: left;
+	text-transform: none;
 }
 
 /*--------------------------------------------------------------
-# Navigation
+2.0 General Block Settings
 --------------------------------------------------------------*/
-/*--------------------------------------------------------------
-## Links
---------------------------------------------------------------*/
-.mce-content-body a,
-.wp-block-freeform.core-blocks-rich-text__tinymce a,
-.wp-block-categories a,
-.wp-block-latest-posts a {
+
+/* Links */
+
+.edit-post-visual-editor a,
+.editor-block-list__block a,
+.wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #aaa;
 }
 
 /*--------------------------------------------------------------
-## Gutenberg Styles
+3.0 Blocks - Common
+--------------------------------------------------------------*/
+
+/* File */
+
+.wp-block-file__textlink {
+	color: #aaa;
+}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus {
+	background-color: #aaa;
+}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
 --------------------------------------------------------------*/
 
 /* Buttons */
 
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus {
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
 	background-color: #aaa;
+}
+
+/*--------------------------------------------------------------
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/* Latest Comments */
+
+.wp-block-latest-comments__comment-meta {
+	font-family: inherit;
 }

--- a/radcliffe-2/assets/css/editor-style-vintage.css
+++ b/radcliffe-2/assets/css/editor-style-vintage.css
@@ -1,20 +1,72 @@
-/*!
-Editor Styles for Radcliffe 2: Vintage Style Pack
+/*
+Theme Name: Radcliffe 2 - Vintage Style Pack
+Description: Used to style Gutenberg Blocks in the editor.
+*/
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Typography
+2.0 General Block Settings
+3.0 Blocks - Common
+4.0 Blocks - Formatting
+5.0 Blocks - Layout Elements
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+1.0 General Typography
 --------------------------------------------------------------*/
 
 /* Temporary method to include Google Fonts */
+
 @import url( "https://fonts.googleapis.com/css?family=Libre+Baskerville:400,400italic,700" );
 
-/* Widths */
-.wp-block-cover-image.alignleft,
-.wp-block-cover-image.alignright {
-	left: auto;
-	margin-left: 0;
-	margin-right: 0;
+.edit-post-visual-editor .editor-block-list__block,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+	font-family: 'Libre Baskerville', 'Helvetica Neue', Helvetica, arial, sans-serif;
 }
 
-.edit-post-visual-editor figure {
-	margin: auto;
+.edit-post-visual-editor .editor-block-list__block,
+.edit-post-visual-editor .editor-block-list__block p,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+	font-size: 18px;
+	line-height: 1.8;
+}
+
+/* Post title */
+
+.editor-post-title__block .editor-post-title__input {
+	font-family: 'Libre Baskerville', 'Helvetica Neue', Helvetica, arial, sans-serif;
+	font-weight: 400;
+}
+
+/* Headings */
+
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
+	font-family: 'Libre Baskerville', 'Helvetica Neue', Helvetica, arial, sans-serif;
+	font-weight: 400;
+}
+
+/*--------------------------------------------------------------
+2.0 General Block Settings
+--------------------------------------------------------------*/
+
+/* Editor Layout */
+
+.edit-post-layout {
+	background-color: #eae8dc;
 }
 
 @media screen and (min-width: 600px) {
@@ -39,8 +91,7 @@ Editor Styles for Radcliffe 2: Vintage Style Pack
 		width: 740px;
 	}
 
-	.editor-block-list__layout .editor-block-list__block[data-align="full"],
-	.editor-block-list__layout .editor-block-list__block[data-type="core/cover-image"] {
+	.editor-block-list__layout .editor-block-list__block[data-align="full"] {
 		margin-left: calc(30% - 30vw);
 		margin-right: calc(30% - 30vw);
 		width: auto;
@@ -58,20 +109,16 @@ Editor Styles for Radcliffe 2: Vintage Style Pack
 	}
 }
 
-/* Editor Layout */
-.edit-post-layout {
-	background-color: #eae8dc;
-}
-
 .editor-writing-flow {
 	border: 4px double #c7c4b4;
 	background-color: rgba(255,255,255,0.3);
 	padding-bottom: 4em;
 }
 
-.editor-block-list__layout .editor-block-list__block[data-align="full"],
-.editor-block-list__layout .editor-block-list__block[data-align="wide"],
-.wp-block-cover-image {
+/* Alignments */
+
+.editor-block-list__layout .editor-block-list__block[data-align="full"]:not([data-type="core/cover"]),
+.editor-block-list__layout .editor-block-list__block[data-align="wide"]:not([data-type="core/cover"]) {
 	background-color: rgba(255,255,255,0.7);
 	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,ffffff+100&0.8+0,1+20,1+80,0.8+100 */
 	background: -moz-linear-gradient(top, rgba(255,255,255,0.6) 0%, rgba(255,255,255,1) 15%, rgba(255,255,255,1) 85%, rgba(255,255,255,0.6) 100%); /* FF3.6-15 */
@@ -88,69 +135,86 @@ Editor Styles for Radcliffe 2: Vintage Style Pack
 	outline: none;
 }
 
-/*--------------------------------------------------------------
-# Typography
---------------------------------------------------------------*/
+/* Figure styles */
 
-.edit-post-visual-editor p,
-.edit-post-visual-editor li {
-	font-size: 18px;
+.edit-post-visual-editor figure {
+	margin: auto;
 }
 
-.edit-post-visual-editor,
-.edit-post-visual-editor p,
-.edit-post-visual-editor button,
-.edit-post-visual-editor input,
-.edit-post-visual-editor select,
-.edit-post-visual-editor optgroup,
-.edit-post-visual-editor textarea {
-	color: #222;
-	font-family: 'Libre Baskerville', 'Helvetica Neue', Helvetica, arial, sans-serif;
-}
+/* Link styles */
 
-h1.mce-content-body,
-h2.mce-content-body,
-h3.mce-content-body,
-h4.mce-content-body,
-h5.mce-content-body,
-h6.mce-content-body,
-.edit-post-visual-editor textarea.editor-post-title__input,
-.mce-content-body h1,
-.mce-content-body h2,
-.mce-content-body h3,
-.mce-content-body h4,
-.mce-content-body h5,
-.mce-content-body h6,
-#poststuff h1,
-#poststuff h2,
-#poststuff h3,
-#poststuff h4,
-#poststuff h5,
-#poststuff h6 {
-	font-family: 'Libre Baskerville', 'Helvetica Neue', Helvetica, arial, sans-serif;
-	font-weight: 400;
-}
-
-/* Post/Page title */
-.edit-post-visual-editor textarea.editor-post-title__input {
-	font-weight: 400;
-}
-
-/*--------------------------------------------------------------
-# Navigation
---------------------------------------------------------------*/
-/*--------------------------------------------------------------
-## Links
---------------------------------------------------------------*/
-.mce-content-body a,
-.wp-block-freeform.core-blocks-rich-text__tinymce a,
-.wp-block-categories a,
-.wp-block-latest-posts a {
+.edit-post-visual-editor a,
+.editor-block-list__block a,
+.wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #2b6e9d;
 }
 
+/* Blockquote styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
+	background-color: #c5c3bf;
+}
+
 /*--------------------------------------------------------------
-## Gutenberg Styles
+3.0 Blocks - Common
+--------------------------------------------------------------*/
+
+/* Quote */
+
+.wp-block-quote::before,
+.wp-block-quote::after {
+	background-color: #c5c3bf;
+}
+
+/* File */
+
+.wp-block-file__textlink {
+	color: #2b6e9d;
+}
+
+.wp-block-file .wp-block-file__button {
+	border-radius: 0;
+	border: 3px double #c7c4b4;
+	font-family: inherit;
+}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus {
+	background-color: #2b6e9d;
+	opacity: 1.0;
+}
+
+/* Cover */
+
+.editor-block-list__block[data-align="full"] .wp-block-cover,
+.editor-block-list__block[data-align="full"] .wp-block-cover-image,
+.editor-block-list__block[data-align="wide"] .wp-block-cover,
+.editor-block-list__block[data-align="wide"] .wp-block-cover-image {
+	border: 4px double #c7c4b4;
+}
+
+.wp-block-cover-image.alignleft,
+.wp-block-cover.alignleft,
+.wp-block-cover-image.alignright,
+.wp-block-cover.alignright {
+	left: auto;
+	margin-left: 0;
+	margin-right: 0;
+}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
+--------------------------------------------------------------*/
+
+/* Pullquote */
+
+.wp-block-pullquote {
+	border-color: #c5c3bf;
+}
+
+/*--------------------------------------------------------------
+5.0 Blocks - Layout Elements
 --------------------------------------------------------------*/
 
 /* Buttons */
@@ -172,3 +236,15 @@ h6.mce-content-body,
 .wp-block-pullquote cite {
 	color: #666;
 }
+
+/*--------------------------------------------------------------
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/* Latest Comments */
+
+.wp-block-latest-comments__comment-meta {
+	font-family: inherit;
+}
+
+

--- a/radcliffe-2/assets/css/editor-style.css
+++ b/radcliffe-2/assets/css/editor-style.css
@@ -91,6 +91,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	clear: both;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-weight: 700;
 	line-height: 1.1;
 }
 
@@ -155,6 +156,21 @@ Description: Used to style Gutenberg Blocks in the editor.
 	box-sizing: inherit;
 }
 
+.mce-content-body *[class^="wp-block-"] {
+	margin-bottom: 1.5em;
+}
+
+.mce-content-body *[class^="wp-block-"].alignleft,
+.mce-content-body *[class^="wp-block-"].alignright {
+	max-width: 50%;
+}
+
+.mce-content-body .alignfull,
+.mce-content-body .alignwide,
+.mce-content-body .aligncenter {
+	clear: both;
+}
+
 /* Link styles */
 
 .edit-post-visual-editor a,
@@ -203,23 +219,9 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 /* List styles */
 
-.wp-block-freeform.block-library-rich-text__tinymce ul,
-.wp-block-freeform.block-library-rich-text__tinymce ol {
-	margin: 0 0 1.6em;
-	padding: 0;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce ul {
+.wp-block-freeform.block-library-rich-text__tinymce ul ul,
+.wp-block-freeform.block-library-rich-text__tinymce ol ul {
 	list-style: disc;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce ol {
-	list-style: decimal;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce li > ul,
-.wp-block-freeform.block-library-rich-text__tinymce li > ol {
-	margin-bottom: 0;
 }
 
 /* Definition list styles */
@@ -267,6 +269,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 .wp-block-freeform.block-library-rich-text__tinymce th,
 .wp-block-freeform.block-library-rich-text__tinymce td {
+	border: 0;
 	border-bottom: 1px solid #eee;
 	line-height: 120%;
 	margin: 0;
@@ -327,6 +330,45 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-size: 125%;
 }
 
+/* Blockquote */
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+	border: 0;
+	font-style: italic;
+	margin: 0 1.5em;
+	padding: 0;
+	text-align: center;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote p {
+	color: #666;
+	font-size: 22px;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote cite {
+	color: #999;
+	font-size: 22px;
+	font-style: italic;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
+	background: #ddd;
+	content: "";
+	display: block;
+	height: 2px;
+	margin: 20px auto;
+	width: 80px;
+}
+
+@media (min-width: 600px) {
+	.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
+	.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
+		margin: 36px auto;
+		width: 108px;
+	}
+}
+
 /*--------------------------------------------------------------
 3.0 Blocks - Common Blocks
 --------------------------------------------------------------*/
@@ -336,6 +378,17 @@ Description: Used to style Gutenberg Blocks in the editor.
 p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 5em;
 	margin-top: 0.15em;
+}
+
+/* Image */
+
+.wp-block-image {
+	display: inline-block; /* helps with smaller, unaligned images */
+}
+
+.wp-block-image div {
+	max-height: 100% !important;
+	max-width: 100% !important;
 }
 
 /* Quote */
@@ -368,6 +421,32 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-style: italic;
 }
 
+.wp-block-quote::before,
+.wp-block-quote::after {
+	background: #ddd;
+	content: "";
+	display: block;
+	height: 2px;
+	margin: 20px auto;
+	width: 80px;
+}
+
+@media (min-width: 600px) {
+	.wp-block-quote::before,
+	.wp-block-quote::after {
+		margin: 36px auto;
+		width: 108px;
+	}
+}
+
+/* Audio */
+
+.wp-block-audio audio {
+	display: block;
+	min-width: 270px;
+	width: 100%;
+}
+
 /* Cover */
 
 .edit-post-visual-editor .editor-block-list__block .wp-block-cover-image .wp-block-cover-image-text,
@@ -379,10 +458,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 2em;
 }
 
-.editor-block-list__block [data-align="wide"] .wp-block-cover-image,
-.editor-block-list__block [data-align="wide"] .wp-block-cover,
-.editor-block-list__block [data-align="full"] .wp-block-cover-image,
-.editor-block-list__block [data-align="full"] .wp-block-cover {
+.editor-block-list__block[data-align="wide"] .wp-block-cover-image,
+.editor-block-list__block[data-align="wide"] .wp-block-cover,
+.editor-block-list__block[data-align="full"] .wp-block-cover-image,
+.editor-block-list__block[data-align="full"] .wp-block-cover {
 	height: 75vh;
 	min-height: 400px;
 }
@@ -414,23 +493,32 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Verse */
 
+.wp-block-verse {
+	background-color: transparent;
+	font-family: inherit;
+	font-size: 22px;
+	font-style: italic;
+}
+
+.wp-block-verse pre {
+	padding: 0;
+}
+
 /* Code */
 
-.wp-block-code .editor-plain-text {
-	font-family: "Courier 10 Pitch", Courier, monospace;
-	font-size: 16px;
-	line-height: 1.6;
-	margin-bottom: 1.6em;
-	max-width: 100%;
-	overflow: auto;
+.wp-block-code {
+	background: #eee;
+	border: 0;
+	border-radius: 0;
 	padding: 1.6em;
 	word-wrap: nowrap;
 }
 
 .wp-block-code .editor-plain-text {
-	margin-bottom: 0;
+	background: transparent;
+	font-family: "Courier 10 Pitch", Courier, monospace;
+	font-size: 16px;
 }
-
 
 /* Preformatted */
 
@@ -445,9 +533,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Pullquote */
 
 .wp-block-pullquote {
-	border: 0;
+	border-bottom: 2px solid #ddd;
+	border-top: 3px solid #ddd;
 	font-style: italic;
-	padding: 0;
 }
 
 .edit-post-visual-editor .wp-block-pullquote p {
@@ -461,6 +549,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-style: italic;
 	opacity: 0.8;
 	text-transform: capitalize;
+}
+
+.editor-block-list__block[data-align="right"] .wp-block-pullquote,
+.editor-block-list__block[data-align="left"] .wp-block-pullquote {
+	max-width: 300px;
 }
 
 /* Table */
@@ -480,6 +573,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-table tbody {
+	border: 0;
 	border-bottom: 1px solid #eee;
 	border-top: 1px solid #eee;
 }
@@ -492,6 +586,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-table th,
 .wp-block-table td {
+	border: 0;
 	border-bottom: 1px solid #eee;
 	line-height: 120%;
 	margin: 0;
@@ -507,6 +602,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	background: #f9f9f9;
 }
 
+.wp-block-table__cell-content {
+	padding: 0;
+}
+
 .rtl .wp-block-table th {
 	text-align: right;
 }
@@ -517,372 +616,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Buttons */
 
-/* Separator */
-
-/*--------------------------------------------------------------
-6.0 Blocks - Widgets
---------------------------------------------------------------*/
-
-
-/*--------------------------------------------------------------
-# Elements
---------------------------------------------------------------*/
-
-
-
-.editor-block-list__block[data-align="right"] .wp-block-pullquote,
-.editor-block-list__block[data-align="left"] .wp-block-pullquote {
-	max-width: 300px;
-}
-
-
-/*--------------------------------------------------------------
-# Forms
---------------------------------------------------------------*/
-.mce-content-body button,
-.mce-content-body input[type="button"],
-.mce-content-body input[type="reset"],
-.mce-content-body input[type="submit"] {
-	border: 0;
-	border-radius: 3px;
-	background-color: #FC814A;
-	color: #fff;
-	font-weight: bold;
-	line-height: 1;
-	padding: .6em 1em;
-}
-
-.mce-content-body button:hover,
-.mce-content-body input[type="button"]:hover,
-.mce-content-body input[type="reset"]:hover,
-.mce-content-body input[type="submit"]:hover {
-	background-color: #c1582a;
-}
-
-.mce-content-body button:active,
-.mce-content-body button:focus,
-.mce-content-body input[type="button"]:active,
-.mce-content-body input[type="button"]:focus,
-.mce-content-body input[type="reset"]:active,
-.mce-content-body input[type="reset"]:focus,
-.mce-content-body input[type="submit"]:active,
-.mce-content-body input[type="submit"]:focus {
-	border-color: #aaa #bbb #bbb;
-}
-
-.mce-content-body input[type="text"],
-.mce-content-body input[type="email"],
-.mce-content-body input[type="url"],
-.mce-content-body input[type="password"],
-.mce-content-body input[type="search"],
-.mce-content-body input[type="number"],
-.mce-content-body input[type="tel"],
-.mce-content-body input[type="range"],
-.mce-content-body input[type="date"],
-.mce-content-body input[type="month"],
-.mce-content-body input[type="week"],
-.mce-content-body input[type="time"],
-.mce-content-body input[type="datetime"],
-.mce-content-body input[type="datetime-local"],
-.mce-content-body input[type="color"],
-.mce-content-body textarea {
-	color: #666;
-	border: 1px solid #ccc;
-	border-radius: 3px;
-	padding: 3px;
-}
-
-.mce-content-body input[type="text"]:focus,
-.mce-content-body input[type="email"]:focus,
-.mce-content-body input[type="url"]:focus,
-.mce-content-body input[type="password"]:focus,
-.mce-content-body input[type="search"]:focus,
-.mce-content-body input[type="number"]:focus,
-.mce-content-body input[type="tel"]:focus,
-.mce-content-body input[type="range"]:focus,
-.mce-content-body input[type="date"]:focus,
-.mce-content-body input[type="month"]:focus,
-.mce-content-body input[type="week"]:focus,
-.mce-content-body input[type="time"]:focus,
-.mce-content-body input[type="datetime"]:focus,
-.mce-content-body input[type="datetime-local"]:focus,
-.mce-content-body input[type="color"]:focus,
-.mce-content-body textarea:focus {
-	color: #111;
-}
-
-.mce-content-body select {
-	border: 1px solid #ccc;
-}
-
-.mce-content-body textarea {
-	width: 100%;
-}
-
-/*--------------------------------------------------------------
-# Navigation
---------------------------------------------------------------*/
-/*--------------------------------------------------------------
-## Links
---------------------------------------------------------------*/
-.mce-content-body a,
-.wp-block-freeform.core-blocks-rich-text__tinymce a,
-.wp-block-categories a,
-.wp-block-latest-posts a {
-	color: #ca2017;
-	text-decoration: none;
-}
-
-.mce-content-body a:hover,
-.mce-content-body a:focus,
-.mce-content-body a:active,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:hover,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:focus,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:active,
-.wp-block-categories a:hover,
-.wp-block-categories a:focus,
-.wp-block-categories a:active,
-.wp-block-latest-posts a:hover,
-.wp-block-latest-posts a:focus,
-.wp-block-latest-posts a:active {
-	color: #e43a31;
-	text-decoration: underline;
-}
-
-.mce-content-body a:focus,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:focus {
-	outline: thin dotted;
-	text-decoration: none;
-}
-
-.mce-content-body a:hover,
-.mce-content-body a:active,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:hover,
-.wp-block-freeform.core-blocks-rich-text__tinymce a:active {
-	outline: 0;
-}
-
-/*--------------------------------------------------------------
-# Alignments
---------------------------------------------------------------*/
-.mce-content-body .alignleft {
-	display: inline;
-	float: left;
-	margin-right: 1.6em;
-}
-
-.editor-block-list__layout .editor-block-list__block[data-align="left"] .editor-block-list__block-edit {
-	margin-right: 1.0em;
-}
-
-.mce-content-body .alignright {
-	display: inline;
-	float: right;
-	margin-left: 1.6em;
-}
-
-.editor-block-list__layout .editor-block-list__block[data-align="right"] .editor-block-list__block-edit {
-	margin-left: 1.0em;
-}
-
-.mce-content-body .aligncenter {
-	clear: both;
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.mce-content-body .aligncenter:not(.wp-block-gallery) {
-	display: block;
-}
-
-/* Make sure embeds and iframes fit their containers. */
-.mce-content-body embed,
-.mce-content-body iframe,
-.mce-content-body object {
-	max-width: 100%;
-}
-
-/*--------------------------------------------------------------
-## Captions
---------------------------------------------------------------*/
-.mce-content-body .wp-caption,
-.mce-content-body .gallery-caption {
-	font-size: 0.8em;
-	margin-bottom: 1.6em;
-	max-width: 100%;
-}
-
-.mce-content-body .wp-caption img[class*="wp-image-"] {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.mce-content-body .wp-caption .wp-caption-text {
-	margin: 0.8075em 0;
-}
-
-.mce-content-body .wp-caption-text {
-	opacity: 0.8;
-	text-align: center;
-}
-
-/*--------------------------------------------------------------
-## Galleries
---------------------------------------------------------------*/
-.mce-content-body .gallery {
-	margin: 0 -2% 1.6em;
-}
-
-.mce-content-body .gallery-item {
-	display: inline-block;
-	padding: 0 1% 0;
-	text-align: center;
-	vertical-align: top;
-	width: 100%;
-}
-
-.mce-content-body .gallery-columns-2 .gallery-item {
-	max-width: 50%;
-}
-
-.mce-content-body .gallery-columns-3 .gallery-item {
-	max-width: 33.33%;
-}
-
-.mce-content-body .gallery-columns-4 .gallery-item {
-	max-width: 25%;
-}
-
-.mce-content-body .gallery-columns-5 .gallery-item {
-	max-width: 20%;
-}
-
-.mce-content-body .gallery-columns-6 .gallery-item {
-	max-width: 16.66%;
-}
-
-.mce-content-body .gallery-columns-7 .gallery-item {
-	max-width: 14.28%;
-}
-
-.mce-content-body .gallery-columns-8 .gallery-item {
-	max-width: 12.5%;
-}
-
-.mce-content-body .gallery-columns-9 .gallery-item {
-	max-width: 11.11%;
-}
-
-.mce-content-body .gallery-caption {
-	display: block;
-}
-
-/*--------------------------------------------------------------
-## Gutenberg Styles
---------------------------------------------------------------*/
-
-.mce-content-body *[class^="wp-block-"] {
-	margin-bottom: 1.5em;
-}
-
-.mce-content-body *[class^="wp-block-"].alignleft,
-.mce-content-body *[class^="wp-block-"].alignright {
-	max-width: 50%;
-}
-
-.mce-content-body .alignfull,
-.mce-content-body .alignwide,
-.mce-content-body .aligncenter {
-	clear: both;
-}
-
-/* Images */
-.wp-block-image {
-	display: inline-block; /* helps with smaller, unaligned images */
-}
-
-/* Override inline width on un-aligned images */
-.wp-block-image div {
-	max-height: 100% !important;
-	max-width: 100% !important;
-}
-
-/* Audio */
-
-.wp-block-audio audio {
-	display: block;
-	min-width: 270px;
-	width: 100%;
-}
-
-/* Blockquotes */
-
-.wp-block-freeform.block-library-rich-text__tinymce blockquote {
-	border: 0;
-	margin: 0 1.5em;
-	padding: 0;
-	text-align: center;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce blockquote p {
-	color: #666;
-	font-size: 22px;
-	font-style: italic;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce blockquote cite {
-	color: #999;
-	font-size: 22px;
-}
-
-.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
-.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
-	background: #ddd;
-	content: "";
-	display: block;
-	height: 2px;
-	margin: 20px auto;
-	width: 80px;
-}
-
-@media (min-width: 600px) {
-	.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
-	.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
-		margin: 36px auto;
-		width: 108px;
-	}
-}
-
-
-/* Tables */
-
-/* Verse */
-.wp-block-verse {
-	background-color: transparent;
-	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
-	font-size: 22px;
-	font-style: italic;
-	padding: 0;
-}
-
-/* Separator */
-.wp-block-separator {
-	background: #ccc;
-	border: none;
-	height: 1px;
-	max-width: none;
-	margin: 0 auto;
-}
-
-/* Buttons */
-
-.wp-block-button {
-	display: block;
-}
-
 .wp-block-button .wp-block-button__link {
-	background-color: #222;
 	border: 0;
 	border-radius: 3px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
@@ -892,8 +626,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	text-align: center;
 }
 
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus {
+.wp-block-button__link {
+	background-color: #222;
+}
+
+.wp-block-button__link:hover,
+.wp-block-button__link:focus {
 	background-color: #ca2017;
 }
 
@@ -908,25 +646,59 @@ p.has-drop-cap:not(:focus)::first-letter {
 	line-height: 1.25;
 }
 
+/* Separator */
 
-@media ( min-width: 600px ) {
-	.editor-block-list__layout .editor-block-list__block[data-align="full"] {
-		max-width: calc( 100% + 100px );
-	}
+.wp-block-separator {
+	background: #ccc;
+	border: none;
+	height: 1px;
+	max-width: none;
+	margin: 0 auto;
+}
+
+/*--------------------------------------------------------------
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+/* Categories, Latest Posts & Archives */
+
+.block-editor ul.wp-block-archives,
+.block-editor ul.wp-block-latest-comments,
+.block-editor ul.wp-block-latest-posts,
+.block-editor ul.wp-block-categories__list {
+	list-style: none;
+	padding: 0;
+}
+
+.wp-block-archives li,
+.wp-block-categories__list li {
+	padding: 0.25em 0;
+}
+
+.wp-block-archives li:not(:last-child),
+.wp-block-categories__list li:not(:last-child) {
+	border-bottom: 1px solid rgba(0,0,0,0.075);
+}
+
+.wp-block-categories__list ul ul {
+	padding-left: 2em;
+}
+
+.wp-block-categories__list ul ul li:last-child {
+	padding-bottom: 0;
 }
 
 /* Latest Posts */
+
 .wp-block-latest-posts__post-date {
 	color: inherit;
 	margin-bottom: 0;
 	opacity: 0.8;
 }
 
-.editor-block-list__block[data-type="core/latest-posts"] .wp-block-latest-posts,
+.wp-block-latest-posts,
 .wp-block-latest-posts li {
 	list-style: none;
-	margin: 0;
-	padding: 0;
 }
 
 .wp-block-latest-posts li {
@@ -934,200 +706,38 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-latest-posts li:not(:last-child) {
-	border-bottom: 1px solid rgba(0,0,0,0.075);
+	border-bottom: 1px solid rgba(0,0,0,0.2);
 }
 
 .wp-block-latest-posts.is-grid li {
 	border: 0;
-	padding: 0.25em 0;
-}
-/* Categories */
-
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories ul,
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories li {
-	list-style: none;
-	margin: 0;
-	padding: 0;
 }
 
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories__list li,
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories li {
-	padding: 0.25em 0;
+/* Latest Comments */
+
+.wp-block-latest-comments.not(.alignwide),
+.wp-block-latest-comments.not(.alignfull) {
+	margin-left: 0;
+	margin-right: 0;
 }
 
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories__list li:not(:last-child),
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories li:not(:last-child) {
-	border-bottom: 1px solid rgba(0,0,0,0.075);
+.wp-block-latest-comments__comment,
+.wp-block-latest-comments__comment-date {
+	font-size: inherit;
 }
 
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories__list ul ul li:last-child,
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories ul ul li:last-child {
-	padding-bottom: 0;
+.wp-block-latest-comments__comment-meta {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 80%;
+	font-weight: bold;
+	margin-bottom: 0;
 }
 
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories__list ul ul,
-.editor-block-list__block[data-type="core/categories"] .wp-block-categories ul ul {
-	padding-left: 2em;
+.wp-block-latest-comments__comment-excerpt p {
+	font-size: 90%;
 }
 
-/* Colours - defualt color palette */
-
-.has-white-color,
-.edit-post-visual-editor .has-colorful-white-color,
-.edit-post-visual-editor .has-modern-white-color,
-.wp-block-button .wp-block-button__link.has-white-color,
-.wp-block-button .wp-block-button__link.has-colorful-white-color,
-.wp-block-button .wp-block-button__link.has-modern-white-color {
-	color: #fff;
+.wp-block-latest-comments__comment-date {
+	color: #707070;
+	font-size: 80%;
 }
-
-.has-dark-grey-color,
-.edit-post-visual-editor .has-colorful-dark-grey-color,
-.edit-post-visual-editor .has-vintage-dark-grey-color,
-.edit-post-visual-editor .has-modern-dark-grey-color,
-.wp-block-button .wp-block-button__link.has-dark-grey-color,
-.wp-block-button .wp-block-button__link.has-colorful-dark-grey-color,
-.wp-block-button .wp-block-button__link.has-vintage-dark-grey-color,
-.wp-block-button .wp-block-button__link.has-modern-dark-grey-color {
-	color: #222;
-}
-
-.has-light-grey-color,
-.edit-post-visual-editor .has-vintage-light-grey-color,
-.wp-block-button .wp-block-button__link.has-vintage-light-grey-color {
-	color: #666;
-}
-
-.has-red-color,
-.wp-block-button .wp-block-button__link.has-red-color {
-	color: #ca2017;
-}
-
-.has-white-background-color,
-.has-colorful-white-background-color,
-.has-modern-white-background-color,
-.wp-block-button .wp-block-button__link.has-white-background-color,
-.wp-block-button .wp-block-button__link.has-colorful-white-background-color,
-.wp-block-button .wp-block-button__link.has-modern-white-background-color {
-	background-color: #fff
-}
-
-.has-dark-grey-background-color,
-.has-colorful-dark-grey-background-color,
-.has-vinatge-dark-grey-background-color,
-.has-modern-dark-grey-background-color,
-.wp-block-button .wp-block-button__link.has-dark-grey-background-color,
-.wp-block-button .wp-block-button__link.has-colorful-dark-grey-background-color,
-.wp-block-button .wp-block-button__link.has-vintage-dark-grey-background-color,
-.wp-block-button .wp-block-button__link.has-modern-dark-grey-background-color {
-	background-color: #222;
-}
-
-.has-light-grey-background-color,
-.has-vintage-light-grey-background-color,
-.wp-block-button .wp-block-button__link.has-light-grey-background-color,
-.wp-block-button .wp-block-button__link.has-vintge-light-grey-background-color {
-	background-color: #666;
-}
-
-.has-red-background-color,
-.wp-block-button .wp-block-button__link.has-red-background-color {
-	background-color: #ca2017;
-}
-
-/* Colours - Colorful color palette */
-
-.edit-post-visual-editor .has-colorful-light-grey-color,
-.wp-block-button .wp-block-button__link.has-colorful-light-grey-color {
-	color: #e5e5e5;
-}
-
-.has-colorful-light-grey-background-color,
-.wp-block-button .wp-block-button__link.has-colorful-light-grey-background-color {
-	background-color: #e5e5e5;
-}
-
-.edit-post-visual-editor .has-colorful-orange-color,
-.wp-block-button .wp-block-button__link.has-colorful-orange-color {
-	color: #d97059;
-}
-
-.has-colorful-orange-background-color,
-.wp-block-button .wp-block-button__link.has-coloful-orange-background-color {
-	background-color: #d97059;
-}
-
-.edit-post-visual-editor .has-colorful-green-color,
-.wp-block-button .wp-block-button__link.has-colorful-green-color {
-	color: #71db9d;
-}
-
-.has-colorful-green-background-color,
-.wp-block-button .wp-block-button__link.has-colorful-green-background-color {
-	background-color: #71db9d;
-}
-
-.edit-post-visual-editor .has-colorful-blue-color,
-.wp-block-button .wp-block-button__link.has-colorful-blue-color {
-	color: #4ba3c3;
-}
-
-.has-colorful-blue-background-color,
-.wp-block-button .wp-block-button__link.has-colorful-blue-background-color {
-	background-color: #4ba3c3;
-}
-
-/* Colours - Vintage color palette */
-
-.edit-post-visual-editor .has-vintage-off-white-color,
-.wp-block-button .wp-block-button__link.has-vintage-off-white-color {
-	color: #eae8dc;
-}
-
-.has-vintage-off-white-background-color,
-.wp-block-button .wp-block-button__link.has-vintage-off-white-background-color {
-	background-color: #eae8dc;
-}
-
-.edit-post-visual-editor .has-vintage-light-brown-color,
-.wp-block-button .wp-block-button__link.has-vintage-light-brown-color {
-	color: #c7c4b4;
-}
-
-.has-vintage-light-brown-background-color,
-.wp-block-button .wp-block-button__link.has-vintage-light-brown-background-color {
-	background-color: #c7c4b4;
-}
-
-.edit-post-visual-editor .has-vintage-blue-color,
-.wp-block-button .wp-block-button__link.has-vintage-blue-color {
-	color: #2b6e9d;
-}
-
-.has-vintage-blue-background-color,
-.wp-block-button .wp-block-button__link.has-vintage-blue-background-color {
-	background-color: #2b6e9d;
-}
-
-/* Colours - Modern color palette */
-
-.edit-post-visual-editor .has-modern-light-grey-color,
-.wp-block-button .wp-block-button__link.has-modern-light-grey-color {
-	color: #f1f1f1;
-}
-
-.has-modern-light-grey-background-color,
-.wp-block-button .wp-block-button__link.has-modern-light-grey-background-color {
-	background-color: #f1f1f1;
-}
-
-.edit-post-visual-editor .has-modern-medium-grey-color,
-.wp-block-button .wp-block-button__link.has-modern-medium-grey-color {
-	color: #aaa;
-}
-
-.has-modern-medium-grey-background-color,
-.wp-block-button .wp-block-button__link.has-modern-medium-grey-background-color {
-	background-color: #aaa;
-}
-

--- a/radcliffe-2/assets/css/editor-style.css
+++ b/radcliffe-2/assets/css/editor-style.css
@@ -1,119 +1,422 @@
-/*!
-Editor Styles for Radcliffe 2
---------------------------------------------------------------*/
-
-/* Widths */
-
-@media screen and ( min-width: 788px ) {
-	/* Main column width */
-	body.gutenberg-editor-page .edit-post-visual-editor .editor-post-title__block,
-	body.gutenberg-editor-page .edit-post-visual-editor .editor-default-block-appender,
-	body.gutenberg-editor-page .edit-post-visual-editor .editor-block-list__block {
-	    max-width: 770px; /* 740px + 30px for editor block margins */
-	}
-}
+/*
+Theme Name: Radcliffe 2
+Description: Used to style Gutenberg Blocks in the editor.
+*/
 
 /*--------------------------------------------------------------
-# Typography
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Typography
+2.0 General Block Settings
+3.0 Blocks - Common Blocks
+4.0 Blocks - Formatting
+5.0 Blocks - Layout Elements
+6.0 Blocks - Widgets
 --------------------------------------------------------------*/
 
-.edit-post-visual-editor,
-.edit-post-visual-editor p,
-.edit-post-visual-editor button,
-.edit-post-visual-editor input,
-.edit-post-visual-editor select,
-.edit-post-visual-editor optgroup,
-.edit-post-visual-editor textarea,
-.edit-post-visual-editor blockquote {
-	color: #222;
+/*--------------------------------------------------------------
+1.0 General Typography
+--------------------------------------------------------------*/
+
+.edit-post-visual-editor .editor-block-list__block,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
 	font-family: Palatino,"Palatino Linotype","Palatino LT STD","Book Antiqua",Times,"Times New Roman",serif;
-	font-size: 20px;
+}
+
+/* Font size */
+
+.edit-post-visual-editor .editor-block-list__block,
+.edit-post-visual-editor .editor-block-list__block p,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+	font-size: 18px;
 	line-height: 1.8;
+}
+
+@media (min-width: 600px) {
+	.edit-post-visual-editor .editor-block-list__block,
+	.edit-post-visual-editor .editor-block-list__block p,
+	.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
+		font-size: 20px;
+	}
 }
 
 .blocks-rich-text__tinymce.mce-content-body {
 	line-height: inherit;
 }
 
-h1.mce-content-body,
-h2.mce-content-body,
-h3.mce-content-body,
-h4.mce-content-body,
-h5.mce-content-body,
-h6.mce-content-body,
-.edit-post-visual-editor textarea.editor-post-title__input,
-.mce-content-body h1,
-.mce-content-body h2,
-.mce-content-body h3,
-.mce-content-body h4,
-.mce-content-body h5,
-.mce-content-body h6,
-#poststuff h1,
-#poststuff h2,
-#poststuff h3,
-#poststuff h4,
-#poststuff h5,
-#poststuff h6 {
-	clear: both;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-	line-height: 1.1;
-	margin-top: 0;
+/* Color */
+
+.edit-post-visual-editor .editor-block-list__block {
+	color: #222;
 }
 
-/* Post/Page title */
-.edit-post-visual-editor textarea.editor-post-title__input {
+/* Post title */
+
+.editor-post-title__block .editor-post-title__input {
 	font-family: Palatino,"Palatino Linotype","Palatino LT STD","Book Antiqua",Times,"Times New Roman",serif;
-	font-size: 60px;
+	font-size: 36px;
 	line-height: 1.2;
 	text-align: center;
+}
+
+@media all and (min-width: 600px) {
+	.editor-post-title__block .editor-post-title__input {
+		font-size: 50px;
+	}
+}
+
+@media screen and (min-width: 768px) {
+	.editor-post-title__block .editor-post-title__input {
+		font-size: 60px;
+	}
 }
 
 .edit-post-visual-editor .editor-post-title {
 	max-width: 100%;
 }
 
-h1.editor-rich-text__tinymce.mce-content-body {
+/* Headings */
+
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
+	clear: both;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	line-height: 1.1;
+}
+
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1 {
 	font-size: 36px;
 	line-height: 1.25;
 }
 
-h2.editor-rich-text__tinymce.mce-content-body,
-#poststuff .wp-block-heading h2 {
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2 {
 	font-size: 30px;
 	line-height: 1.2;
 }
 
-h3.editor-rich-text__tinymce.mce-content-body {
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3 {
 	font-size: 25px;
 	line-height: 1.44;
 }
 
-h4.editor-rich-text__tinymce.mce-content-body {
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4 {
 	font-size: 20px;
 	line-height: 1.8em
 }
 
-h5.editor-rich-text__tinymce.mce-content-body,
-h6.editor-rich-text__tinymce.mce-content-body {
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-size: 15px;
 	line-height: 2.4em;
 	text-transform: uppercase;
 }
 
-.mce-content-body dfn,
-.mce-content-body cite,
-.mce-content-body em,
-.mce-content-body i {
-	font-style: italic;
+@media screen and (min-width: 768px) {
+	.edit-post-visual-editor h1,
+	.wp-block-freeform.block-library-rich-text__tinymce h1 {
+		font-size: 40px;
+	}
 }
 
-.mce-content-body address {
+/*--------------------------------------------------------------
+2.0 General Block Settings
+--------------------------------------------------------------*/
+
+/* Main content width */
+
+@media screen and ( min-width: 788px ) {
+	.wp-block {
+		max-width: 770px; /* 740px + 30px for editor block margins */
+	}
+}
+
+/* All elements */
+
+.edit-post-visual-editor *,
+.edit-post-visual-editor *:before,
+.edit-post-visual-editor *:after {
+	/* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+	box-sizing: inherit;
+}
+
+/* Link styles */
+
+.edit-post-visual-editor a,
+.editor-block-list__block a,
+.wp-block-freeform.block-library-rich-text__tinymce a {
+	color: #ca2017;
+	text-decoration: none;
+}
+
+/* Caption styles */
+
+[class^="wp-block-"] figcaption {
+	font-size: 80%;
+}
+
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
+	color: inherit;
+	opacity: 0.8;
+}
+
+/* Address styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce address {
 	margin: 0 0 1.8em;
 }
 
-.mce-content-body pre,
-.wp-block-code .editor-plain-text,
-.wp-block-preformatted pre {
+/* Preformatted styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce pre {
+	background: #eee;
+	font-family: "Courier 10 Pitch", Courier, monospace;
+	font-size: 16px;
+	line-height: 1.6;
+	margin-bottom: 1.6em;
+	padding: 1.6em;
+}
+
+/* HR styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce hr {
+	background-color: #ccc;
+	border: 0;
+	height: 1px;
+	margin-bottom: 1.6em;
+}
+
+/* List styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce ul,
+.wp-block-freeform.block-library-rich-text__tinymce ol {
+	margin: 0 0 1.6em;
+	padding: 0;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce ul {
+	list-style: disc;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce ol {
+	list-style: decimal;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce li > ul,
+.wp-block-freeform.block-library-rich-text__tinymce li > ol {
+	margin-bottom: 0;
+}
+
+/* Definition list styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce dt {
+	font-weight: bold;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce dd {
+	margin: 0 1.5em 1.5em;
+}
+
+/* Figure styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce figure {
+	margin: 1em 0;
+}
+
+/* Table styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce table {
+	border-collapse: collapse;
+	border-spacing: 0;
+	border: 0;
+	empty-cells: show;
+	font-size: 0.9em;
+	margin: 0 0 1.6em;
+	width: 100%;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce thead {
+	vertical-align: bottom;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce tbody {
+	border-bottom: 1px solid #eee;
+	border-top: 1px solid #eee;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce th {
+	color: #444;
+	font-weight: bold;
+	text-align: left;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce th,
+.wp-block-freeform.block-library-rich-text__tinymce td {
+	border-bottom: 1px solid #eee;
+	line-height: 120%;
+	margin: 0;
+	padding: 0.75em;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce tr:last-child td {
+	border-bottom: none;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce table tbody > tr:nth-child(odd) > th,
+.wp-block-freeform.block-library-rich-text__tinymce table tbody > tr:nth-child(odd) > td {
+	background: #f9f9f9;
+}
+
+.rtl .wp-block-freeform.block-library-rich-text__tinymce th {
+	text-align: right;
+}
+
+/* Code, KBD, TT and Var styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce code,
+.wp-block-freeform.block-library-rich-text__tinymce kbd,
+.wp-block-freeform.block-library-rich-text__tinymce tt,
+.wp-block-freeform.block-library-rich-text__tinymce var {
+	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	font-size: 16px;
+}
+
+/* DFN, Cite, Em, i styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce dfn,
+.wp-block-freeform.block-library-rich-text__tinymce cite,
+.wp-block-freeform.block-library-rich-text__tinymce em,
+.wp-block-freeform.block-library-rich-text__tinymce i {
+	font-style: italic;
+}
+
+/* Abbr, Acronym styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce abbr,
+.wp-block-freeform.block-library-rich-text__tinymce acronym {
+	border-bottom: 1px dotted #666;
+	cursor: help;
+}
+
+/* Mark, Ins styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce mark,
+.wp-block-freeform.block-library-rich-text__tinymce ins {
+	background: #fff9c0;
+	text-decoration: none;
+}
+
+/* Big styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce big {
+	font-size: 125%;
+}
+
+/*--------------------------------------------------------------
+3.0 Blocks - Common Blocks
+--------------------------------------------------------------*/
+
+/* Paragraph */
+
+p.has-drop-cap:not(:focus)::first-letter {
+	font-size: 5em;
+	margin-top: 0.15em;
+}
+
+/* Quote */
+
+.wp-block-quote:not(.is-large):not(.is-style-large) {
+	border: 0;
+	padding: 0;
+}
+
+.wp-block-quote {
+	font-style: italic;
+	margin: 0 1.5em;
+	text-align: center;
+}
+
+.edit-post-visual-editor .editor-block-list__block .wp-block-quote p {
+	color: #666;
+	font-size: 22px;
+}
+
+.edit-post-visual-editor .editor-block-list__block .wp-block-quote.is-style-large p,
+.edit-post-visual-editor .editor-block-list__block .wp-block-quote.is-large p {
+	font-size: 28px;
+}
+
+.wp-block-quote .wp-block-quote__citation,
+.wp-block-quote:not(.is-large):not(.is-style-large) .wp-block-quote__citation {
+	color: #999;
+	font-size: 22px;
+	font-style: italic;
+}
+
+/* Cover */
+
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image .wp-block-cover-image-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image .wp-block-cover-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image h2,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover .wp-block-cover-image-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover .wp-block-cover-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover h2 {
+	font-size: 2em;
+}
+
+.editor-block-list__block [data-align="wide"] .wp-block-cover-image,
+.editor-block-list__block [data-align="wide"] .wp-block-cover,
+.editor-block-list__block [data-align="full"] .wp-block-cover-image,
+.editor-block-list__block [data-align="full"] .wp-block-cover {
+	height: 75vh;
+	min-height: 400px;
+}
+
+/* File */
+
+.wp-block-file__textlink {
+	color: #ca2017;
+}
+
+.wp-block-file .wp-block-file__button {
+	background: #222;
+	border-radius: 3px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	line-height: 1.29;
+	padding: 9px 18px;
+}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus {
+	background: #ca2017;
+	opacity: 1.0;
+}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
+--------------------------------------------------------------*/
+
+/* Verse */
+
+/* Code */
+
+.wp-block-code .editor-plain-text {
 	font-family: "Courier 10 Pitch", Courier, monospace;
 	font-size: 16px;
 	line-height: 1.6;
@@ -129,191 +432,109 @@ h6.editor-rich-text__tinymce.mce-content-body {
 }
 
 
-.mce-content-body blockquote {
-	margin: 0 1.5em;
-}
+/* Preformatted */
 
-.mce-content-body code,
-.mce-content-body kbd,
-.mce-content-body tt,
-.mce-content-body var {
-	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+.wp-block-preformatted pre {
+	background: #eee;
+	font-family: "Courier 10 Pitch", Courier, monospace;
 	font-size: 16px;
-	font-size: 1.6rem;
+	line-height: 1.6;
+	padding: 1.6em;
 }
 
-.mce-content-body abbr,
-.mce-content-body acronym {
-	border-bottom: 1px dotted #666;
-	cursor: help;
-}
+/* Pullquote */
 
-.mce-content-body mark,
-.mce-content-body ins {
-	background: #fff9c0;
-	text-decoration: none;
-}
-
-.mce-content-body big {
-	font-size: 125%;
-}
-
-/*--------------------------------------------------------------
-# Elements
---------------------------------------------------------------*/
-
-.edit-post-visual-editor *,
-.edit-post-visual-editor *:before,
-.edit-post-visual-editor *:after {
-	/* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
-	box-sizing: inherit;
-}
-
-/* Subhead */
-.edit-post-visual-editor p.wp-block-subhead {
-	color: inherit;
-}
-
-.mce-content-body hr {
-	background-color: #ccc;
+.wp-block-pullquote {
 	border: 0;
-	height: 1px;
-	margin-bottom: 1.6em;
-}
-
-.mce-content-body ul,
-.mce-content-body ol {
-	margin: 0 0 1.6em;
+	font-style: italic;
 	padding: 0;
 }
 
-.mce-content-body ul {
-	list-style: disc;
+.edit-post-visual-editor .wp-block-pullquote p {
+	color: #666;
+	margin-bottom: 1.8em;
 }
 
-.mce-content-body ol {
-	list-style: decimal;
+.edit-post-visual-editor .wp-block-pullquote__citation {
+	color: #666;
+	font-size: 1.1em;
+	font-style: italic;
+	opacity: 0.8;
+	text-transform: capitalize;
 }
 
-.mce-content-body li > ul,
-.mce-content-body li > ol {
-	margin-bottom: 0;
-}
+/* Table */
 
-.mce-content-body dt {
-	font-weight: bold;
-}
-
-.edit-post-visual-editor dd {
-	margin: 0 1.5em 1.5em;
-}
-
-.edit-post-visual-editor img {
-	height: auto;
-	/* Make sure images are scaled correctly. */
-	max-width: 100%;
-	/* Adhere to container width. */
-}
-
-.edit-post-visual-editor figure {
-	margin: 1em 0;
-	/* Extra wide images within figure tags don't overflow the content area. */
-}
-
-.edit-post-visual-editor table {
+.wp-block-table {
 	border-collapse: collapse;
 	border-spacing: 0;
+	border: 0;
 	empty-cells: show;
 	font-size: 0.9em;
 	margin: 0 0 1.6em;
 	width: 100%;
 }
 
-.edit-post-visual-editor thead {
+.wp-block-table thead {
 	vertical-align: bottom;
-	white-space: nowrap;
 }
 
-.edit-post-visual-editor tbody {
+.wp-block-table tbody {
 	border-bottom: 1px solid #eee;
 	border-top: 1px solid #eee;
 }
 
-.edit-post-visual-editor th {
+.wp-block-table th {
 	color: #444;
 	font-weight: bold;
 	text-align: left;
 }
 
-.edit-post-visual-editor th,
-.edit-post-visual-editor td {
+.wp-block-table th,
+.wp-block-table td {
 	border-bottom: 1px solid #eee;
 	line-height: 120%;
 	margin: 0;
-	overflow: visible;
-	padding: 2%;
+	padding: 0.75em;
 }
 
-.edit-post-visual-editor tr:last-child td {
+.wp-block-table tr:last-child td {
 	border-bottom: none;
 }
 
-.wp-block-freeform.mce-content-body table tbody > tr:nth-child(2n+1) > th,
-.wp-block-freeform.mce-content-body table tbody > tr:nth-child(odd) > td,
-.edit-post-visual-editor table tbody > tr:nth-child(odd) > th,
-.edit-post-visual-editor table tbody > tr:nth-child(odd) > td {
+.wp-block-table tbody > tr:nth-child(odd) > th,
+.wp-block-table tbody > tr:nth-child(odd) > td {
 	background: #f9f9f9;
 }
 
-.edit-post-visual-editor blockquote {
-
+.rtl .wp-block-table th {
+	text-align: right;
 }
+
+/*--------------------------------------------------------------
+5.0 Blocks - Layout Elements
+--------------------------------------------------------------*/
+
+/* Buttons */
+
+/* Separator */
+
+/*--------------------------------------------------------------
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+
+/*--------------------------------------------------------------
+# Elements
+--------------------------------------------------------------*/
+
+
 
 .editor-block-list__block[data-align="right"] .wp-block-pullquote,
 .editor-block-list__block[data-align="left"] .wp-block-pullquote {
 	max-width: 300px;
 }
 
-.edit-post-visual-editor th,
-.edit-post-visual-editor td {
-	border-right: 0;
-}
-
-.edit-post-visual-editor table {
-	border-collapse: separate;
-	border-spacing: 0;
-	border-width: 1px 0 0 1px;
-	margin: 0 0 1.75em;
-	table-layout: fixed;
-	/* Prevents HTML tables from becoming too wide */
-	width: 100%;
-}
-
-.edit-post-visual-editor caption,
-.edit-post-visual-editor th,
-.edit-post-visual-editor td {
-	font-weight: normal;
-	text-align: left;
-}
-
-.edit-post-visual-editor th {
-	border-width: 0 1px 1px 0;
-	font-weight: 700;
-}
-
-.edit-post-visual-editor td {
-	border-width: 0 1px 1px 0;
-}
-
-.edit-post-visual-editor th,
-.edit-post-visual-editor td {
-	padding: 0.4375em;
-}
-
-.mce-content-body table tbody > tr:nth-child(odd) > th,
-.mce-content-body table tbody > tr:nth-child(odd) > td {
-	background: rgba(0,0,0,.15);
-}
 
 /*--------------------------------------------------------------
 # Forms
@@ -595,32 +816,28 @@ h6.editor-rich-text__tinymce.mce-content-body {
 	width: 100%;
 }
 
-/* Blockquotes*/
+/* Blockquotes */
 
-.edit-post-visual-editor .wp-block-quote:not(.is-large) {
-	border-left: 0;
-	padding-left: 0;
-}
-
-.wp-block-freeform.core-blocks-rich-text__tinymce blockquote {
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
 	border: 0;
+	margin: 0 1.5em;
 	padding: 0;
 	text-align: center;
 }
 
-.wp-block-freeform.core-blocks-rich-text__tinymce blockquote {
+.wp-block-freeform.block-library-rich-text__tinymce blockquote p {
 	color: #666;
-}
-
-.edit-post-visual-editor .wp-block-quote,
-.editor-post-visual-editor blockquote {
+	font-size: 22px;
 	font-style: italic;
-	margin: 0 1.5em;
-	text-align: center;
 }
 
-.edit-post-visual-editor blockquote::before,
-.edit-post-visual-editor blockquote::after {
+.wp-block-freeform.block-library-rich-text__tinymce blockquote cite {
+	color: #999;
+	font-size: 22px;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
+.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
 	background: #ddd;
 	content: "";
 	display: block;
@@ -629,66 +846,16 @@ h6.editor-rich-text__tinymce.mce-content-body {
 	width: 80px;
 }
 
-
 @media (min-width: 600px) {
-	.edit-post-visual-editor blockquote::before,
-	.edit-post-visual-editor blockquote::after {
+	.wp-block-freeform.block-library-rich-text__tinymce blockquote::before,
+	.wp-block-freeform.block-library-rich-text__tinymce blockquote::after {
 		margin: 36px auto;
 		width: 108px;
 	}
 }
 
-.edit-post-visual-editor .wp-block-quote p,
-.editor-post-visual-editor blockquote p {
-	color: #666;
-	font-size: 22px;
-}
-
-.edit-post-visual-editor .wp-block-quote cite,
-.editor-post-visual-editor blockquote cite {
-	color: #999;
-	font-size: 13px;
-}
-
-/* Pullquotes */
-.wp-block-pullquote {
-	border: 0;
-	font-style: italic;
-	padding: 0;
-}
-
-.edit-post-visual-editor .wp-block-pullquote p {
-	color: #666;
-	margin-bottom: 1.8em;
-}
-
-.edit-post-visual-editor .wp-block-pullquote__citation {
-	color: #666;
-	font-size: 1.1em;
-	font-style: italic;
-	opacity: 0.8;
-	text-transform: capitalize;
-}
-
-/* Cover Images */
-.edit-post-visual-editor .editor-block-list__block[data-type="core/cover-image"] {
-	max-width: 100%;
-}
-
-.editor-block-list__block .wp-block-cover-image {
-	height: 75vh;
-	min-height: 400px;
-}
-
-.editor-block-list__block .wp-block-cover-image p,
-.editor-block-list__block .wp-block-cover-image h2 {
-	line-height: 1.2;
-}
 
 /* Tables */
-.wp-block-table {
-	display: table;
-}
 
 /* Verse */
 .wp-block-verse {
@@ -719,7 +886,6 @@ h6.editor-rich-text__tinymce.mce-content-body {
 	border: 0;
 	border-radius: 3px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-	font-size: 1.4rem;
 	font-size: 14px;
 	line-height: 1.25;
 	padding: .6em 1em;
@@ -737,6 +903,11 @@ h6.editor-rich-text__tinymce.mce-content-body {
 .wp-block-button.alignfull {
 	display: block;
 }
+
+.wp-block-button .editor-rich-text__tinymce.mce-content-body {
+	line-height: 1.25;
+}
+
 
 @media ( min-width: 600px ) {
 	.editor-block-list__layout .editor-block-list__block[data-align="full"] {

--- a/radcliffe-2/functions.php
+++ b/radcliffe-2/functions.php
@@ -78,100 +78,122 @@ function radcliffe_2_setup() {
 	// Add theme support for selective refresh for widgets.
 	add_theme_support( 'customize-selective-refresh-widgets' );
 
+	// Add support for responsive embeds.
+	add_theme_support( 'responsive-embeds' );
+
 	// Gutenberg: Add Custom Palette
 	$stylepack = get_theme_mod( 'active_style_pack' );
 
-	if ( 'default' === $stylepack ) {
-		add_theme_support( 'editor-color-palette',
+	if ( 'vintage' === $stylepack ) {
+		add_theme_support( 'editor-color-palette', array(
 			array(
-				'name' => 'white',
-				'color' => '#ffffff',
+				'name'  => esc_html__( 'Vintage Off-White', 'radcliffe-2' ),
+				'slug'  => 'vintage-off-white',
+				'color' => '#3e69dc',
 			),
 			array(
-				'name' => 'dark grey',
-				'color' => '#222222',
-			),
-			array(
-				'name' => 'light gray',
-				'color' => '#666666',
-			),
-			array(
-				'name' => 'red',
-				'color' => '#ca2017',
-			)
-		);
-	} else if ( 'vintage' === $stylepack ) {
-		add_theme_support( 'editor-color-palette',
-			array(
-				'name' => 'vintage off-white',
-				'color' => '#eae8dc',
-			),
-			array(
-				'name' => 'vintage light brown',
+				'name'  => esc_html__( 'Vintage Light Brown', 'radcliffe-2' ),
+				'slug'  => 'vintage-light-brown',
 				'color' => '#c7c4b4',
 			),
 			array(
-				'name' => 'vintage light grey',
-				'color' => '#666666',
+				'name'  => esc_html__( 'Vintage Light Gray', 'radcliffe-2' ),
+				'slug'  => 'vintage-light-gray',
+				'color' => '#666',
 			),
 			array(
-				'name' => 'vintage dark grey',
-				'color' => '#222222',
+				'name'  => esc_html__( 'Vintage Dark Gray', 'radcliffe-2' ),
+				'slug'  => 'vintage-dark-gray',
+				'color' => '#222',
 			),
 			array(
-				'name' => 'vintage blue',
+				'name'  => esc_html__( 'Vintage Blue', 'radcliffe-2' ),
+				'slug'  => 'vintage-blue',
 				'color' => '#2b6e9d',
 			)
-		);
+		) );
 	} else if ( 'colorful' === $stylepack ) {
-		add_theme_support( 'editor-color-palette',
+		add_theme_support( 'editor-color-palette', array(
 			array(
-				'name' => 'colorful white',
-				'color' => '#ffffff',
+				'name'  => esc_html__( 'Colorful White', 'radcliffe-2' ),
+				'slug'  => 'colorful-white',
+				'color' => '#fff',
 			),
 			array(
-				'name' => 'colorful light grey',
+				'name'  => esc_html__( 'Colorful Light Gray', 'radcliffe-2' ),
+				'slug'  => 'colorful-light-gray',
 				'color' => '#e5e5e5',
 			),
 			array(
-				'name' => 'colorful dark grey',
+				'name'  => esc_html__( 'Colorful Dark Gray', 'radcliffe-2' ),
+				'slug'  => 'colorful-dark-gray',
 				'color' => '#222222',
 			),
 			array(
-				'name' => 'colorful blue',
+				'name'  => esc_html__( 'Colorful Blue', 'radcliffe-2' ),
+				'slug'  => 'colorful-blue',
 				'color' => '#4ba3c3',
 			),
 			array(
-				'name' => 'colorful green',
+				'name'  => esc_html__( 'Colorful Green', 'radcliffe-2' ),
+				'slug'  => 'colorful-green',
 				'color' => '#71db9d',
 			),
 			array(
-				'name' => 'colorful orange',
+				'name'  => esc_html__( 'Colorful Orange', 'radcliffe-2' ),
+				'slug'  => 'colorful-orange',
 				'color' => '#d97059',
 			)
-		);
+		) );
 	} else if ( 'modern' === $stylepack ) {
-		add_theme_support( 'editor-color-palette',
+		add_theme_support( 'editor-color-palette', array(
 			array(
-				'name' => 'modern white',
-				'color' => '#ffffff',
+				'name'  => esc_html__( 'Modern White', 'radcliffe-2' ),
+				'slug'  => 'modern-white',
+				'color' => '#fff',
 			),
 			array(
-				'name' => 'modern light grey',
+				'name'  => esc_html__( 'Modern Light Gray', 'radcliffe-2' ),
+				'slug'  => 'modern-light-gray',
 				'color' => '#f1f1f1',
 			),
 			array(
-				'name' => 'modern medium grey',
-				'color' => '#aaaaaa',
+				'name'  => esc_html__( 'Modern Medium Gray', 'radcliffe-2' ),
+				'slug' => 'modern-medium-gray',
+				'color' => '#aaa',
 			),
 			array(
-				'name' => 'modern dark grey',
-				'color' => '#222222',
+				'name'  => esc_html__( 'Modern Dark Gray', 'radcliffe-2' ),
+				'slug'  => 'modern-dark-gray',
+				'color' => '#222',
 			)
-		);
+		) );
+	} else {
+		add_theme_support( 'editor-color-palette', array(
+			array(
+				'name'  => esc_html__( 'White', 'radcliffe-2' ),
+				'slug'  => 'white',
+				'color' => '#fff',
+			),
+			array(
+				'name'  => esc_html__( 'Dark Gray', 'radcliffe-2' ),
+				'slug'  => 'dark-gray',
+				'color' => '#222',
+			),
+			array(
+				'name'  => esc_html__( 'Light Gray', 'radcliffe-2' ),
+				'slug'  => 'light-gray',
+				'color' => '#666666',
+			),
+			array(
+				'name'  => esc_html__( 'Red', 'radcliffe-2' ),
+				'slug' => 'red',
+				'color' => '#ca2017',
+			)
+		) );
 	}
 
-	// Gutenberg: Add support for wide alignment
+	// Add support for wide alignment
 	add_theme_support( 'align-wide' );
 }
 endif;


### PR DESCRIPTION
* Reorders checks for which editor colour palette to load; with the original set up, the default palette was never loaded. 
* Reorders stylesheets to match other themes.
* Removes unneeded editor styles.
* Makes Cover block only wide when the wide and full alignments are applied.
* Fix issues with table full and wide widths. 
* Add updated versions of Gutenberg CSS selectors. 