### PR TITLE
Libre 2: Allow Images to be Centred

### DIFF
--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -75,9 +75,9 @@ Description: Used to style Gutenberg Blocks.
 
 /* Figures */
 
-figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull),
-[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull) figure,
-[class^="wp-block-"] figure:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull), {
+figure[class^="wp-block-"]:not(figure.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull),
+[class^="wp-block-"]:not(figure.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull) figure,
+[class^="wp-block-"] figure:not(figure.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull), {
 	margin-left: 0;
 	margin-right: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I'm hoping that this PR will allow smaller images added using the Image Block to be centred on the front-end of sites using the Libre 2 theme, as can be seen here:

![sdgffdsgdfsgsdfg](https://user-images.githubusercontent.com/43215253/49533649-7aef3200-f8b7-11e8-894e-fcf414f67358.png)

(cc @laurelfulford) 

#### Related issue(s): #404 
