### PR TITLE
Affinity: Fix button styles

### DIFF
--- a/affinity/blocks.css
+++ b/affinity/blocks.css
@@ -181,38 +181,44 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	border-radius: 0;
 	display: inline-block;
 	font-size: 13.2px;
 	font-family: Raleway, "Helvetica Neue", sans-serif;
 	text-transform: uppercase;
 	letter-spacing: 1px;
 	font-weight: bold;
+	left: 4px;
 	line-height: 1;
+	position: relative;
 	transition: 0.3s;
 	text-decoration: none;
 }
 
-.wp-block-button__link:not(.has-text-color),
-.wp-block-button__link:not(.has-text-color):hover,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):active {
+.wp-block-button:not(.is-style-outline) .wp-block-button__link {
+	border: 2px solid white;
+}
+
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color),
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color):hover,
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color):focus,
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color):active {
 	color: white;
 }
 
-.wp-block-button__link:not(.has-background) {
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background) {
 	background-color: #99908a;
-	outline: 4px solid #99908a;
-	border: 2px solid white;
-	position: relative;
-	left: 4px;
+	box-shadow: 0 0 0 4px #99908a;
 }
 
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):focus,
-.wp-block-button__link:not(.has-background):hover {
-	outline-color: #5e5853;
+.entry-content .wp-block-button .wp-block-button__link:active,
+.entry-content .wp-block-button .wp-block-button__link.has-background:active,
+.entry-content .wp-block-button .wp-block-button__link:focus,
+.entry-content .wp-block-button .wp-block-button__link.has-background:focus,
+.entry-content .wp-block-button .wp-block-button__link:hover,
+.entry-content .wp-block-button .wp-block-button__link.has-background:hover {
+	box-shadow: 0 0 0 4px #5e5853;
 	background-color: #5e5853;
+	color: #fff;
 }
 
 /* Seperator */
@@ -269,4 +275,52 @@ hr.wp-block-separator {
 
 .wp-block-latest-comments__comment-excerpt p:last-child {
 	margin-bottom: 0;
+}
+
+/*--------------------------------------------------------------
+6.0 Colors
+--------------------------------------------------------------*/
+
+.wp-block-button__link.has-pale-pink-background-color:link {
+	box-shadow: 0 0 0 4px #f78da7;
+}
+
+.wp-block-button__link.has-vivid-red-background-color:link {
+	box-shadow: 0 0 0 4px #cf2e2e;
+}
+
+.wp-block-button__link.has-luminous-vivid-orange-background-color:link {
+	box-shadow: 0 0 0 4px #ff6900;
+}
+
+.wp-block-button__link.has-luminous-vivid-amber-background-color:link {
+	box-shadow: 0 0 0 4px #fcb900;
+}
+
+.wp-block-button__link.has-light-green-cyan-background-color:link {
+	box-shadow: 0 0 0 4px #7bdcb5;
+}
+
+.wp-block-button__link.has-vivid-green-cyan-background-color:link {
+	box-shadow: 0 0 0 4px #00d084;
+}
+
+.wp-block-button__link.has-pale-cyan-blue-background-color:link {
+	box-shadow: 0 0 0 4px #8ed1fc;
+}
+
+.wp-block-button__link.has-vivid-cyan-blue-background-color:link {
+	box-shadow: 0 0 0 4px #0693e3;
+}
+
+.wp-block-button__link.has-very-light-gray-background-color:link {
+	box-shadow: 0 0 0 4px #eee;
+}
+
+.wp-block-button__link.has-cyan-bluish-gray-background-color:link {
+	box-shadow: 0 0 0 4px #abb8c3;
+}
+
+.wp-block-button__link.has-very-dark-gray-background-color:link {
+	box-shadow: 0 0 0 4px #313131;
 }

--- a/affinity/editor-blocks.css
+++ b/affinity/editor-blocks.css
@@ -706,8 +706,11 @@
 --------------------------------------------------------------*/
 
 /* Buttons */
-.wp-block-button .wp-block-button__link {
-	border-radius: 0;
+.wp-block-button__link {
+	background-color: #99908a;
+	box-shadow: 0 0 0 4px #99908a;
+	border: 2px solid #fff;
+	color: #fff;
 	display: inline-block;
 	font-size: 13.2px;
 	font-family: Raleway, "Helvetica Neue", sans-serif;
@@ -717,33 +720,58 @@
 	line-height: 1 !important;
 	transition: 0.3s;
 	text-decoration: none;
-}
-
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus,
-.wp-block-button .wp-block-button__link:active {
-}
-
-.wp-block-button__link:not(.has-text-color),
-.wp-block-button__link:not(.has-text-color):active,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):hover {
-	color: white;
-}
-
-.wp-block-button__link:not(.has-background) {
-	background-color: #99908a;
-	outline: 4px solid #99908a;
-	border: 2px solid white;
 	position: relative;
 	left: 4px;
 }
 
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):focus,
-.wp-block-button__link:not(.has-background):hover {
-	outline-color: #5e5853;
-	background-color: #5e5853;
+.wp-block-button.is-style-outline .wp-block-button__link {
+	border-color: currentColor;
+	box-shadow: none;
+	color: #99908a;
+}
+
+.wp-block-button__link.has-pale-pink-background-color {
+	box-shadow: 0 0 0 4px #f78da7;
+}
+
+.wp-block-button__link.has-vivid-red-background-color {
+	box-shadow: 0 0 0 4px #cf2e2e;
+}
+
+.wp-block-button__link.has-luminous-vivid-orange-background-color {
+	box-shadow: 0 0 0 4px #ff6900;
+}
+
+.wp-block-button__link.has-luminous-vivid-amber-background-color {
+	box-shadow: 0 0 0 4px #fcb900;
+}
+
+.wp-block-button__link.has-light-green-cyan-background-color {
+	box-shadow: 0 0 0 4px #7bdcb5;
+}
+
+.wp-block-button__link.has-vivid-green-cyan-background-color {
+	box-shadow: 0 0 0 4px #00d084;
+}
+
+.wp-block-button__link.has-pale-cyan-blue-background-color {
+	box-shadow: 0 0 0 4px #8ed1fc;
+}
+
+.wp-block-button__link.has-vivid-cyan-blue-background-color {
+	box-shadow: 0 0 0 4px #0693e3;
+}
+
+.wp-block-button__link.has-very-light-gray-background-color {
+	box-shadow: 0 0 0 4px #eee;
+}
+
+.wp-block-button__link.has-cyan-bluish-gray-background-color {
+	box-shadow: 0 0 0 4px #abb8c3;
+}
+
+.wp-block-button__link.has-very-dark-gray-background-color {
+	box-shadow: 0 0 0 4px #313131;
 }
 
 /* Separator */


### PR DESCRIPTION
This update corrects Affinity's button block styles, so you can actually use the default rounded, and assign the outline and square options.

See #434.