### PR TITLE
Intergalactic 2: Fixes color annotations so that site title doesn’t disappear

### DIFF
--- a/intergalactic-2/inc/wpcom-colors.php
+++ b/intergalactic-2/inc/wpcom-colors.php
@@ -61,7 +61,7 @@ add_color_rule( 'extra', '#222222', array(
 	array( 'button, input[type="button"], input[type="reset"], input[type="submit"]', 'color', 'bg' ),
 	array( '.lines, .lines:before, .lines:after', 'background-color', 'bg' ),
 	array( '.comment-author .fn a, .comment-author .fn a:visited', 'color', 'bg' ),
-	array( '.search .site-title a, .search .site-title a:visited, .search .site-title a:hover, .archive .site-title a, .archive .site-title a:visited, .archive .site-title a:hover, .blog .site-title a, .blog .site-title a:visited, .blog .site-title a:hover, .page .site-title a, .page .site-title a:visited, .page .site-title a:hover', 'color', 'bg' ),
+	array( '.search .site-title a, .search .site-title a:visited, .search .site-title a:hover, .archive .site-title a, .archive .site-title a:visited, .archive .site-title a:hover, .blog .site-title a, .blog .site-title a:visited, .blog .site-title a:hover, .page:not(.singular) .site-title a, .page:not(.singular) .site-title a:visited, .page:not(.singular) .site-title a:hover', 'color', 'bg' ),
 
 	array( '.entry-content a.more-link:hover, .entry-content a.more-link:active, .entry-content a.more-link:focus', 'color', '#fff' ),
 ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

• Adds a `:not(.singular)` selector to page views so that the site-title can respect the colors set in the customizer

#### Related issue(s):

Fixes: #225 

## Before

![intergalactic-2-colors-before](https://user-images.githubusercontent.com/7596032/44005537-eae5f438-9e42-11e8-9ebf-2a9b64842962.gif)

## After

![intergalactic-2-colors-after](https://user-images.githubusercontent.com/709581/52449766-72f57d80-2b06-11e9-8009-a32092d21d01.gif)