### PR TITLE
Button 2: Make infinite scroll button styles more specific

### DIFF
--- a/button-2/style.css
+++ b/button-2/style.css
@@ -479,7 +479,7 @@ button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"],
-#infinite-handle span button {
+#primary #infinite-handle span button {
 	margin-top: 5px;
 	margin-left: 5px;
 	padding: .75em 1em;
@@ -502,7 +502,7 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover,
-#infinite-handle span button:hover {
+#primary #infinite-handle span button:hover {
 	color: white;
 	outline: 5px solid #f78769;
 	background: #f78769;
@@ -518,8 +518,8 @@ input[type="reset"]:active,
 input[type="reset"]:focus,
 input[type="submit"]:active,
 input[type="submit"]:focus,
-#infinite-handle span button:active,
-#infinite-handle span button:focus {
+#primary #infinite-handle span button:active,
+#primary #infinite-handle span button:focus {
 	color: white;
 	outline: 5px solid #f78769;
 	background: #f78769;
@@ -541,15 +541,15 @@ input[type="submit"] + button,
 input[type="submit"] + input[type="button"],
 input[type="submit"] + input[type="reset"],
 input[type="submit"] + input[type="submit"],
-#infinite-handle span button + button,
-#infinite-handle span button + input[type="button"],
-#infinite-handle span button + input[type="reset"],
-#infinite-handle span button + input[type="submit"] {
+#primary #infinite-handle span button + button,
+#primary #infinite-handle span button + input[type="button"],
+#primary #infinite-handle span button + input[type="reset"],
+#primary #infinite-handle span button + input[type="submit"] {
 	margin-left: .75em;
 }
 
-#infinite-handle span:hover button,
-#infinite-handle span button:hover {
+#primary #infinite-handle span:hover button,
+#primary #infinite-handle span button:hover {
 	margin-top: 5px;
 	margin-left: 5px;
 	padding: .75em 1em;
@@ -1824,13 +1824,13 @@ div#respond {
 	padding-top: 27px;
 }
 
-#infinite-handle {
+#primary #infinite-handle {
 	clear: both;
 	width: 100%;
 	margin: 0 auto;
 	text-align: center;
 }
-#infinite-handle span {
+#primary #infinite-handle span {
 	color: inherit;
 	border: 0;
 	border-radius: 0;


### PR DESCRIPTION
Make the infinite scroll button styles more specific, to override the styles coming from jetpack.css.

Fixes #518.