### PR TITLE
Multiple Themes: Update caption colours

### DIFF
--- a/affinity/blocks.css
+++ b/affinity/blocks.css
@@ -21,6 +21,7 @@ Description: Used to style Gutenberg Blocks.
 /* Captions */
 
 [class^="wp-block-"]:not(.wp-block-gallery) figcaption {
+	color: inherit;
 	font-size: 13.2px;
 	font-style: italic;
 	margin-bottom: 1.6em;

--- a/photos/blocks.css
+++ b/photos/blocks.css
@@ -164,7 +164,6 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-image figcaption {
-	color: #606060;
 	font-size: 0.8em;
 	margin-top: 0;
 	padding-top: 0.625em;
@@ -177,10 +176,8 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 /* Captions */
-.wp-block-image figcaption,
-.wp-block-audio figcaption,
-.wp-block-video figcaption {
-	color: #606060;
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
+	color: inherit;
 }
 
 /* Blockquotes*/


### PR DESCRIPTION
Update the caption colours for Affinity and Photos, so they inherit the text colour used elsewhere in the theme.

#### Related issue(s):

#459