### PR TITLE
Photos: Fix issues introduced to custom header

### DIFF
--- a/photos/functions.php
+++ b/photos/functions.php
@@ -232,6 +232,11 @@ require get_template_directory() . '/inc/logo-resizer.php';
 require get_template_directory() . '/inc/jetpack.php';
 
 /**
+ * Load Custom Header funtionality.
+ */
+require get_template_directory() . '/inc/custom-header.php';
+
+/**
  * SVG icons functions and filters.
  */
 require get_template_directory() . '/inc/icon-functions.php';

--- a/photos/inc/custom-header.php
+++ b/photos/inc/custom-header.php
@@ -25,6 +25,7 @@ function photos_custom_header_setup() {
 		'height'                 => 400,
 		'flex-height'            => true,
 		'flex-width'             => true,
+		'wp-head-callback'       => 'photos_header_style'
 	) ) );
 }
 add_action( 'after_setup_theme', 'photos_custom_header_setup' );


### PR DESCRIPTION
Make sure new custom header file is being loaded, and the styles to hide site title and description are being added via callback. 

Fixes #591; see #319.