### PR TITLE
Apostrophe: Update subscribe button styles 

### DIFF
--- a/apostrophe-2/inc/wpcom-colors.php
+++ b/apostrophe-2/inc/wpcom-colors.php
@@ -67,6 +67,17 @@ add_color_rule( 'txt', '#117bb8', array(
 		  .sidebar-primary input[type="submit"]', 'color', 'link', 10 ),
 
   array( '.sidebar-primary button:hover,
+  		  .sidebar-primary button:focus,
+		  .sidebar-primary input[type="button"]:focus,
+		  .sidebar-primary input[type="button"]:hover,
+		  .sidebar-primary input[type="reset"]:focus,
+		  .sidebar-primary input[type="reset"]:hover,
+		  .sidebar-primary input[type="submit"]:focus,
+		  .sidebar-primary input[type="submit"]:hover,
+		  #subscribe-blog input[type="submit"]:focus,
+		  #subscribe-blog input[type="submit"]:hover', 'color', 'txt', 10 ),
+
+  array( '.sidebar-primary button:hover,
 		  .sidebar-primary input[type="button"]:hover,
 		  .sidebar-primary input[type="reset"]:hover,
 		  .sidebar-primary input[type="submit"]:hover', 'border-color', 'link' ),

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -1288,6 +1288,16 @@ a:active {
 	margin: 0;
 }
 
+/* Follow Blog widget */
+#subscribe-blog input[type="submit"] {
+	color: #fff;
+}
+
+#subscribe-blog input[type="submit"]:focus,
+#subscribe-blog input[type="submit"]:hover {
+	color: #159ae7;
+}
+
 /* Remove exatra spacing below lists and other elements. */
 .widget > ol,
 .widget > ul,
@@ -1884,7 +1894,8 @@ article:hover .apostrophe-2-inline-controls {
 }
 
 .widget-area .sidebar-primary aside .widgettitle,
-.widget-area .sidebar-primary aside .widget-title {
+.widget-area .sidebar-primary aside .widget-title,
+.widget-area .sidebar-primary aside .widget-title label {
 	color: #fff;
 }
 


### PR DESCRIPTION
Update Apostrophe 2's styles to make sure the subscribe button has sufficient contrast, including updates to the custom colour annotations.

Also includes a fix for the grey title text with the default colour scheme.

See #496.

