### PR TITLE
Pique: Minor fixes to Gutenberg implementation

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -208,7 +208,7 @@ body.archive .wp-block-archives.alignfull {
 
 p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 5em;
-	margin-top: 0.15em;
+	margin-top: 0.125em;
 }
 
 /* Gallery */
@@ -382,12 +382,9 @@ body.home .wp-block-table.alignwide .wp-block-table.alignfull {
 
 /* Buttons */
 
-.wp-block-button .wp-block-button__link:not(.has-text-color) {
-	color: #eff6f9;
-}
-
-.wp-block-button .wp-block-button__link:not(.has-background) {
+.wp-block-button__link {
 	background-color: #83b6cc;
+	color: #eff6f9;
 }
 
 .wp-block-button .wp-block-button__link {
@@ -471,8 +468,18 @@ body.home .wp-block-table.alignwide .wp-block-table.alignfull {
 	margin-right: 0;
 }
 
+.wp-block-latest-comments__comment-excerpt p {
+	font-size: inherit;
+}
+
 .wp-block-latest-comments__comment-date {
 	color: inherit;
+	font-family: Karla, Arial, sans-serif;
+	font-size: 13.6px;
+	font-size: 0.85rem;
+	font-weight: bold;
+	letter-spacing: 0.05rem;
+	text-transform: uppercase;
 }
 
 /* Latest Posts */

--- a/pique/assets/css/editor-blocks.css
+++ b/pique/assets/css/editor-blocks.css
@@ -178,13 +178,6 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-size: 23.4px;
 }
 
-/* List styles */
-
-.wp-block-freeform.block-library-rich-text__tinymce li,
-.editor-styles-wrapper li {
-	margin-bottom: 0;
-}
-
 /* Code styles */
 
 .wp-block-freeform.block-library-rich-text__tinymce code {
@@ -217,7 +210,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 /* Pre styles */
 
 .wp-block-freeform.block-library-rich-text__tinymce pre {
-
+	color: inherit;
 }
 
 /*--------------------------------------------------------------
@@ -228,7 +221,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 5em;
-	margin-top: 0.15em;
+	margin-top: 0.125em;
 }
 
 /* Quote */
@@ -495,11 +488,21 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Latest Comments */
 
-.editor-styles-wrapper .wp-block-latest-comments {
-	padding-left: 0;
-	padding-right: 0;
+.wp-block-latest-comments {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.wp-block-latest-comments__comment-excerpt p {
+	font-size: inherit;
 }
 
 .wp-block-latest-comments__comment-date {
 	color: inherit;
+	font-family: Karla, Arial, sans-serif;
+	font-size: 13.6px;
+	font-size: 0.85rem;
+	font-weight: bold;
+	letter-spacing: 0.05rem;
+	text-transform: uppercase;
 }


### PR DESCRIPTION
Minor fixes to Gutenberg implementation, including:
* Remove bottom margin styles from lists in editor.
* Update colour for pre tags in editor.
* Adjust top margin on drop caps.
* Update comment widget styles to better match theme's comment styles.
