### PR TITLE
Libre 2: Fix Centre Alignment of Images & Captions

### DIFF
--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -91,7 +91,7 @@ figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):no
 	position: relative;
 }
 
-[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption :not(.aligncenter) {
 	text-align: left;
 }
 
@@ -105,9 +105,18 @@ figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):no
 	width: 25%;
 }
 
+[class^="wp-block-"]:not(.wp-block-gallery) .aligncenter figcaption::after {
+        margin-right: auto;
+        margin-left: auto;
+}
+
 [class^="wp-block-"].alignfull:not(.wp-block-gallery) figcaption {
 	padding-left: 2vw;
 	padding-right: 2vw;
+}
+
+[class^="wp-block-"]:not(.wp-block-gallery) .aligncenter figcaption {
+        text-align: center;
 }
 
 .rtl [class^="wp-block-"]:not(.wp-block-gallery) figcaption {
@@ -232,6 +241,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-video video {
 	width: 100%;
+}
+
+/* Image */
+.wp-block-image .aligncenter {
+        text-align: center;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

#408 doesn't seem to work like intended, and it seems I can't modify that PR as captions aren't shown when trying to do so. Therefore, after trying to look for an alternative, I've created a new PR to try and solve the issue of images not aligning when using the Image Block on the Libre 2 theme. 

I'm not too sure if this is the most effective way at solving this problem, but I'm hoping it does work. 

**Before:**

![gfsdgfsdfgsfgsd](https://user-images.githubusercontent.com/43215253/49603923-7e042400-f984-11e8-83d7-f08ca7e79377.png)

**After:**

![gfsfgddfgsgdf](https://user-images.githubusercontent.com/43215253/49614991-09d97880-f9a4-11e8-8fb1-94f78a9e4834.png)

(cc @laurelfulford) 

#### Related issue(s): #404 

