### PR TITLE
Lodestar, Illustratr & Galactic 2: Remove Uppercase in Post Titles

### DIFF
--- a/illustratr/editor-blocks.css
+++ b/illustratr/editor-blocks.css
@@ -61,7 +61,6 @@
 	color: #24282d;
 	font-family: "Source Sans Pro", sans-serif;
 	font-weight: 900;
-	text-transform: uppercase;
 	font-size: 1.2em;
 }
 

--- a/intergalactic-2/editor-blocks.css
+++ b/intergalactic-2/editor-blocks.css
@@ -68,8 +68,7 @@
 	font-family: Lato, Helvetica, sans-serif;
 	font-weight: bold;
 	font-size: 30px;
-	text-align: center;
-	text-transform: uppercase;
+	text-align: center;	
 }
 
 .wp-block.editor-post-title__block {

--- a/lodestar/assets/css/editor-blocks.css
+++ b/lodestar/assets/css/editor-blocks.css
@@ -42,8 +42,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-size: 34px;
 	font-weight: 800;
 	letter-spacing: 0.1em;
-	line-height: 1.25;
-	text-transform: uppercase;
+	line-height: 1.25;	
 }
 
 /* Headings */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

As mentioned in #413, Illustratr, Intergalactic 2 and Lodestar all has themes which transform the post title in the Editor with intent to make the editor and front-end match, but this can cause confusion. So, this PR intends to stop that from happening so the user can decide to use capital letters. 


#### Related issue(s): #413, #415 
