### PR TITLE
Libretto:  Align quote icon to right when text is right aligned

### DIFF
--- a/libretto/css/blocks.css
+++ b/libretto/css/blocks.css
@@ -118,6 +118,18 @@ p.has-drop-cap:not(:focus)::first-letter {
 	text-align: right;
 }
 
+.wp-block-quote[style="text-align:right"]:before {
+	content: "\201D";
+	left: auto;
+	right: -35px;
+}
+
+.rtl .wp-block-quote[style="text-align:left"]:before {
+	content: "\201C";
+	left: -35px;
+	right: auto;
+}
+
 /* Audio */
 
 .wp-block-audio {

--- a/libretto/css/editor-blocks.css
+++ b/libretto/css/editor-blocks.css
@@ -529,7 +529,9 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	padding: 0;
 }
 
-.editor-block-list__block .wp-block-quote:before {
+.wp-block-quote:before,
+.rtl .wp-block-quote[style*="text-align:left"]:before,
+.rtl .wp-block-quote[style*="text-align: left"]:before {
 	color: #ebe7e1;
 	content: "\201C";
 	display: block;
@@ -542,7 +544,9 @@ See: https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari
 	z-index: -1;
 }
 
-.rtl .editor-block-list__block .wp-block-quote:before {
+.rtl .wp-block-quote:before,
+.wp-block-quote[style*="text-align:right"]:before,
+.wp-block-quote[style*="text-align: right"]:before {
 	content: "\201D";
 	left: auto;
 	right: -35px;


### PR DESCRIPTION
Align quote icon to right when text is right aligned, to mirror border behaviour coming to the quote block in Gutenberg 5.2.

See #594.