### PR TITLE
Professional Business: Fix Centre Alignment

### DIFF
--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -3519,14 +3519,6 @@ body.page .main-navigation {
   }
 }
 
-@media only screen and (min-width: 768px) {
-  .entry .entry-content > *.aligncenter,
-  .entry .entry-summary > *.aligncenter {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
 /*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Remove the media query which was overriding this margin from being set, which shouldn't be overriden because an aligncenter class is present:

https://github.com/Automattic/themes/blob/040fda40e8d55dd8dcbd6219d66eae3c034100f8/professional-business/style.css#L3502-L3506

This is currently resulting in an issue with alignments with galleries. 

**Before:**

![hgfghfghffgh](https://user-images.githubusercontent.com/43215253/54159947-28895880-4446-11e9-8b28-6ea89eeaebd2.png)

**After:**

![gfdgfdgfdg](https://user-images.githubusercontent.com/43215253/54159964-3343ed80-4446-11e9-9906-037c1cad0302.png)

#### Related issue(s):

@automattic-ian mentioned this bug in Automattic/wp-calypso#28756