### PR TITLE
Independent Publisher 2: Adjust menu styles to prevent white on white text

### DIFF
--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -1047,11 +1047,6 @@ input::-moz-focus-inner {
 	color: #00aadc;
 }
 
-.main-navigation > div > ul > li.current-menu-item > ul > li a,
-.main-navigation > div > ul > li.current_page_item > ul > li a {
-	color: #fff;
-}
-
 /* Small menu. */
 .menu-toggle,
 .main-navigation.toggled ul {
@@ -3133,6 +3128,11 @@ time.published + .updated {
 	.main-navigation ul ul li.page_item_has_children > a:after {
 		-webkit-transform: rotate(0deg);
 		transform: rotate(0deg);
+	}
+
+	.main-navigation > div > ul > li.current-menu-item > ul > li a,
+	.main-navigation > div > ul > li.current_page_item > ul > li a {
+		color: #fff;
 	}
 
 	.post-navigation .nav-links .nav-previous {


### PR DESCRIPTION
Strongly based on #277:

This update adjusts the styles for the mobile menu, so when viewing the children of the current page in the mobile menu, you don't get white text on white background.

Fixes #276.