### PR TITLE
Canard: Minor fixes to Gutenberg styles

### DIFF
--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -111,6 +111,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	outline: none;
 }
 
+.rtl .wp-block-file * + .wp-block-file__button {
+	margin-left: 0.75em;
+	margin-right: 0;
+}
+
 /*--------------------------------------------------------------
 3.0 Blocks - Formatting Blocks
 --------------------------------------------------------------*/
@@ -119,7 +124,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-verse {
 	background: transparent;
-	border-left: 0;
+	border: 0;
 	color: inherit;
 	font-family: inherit;
 	line-height: inherit;

--- a/canard/editor-blocks.css
+++ b/canard/editor-blocks.css
@@ -115,17 +115,6 @@
 	margin-bottom: 30px;
 }
 
-/* Images */
-
-.wp-block-image figcaption {
-	color: #777;
-	font-family: Lato, sans-serif;
-	font-size: 16px;
-	line-height: 1.25;
-	margin-bottom: 25px;
-	max-width: 100%;
-}
-
 /*--------------------------------------------------------------
 2.0 General Block Styles
 --------------------------------------------------------------*/
@@ -259,7 +248,6 @@
 	font-family: Lato, sans-serif;
 	font-size: 16px;
 	line-height: 1.25;
-	margin-bottom: 25px;
 	max-width: 100%;
 }
 
@@ -271,6 +259,17 @@
 
 .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 	font-size: 64px;
+}
+
+/* Image */
+
+.wp-block-image figcaption {
+	color: #777;
+	font-family: Lato, sans-serif;
+	font-size: 16px;
+	line-height: 1.25;
+	margin-bottom: 25px;
+	max-width: 100%;
 }
 
 /* Quote */
@@ -333,6 +332,7 @@
 }
 
 .wp-block-quote__citation {
+	color: inherit;
 	font-style: normal;
 	font-weight: bold;
 	font-size: inherit;
@@ -559,7 +559,7 @@
 .wp-block-freeform.block-library-rich-text__tinymce pre {
 	background: #eee;
 	border-left: 2px solid #d11415;
-	font-size: 1em;
+	font-size: 16px;
 	max-width: 100%;
 	overflow: auto;
 	padding: 30px;
@@ -571,6 +571,8 @@
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce table {
+	border: 0;
+	border-collapse: collapse;
 	border-top: 1px solid #ddd;
 	margin: 0 0 30px;
 	text-align: left;
@@ -588,12 +590,18 @@
 	padding: 5px;
 }
 
+.wp-block-freeform.block-library-rich-text__tinymce table thead {
+	background-color: #eee;
+}
+
 .wp-block-freeform.block-library-rich-text__tinymce table td a,
 .wp-block-freeform.block-library-rich-text__tinymce table th a {
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce table th {
 	border-bottom: 1px solid #ddd;
+	font-family: Lato, sans-serif;
+	text-transform: uppercase;
 }
 
 .rtl .wp-block-freeform.block-library-rich-text__tinymce th,
@@ -698,6 +706,16 @@
 
 .rtl .wp-block-table {
 	text-align: right;
+}
+
+/* Definition List styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce dt {
+	font-weight: bold;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce dd {
+	margin: 0 0 30px;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
This PR includes some small fixes for issues in the Gutenberg styles, including:

* For RTL, add space between link and button in file block.
* For RTL, remove border from verse block.
* Remove bottom margin from captions in editor.
* Correct citation font size in editor.
* Correct pre tag font size in editor.
* Add background thead in editor.
* Correct font size in th in editor.
* Add styles for definition lists in editor.