### PR TITLE
Affinity: Fix Overlap with "Menu" Button on Mobile

### DIFF
--- a/affinity/style.css
+++ b/affinity/style.css
@@ -1265,7 +1265,7 @@ body {
   font-size: 0.825rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  margin: 0;
+  margin: 0 30% 0 0;
   position: absolute;
   left: 1.6em;
   top: 1.6em;
@@ -2436,7 +2436,8 @@ object {
   .site-title {
     text-align: left;
     -webkit-transform: translateY(0);
-    transform: translateY(0);
+    transform: translateY(0);	  	 
+    width: 100%;
     position: relative;
     top: auto;
     left: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR intends to fix the overlap with long site titles on mobile with sites using the Affinity theme by setting a margin of 30%, however adding `width: 100%` to desktop viewing. 

**Current:**

![ezgif com-video-to-gif_3](https://user-images.githubusercontent.com/43215253/50486626-b8486a80-09f2-11e9-9031-82d580b51198.gif)

**Proposed:**

![ezgif com-video-to-gif_2](https://user-images.githubusercontent.com/43215253/50486631-c0a0a580-09f2-11e9-805b-b1b77d22daa2.gif)

(cc @laurelfulford) 

#### Related issue(s):

Fixes #412 