### PR TITLE
Shoreditch: Update quote block border styles

### DIFF
--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -200,6 +200,23 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0 0 0 1.875rem;
 }
 
+.wp-block-quote[style*="text-align:center"] {
+	border: 0;
+	padding: 0;
+}
+
+.wp-block-quote[style*="text-align:right"] {
+	border-left-width: 0;
+	border-right-width: 2px;
+	padding: 0 1.875rem 0 0;
+}
+
+.rtl .wp-block-quote[style*="text-align:left"] {
+	border-left-width: 2px;
+	border-right-width: 0;
+	padding: 0 0 0 1.875rem;
+}
+
 .wp-block-quote.is-large p,
 .wp-block-quote.is-style-large p {
 	font-size: 26px;

--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -315,7 +315,13 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-quote:not(.is-large):not(.is-style-large),
 .wp-block-quote.is-large,
-.wp-block-quote.is-style-large {
+.wp-block-quote.is-style-large,
+.rtl .wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:left"],
+.rtl .wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: left"],
+.rtl .wp-block-quote.is-large[style*="text-align:left"],
+.rtl .wp-block-quote.is-large[style*="text-align: left"],
+.rtl .wp-block-quote.is-style-large[style*="text-align:left"],
+.rtl .wp-block-quote.is-style-large[style*="text-align: left"] {
 	border: 0 solid #3e69dc;
 	border-left-width: 2px;
 	color: inherit;
@@ -348,6 +354,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 26px
 }
 
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:right"],
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: right"],
+.wp-block-quote.is-large[style*="text-align:right"],
+.wp-block-quote.is-large[style*="text-align: right"],
+.wp-block-quote.is-style-large[style*="text-align:right"],
+.wp-block-quote.is-style-large[style*="text-align:right"],
 .rtl .wp-block-quote:not(.is-large):not(.is-style-large),
 .rtl .wp-block-quote.is-large,
 .rtl .wp-block-quote.is-style-large {
@@ -359,6 +371,17 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .rtl .wp-block-quote .wp-block-quote__citation {
 	text-align: right;
+}
+
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:center"],
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: center"],
+.wp-block-quote.is-large[style*="text-align:center"],
+.wp-block-quote.is-large[style*="text-align: center"],
+.wp-block-quote.is-style-large[style*="text-align:center"],
+.wp-block-quote.is-style-large[style*="text-align:center"] {
+	border: 0;
+	padding-left: 0;
+	padding-right: 0;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Update quote block border styles to work better with the new styles planned for Gutenberg 5.2.

See #594.