### PR TITLE
Illustratr: Update styles for buttons

### DIFF
--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -305,14 +305,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-button .wp-block-button__link {
 	padding: 10px 20px;
-	border: 1px solid;
-	box-shadow: none;
-	border-radius: 0;
 	display: inline-block;
 	text-transform: uppercase;
 	font-weight: 900;
-	cursor: pointer;
-	/* Improves usability and consistency of cursor style between image-type 'input' and others */
 }
 
 @media screen and (max-width: 767px) {
@@ -324,22 +319,21 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-button__link {
 	background: #464d4d;
 	color: white;
-	border: 1px solid #464d4d;
 }
 
-.wp-block-button__link:active,
-.wp-block-button__link:focus,
-.wp-block-button__link:hover {
-	color: white;
-	background: #e06d5e;
-	border-color: #e06d5e;
-}
-
-.wp-block-button__link.has-background:active,
-.wp-block-button__link.has-background:focus,
-.wp-block-button__link.has-background:hover {
+.is-style-outline .wp-block-button__link {
 	border-color: currentColor;
-	opacity: 0.8;
+}
+
+.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: #464d4d;
+}
+
+.entry-content .wp-block-button .wp-block-button__link:active,
+.entry-content .wp-block-button .wp-block-button__link:focus,
+.entry-content .wp-block-button .wp-block-button__link:hover {
+	background: #e06d5e;
+	color: #fff;
 }
 
 /* Seperator */

--- a/illustratr/editor-blocks.css
+++ b/illustratr/editor-blocks.css
@@ -750,42 +750,22 @@
 /* Buttons */
 .wp-block-button .wp-block-button__link {
 	padding: 10px 20px;
-	border: 1px solid;
-	box-shadow: none;
-	border-radius: 0;
 	display: inline-block;
 	text-transform: uppercase;
 	font-weight: 900;
-	cursor: pointer;
-	/* Improves usability and consistency of cursor style between image-type 'input' and others */
 }
 
-.wp-block-button .wp-block-button__link:active,
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus {
-}
-
-.wp-block-button__link:not(.has-background) {
+.wp-block-button__link {
 	background: #464d4d;
-	border: 1px solid #464d4d;
+	color: #fff;
 }
 
-.wp-block-button__link:not(.has-background):focus {
-	background: #e06d5e;
+.is-style-outline .wp-block-button__link {
+	border-color: currentColor;
 }
 
-.wp-block-button__link:not(.has-text-color),
-.wp-block-button__link:not(.has-text-color):active,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):hover {
-	color: white;
-}
-
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):focus,
-.wp-block-button__link:not(.has-background):hover {
-	background: #e06d5e;
-	border-color: #e06d5e;
+.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: #464d4d;
 }
 
 /* Separator */


### PR DESCRIPTION
This update corrects Illustratr's button block styles, so you can actually use the default rounded, and assign the outline and square options.

See #434.