### PR TITLE
Lodestar: Align Menu Left in the Customiser

### DIFF
--- a/lodestar/style.css
+++ b/lodestar/style.css
@@ -2717,13 +2717,9 @@ object {
 	.main-navigation ul.nav-menu {
 		margin-bottom: 0;
 		padding: 0;
-		text-align: center;
-	}
-
-	.has-top-content .main-navigation ul.nav-menu {
 		text-align: left;
 	}
-
+	
 	.main-navigation li {
 		display: inline-block;
 		position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

For some reason, the Customizer aligns the menu in the centre until Header Text is added. It shouldn't, because it's aligned left on the live site in all cases, so this PR intends to fix that. 

**Before:**

![gfsdsfgdfsgd](https://user-images.githubusercontent.com/43215253/50487448-5be74a00-09f6-11e9-80d0-e6e725873c6e.png)

**After:**

![sgfdfgsdgfds](https://user-images.githubusercontent.com/43215253/50487458-63a6ee80-09f6-11e9-890c-23d1ff586b21.png)

(cc @laurelfulford) 

#### Related issue(s):

Fixes #327 

