### PR TITLE
Libretto: Prevent Title Block Link Overlap with Menu

### DIFF
--- a/libretto/style.css
+++ b/libretto/style.css
@@ -823,6 +823,7 @@ body:not(.libretto-has-header-image) .title-block {
   left: 20%;
   position: absolute;
   text-shadow: 0 1px 0 #000;
+  width: 60%;
   z-index: 1;
 }
 

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -772,6 +772,7 @@ body {
 /* Style page title blocks */
 .title-block {
   text-align: center;
+  pointer-events: none;
 }
 
 .title-block h1 {
@@ -871,12 +872,8 @@ body:not(.libretto-has-header-image) .title-block {
   padding: 0;
 }
 
-:not(.libretto-has-header-image) .title-block {
-  pointer-events: none;
-}
-
-img.site-logo.attachment-libretto-logo,.site-title {
-pointer-events: all;
+.site-logo.attachment-libretto-logo,.site-title {
+  pointer-events: all;
 }
 
 /*--------------------------------------------------------------

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -772,7 +772,6 @@ body {
 /* Style page title blocks */
 .title-block {
   text-align: center;
-  pointer-events: none;
 }
 
 .title-block h1 {
@@ -821,10 +820,9 @@ body:not(.libretto-has-header-image) .title-block {
   border-bottom: none;
   bottom: 0;
   color: #faf9f5;
-  left: 20%;
+  /* left: 40%; - still no luck in aligning */
   position: absolute;
   text-shadow: 0 1px 0 #000;
-  width: 60%;
   z-index: 1;
 }
 
@@ -870,10 +868,6 @@ body:not(.libretto-has-header-image) .title-block {
   box-shadow: none;
   font-weight: normal;
   padding: 0;
-}
-
-.site-logo.attachment-libretto-logo,.site-title {
-  pointer-events: all;
 }
 
 /*--------------------------------------------------------------
@@ -2651,7 +2645,7 @@ object {
   }
 
   .title-block .site-logo-link {
-    display: block;
+    display: inline-block;
     margin-bottom: 1.5rem;
   }
 

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -820,9 +820,10 @@ body:not(.libretto-has-header-image) .title-block {
   border-bottom: none;
   bottom: 0;
   color: #faf9f5;
-  /* left: 40%; - still no luck in aligning */
+  left: 50%;
   position: absolute;
   text-shadow: 0 1px 0 #000;
+  transform: translateX(-50%);
   z-index: 1;
 }
 

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -871,6 +871,14 @@ body:not(.libretto-has-header-image) .title-block {
   padding: 0;
 }
 
+:not(.libretto-has-header-image) .title-block {
+  pointer-events: none;
+}
+
+img.site-logo.attachment-libretto-logo,.site-title {
+pointer-events: all;
+}
+
 /*--------------------------------------------------------------
 5.2 Footer
 ---------------------------------------------------------------*/

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -820,10 +820,9 @@ body:not(.libretto-has-header-image) .title-block {
   border-bottom: none;
   bottom: 0;
   color: #faf9f5;
-  left: 50%;
+  left: 20%;
   position: absolute;
   text-shadow: 0 1px 0 #000;
-  transform: translateX(-50%);
   z-index: 1;
 }
 
@@ -1080,6 +1079,11 @@ a:active {
   list-style: none;
   margin: 0;
   padding: 0 5px 0 0;
+}
+
+#site-navigation .menu {
+  position: relative;
+  z-index: 2;
 }
 
 #site-navigation .menu li {
@@ -2646,7 +2650,7 @@ object {
   }
 
   .title-block .site-logo-link {
-    display: inline-block;
+    display: block;
     margin-bottom: 1.5rem;
   }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change should mean that only the image and the site title will redirect, allowing for the users to visit the intended pages by clicking their names on the menu. I've tried to explain it in this image here: https://prnt.sc/lkvaj0

#### Related issue(s):

#369