### PR TITLE
Several themes: Inherit Caption Colours with Gutenberg Blocks

### DIFF
--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -21,7 +21,7 @@ Description: Used to style Gutenberg Blocks.
 /* Captions */
 
 [class^="wp-block-"] figcaption {
-	color: #777;
+	color: inherit;
 	font-family: Lato, sans-serif;
 	font-size: 16px;
 	line-height: 1.25;

--- a/gazette/css/blocks.css
+++ b/gazette/css/blocks.css
@@ -27,7 +27,7 @@ Description: Used to style Gutenberg Blocks.
 }
 
 [class^="wp-block-"]:not(.wp-block-gallery) figcaption {
-	color: #777;
+	color: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/independent-publisher-2/css/blocks.css
+++ b/independent-publisher-2/css/blocks.css
@@ -74,7 +74,7 @@ body:not(.has-sidebar) .wp-block-latest-posts.alignfull {
 	font-size: 14.25px;
 	font-weight: 400;
 	font-style: italic;
-	color: #939393;
+	color: inherit;
 
 }
 

--- a/intergalactic-2/blocks.css
+++ b/intergalactic-2/blocks.css
@@ -83,6 +83,7 @@ Description: Used to style Gutenberg Blocks.
 /* Captions */
 
 [class^="wp-block-"] figcaption {
+	color: inherit;	
 	font-size: .778em;
 }
 

--- a/rebalance/blocks.css
+++ b/rebalance/blocks.css
@@ -21,7 +21,7 @@ Description: Used to style Gutenberg Blocks.
 /* Captions */
 
 [class^="wp-block-"] figcaption {
-	color: #999;
+	color: inherit;
 	font-size: 14px;
 	line-height: 1.525em;
 	text-align: center;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Inherits the caption colour for five themes: Canard, Gazette, Independent Publisher 2, Intergalactic 2 and Rebalance 

Other themes may have a set caption colour, but even though you can change the colour of the background of the site, you can't change the background colour behind the caption. Examples of these themes include Libretto, Textbook and Toujours. The only theme where there's still an issue which this PR won't help with is Photos, the caption issue is present but setting the colour to inherit only makes it worse for some reason. 

The effect of this change is to make the colour of the caption far more readable on darker coloured backgrounds, since they currently fail the accessibility [guidelines](https://dotcombrand.wordpress.com/colors/) of a colour ratio. 

### Example 

**Before:**

![before_dgdgfdgfgdf](https://user-images.githubusercontent.com/43215253/50559109-8d5c6000-0ceb-11e9-8350-145c8a8f35f9.png)

**After:**

![after_gdgfdfdg](https://user-images.githubusercontent.com/43215253/50559112-94836e00-0ceb-11e9-86bf-a7f19b881772.png)

**Not needed - changing the background only changes what's currently black, not the colour behind the caption itself**

![not_needed_button_2](https://user-images.githubusercontent.com/43215253/50559118-a402b700-0ceb-11e9-9409-e50388db5748.png)

#### Related issue(s):
#459 