### PR TITLE
Ixion: Remove 'visibility: hidden' from search

### DIFF
--- a/ixion/style.css
+++ b/ixion/style.css
@@ -1753,7 +1753,6 @@ object {
 	transition: 0.3s ease;
 	padding-left: 0;
 	width: 0;
-	visibility: hidden;
 }
 .site-header .search-form:hover .search-field,
 .site-header .search-field:focus {


### PR DESCRIPTION
Remove `visibility: hidden` from search -- it was making the search inaccessible via keyboard, and not having it there doesn't appear to cause any adverse effects.

Fixes: #498 