### PR TITLE
Apostrophe 2: Improve Header Contrast

### DIFF
--- a/apostrophe-2/css/editor-blocks.css
+++ b/apostrophe-2/css/editor-blocks.css
@@ -59,7 +59,7 @@
 	line-height: 1.5;
 	margin: 1.13636% 0 0.50505%;
 	word-wrap: break-word;
-	color: silver;
+	color: dimgray;
 	font-size: 42px;
 	font-weight: 300;
 	line-height: 1.25;
@@ -82,7 +82,7 @@
 }
 
 .edit-post-visual-editor h1 {
-	color: silver;
+	color: dimgray;
 	font-size: 42px;
 	font-weight: 300;
 	line-height: 1.25;

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -403,7 +403,7 @@ h6 a {
 }
 
 h1 {
-	color: silver;
+	color: dimgray;
 	font-size: 42px;
 	font-size: 4.2rem;
 	font-weight: 300;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The dotcombrand page mentions the importance of a suitable colour contrast [here](https://dotcombrand.wordpress.com/colors/), and needs to be at least 3:1 for Headings. 

> 1.4.3 Contrast (Minimum): The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for the following: (Level AA)

> Large Text: Large-scale text and images of large-scale text have a contrast ratio of at least 3:1

When it comes to Apostrophe 2, the contrast ratio is only 1.82:1. If that was to pass the minimum guidelines, then the HEX code _#949494_ could be used, however feedback in the forums requests something even darker such as black. Apostrophe [also uses silver](https://wpcom-themes.svn.automattic.com/apostrophe/style.css) which fails, so this PR proposes using **dimgray** for Apostrophe 2 headers. 

That would comfortably pass the guidelines: https://contrast-ratio.com/#dimgray-on-white

It's also a colour instead of a HEX, and grey probably isn't the best to use because that's already used for H3 and H4. 

### Screenshots:

**Currently in the Editor:**

![dfghfgdhhgf](https://user-images.githubusercontent.com/43215253/50480375-8542ae80-09d3-11e9-82ae-b25f52384e70.png)

**Proposed:**

![gfdsfgsgfgsfd-1](https://user-images.githubusercontent.com/43215253/50480391-98ee1500-09d3-11e9-8855-8bc2f30448ab.png)

**Currently as the post title:**

![beforefsdfsds](https://user-images.githubusercontent.com/43215253/50480402-b02d0280-09d3-11e9-9bab-508bb954752d.png)

**Proposed:**

![gfhgfdhgfhfd-1](https://user-images.githubusercontent.com/43215253/50480411-ba4f0100-09d3-11e9-8221-c842aa613d96.png)

Although the contrast needs to be improved to pass accessibility guidelines, I'm not certain this is the best colour as it's a ratio of 5.48:1 when it only needs to be 3:1. However, I feel like it's the most effective to use in terms of consistency and contrast, especially from the feedback of using a darker colour. 

#### Related issue(s): 
Fixes #419 
