### PR TITLE
Apostrophe 2: Ensure "Follow" Button is Readable

### DIFF
--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -1255,8 +1255,9 @@ a:active {
 	max-width: 100%;
 }
 
-/* Form elements should span the full width. */
+/* Form elements should span the full width and be readable. */
 .widget input {
+	color: inherit;	
 	width: 100%;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Inherit the colour for `input` of widgets, so that the Follow button is readable when using the default colour palletes, but isn't changed when using any other pallete. 

**Current:**

![ezgif-5-8aef022aa21a](https://user-images.githubusercontent.com/43215253/51267982-da605780-19b6-11e9-8f4c-496c8e697695.gif)

**Proposed:**

![ezgif-5-8d73e0e470a4](https://user-images.githubusercontent.com/43215253/51267997-e21ffc00-19b6-11e9-8966-72786816e186.gif)


#### Related issue(s):

Fixes #496
