### PR TITLE
Sketch: Remove uppercase on post titles in editor

### DIFF
--- a/sketch/css/editor-blocks.css
+++ b/sketch/css/editor-blocks.css
@@ -55,7 +55,6 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-size: 28px;
 	font-weight: normal;
 	letter-spacing: 1px;
-	text-transform: uppercase;
 }
 
 /* Headings */


### PR DESCRIPTION
Remove uppercase styles for post title in editor.

This does reflect how the theme looks on the front-end, but it obscures what's actually being typed into the post title field - there's no way to know if you're actually using the case you want to use. 

Fixes #413.
