### PR TITLE
Lodestar: Fix issue with portfolio archive pagination

### DIFF
--- a/lodestar/inc/jetpack.php
+++ b/lodestar/inc/jetpack.php
@@ -111,7 +111,7 @@ function lodestar_infinite_scroll_render() {
 			wc_get_template_part( 'content', 'product' );
 		} else if ( is_search() ) {
 			get_template_part( 'components/post/content', 'search' );
-		} else if ( is_post_type_archive( 'jetpack-portfolio' ) ) {
+		} else if ( is_post_type_archive( 'jetpack-portfolio' ) || is_tax( 'jetpack-portfolio-tag' ) || is_tax( 'jetpack-portfolio-type' ) ) {
 			get_template_part( 'components/features/portfolio/content', 'portfolio' );
 		} else if ( is_post_type_archive( 'jetpack-testimonial' ) ) {
 			get_template_part( 'components/features/testimonials/content', 'testimonials' );

--- a/lodestar/taxonomy-jetpack-portfolio-tag.php
+++ b/lodestar/taxonomy-jetpack-portfolio-tag.php
@@ -8,8 +8,9 @@ get_header();
 
 $jetpack_portfolio_content = get_option( 'jetpack_portfolio_content' ); ?>
 
+<div class="wrap">
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main class="site-main" role="main">
 
 		<?php
 			if ( have_posts() ) {
@@ -21,5 +22,6 @@ $jetpack_portfolio_content = get_option( 'jetpack_portfolio_content' ); ?>
 
 		</main><!-- #main -->
 	</div><!-- #primary -->
+</div><!-- .wrap -->
 <?php
 get_footer();

--- a/lodestar/taxonomy-jetpack-portfolio-type.php
+++ b/lodestar/taxonomy-jetpack-portfolio-type.php
@@ -10,7 +10,7 @@ $jetpack_portfolio_content = get_option( 'jetpack_portfolio_content' ); ?>
 
 <div class="wrap">
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main class="site-main" role="main">
 
 		<?php
 			if ( have_posts() ) {


### PR DESCRIPTION
Update Lodestar's Jetpack infinite scroll logic, so the correct template part is used in the Portfolio tag and type taxonomy archives.

Fixes: #444.