### PR TITLE
Radcliffe 2: This update syncs up the copies of the contact info files

### DIFF
--- a/radcliffe-2/contact-info/contact-info-customize-preview.js
+++ b/radcliffe-2/contact-info/contact-info-customize-preview.js
@@ -29,7 +29,7 @@
 	} );
 
 	// Update the contact info address in real time...
-	wp.customize( 'radcliffe_2_contact_info_address', function( value ) {
+	wp.customize( 'site_contact_info[address]', function( value ) {
 		value.bind( function( to ) {
 			$( '.contact-info-area .contact-info-address .contact-info-label' ).text( to );
 
@@ -44,7 +44,7 @@
 	} );
 
 	// Update the contact info phone in real time...
-	wp.customize( 'radcliffe_2_contact_info_phone', function( value ) {
+	wp.customize( 'site_contact_info[phone]', function( value ) {
 		value.bind( function( to ) {
 			$( '.contact-info-area .contact-info-phone .contact-info-label' ).text( to );
 
@@ -59,7 +59,7 @@
 	} );
 
 	// Update the contact info email in real time...
-	wp.customize( 'radcliffe_2_contact_info_email', function( value ) {
+	wp.customize( 'site_contact_info[email]', function( value ) {
 		value.bind( function( to ) {
 			$( '.contact-info-area .contact-info-email .contact-info-label' ).text( to );
 

--- a/radcliffe-2/contact-info/contact-info-customizer.php
+++ b/radcliffe-2/contact-info/contact-info-customizer.php
@@ -31,12 +31,14 @@ function radcliffe_2_contact_info_customize_register( $wp_customize ) {
 	) );
 
 	/* Address */
-	$wp_customize->add_setting( 'radcliffe_2_contact_info_address', array(
-		'sanitize_callback' => 'sanitize_text_field',
-		'transport'         => 'postMessage',
+	$wp_customize->add_setting( 'site_contact_info[address]', array(
+		'type'                 => 'option',
+		'sanitize_callback'    => 'sanitize_text_field',
+		'sanitize_js_callback' => radcliffe_2_generate_contact_compat_callback( 'address' ),
+		'transport'            => 'postMessage',
 	) );
 
-	$wp_customize->add_control( 'radcliffe_2_contact_info_address', array(
+	$wp_customize->add_control( 'site_contact_info[address]', array(
 		'label'             => esc_html__( 'Address', 'radcliffe-2' ),
 		'section'           => 'radcliffe_2_contact_info',
 		'type'              => 'textarea',
@@ -46,12 +48,14 @@ function radcliffe_2_contact_info_customize_register( $wp_customize ) {
 	) );
 
 	/* Phone */
-	$wp_customize->add_setting( 'radcliffe_2_contact_info_phone', array(
-		'sanitize_callback' => 'sanitize_text_field',
-		'transport'         => 'postMessage',
+	$wp_customize->add_setting( 'site_contact_info[phone]', array(
+		'type'                 => 'option',
+		'sanitize_callback'    => 'sanitize_text_field',
+		'sanitize_js_callback' => radcliffe_2_generate_contact_compat_callback( 'phone' ),
+		'transport'            => 'postMessage',
 	) );
 
-	$wp_customize->add_control( 'radcliffe_2_contact_info_phone', array(
+	$wp_customize->add_control( 'site_contact_info[phone]', array(
 		'label'             => esc_html__( 'Phone', 'radcliffe-2' ),
 		'section'           => 'radcliffe_2_contact_info',
 		'type'              => 'text',
@@ -61,12 +65,14 @@ function radcliffe_2_contact_info_customize_register( $wp_customize ) {
 	) );
 
 	/* Email */
-	$wp_customize->add_setting( 'radcliffe_2_contact_info_email', array(
-		'sanitize_callback' => 'sanitize_email',
-		'transport'         => 'postMessage',
+	$wp_customize->add_setting( 'site_contact_info[email]', array(
+		'type'                 => 'option',
+		'sanitize_callback'    => 'sanitize_email',
+		'sanitize_js_callback' => radcliffe_2_generate_contact_compat_callback( 'email' ),
+		'transport'            => 'postMessage',
 	) );
 
-	$wp_customize->add_control( 'radcliffe_2_contact_info_email', array(
+	$wp_customize->add_control( 'site_contact_info[email]', array(
 		'label'             => esc_html__( 'Email', 'radcliffe-2' ),
 		'section'           => 'radcliffe_2_contact_info',
 		'type'              => 'email',
@@ -91,6 +97,29 @@ function radcliffe_2_contact_info_customize_register( $wp_customize ) {
 	) );
 }
 add_action( 'customize_register', 'radcliffe_2_contact_info_customize_register' );
+
+/**
+ * For use in `sanitize_js_callback` params to filter in our old,
+ * theme-mod based options. Using a generator because repetition is boring.
+ *
+ * @param  string $name The field we're maybe filtering in
+ * @return function     A function for use in `sanitize_js_callback`
+ */
+function radcliffe_2_generate_contact_compat_callback( $name ) {
+	return function( $value ) use ( $name ) {
+		// if there's a value, we're fine
+		if ( ! empty( $value ) ) {
+			return $value;
+		}
+		// pull from the old theme mod value
+		$option = get_theme_mod( 'radcliffe_2_contact_info_' . $name );
+		if ( ! empty( $option ) ) {
+			return $option;
+		}
+		// nothing to see here
+		return $value;
+	};
+}
 
 /**
  * Sanitize the checkbox.

--- a/radcliffe-2/contact-info/contact-info-functions.php
+++ b/radcliffe-2/contact-info/contact-info-functions.php
@@ -5,9 +5,9 @@ if ( ! function_exists( 'radcliffe_2_contact_info' ) ) :
  */
 function radcliffe_2_contact_info( $section ) {
 	$location = get_theme_mod( 'radcliffe_2_contact_info_location',  'header' );
-	$address  = get_theme_mod( 'radcliffe_2_contact_info_address', '' );
-	$phone    = get_theme_mod( 'radcliffe_2_contact_info_phone',   '' );
-	$email    = get_theme_mod( 'radcliffe_2_contact_info_email',   '' );
+	$address  = get_option( 'site_contact_info' )['address'] ?: get_theme_mod( 'radcliffe_2_contact_info_address', '' );
+	$phone    = get_option( 'site_contact_info' )['phone'] ?: get_theme_mod( 'radcliffe_2_contact_info_phone',   '' );
+	$email    = get_option( 'site_contact_info' )['email'] ?: get_theme_mod( 'radcliffe_2_contact_info_email',   '' );
 	$hours    = get_theme_mod( 'radcliffe_2_contact_info_hours',   '' );
 
 	// If Address, Phone, Email and Hours are empty, return.


### PR DESCRIPTION
This update syncs up the copies of the contact info files on WP.com with GitHub, as they've gotten ahead in r52410-wpcom-themes.

Noticed while investigating #492.