### PR TITLE
Apostrophe 2: Fix button styles

### DIFF
--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -318,8 +318,6 @@ body {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	border-radius: 0;
-	border: 2px solid currentColor;
 	cursor: pointer;
 	display: inline-block;
 	font-family: "Open Sans", Arial, sans-serif;
@@ -333,29 +331,27 @@ body {
 }
 
 .wp-block-button__link:not(.has-background) {
-	border: 2px solid #117bb8;
-	background: rgba(255, 255, 255, 0.25);
+	background-color: #117bb8;
 }
 
-.wp-block-button__link:not(.has-background):focus {
-	background-color: #ceeafa;
-	border-color: #0d5c89;
-	margin-top: 6px;
-	outline: none;
+.wp-block-button__link:not(.has-text-color) {
+	color: #fff;
 }
 
-.wp-block-button__link:not(.has-text-color),
-.wp-block-button__link:not(.has-text-color):active,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):hover {
-	color: #159ae7;
+.wp-block-button.is-style-outline .wp-block-button__link {
+	background-color: transparent;
 }
 
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):focus,
-.wp-block-button__link:not(.has-background):hover {
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: #117bb8;
+}
+
+.wp-block-button .wp-block-button__link:active,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:hover {
 	background-color: #e5f4fd;
-	border-color: #159ae7;
+	color: #159ae7;
+	border-color: transparent;
 }
 
 /* Seperator */

--- a/apostrophe-2/css/editor-blocks.css
+++ b/apostrophe-2/css/editor-blocks.css
@@ -700,8 +700,8 @@
 
 /* Buttons */
 .wp-block-button .wp-block-button__link {
-	border-radius: 0;
-	border: 2px solid currentColor;
+	background-color: #117bb8;
+	color: #fff;
 	cursor: pointer;
 	display: inline-block;
 	font-family: "Open Sans", Arial, sans-serif;
@@ -714,34 +714,9 @@
 	text-decoration: none;
 }
 
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus,
-.wp-block-button .wp-block-button__link:active {
-}
-
-.wp-block-button__link:not(.has-text-color),
-.wp-block-button__link:not(.has-text-color):active,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):hover {
-	color: #159ae7;
-}
-
-.wp-block-button__link:not(.has-background) {
-	border: 2px solid #117bb8;
-	background: rgba(255, 255, 255, 0.25);
-}
-
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):hover {
-	background-color: #e5f4fd;
-	border-color: #159ae7;
-}
-
-.wp-block-button__link:not(.has-background):focus {
-	background-color: #ceeafa;
-	border-color: #0d5c89;
-	margin-top: 6px;
-	outline: none;
+.wp-block-button.is-style-outline .wp-block-button__link {
+	background: transparent;
+	color: #117bb8;
 }
 
 /* Separator */


### PR DESCRIPTION
This update corrects Apostrophe 2's button block styles, so you can actually use the default rounded, and assign the outline and square options.

See #434.