### PR TITLE
Penscratch 2: Fix No-Sidebar Layout

### DIFF
--- a/penscratch-2/style.css
+++ b/penscratch-2/style.css
@@ -1918,6 +1918,8 @@ div.sharedaddy div.sd-block {
 }
 @media screen and (min-width: 55em) {
 	.no-sidebar .site {
+		margin-right: auto; 
+		margin-left: auto;								
 		max-width: 872px;
 		padding: 54px 108px;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adds `margin-right (and left): auto` to the site when there isn't a sidebar. Though `margin: 14px auto` works well when the issue occurs, it results in the content being higher on larger screens because it overrides the margin [here](https://github.com/Automattic/themes/blob/master/penscratch-2/style.css#L1911). This approach doesn't cause that effect. 

**Before:**

![ezgif-2-582f41f6c020](https://user-images.githubusercontent.com/43215253/50574539-55841400-0de2-11e9-86fc-ff20b3086f99.gif)

**After:**

![ezgif-2-fb4e2832fb09](https://user-images.githubusercontent.com/43215253/50574533-3c7b6300-0de2-11e9-9cb2-942291ee1f7e.gif)


#### Related issue(s):
Fixes #371
