### PR TITLE
Several themes: Remove Uppercase from Editor

### DIFF
--- a/affinity/editor-blocks.css
+++ b/affinity/editor-blocks.css
@@ -358,8 +358,7 @@
 	border-radius: 0;
 	display: inline-block;
 	font-size: 13.2px;
-	font-family: Raleway, "Helvetica Neue", sans-serif;
-	text-transform: uppercase;
+	font-family: Raleway, "Helvetica Neue", sans-serif;	
 	letter-spacing: 1px;
 	font-weight: bold;
 	line-height: 1;
@@ -650,8 +649,7 @@
 
 .wp-block-pullquote .wp-block-pullquote__citation {
 	color: #99908a;
-	display: block;
-	text-transform: uppercase;
+	display: block;	
 	font-size: 14px;
 }
 
@@ -699,8 +697,7 @@
 	border-radius: 0;
 	display: inline-block;
 	font-size: 13.2px;
-	font-family: Raleway, "Helvetica Neue", sans-serif;
-	text-transform: uppercase;
+	font-family: Raleway, "Helvetica Neue", sans-serif;	
 	letter-spacing: 1px;
 	font-weight: bold;
 	line-height: 1 !important;

--- a/altofocus/assets/stylesheets/editor-blocks.css
+++ b/altofocus/assets/stylesheets/editor-blocks.css
@@ -368,8 +368,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: 300;
 	line-height: 1;
 	outline: none;
-	padding: 1em 25px;
-	text-transform: uppercase;
+	padding: 1em 25px;	
 	-webkit-transition: all 0.3s ease;
 	-moz-transition: all 0.3s ease;
 	-o-transform: all 0.3s ease;
@@ -506,8 +505,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: 300;
 	line-height: 1;
 	outline: none;
-	padding: 1em 25px;
-	text-transform: uppercase;
+	padding: 1em 25px;	
 	-webkit-transition: all 0.3s ease;
 	-moz-transition: all 0.3s ease;
 	-o-transform: all 0.3s ease;

--- a/apostrophe-2/css/editor-blocks.css
+++ b/apostrophe-2/css/editor-blocks.css
@@ -104,8 +104,7 @@
 .edit-post-visual-editor h4 {
 	color: gray;
 	font-size: 21px;
-	font-weight: 600;
-	text-transform: uppercase;
+	font-weight: 600;	
 }
 
 .edit-post-visual-editor h5 {
@@ -118,8 +117,7 @@
 	color: #5a5a5a;
 	font-size: 17px;
 	font-weight: 600;
-	letter-spacing: 1px;
-	text-transform: uppercase;
+	letter-spacing: 1px;	
 }
 
 /* Paragraphs */

--- a/button-2/editor-blocks.css
+++ b/button-2/editor-blocks.css
@@ -501,8 +501,7 @@ pre.wp-block-verse {
 	line-height: 1;
 	margin: 5px;
 	padding: .75em 1em;
-	text-shadow: none;
-	text-transform: uppercase;
+	text-shadow: none;	
 	transition: .3s;
 }
 

--- a/canard/editor-blocks.css
+++ b/canard/editor-blocks.css
@@ -396,8 +396,7 @@
 	color: #fff;
 	font-family: Lato, sans-serif;
 	font-weight: bold;
-	padding: 5.5px 13px;
-	text-transform: uppercase;
+	padding: 5.5px 13px;	
 }
 
 /*--------------------------------------------------------------
@@ -682,8 +681,7 @@
 	border-bottom: 1px solid #ddd;
 	font-family: "Lato", sans-serif;
 	font-weight: bold;
-	padding: 0;
-	text-transform: uppercase;
+	padding: 0;	
 }
 
 .wp-block-table td {
@@ -711,8 +709,7 @@
 	display: inline-block;
 	font-family: Lato, sans-serif;
 	font-weight: bold;
-	padding: 5.5px 13px;
-	text-transform: uppercase;
+	padding: 5.5px 13px;	
 }
 
 .wp-block-button .wp-block-button__link:hover,

--- a/dara/editor-blocks.css
+++ b/dara/editor-blocks.css
@@ -306,8 +306,7 @@
 	font-family: "Source Sans Pro", Helvetica, sans-serif;
 	font-size: 16px;
 	font-weight: bold;
-	margin: .4em 0;
-	text-transform: uppercase;
+	margin: .4em 0;	
 }
 
 .rtl .editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large) {
@@ -394,8 +393,7 @@
 	line-height: 2;
 	padding: .25em 1em .4em;
 	text-align: center;
-	vertical-align: middle;
-	text-transform: uppercase;
+	vertical-align: middle;	
 	border-radius: 3px;
 	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
 	-webkit-appearance: none;
@@ -472,8 +470,7 @@
 	font-family: "Source Sans Pro", Helvetica, sans-serif;
 	font-size: 16px;
 	font-weight: bold;
-	margin: .4em 0;
-	text-transform: uppercase;
+	margin: .4em 0;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce blockquote cite:before {
@@ -603,7 +600,7 @@
 .wp-block-freeform.block-library-rich-text__tinymce table th {
 	font-weight: bold;
 	padding: 0.4em;
-	text-transform: uppercase;
+	
 }
 
 .rtl .wp-block-freeform.block-library-rich-text__tinymce th,
@@ -684,7 +681,6 @@
 	font-size: 16px;
 	font-weight: bold;
 	margin: .4em 0;
-	text-transform: uppercase;
 }
 
 .wp-block-pullquote .wp-block-pullquote__citation:before {
@@ -721,7 +717,6 @@
 	font-weight: bold;
 	padding: 0.4em;
 	text-align: left;
-	text-transform: uppercase;
 }
 
 .rtl .editor-block-list__block table.wp-block-table th {
@@ -747,8 +742,7 @@
 	line-height: 2;
 	padding: .25em 1em .4em;
 	text-align: center;
-	vertical-align: middle;
-	text-transform: uppercase;
+	vertical-align: middle;	
 	border-radius: 3px;
 	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
 	-webkit-appearance: none;

--- a/dyad-2/editor-style.css
+++ b/dyad-2/editor-style.css
@@ -311,16 +311,13 @@ h4 {
 h5 {
 	font-family: "Lato", "Helvetica Neue", Helvetica, sans-serif;
 	font-size: 1.7rem;
-	letter-spacing: 0.05em;
-	text-transform: uppercase;
+	letter-spacing: 0.05em;	
 }
 
 h6 {
 	font-family: "Lato", "Helvetica Neue", Helvetica, sans-serif;
 	font-size: 1.5rem;
 	letter-spacing: 0.05em;
-	text-transform: uppercase;
-
 }
 
 p {
@@ -499,8 +496,7 @@ td, th {
 th {
 	font-size: 85%;
 	letter-spacing: 0.05em;
-	padding: ;
-	text-transform: uppercase;
+	padding: ;	
 }
 
 th,

--- a/gazette/css/editor-blocks.css
+++ b/gazette/css/editor-blocks.css
@@ -187,8 +187,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 	border-bottom: 1px solid #ddd;
 	font-family: "Lato", sans-serif;
 	font-weight: bold;
-	padding: 5px;
-	text-transform: uppercase;
+	padding: 5px;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce td {
@@ -344,7 +343,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: bold;
 	line-height: 1.875;
 	padding: 5.5px 13px;
-	text-transform: uppercase;
 }
 
 .wp-block-file .wp-block-file__button:hover,
@@ -454,8 +452,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	border-bottom: 1px solid #ddd;
 	font-family: "Lato", sans-serif;
 	font-weight: bold;
-	padding: 0;
-	text-transform: uppercase;
+	padding: 0;	
 }
 
 .wp-block-table td {
@@ -487,8 +484,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 16px;
 	font-weight: bold;
 	line-height: 1.875;
-	padding: 5.5px 13px;
-	text-transform: uppercase;
+	padding: 5.5px 13px;	
 }
 
 .wp-block-button .wp-block-button__link:hover,

--- a/illustratr/editor-blocks.css
+++ b/illustratr/editor-blocks.css
@@ -416,7 +416,6 @@
 	border: 1px solid #464d4d;
 	border-radius: 0;
 	color: white;
-	text-transform: uppercase;
 	font-weight: 900;
 	cursor: pointer;
 	/* Improves usability and consistency of cursor style between image-type 'input' and others */
@@ -795,7 +794,6 @@
 	box-shadow: none;
 	border-radius: 0;
 	display: inline-block;
-	text-transform: uppercase;
 	font-weight: 900;
 	cursor: pointer;
 	/* Improves usability and consistency of cursor style between image-type 'input' and others */

--- a/intergalactic-2/editor-blocks.css
+++ b/intergalactic-2/editor-blocks.css
@@ -98,8 +98,7 @@
 .edit-post-visual-editor h6 {
 	font-weight: bold;
 	clear: both;
-	margin: .75em 0;
-	text-transform: uppercase;
+	margin: .75em 0;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce h1,
@@ -483,9 +482,7 @@
 	cursor: pointer;
 	-webkit-transition: .3s all ease-in-out;
 	   -moz-transition: .3s all ease-in-out;
-			transition: .3s all ease-in-out;
-	text-transform: uppercase;
-
+			transition: .3s all ease-in-out;	
 	color: #222;
 	border: 2px solid #222;
 	background: transparent;
@@ -652,8 +649,7 @@
 	cursor: pointer;
 	-webkit-transition: .3s all ease-in-out;
 	   -moz-transition: .3s all ease-in-out;
-			transition: .3s all ease-in-out;
-	text-transform: uppercase;
+			transition: .3s all ease-in-out;	
 	border: 2px solid currentColor;
 	box-shadow: none;
 	text-shadow: none;

--- a/ixion/editor-blocks.css
+++ b/ixion/editor-blocks.css
@@ -105,15 +105,13 @@
 
 .edit-post-visual-editor h4 {
 	color: #a5a29d;
-	font-size: 20px;
-	text-transform: uppercase;
+	font-size: 20px;	
 	letter-spacing: 1px;
 }
 
 .edit-post-visual-editor h5 {
 	color: #a5a29d;
-	font-size: 16px;
-	text-transform: uppercase;
+	font-size: 16px;	
 	letter-spacing: 1px;
 }
 
@@ -121,7 +119,6 @@
 	color: #a5a29d;
 	font-size: 14px;
 	letter-spacing: 1px;
-	text-transform: uppercase;
 }
 
 /* Paragraphs */
@@ -324,8 +321,7 @@
 	box-shadow: none;
 	color: white;
 	font-size: 16px;
-	font-weight: bold;
-	text-transform: uppercase;
+	font-weight: bold;	
 	letter-spacing: 1px;
 	line-height: 1;
 	padding: 1.4em 1.6em 1.2em;
@@ -467,22 +463,19 @@
 .wp-block-freeform.block-library-rich-text__tinymce h4 {
 	color: #a5a29d;
 	font-size: 20px;
-	text-transform: uppercase;
 	letter-spacing: 1px;
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce h5 {
 	color: #a5a29d;
-	font-size: 16px;
-	text-transform: uppercase;
+	font-size: 16px;	
 	letter-spacing: 1px;
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	color: #a5a29d;
 	font-size: 14px;
-	letter-spacing: 1px;
-	text-transform: uppercase;
+	letter-spacing: 1px;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce pre {
@@ -619,8 +612,7 @@ table.wp-block-table th {
 	border-radius: 0;
 	box-shadow: none;
 	font-size: 16px;
-	font-weight: bold;
-	text-transform: uppercase;
+	font-weight: bold;	
 	letter-spacing: 1px;
 	line-height: 1;
 	padding: 1.4em 1.6em 1.2em;

--- a/karuna/editor-blocks.css
+++ b/karuna/editor-blocks.css
@@ -60,8 +60,7 @@
 .edit-post-visual-editor h6 {
 	clear: both;
 	font-weight: bold;
-	font-family: Karla, sans-serif;
-	text-transform: uppercase;
+	font-family: Karla, sans-serif;	
 }
 
 .edit-post-visual-editor h1 {
@@ -361,7 +360,6 @@
 	padding: 0.8em 1.6em 0.8em;
 	text-shadow: none;
 	text-decoration: none;
-	text-transform: uppercase;
 	transition: 0.3s;
 }
 
@@ -480,8 +478,7 @@
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	clear: both;
 	font-weight: bold;
-	font-family: Karla, sans-serif;
-	text-transform: uppercase;
+	font-family: Karla, sans-serif;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce h1 {
@@ -678,8 +675,7 @@
 	line-height: 1;
 	padding: 0.8em 1.6em 0.8em;
 	text-shadow: none;
-	text-decoration: none;
-	text-transform: uppercase;
+	text-decoration: none;	
 	transition: 0.3s;
 }
 

--- a/libretto/css/editor-blocks.css
+++ b/libretto/css/editor-blocks.css
@@ -110,8 +110,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-size: 21px;
 	letter-spacing: 2px;
 	margin: 4em 0 2em;
-	padding-bottom: 0.5em;
-	text-transform: uppercase;
+	padding-bottom: 0.5em;	
 }
 
 .edit-post-visual-editor h3 {
@@ -126,8 +125,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-family: Montserrat, "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 16px;
 	letter-spacing: 1px;
-	margin: 3em 0 1.5em;
-	text-transform: uppercase;
+	margin: 3em 0 1.5em;	
 }
 
 .edit-post-visual-editor h5 {
@@ -142,8 +140,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-family: Montserrat, "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 14px;
 	letter-spacing: 1px;
-	margin: 1.5em 0 0.75em;
-	text-transform: uppercase;
+	margin: 1.5em 0 0.75em;	
 }
 
 /* Images */
@@ -392,8 +389,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-size: 16px;
 	font-style: normal;
 	letter-spacing: 1px;
-	margin-top: 1em;
-	text-transform: uppercase;
+	margin-top: 1em;	
 	text-align: right;
 	width: 100%;
 }
@@ -475,8 +471,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	line-height: 24px;
 	outline: 4px solid #a09a92;
 	padding: 7px 14px;
-	position: relative;
-	text-transform: uppercase;
+	position: relative;	
 }
 
 .wp-block-file .wp-block-file__button:hover,
@@ -594,8 +589,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-size: 16px;
 	font-style: normal;
 	letter-spacing: 1px;
-	margin-top: 1em;
-	text-transform: uppercase;
+	margin-top: 1em;	
 	text-align: right;
 	width: 100%;
 }
@@ -859,8 +853,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	font-style: normal;
 	font-weight: normal;
 	letter-spacing: 1px;
-	margin-top: 1em;
-	text-transform: uppercase;
+	margin-top: 1em;	
 	text-align: center;
 }
 
@@ -914,7 +907,6 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	padding: 7px 14px;
 	line-height: 24px;
 	position: relative;
-	text-transform: uppercase;
 }
 
 .wp-block-button .wp-block-button__link:active,

--- a/lodestar/assets/css/editor-blocks.css
+++ b/lodestar/assets/css/editor-blocks.css
@@ -63,8 +63,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-family: "Work Sans", "Helvetica Neue", helvetica, arial, sans-serif;
 	font-weight: 800;
 	letter-spacing: 0.1em;
-	line-height: 1.25;
-	text-transform: uppercase;
+	line-height: 1.25;	
 }
 
 .edit-post-visual-editor h1,
@@ -318,8 +317,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	letter-spacing: 0.05em;
 	line-height: 1;
 	padding: 1em 1.5em;
-	text-shadow: none;
-	text-transform: uppercase;
+	text-shadow: none;	
 	transition: background 0.2s;
 }
 
@@ -419,8 +417,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	letter-spacing: 0.05em;
 	line-height: 1;
 	padding: 1em 1.5em;
-	text-shadow: none;
-	text-transform: uppercase;
+	text-shadow: none;	
 	transition: background 0.2s;
 }
 

--- a/penscratch-2/editor-style.css
+++ b/penscratch-2/editor-style.css
@@ -440,8 +440,7 @@ th {
 th {
     font-weight: bold;
     padding-bottom: 4px;
-    letter-spacing: 1px;
-    text-transform: uppercase;
+    letter-spacing: 1px;    
     border-bottom-width: 3px;
 }
 

--- a/pique/assets/css/editor-blocks.css
+++ b/pique/assets/css/editor-blocks.css
@@ -79,16 +79,14 @@ Description: Used to style Gutenberg Blocks in the editor.
 .wp-block-freeform.block-library-rich-text__tinymce h2 {
 	font-size: 25.6px;
 	font-weight: 600;
-	letter-spacing: 2px;
-	text-transform: uppercase;
+	letter-spacing: 2px;	
 }
 
 .edit-post-visual-editor h3,
 .wp-block-freeform.block-library-rich-text__tinymce h3 {
 	font-size: 1.2em;
 	font-weight: 700;
-	letter-spacing: 1px;
-	text-transform: uppercase;
+	letter-spacing: 1px;	
 }
 
 .edit-post-visual-editor h4,
@@ -283,8 +281,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: 700;
 	letter-spacing: 1px;
 	margin-top: 1.5rem;
-	text-align: right;
-	text-transform: uppercase;
+	text-align: right;	
 }
 
 .wp-block-quote.is-large .wp-block-quote__citation,
@@ -327,8 +324,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	letter-spacing: 1px;
 	line-height: 1;
 	padding: 1em 3em;
-	text-shadow: none;
-	text-transform: uppercase;
+	text-shadow: none;	
 	transition: background-color 0.125s ease-in;
 	-webkit-appearance: none;
 }
@@ -455,8 +451,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	letter-spacing: 1px;
 	line-height: 1;
 	padding: 1em 3em;
-	text-shadow: none;
-	text-transform: uppercase;
+	text-shadow: none;	
 	transition: background-color 0.125s ease-in;
 	-webkit-appearance: none;
 }

--- a/publication/editor-blocks.css
+++ b/publication/editor-blocks.css
@@ -349,8 +349,7 @@
 	color: #fff;
 	font-weight: bold;
 	line-height: 1;
-	padding: 6px 12px;
-	text-transform: uppercase;
+	padding: 6px 12px;	
 }
 
 .wp-block-file .wp-block-file__button:hover,
@@ -545,8 +544,7 @@
 	background: #eee;
 	border-bottom: 1px solid #ddd;
 	padding: 6px;
-	font-weight: bold;
-	text-transform: uppercase;
+	font-weight: bold;	
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce table tr:nth-of-type(even) {
@@ -647,8 +645,7 @@
 	font-weight: bold;
 	font-size: 16px;
 	font-style: normal;
-	letter-spacing: 1px;
-	text-transform: uppercase;
+	letter-spacing: 1px;		
 }
 
 /* Table */
@@ -701,8 +698,7 @@
 	border-radius: 0;
 	border: 0;
 	font-weight: bold;
-	padding: 6px 12px;
-	text-transform: uppercase;
+	padding: 6px 12px;	
 }
 
 .wp-block-button .wp-block-button__link:active,

--- a/radcliffe-2/assets/css/editor-style.css
+++ b/radcliffe-2/assets/css/editor-style.css
@@ -124,8 +124,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 .edit-post-visual-editor h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-size: 15px;
-	line-height: 2.4em;
-	text-transform: uppercase;
+	line-height: 2.4em;	
 }
 
 @media screen and (min-width: 768px) {

--- a/scratchpad/editor-blocks.css
+++ b/scratchpad/editor-blocks.css
@@ -100,13 +100,11 @@
 }
 
 .edit-post-visual-editor h5 {
-	font-size: 16px;
-	text-transform: uppercase;
+	font-size: 16px;	
 }
 
 .edit-post-visual-editor h6 {
-	font-size: 14px;
-	text-transform: uppercase;
+	font-size: 14px;	
 }
 
 @media only screen and (max-width: 800px) {
@@ -430,7 +428,6 @@
 	outline: none;
 	padding: 10px 20px;
 	text-shadow: none;
-	text-transform: uppercase;
 	-webkit-transition: color 0.2s, border-color 0.2s;
 	-moz-transition: color 0.2s, border-color 0.2s;
 	transition: color 0.2s, border-color 0.2s;
@@ -600,12 +597,10 @@
 
 .wp-block-freeform.block-library-rich-text__tinymce h5 {
 	font-size: 16px;
-	text-transform: uppercase;
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-size: 14px;
-	text-transform: uppercase;
 }
 
 @media only screen and (max-width: 800px) {
@@ -820,7 +815,6 @@
 	outline: none;
 	padding: 10px 20px;
 	text-shadow: none;
-	text-transform: uppercase;
 	-webkit-transition: color 0.2s, border-color 0.2s;
 	   -moz-transition: color 0.2s, border-color 0.2s;
 	        transition: color 0.2s, border-color 0.2s;

--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -410,8 +410,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: bold;
 	letter-spacing: 0.0625em;
 	line-height: 1.3847;
-	padding: 0.5625rem 1.5em;
-	text-transform: uppercase;
+	padding: 0.5625rem 1.5em;	
 }
 
 .wp-block-file .wp-block-file__button:hover,
@@ -535,8 +534,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: bold;
 	letter-spacing: 0.0625em;
 	line-height: 1.3847;
-	padding: 0.5625rem 1.5em;
-	text-transform: uppercase;
+	padding: 0.5625rem 1.5em;	
 }
 
 .wp-block-button__link:hover,

--- a/sketch/css/editor-blocks.css
+++ b/sketch/css/editor-blocks.css
@@ -73,8 +73,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 .edit-post-visual-editor h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-weight: 400;
-	letter-spacing: 1px;
-	text-transform: uppercase;
+	letter-spacing: 1px;	
 }
 
 .edit-post-visual-editor h1,
@@ -175,8 +174,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-weight: bold;
 	letter-spacing: 2px;
 	padding-bottom: 4px;
-	text-align: left;
-	text-transform: uppercase;
+	text-align: left;	
 }
 
 .rtl .wp-block-freeform.block-library-rich-text__tinymce table th {
@@ -385,8 +383,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 16px;
 	font-weight: 400;
 	letter-spacing: 2px;
-	padding: 10px 14px;
-	text-transform: uppercase;
+	padding: 10px 14px;	
 	-webkit-transition: all 0.3s ease-in-out;
 	-moz-transition: all 0.3s ease-in-out;
 	-o-transition: all 0.3s ease-in-out
@@ -474,8 +471,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: bold;
 	letter-spacing: 2px;
 	padding-bottom: 4px;
-	text-align: left;
-	text-transform: uppercase;
+	text-align: left;	
 }
 
 .wp-block-table__cell-content {
@@ -502,7 +498,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-weight: 400;
 	letter-spacing: 2px;
 	padding: 10px 14px;
-	text-transform: uppercase;
 	-webkit-transition: all 0.3s ease-in-out;
 	-moz-transition: all 0.3s ease-in-out;
 	-o-transition: all 0.3s ease-in-out

--- a/textbook/assets/css/editor-blocks.css
+++ b/textbook/assets/css/editor-blocks.css
@@ -83,8 +83,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 .wp-block-freeform.block-library-rich-text__tinymce h5,
 .edit-post-visual-editor h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
-	font-family: "Libre Franklin", "Helvetica Neue", Helvetica, Arial, sans-serif;
-	text-transform: uppercase;
+	font-family: "Libre Franklin", "Helvetica Neue", Helvetica, Arial, sans-serif;	
 }
 
 .edit-post-visual-editor h1,
@@ -180,7 +179,6 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-weight: 700;
 	letter-spacing: .075em;
 	line-height: 1.2375em;
-	text-transform: uppercase;
 }
 
 .rtl .wp-block-freeform.block-library-rich-text__tinymce table th,
@@ -494,8 +492,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 12.8px;
 	font-weight: 700;
 	letter-spacing: .075em;
-	line-height: 1.2375em;
-	text-transform: uppercase;
+	line-height: 1.2375em;	
 }
 
 .wp-block-table__cell-content {

--- a/toujours/editor-style.css
+++ b/toujours/editor-style.css
@@ -49,21 +49,18 @@ body#tinymce.wp-editor,
 	font-size: 20px;
 	font-weight: 500;
 	letter-spacing: 0.08em;
-	text-transform: uppercase;
 }
 
 #tinymce.wp-editor h5 {
 	font-size: 18px;
 	font-weight: 500;
 	letter-spacing: 0.08em;
-	text-transform: uppercase;
 }
 
 #tinymce.wp-editor h6 {
 	font-size: 16px;
 	font-weight: 500;
 	letter-spacing: 0.08em;
-	text-transform: uppercase;
 }
 
 #tinymce.wp-editor p {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

As mentioned in #413, there can be a lot of confusion caused by the capitalising of things in the editor, but it's done to reflect how the theme actually looks front-end. This PR intends to remove most of those, as the confusion could outweigh the benefits from matching editors, and could cause further issues, as discussed in #413, although ultimately, it may just be worth leaving it as it is. 

That mainly means remove capitals from:

- Headings
- Table Headings 
- Citations (Pullquotes and Quotes) 
- Buttons (both the Button and the File Block) 

The individual ones for each theme are mentioned on each commit, and I'm fairly certain I've not missed anything and I've not removed anything unless it is necessary to do so. 

I've done this in a different PR to #417 in case it's decided that it's worth leaving other parts of the Editor as be. 

(cc @laurelfulford) 

#### Related issue(s): #413 #415 #417
