### PR TITLE
Radcliffe 2: Update headstart annotations

### DIFF
--- a/radcliffe-2/inc/headstart/en-bar.json
+++ b/radcliffe-2/inc/headstart/en-bar.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Your bar website, powered by WordPress.com",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,

--- a/radcliffe-2/inc/headstart/en-cafe.json
+++ b/radcliffe-2/inc/headstart/en-cafe.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Your cafe website, powered by WordPress.com",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,

--- a/radcliffe-2/inc/headstart/en-mexican-restaurant.json
+++ b/radcliffe-2/inc/headstart/en-mexican-restaurant.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Your mexican restaurant website, powered by WordPress.com",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,

--- a/radcliffe-2/inc/headstart/en-movie-theater.json
+++ b/radcliffe-2/inc/headstart/en-movie-theater.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Your movie theater website, powered by WordPress.com",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,

--- a/radcliffe-2/inc/headstart/en-parking-garage.json
+++ b/radcliffe-2/inc/headstart/en-parking-garage.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Your parking garage website, powered by WordPress.com",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,

--- a/radcliffe-2/inc/headstart/en.json
+++ b/radcliffe-2/inc/headstart/en.json
@@ -47,7 +47,7 @@
     "content": [
         {
             "post_title": "Home",
-            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button below, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
+            "post_content": "<p>You're ready to add your own words and images to this page! Open the editor by clicking the <strong>Edit<\/strong> button, and make this page your own. (And for a general WordPress.com get-started guide, head to <a href=\"https:\/\/learn.wordpress.com\">learn.wordpress.com<\/a>.)<\/p>",
             "post_excerpt": "",
             "post_status": "publish",
             "menu_order": 1,


### PR DESCRIPTION
Update headstart content to remove the 'below' when referring to the edit link. 

Fixes #509.
