### PR TITLE
Dara: Minor fixes to Gutenberg styles

### DIFF
--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -70,14 +70,6 @@ blockquote cite {
 	font-style: normal;
 }
 
-.wp-block-quote:not(.is-large):not(.is-style-large).alignleft,
-.wp-block-quote:not(.is-large):not(.is-style-large).alignright {
-}
-
-.rtl .wp-block-quote:not(.is-large):not(.is-style-large).alignleft,
-.rtl .wp-block-quote:not(.is-large):not(.is-style-large).alignright {
-}
-
 .wp-block-quote cite {
 	display: block;
 	font-family: "Source Sans Pro", Helvetica, sans-serif;
@@ -86,9 +78,6 @@ blockquote cite {
 	font-weight: bold;
 	margin: .4em 0;
 	text-transform: uppercase;
-}
-
-.wp-block-quote cite:before {
 }
 
 .wp-block-quote.is-large cite,
@@ -119,6 +108,20 @@ blockquote cite {
 	border: 0;
 }
 
+.rtl .wp-block-quote.is-large cite,
+.rtl .wp-block-quote.is-large footer,
+.rtl .wp-block-quote.is-style-large cite,
+.rtl .wp-block-quote.is-style-large footer {
+	text-align: right;
+}
+
+.rtl .wp-block-quote.is-large,
+.rtl .wp-block-quote.is-style-large {
+	padding-left: 0;
+	padding-right: 1.6em;
+}
+
+
 /* Audio */
 
 .wp-block-audio audio {
@@ -137,7 +140,8 @@ blockquote cite {
 
 /* File */
 
-.wp-block-file .wp-block-file__button {
+.wp-block-file .wp-block-file__button,
+.wp-block-file .wp-block-file__button:visited {
 	background-color: #15b6b8;
 	border-style: none;
 	color: #fff;
@@ -156,21 +160,9 @@ blockquote cite {
 	-webkit-appearance: none;
 }
 
-.wp-block-file .wp-block-file__button:hover,
-.wp-block-file .wp-block-file__button:focus {
-	border: 2px solid #117bb8;
-	background: rgba(255, 255, 255, 0.25);
-	color: #159ae7;
-}
-
 .wp-block-file .wp-block-file__button:focus {
 	opacity: 0.85;
 	color: #fff;
-}
-
-.rtl .wp-block-file * + .wp-block-file__button {
-	margin-left: 0.8em;
-	margin-right: 0;
 }
 
 /*--------------------------------------------------------------
@@ -184,6 +176,7 @@ blockquote cite {
 	color: inherit;
 	font-family: inherit;
 	font-size: inherit;
+	font-style: italic;
 	line-height: inherit;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -195,6 +188,13 @@ blockquote cite {
 
 .wp-block-code {
 	font-family: "Courier 10 Pitch", Courier, monospace;
+	overflow: auto;
+}
+
+/* Preformatted */
+
+.wp-block-preformatted {
+	overflow: auto;
 }
 
 /* Pullquote */
@@ -242,33 +242,6 @@ blockquote cite {
 
 .wp-block-pullquote cite {
 	font-size: 16px;
-}
-
-.wp-block-pullquote cite:before {
-}
-
-/* Table */
-
-.wp-block-table,
-.wp-block-table th,
-.wp-block-table td {
-}
-
-.wp-block-table {
-}
-
-.wp-block-table th,
-.wp-block-table td {
-}
-
-.wp-block-table th {
-}
-
-.wp-block-table td {
-}
-
-.rtl .wp-block-table th,
-.rtl .wp-block-table td {
 }
 
 /*--------------------------------------------------------------
@@ -349,6 +322,15 @@ hr.wp-block-separator {
 5.0 Blocks - Widget Blocks
 --------------------------------------------------------------*/
 
+/* Archives, Categories & Latest Posts */
+
+.wp-block-archives.aligncenter,
+.wp-block-categories.aligncenter,
+.wp-block-latest-posts.aligncenter {
+	list-style-position: inside;
+	text-align: center;
+}
+
 /* Categories */
 
 .wp-block-categories.aligncenter {
@@ -368,6 +350,12 @@ hr.wp-block-separator {
 	margin-right: 0;
 }
 
+.wp-block-latest-comments,
+.wp-block-latest-comments__comment-excerpt p,
+.wp-block-latest-comments__comment-date {
+	font-size: inherit;
+}
+
 .editor-block-list__block .wp-block-latest-comments__comment-meta a {
 	box-shadow: none;
 	font-weight: 700;
@@ -382,6 +370,13 @@ hr.wp-block-separator {
 
 .wp-block-latest-comments__comment-excerpt p:last-child {
 	margin-bottom: 0;
+}
+
+/* Latest Posts */
+
+.wp-block-latest-posts.is-grid {
+	margin-left: 0;
+	margin-right: 0;
 }
 
 /*--------------------------------------------------------------

--- a/dara/editor-blocks.css
+++ b/dara/editor-blocks.css
@@ -144,14 +144,6 @@
 	margin-bottom: 1.6em;
 }
 
-/* Images */
-
-.wp-block-image figcaption {
-	font-size: 15px;
-	font-style: italic;
-	text-align: center;
-}
-
 /*--------------------------------------------------------------
 2.0 General Block Styles
 --------------------------------------------------------------*/
@@ -168,7 +160,6 @@
 .editor-block-list__block a,
 .wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #15b6b8;
-	text-decoration: none;
 }
 
 .edit-post-visual-editor a:hover,
@@ -248,9 +239,16 @@
 
 [class^="wp-block-"] figcaption {
 	color: #686868;
+	font-size: 15px;
 	font-style: italic;
 	line-height: 1.6153846154;
 	padding-top: 0.5384615385em;
+}
+
+/* Definition List styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce dt {
+	font-weight: bold;
 }
 
 /*--------------------------------------------------------------
@@ -263,7 +261,12 @@
 	font-size: 64px;
 }
 
-.rtl .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+/* Images */
+
+.wp-block-image figcaption {
+	font-size: 15px;
+	font-style: italic;
+	text-align: center;
 }
 
 /* Quote */
@@ -302,6 +305,7 @@
 }
 
 .editor-block-list__block .wp-block-quote__citation {
+	color: inherit;
 	display: block;
 	font-family: "Source Sans Pro", Helvetica, sans-serif;
 	font-size: 16px;
@@ -315,10 +319,10 @@
 	padding-right: 2.4em;
 }
 
-.rtl .editor-block-list__block .wp-block-quote {
-	margin-right: 0;
+.rtl .editor-block-list__block .wp-block-quote.is-large,
+.rtl .editor-block-list__block .wp-block-quote.is-style-large {
 	padding-left: 0;
-	padding-right: 2.4em;
+	padding-right: 1.6em;
 }
 
 .rtl .editor-block-list__block .wp-block-quote:before {
@@ -411,6 +415,7 @@
 	background: transparent;
 	color: inherit;
 	font-family: inherit;
+	font-style: italic;
 	line-height: inherit;
 	margin-bottom: 1.6em;
 	max-width: 100%;
@@ -585,7 +590,9 @@
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce table {
+	border: 0;
 	border-bottom: 1px solid #eee;
+	border-collapse: collapse;
 	margin: 0 0 1.6em 0;
 	width: 100%;
 }
@@ -601,13 +608,15 @@
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce table th {
+	border: 0;
 	font-weight: bold;
 	padding: 0.4em;
 	text-transform: uppercase;
+	text-align: left;
 }
 
-.rtl .wp-block-freeform.block-library-rich-text__tinymce th,
-.rtl .wp-block-freeform.block-library-rich-text__tinymce td {
+.rtl .wp-block-freeform.block-library-rich-text__tinymce table th {
+	text-align: right;
 }
 
 /* Preformatted */
@@ -737,6 +746,7 @@
 --------------------------------------------------------------*/
 
 /* Buttons */
+
 .wp-block-button .wp-block-button__link {
 	border-style: none;
 	cursor: pointer;
@@ -752,6 +762,10 @@
 	border-radius: 3px;
 	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
 	-webkit-appearance: none;
+}
+
+.wp-block-button .editor-rich-text__tinymce.mce-content-body {
+	line-height: 30px;
 }
 
 .wp-block-button .wp-block-button__link:active,
@@ -799,6 +813,13 @@
 6.0 Blocks - Widgets
 --------------------------------------------------------------*/
 
+.editor-styles-wrapper .wp-block-archives ul,
+.editor-styles-wrapper .wp-block-categories ul,
+.editor-styles-wrapper .wp-block-categories ul ul,
+.editor-styles-wrapper .wp-block-latest-posts ul {
+	list-style-position: inside;
+}
+
 /* Categories */
 
 .editor-block-list__block[data-align=right] .wp-block-categories__list,
@@ -808,13 +829,15 @@
 
 /* Latest Comments */
 
-.editor-block-list__block .wp-block-latest-comments__comment-meta a {
-	box-shadow: none;
-	font-weight: 700;
-	text-decoration: none;
+.rtl .edit-post-visual-editor .wp-block-latest-comments {
+	margin-left: 0;
+	margin-right: 0;
 }
 
-.wp-block-latest-comments__comment-date {
+.wp-block-latest-comments .wp-block-latest-comments__comment,
+.wp-block-latest-comments__comment-date,
+.edit-post-visual-editor .editor-block-list__block .wp-block-latest-comments__comment-excerpt p {
+	font-size: 15px;
 }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment {

--- a/dara/rtl.css
+++ b/dara/rtl.css
@@ -54,7 +54,6 @@ li > ol {
 }
 
 blockquote {
-	border-right: 2px solid #f2f2f2;
 	padding-right: 1em;
 	padding-left: 0;
 	border-left: none;


### PR DESCRIPTION
Minor fixes to Gutenberg styles, including:

* Remove empty CSS selectors.
* Fix RTL styles for large quote blocks.
* Remove incorrect file button hover styles.
* Add overflow auto to preformatted and code blocks.
* Correct centred styles for widgets.
* Increase font size of comment widget.
* Remove margins from recent posts widget when displayed as grid.
* In themes RTL styles, remove border from block quote.