### PR TITLE
Dyad 2: Fix fade over short posts on blog page

### DIFF
--- a/dyad-2/js/global.js
+++ b/dyad-2/js/global.js
@@ -95,7 +95,7 @@
 				$contentHeight = $content.innerHeight(),
 				$wholeContentHeight = $headerHeight + $contentHeight;
 
-			if ( ( $innerContainHeight - $linkMoreHeight ) <= $wholeContentHeight ) {
+			if ( ( $innerContainHeight - $linkMoreHeight ) < $wholeContentHeight ) {
 				$contain.parent().addClass('too-short');
 			} else {
 				$contain.parent().removeClass('too-short');


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

> The script function adjustPosts() in global.js, meant to apply the class “too-short” to the wrapper div, will ALWAYS apply this class, no matter the length of the content because the wrapper auto-adjusts itself to the exact height of that content. Which in turn will cause the “if smaller than or equal to” be true on all occasions.

• The above fix actually came from a user, but it seems to do the trick.

#### Related issue(s):

Fixes: #133 

## Before

Notice the `.too-short` class at the end of the class list at the bottom of this screenshot.

![image](https://user-images.githubusercontent.com/709581/52509622-dcd55c00-2bc6-11e9-8407-979396d9e648.png)

## After

That class properly goes away after the fix is applied since the fade is no longer needed on short paragraphs. The fading is also gone here but its tough to see on the screenshot.

![image](https://user-images.githubusercontent.com/709581/52509555-a3045580-2bc6-11e9-94d1-26209977cc40.png)
