### PR TITLE
Ixion: Fix Button Responsiveness of File Block

### DIFF
--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -191,6 +191,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	background: #d7b221;
 	box-shadow: none;
 	color: white;
+	display: inline-block;
 	font-size: 16px;
 	font-weight: bold;
 	text-transform: uppercase;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

The site owner who originally reported this bug has switched to the Affinity theme, where for some reason the file block button responsiveness works fine. The only notable difference in the styling is that the Affinity theme contains `display: inline-block` (see [here](https://github.com/Automattic/themes/blob/master/affinity/editor-blocks.css#L370)) and it looks like other themes do too, such as Dara. 

Including that in Ixion should fix the issues with the theme block. The difference to just one file is barely noticeable whatsoever:

**Before:**

![beforefgfsdsfdgfg](https://user-images.githubusercontent.com/43215253/50539147-26b43680-0b73-11e9-8ba0-34b8410922f9.png)

**After:**

![sfdgsdfgfsdfg](https://user-images.githubusercontent.com/43215253/50539151-392e7000-0b73-11e9-8497-dea0c56ec2fe.png)

But when there's multiple files, a major difference can be seen. 

### Desktop/Larger Screens

**Before:**

![gdfssdfgdgsfdgsf](https://user-images.githubusercontent.com/43215253/50539157-61b66a00-0b73-11e9-9bfa-b0ba611fe598.png)

**After:**

![fsdasdafasdfdas](https://user-images.githubusercontent.com/43215253/50539154-55caa800-0b73-11e9-8f1a-58736dc38bdf.png)

### Mobile/Smaller screens

**Before:**

![fasdfdasadsffdas](https://user-images.githubusercontent.com/43215253/50539162-86124680-0b73-11e9-8f3c-c52971f21471.png)

**After:**

![hgdfhgffgdhfdghhg](https://user-images.githubusercontent.com/43215253/50539165-91657200-0b73-11e9-8bc7-d9e939851ad7.png)

However, it seems like there'd be a (granted, very minor) change in size of the button, which you can see in the screenshots above. The button being responsive though seems to make up for that extremely small adjustment. 

(cc @laurelfulford) 

#### Related issue(s):

Fixes #431 