### PR TITLE
Ixion: Remove unneeded style

### DIFF
--- a/ixion/style.css
+++ b/ixion/style.css
@@ -1758,7 +1758,6 @@ object {
 .site-header .search-field:focus {
 	width: 300px;
 	transition: 0.3s ease;
-	visibility: visible;
 }
 .site-header .search-form:hover .search-form-icon:before,
 .site-header .search-field:focus + .search-form-icon:before {


### PR DESCRIPTION
Since the `visibility: hidden` isn't needed for the search, neither is the `visibility: visible`. :)

See #498.

