### PR TITLE
Ixion: Update styles for buttons

### DIFF
--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -318,9 +318,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	border: 0;
-	border-radius: 0;
-	box-shadow: none;
 	font-size: 16px;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -344,9 +341,18 @@ p.has-drop-cap:not(:focus)::first-letter {
 	color: #fff;
 }
 
-.wp-block-button__link:active,
-.wp-block-button__link:focus,
-.wp-block-button__link:hover {
+.is-style-outline .wp-block-button__link {
+	background: transparent;
+	border-color: currentColor;
+}
+
+.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: #d7b221;
+}
+
+.entry-content .wp-block-button .wp-block-button__link:active,
+.entry-content .wp-block-button .wp-block-button__link:focus,
+.entry-content .wp-block-button .wp-block-button__link:hover {
 	background: #c1a01e;
 	color: #fff;
 }

--- a/ixion/editor-blocks.css
+++ b/ixion/editor-blocks.css
@@ -346,15 +346,6 @@
 	transition: 0.3s;
 }
 
-.wp-block-file .wp-block-file__button:hover,
-.wp-block-file .wp-block-file__button:focus {
-	background: #c1a01e;
-	box-shadow: none;
-	color: #fff;
-	transition: 0.3s;
-	text-decoration: none;
-}
-
 /*--------------------------------------------------------------
 4.0 Blocks - Formatting
 --------------------------------------------------------------*/
@@ -618,9 +609,6 @@ table.wp-block-table th {
 
 /* Buttons */
 .wp-block-button .wp-block-button__link {
-	border: 0;
-	border-radius: 0;
-	box-shadow: none;
 	font-size: 16px;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -630,32 +618,13 @@ table.wp-block-table th {
 	transition: 0.3s;
 }
 
-.wp-block-button .wp-block-button__link:active,
-.wp-block-button .wp-block-button__link:hover,
-.wp-block-button .wp-block-button__link:focus {
-	box-shadow: none;
-	transition: 0.3s;
-	text-decoration: none;
-}
-
-.wp-block-button__link:not(.has-background) {
+.wp-block-button__link {
 	background: #d7b221;
-}
-
-.wp-block-button__link:not(.has-text-color) {
 	color: #fff;
 }
 
-.wp-block-button__link:not(.has-text-color):active,
-.wp-block-button__link:not(.has-text-color):focus,
-.wp-block-button__link:not(.has-text-color):hover {
-	color: #fff;
-}
-
-.wp-block-button__link:not(.has-background):active,
-.wp-block-button__link:not(.has-background):focus,
-.wp-block-button__link:not(.has-background):hover {
-	background: #c1a01e;
+.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: #d7b221;
 }
 
 .wp-block-button .editor-rich-text__tinymce.mce-content-body {


### PR DESCRIPTION
This update corrects Ixion's button block styles, so you can actually use the default rounded, and assign the outline and square options.

See #434.