### PR TITLE
Libretto: Remove drop cap, first line styles from first paragraph in editor

### DIFF
--- a/libretto/css/editor-blocks.css
+++ b/libretto/css/editor-blocks.css
@@ -50,18 +50,6 @@
 	margin-right: auto;
 }
 
-/*
-Browser hack that targets Safari only, to prevent first line from disappearing.
-See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome
-*/
-@media not all and (min-resolution:.001dpcm) { @media {
-    .format-standard:not(.post-password-required) .entry-content > p:not(.no-emphasis):first-of-type::after,
-	.page:not(.post-password-required) .entry-content > p:not(.no-emphasis):first-of-type::after,
-	.emphasis::after {
-		display: inline-block;
-	}
-}}
-
 .wp-block > p:not(.no-emphasis):first-of-type + p,
 .page:not(.post-password-required) .entry-content > p:not(.no-emphasis):first-of-type + p,
 .emphasis + p {
@@ -482,7 +470,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 /* Theme has built-in dropcaps and emphasis on the first line of each paragraph */
 
 /* Drop cap and first line */
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(.no-emphasis):first-letter,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(.no-emphasis):not(:focus):first-letter,
 .emphasis:first-letter {
 	color: #b7b1a9;
 	display: inline-block;
@@ -495,7 +483,7 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	margin: 6px 10px 0 -5px;
 }
 
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(.no-emphasis):first-line,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(:focus):not(.no-emphasis):first-line,
 .emphasis:first-line {
 	color: #787065;
 	font-family: "Playfair Display SC";
@@ -505,12 +493,23 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	letter-spacing: 2px;
 }
 
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(.no-emphasis)::after,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type:not(:focus) .wp-block-paragraph:not(:focus):not(.no-emphasis)::after,
 .emphasis::after {
 	clear: both;
 	content: "";
 	display: block;
 }
+
+/*
+Browser hack that targets Safari only, to prevent first line from disappearing.
+See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome
+*/
+@media not all and (min-resolution:.001dpcm) { @media {
+	.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type:not(:focus) .wp-block-paragraph:not(.no-emphasis):first-letter:after,
+	.emphasis:first-letter:after; {
+		display: inline-block;
+	}
+} }
 
 /* Images */
 

--- a/libretto/css/editor-blocks.css
+++ b/libretto/css/editor-blocks.css
@@ -470,7 +470,7 @@
 /* Theme has built-in dropcaps and emphasis on the first line of each paragraph */
 
 /* Drop cap and first line */
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(.no-emphasis):not(:focus):first-letter,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph[data-is-placeholder-visible="false"]:not(.no-emphasis):not(:focus):first-letter,
 .emphasis:first-letter {
 	color: #b7b1a9;
 	display: inline-block;
@@ -483,7 +483,7 @@
 	margin: 6px 10px 0 -5px;
 }
 
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph:not(:focus):not(.no-emphasis):first-line,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type .wp-block-paragraph[data-is-placeholder-visible="false"]:not(:focus):not(.no-emphasis):first-line,
 .emphasis:first-line {
 	color: #787065;
 	font-family: "Playfair Display SC";
@@ -493,7 +493,7 @@
 	letter-spacing: 2px;
 }
 
-.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type:not(:focus) .wp-block-paragraph:not(:focus):not(.no-emphasis)::after,
+.editor-writing-flow .editor-block-list__block[data-type="core/paragraph"]:first-of-type:not(:focus) .wp-block-paragraph[data-is-placeholder-visible="false"]:not(:focus):not(.no-emphasis)::after,
 .emphasis::after {
 	clear: both;
 	content: "";


### PR DESCRIPTION
Remove drop cap, first line styles from first paragraph in editor when it's being focussed on (when the text is getting edited), as it causes the text to get cut off in Safari. 

Also clean up a work around in the editor styles, to actually use the correct selectors for the editor. 

Fixes #458.