### PR TITLE
Shoreditch: Minor fixes to Gutenberg implementation

### DIFF
--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -141,12 +141,14 @@ Description: Used to style Gutenberg Blocks.
 	padding-bottom: 0.25em;
 }
 
+[class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .can-align-wide [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .page-template-full-width-page [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .page-template-panel-page [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption {
 	text-align: left;
 }
 
+.rtl [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .rtl.can-align-wide [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .rtl.page-template-full-width-page [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption,
 .rtl.page-template-panel-page [class^="wp-block-"]:not(.wp-block-gallery):not(.alignfull) figcaption {
@@ -266,6 +268,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	background: #3e69dc;
 	border: 0;
 	border-radius: 5em;
+	box-shadow: none;
 	color: #fff;
 	font-size: 13px;
 	font-size: 0.8125rem;
@@ -357,17 +360,15 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Buttons */
 
-.wp-block-button .wp-block-button__link:not(.has-text-color) {
-	color: #fff;
-}
-
-.wp-block-button .wp-block-button__link:not(.has-background) {
+.wp-block-button__link {
 	background: #3e69dc;
+	color: #fff;
 }
 
 .wp-block-button .wp-block-button__link {
 	border: 0;
 	border-radius: 5em;
+	box-shadow: none;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	font-weight: bold;
@@ -378,11 +379,14 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-button__link:hover,
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-button__link:focus,
-.wp-block-button__link:not(.has-background):focus {
+.wp-block-button__link:focus {
 	background: #2c313f;
 	outline: none;
+}
+
+.wp-block-button__link.has-background:hover,
+.wp-block-button__link.has-background:focus {
+	opacity: 0.8;
 }
 
 @media (min-width: 768px) {
@@ -438,6 +442,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-latest-comments__comment-date {
 	color: inherit;
+}
+
+.wp-block-latest-comments__comment-meta a {
+	box-shadow: none;
 }
 
 .wp-block-latest-comments__comment,

--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -513,6 +513,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-table th,
 .wp-block-table td {
 	border-color: #f3f3f3;
+	text-align: center;
 }
 
 .wp-block-table__cell-content {
@@ -534,9 +535,13 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 0.8125rem;
 	font-weight: bold;
 	letter-spacing: 0.0625em;
-	line-height: 1.3847;
+	line-height: 22.15px;
 	padding: 0.5625rem 1.5em;
 	text-transform: uppercase;
+}
+
+.wp-block-button .editor-rich-text__tinymce.mce-content-body {
+	line-height: 22.15px;
 }
 
 .wp-block-button__link:hover,
@@ -572,12 +577,22 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Latest Comments */
 
-.editor-styles-wrapper .wp-block-latest-comments {
-	padding-left: 0;
-	padding-right: 0;
+.wp-block-latest-comments {
+	margin-left: 0;
+	margin-right: 0;
 }
 
-.wp-block-latest-comments__comment {
+.wp-block-latest-comments__comment-date {
+	color: inherit;
+}
+
+.wp-block-latest-comments__comment-meta a {
+	box-shadow: none;
+}
+
+.wp-block-latest-comments__comment,
+.wp-block-latest-comments__comment-date,
+.wp-block-latest-comments__comment-excerpt p {
 	font-size: inherit;
 }
 

--- a/shoreditch/inc/extras.php
+++ b/shoreditch/inc/extras.php
@@ -38,7 +38,7 @@ function shoreditch_body_classes( $classes ) {
 
 	// Adds a class of no-sidebar specifically to be used for Gutenberg styles, without interfering with the above.
 	if ( ( ! is_page_template( 'panel-page.php' ) && ! is_page_template( 'full-width-page.php' ) )
-		&& ( ( ( is_front_page() && is_home() ) || is_singular() || is_archive() )
+		&& ( ( is_home() || is_singular() || is_archive() )
 		&& ! is_active_sidebar( 'sidebar-1' ) ) ) {
 		$classes[] = 'can-align-wide';
 	}


### PR DESCRIPTION
Minor fixes to Gutenberg implementation, including:
* Update selectors for button blocks, for better custom colour fallbacks.
* Update colour selectors, to account for :visited state.
* Remove bottom border from buttons.
* Make sure wide class is applied when blog page isn't the front page, too.