### PR TITLE
Gazette: Align quote icon to right when text is right aligned

### DIFF
--- a/gazette/css/blocks.css
+++ b/gazette/css/blocks.css
@@ -49,6 +49,14 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Quote */
 
+.wp-block-quote[style*="text-align:right"]::before {
+	float: right;
+}
+
+.rtl .wp-block-quote[style*="text-align:left"]::before {
+	float: left;
+}
+
 /* Audio */
 
 .wp-block-audio {

--- a/gazette/css/editor-blocks.css
+++ b/gazette/css/editor-blocks.css
@@ -300,6 +300,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	width: 30px;
 }
 
+.wp-block-quote[style*="text-align:right"]:before,
+.wp-block-quote[style*="text-align: right"]:before {
+	float: right;
+}
+
 .wp-block-quote .wp-block-quote__citation {
 	color: #555;
 	font-family: Lato, sans-serif;
@@ -316,6 +321,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .rtl .wp-block-quote:before{
 	float: right;
+}
+
+.rtl .wp-block-quote[style*="text-align:left"]:before,
+.rtl .wp-block-quote[style*="text-align: left"]:before {
+	float: left;
 }
 
 


### PR DESCRIPTION
Align quote icon to right when text is right aligned, to mirror border behaviour coming to the quote block in Gutenberg 5.2.

See #594.