### PR TITLE
Button 2: Add name for default image block styles, so it doesn't say 'null'

### DIFF
--- a/button-2/assets/js/block-variations.js
+++ b/button-2/assets/js/block-variations.js
@@ -9,6 +9,7 @@
 
 wp.blocks.registerBlockStyle( 'core/image', {
 	isDefault: true,
+	name: 'default', // Class will be turned into '.is-style-default', though no styles needed.
 	label: 'Default'
 } );
 


### PR DESCRIPTION
Adds `name` for default image block styles, so it doesn't use class `is-style-undefined`. 