### PR TITLE
Canard: Update quote block border styles

### DIFF
--- a/canard/editor-blocks.css
+++ b/canard/editor-blocks.css
@@ -281,6 +281,11 @@
 	border-left: 0;
 }
 
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:right"],
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: right"] {
+	border-right: 0;
+}
+
 .editor-block-list__block .wp-block-quote:before {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Update quote block border styles to work better with the new styles planned for Gutenberg 5.2.

See #594.