### PR TITLE
Radcliffe-2: CSS fix for background of Dropdown menu items leading to same page / page jumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/radcliffe-2/style.css
+++ b/radcliffe-2/style.css
@@ -2574,8 +2574,12 @@ object {
 	}
 
 	.main-navigation li.current-menu-item ~ li.current-menu-item > a {
-		background: transparent;
-		color: #222;
+		background: #222;
+		color: #fff;
+	}
+
+	.main-navigation li.current-menu-item ~ li.current-menu-item > a:hover {
+		background: #ca2017;
 	}
 
 	.main-navigation ul li:hover > ul ul {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Change transparent background appearing for dropdown menu items linking to same page / page jumps. Added red hover background to these as well. 

#### Related issue(s):

#435 