### PR TITLE
Dara: Make centred images aligned centred are centred

### DIFF
--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -26,7 +26,6 @@ Description: Used to style Gutenberg Blocks.
 	font-style: italic;
 	margin: 0.8em 0;
 	text-align: center;
-	width: 100%;
 }
 
 /*--------------------------------------------------------------
@@ -40,12 +39,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 /* Image */
-
-.wp-block-image .alignleft,
-.wp-block-image .alignright,
-.wp-block-image .aligncenter {
-	display: block;
-}
 
 .wp-block-image .aligncenter img {
 	display: block;

--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -47,6 +47,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	display: block;
 }
 
+.wp-block-image .aligncenter img {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 /* Gallery */
 
 .wp-block-gallery {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When images in image blocks are smaller than the available space, they are aligned left, even when they are styled as centred. This update makes these images centred, so they display like they do in the editor.

#### Related issue(s):
See #376.
