### PR TITLE
Pique: Align quote icon to center when text is right aligned

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -224,6 +224,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Quote */
 
+.wp-block-quote::before {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
 .wp-block-quote cite {
 	text-align: right;
 }


### PR DESCRIPTION
Align quote icon to right when text is right aligned, to mirror border behaviour coming to the quote block in Gutenberg 5.2.

See #594.