### PR TITLE
Affinity: Fix Gutenberg gallery block when images link to media files

### DIFF
--- a/affinity/blocks.css
+++ b/affinity/blocks.css
@@ -51,6 +51,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-left: auto;
 }
 
+.wp-block-gallery.is-cropped .blocks-gallery-item a {
+	overflow: hidden;
+}
+
 /* Quote */
 
 .wp-block-quote cite {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This change adds an `overflow: hidden;` setting to the wrapping `<a>` markup to prevent linked images from overflowing and breaking.

## Related issue:

Fixes #473 

## Before

**Mobile:**
![image](https://user-images.githubusercontent.com/709581/52366727-727eb900-2a18-11e9-92c6-f009b969b65a.png)

**Desktop:**
![image](https://user-images.githubusercontent.com/709581/52366781-92ae7800-2a18-11e9-846f-823624e1b170.png)

## After

**Mobile:**
![image](https://user-images.githubusercontent.com/709581/52366858-bd003580-2a18-11e9-845c-c99eea9fe34a.png)

**Desktop:**
![image](https://user-images.githubusercontent.com/709581/52366812-a3f78480-2a18-11e9-82d6-136bf15a0732.png)
