### PR TITLE
Sketch: Update quote block border styles

### DIFF
--- a/sketch/css/blocks.css
+++ b/sketch/css/blocks.css
@@ -87,9 +87,31 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .rtl .wp-block-quote.is-large,
-.rtl .wp-block-quote.is-style-large {
+.rtl .wp-block-quote.is-style-large,
+.wp-block-quote[style*="text-align:right"],
+.wp-block-quote.is-large[style*="text-align:right"],
+.wp-block-quote.is-style-large[style*="text-align:right"] {
+	border-left: 0;
+	border-right: 3px solid #eee;
 	padding-left: 0;
 	padding-right: 24px;
+}
+
+.wp-block-quote[style*="text-align:center"],
+.wp-block-quote.is-large[style*="text-align:center"],
+.wp-block-quote.is-style-large[style*="text-align:center"] {
+	border: 0;
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.rtl .wp-block-quote[style*="text-align:left"],
+.rtl .wp-block-quote.is-large[style*="text-align:left"],
+.rtl .wp-block-quote.is-style-large[style*="text-align:left"] {
+	border-left: 3px solid #eee;
+	border-right: 0;
+	padding-left: 24px;
+	padding-right: 0;
 }
 
 /* Audio */

--- a/sketch/css/editor-blocks.css
+++ b/sketch/css/editor-blocks.css
@@ -297,10 +297,18 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-quote:not(.is-large):not(.is-style-large),
 .wp-block-quote.is-large,
-.wp-block-quote.is-style-large {
+.wp-block-quote.is-style-large,
+.rtl .wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:left"],
+.rtl .wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: left"],
+.rtl .wp-block-quote.is-large[style*="text-align:left"],
+.rtl .wp-block-quote.is-large[style*="text-align: left"],
+.rtl .wp-block-quote.is-style-large[style*="text-align:left"],
+.rtl .wp-block-quote.is-style-large[style*="text-align: left"] {
 	border-left: 3px solid #eee;
+	border-right: 0;
 	line-height: 1.5;
 	padding-left: 24px;
+	padding-right: 0;
 }
 
 .wp-block-quote p,
@@ -347,11 +355,28 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .rtl .wp-block-quote:not(.is-large):not(.is-style-large),
 .rtl .wp-block-quote.is-large,
-.rtl .wp-block-quote.is-style-large {
+.rtl .wp-block-quote.is-style-large,
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:right"],
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: right"],
+.wp-block-quote.is-large[style*="text-align:right"],
+.wp-block-quote.is-large[style*="text-align: right"],
+.wp-block-quote.is-style-large[style*="text-align:right"],
+.wp-block-quote.is-style-large[style*="text-align: right"] {
 	border-left: 0;
 	border-right: 3px solid #eee;
 	padding-left: 0;
 	padding-right: 24px;
+}
+
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align:center"],
+.wp-block-quote:not(.is-large):not(.is-style-large)[style*="text-align: center"],
+.wp-block-quote.is-large[style*="text-align:center"],
+.wp-block-quote.is-large[style*="text-align: center"],
+.wp-block-quote.is-style-large[style*="text-align:center"],
+.wp-block-quote.is-style-large[style*="text-align: center"] {
+	border: 0;
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .rtl .wp-block-quote .wp-block-quote__citation {


### PR DESCRIPTION
Update quote block border styles to work better with the new styles planned for Gutenberg 5.2.

See #594.