### PR TITLE
Libre 2: Fix image block centring 

### DIFF
--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -73,15 +73,6 @@ Description: Used to style Gutenberg Blocks.
 2.0 General Block Styles
 --------------------------------------------------------------*/
 
-/* Figures */
-
-figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull),
-[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull) figure,
-[class^="wp-block-"] figure:not(.aligncenter):not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull) {
-	margin-left: 0;
-	margin-right: 0;
-}
-
 /* Captions */
 
 [class^="wp-block-"] figcaption {
@@ -91,7 +82,7 @@ figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):no
 	position: relative;
 }
 
-[class^="wp-block-"]:not(.wp-block-gallery) figcaption :not(.aligncenter) {
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
 	text-align: left;
 }
 
@@ -105,18 +96,9 @@ figure[class^="wp-block-"]:not(.aligncenter):not(.alignleft):not(.alignright):no
 	width: 25%;
 }
 
-[class^="wp-block-"]:not(.wp-block-gallery) .aligncenter figcaption::after {
-        margin-right: auto;
-        margin-left: auto;
-}
-
 [class^="wp-block-"].alignfull:not(.wp-block-gallery) figcaption {
 	padding-left: 2vw;
 	padding-right: 2vw;
-}
-
-[class^="wp-block-"]:not(.wp-block-gallery) .aligncenter figcaption {
-        text-align: center;
 }
 
 .rtl [class^="wp-block-"]:not(.wp-block-gallery) figcaption {

--- a/libre-2/editor-style.css
+++ b/libre-2/editor-style.css
@@ -63,7 +63,7 @@ svg:not(:root) {
 }
 
 figure {
-	margin: 1em 40px;
+	margin: 1em 0;
 }
 
 hr {

--- a/libre-2/style.css
+++ b/libre-2/style.css
@@ -152,7 +152,7 @@ svg:not(:root) {
 }
 
 figure {
-	margin: 1em 40px;
+	margin: 1em 0;
 }
 
 hr {


### PR DESCRIPTION
This PR builds off of @torres126's work in #411. 

I removed some super-confusing figure styles in the blocks.css that were meant to override the themes default figure styles... but the easiest fix was actually just removing them from the style and editor-styles.css. 

I also set the captions back to aligned left, simply because with them centred for centred blocks, we'd probably need to look at centring them for wide or full blocks, and that might be too noticeable a change :) 

Fixes #404.