### PR TITLE
Dyad 2: Correct how footer widget count was calculated

### DIFF
--- a/dyad-2/functions.php
+++ b/dyad-2/functions.php
@@ -192,9 +192,9 @@ function dyad_2_count_widgets( $id ) {
 
 	if ( array_key_exists( $id, $sidebars_widgets ) ) {
 
-		foreach ( ( array ) $sidebars_widgets[ $id ] as $value ) {
+		foreach ( ( array ) $sidebars_widgets[$id] as $value ) {
 			// Don't count the Cookies or Mailchimp widgets, since they're not visible in the widget area.
-			if ( strpos( $value, 'eu_cookie_law_widget' ) === 0 || strpos( $value, 'widget_mailchimp_subscriber_popup' ) === 0 ) {
+			if ( strpos( $value, 'eu_cookie_law_widget' ) === false && strpos( $value, 'widget_mailchimp_subscriber_popup' ) === false ) {
 				$count++;
 			}
 		}


### PR DESCRIPTION
Correct how footer widget count was calculated -- my original fix broke things in a different way. Fixes #589, #287.
