### PR TITLE
Libre 2: Fix Scrolling on Tablets

### DIFF
--- a/libre-2/style.css
+++ b/libre-2/style.css
@@ -621,7 +621,7 @@ textarea {
 		content: "";
 		position: absolute;
 		top: 0;
-		width: 100%;
+		width: auto;
 	}
 
 	.singular .site-header:before {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

It seems that there's still a scrolling issue with the Libre 2 theme that wasn't fixed in #362, and that can be seen by visiting a site using the Libre 2 theme on a tablet, or setting your device's dimensions to that of a tablet (tested using 1440px, and can also see on my tablet). I'm not too sure if this is worth creating a new issue about, because it seems very similar to #361, and you can also see this bug on the sites linked in that issue. 

It seems that there should be a simple fix though, and unless I'm missing something (please let me know if I am!), this shouldn't change anything that it isn't supposed to, including on a desktop. 

**Before:**

![gsdfgsfdsdfg](https://user-images.githubusercontent.com/43215253/49462090-23848f80-f7ed-11e8-8abc-35b3d357a14b.png)

**After:**

![dfgsgdfsdfsg](https://user-images.githubusercontent.com/43215253/49462102-28e1da00-f7ed-11e8-8345-aa0268701f14.png)

I'm able to recreate this on multiple sites, and the same fix seems to work locally for me. If I'm missing something though, please let me know! 

(cc @laurelfulford) 