### PR TITLE
Multiple Themes: Fix Pinterest Icons Not Displaying

### DIFF
--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -950,7 +950,7 @@ a:active {
 	fill: #007bb6;
 }
 
-.jetpack-social-navigation ul li:hover a[href*="pinterest.com"] .icon {
+.jetpack-social-navigation ul li:hover a[href*="pinterest."] .icon {
 	fill: #cb2027;
 }
 

--- a/canard/style.css
+++ b/canard/style.css
@@ -950,7 +950,7 @@ a:visited {
 }
 
 /* Pinterest */
-.social-navigation a[href*="pinterest.com"]:before {
+.social-navigation a[href*="pinterest."]:before {
 	content: "\f210";
 }
 

--- a/gazette/style.css
+++ b/gazette/style.css
@@ -924,12 +924,12 @@ a:visited {
 }
 
 /* Pinterest */
-.social-navigation a[href*="pinterest.com"]:before {
+.social-navigation a[href*="pinterest."]:before {
 	content: "\f210";
 }
-.social-navigation a[href*="pinterest.com"]:active:before,
-.social-navigation a[href*="pinterest.com"]:focus:before,
-.social-navigation a[href*="pinterest.com"]:hover:before {
+.social-navigation a[href*="pinterest."]:active:before,
+.social-navigation a[href*="pinterest."]:focus:before,
+.social-navigation a[href*="pinterest."]:hover:before {
 	color: #cc2127;
 }
 

--- a/illustratr/style.css
+++ b/illustratr/style.css
@@ -1709,7 +1709,7 @@ Social
 .menu-social li a[href*='plus.google.com']:before {
     content: '\f206';
 }
-.menu-social li a[href*='pinterest.com']:before {
+.menu-social li a[href*='pinterest.']:before {
     content: '\f209';
 }
 .menu-social li a[href*='github.com']:before {

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -951,7 +951,7 @@ body:not(.libretto-has-header-image) .title-block {
   content: "L";
 }
 
-#social a[href*="pinterest.com"]:before {
+#social a[href*="pinterest."]:before {
   content: "N";
 }
 
@@ -1008,7 +1008,7 @@ body:not(.libretto-has-header-image) .title-block {
   background: #007bb6;
 }
 
-#social a[href*="pinterest.com"]:hover:before {
+#social a[href*="pinterest."]:hover:before {
   background: #cb2027;
 }
 

--- a/publication/style.css
+++ b/publication/style.css
@@ -1118,7 +1118,7 @@ a:visited {
 }
 
 /* Pinterest */
-.social-navigation a[href*="pinterest.com"]:before {
+.social-navigation a[href*="pinterest."]:before {
 	content: "\f210";
 }
 

--- a/rebalance/style.css
+++ b/rebalance/style.css
@@ -1031,7 +1031,7 @@ a:active {
 	content: '\f0e1';
 }
 
-.social-menu a[href*="pinterest.com"]:before {
+.social-menu a[href*="pinterest."]:before {
 	content: '\f0d2';
 }
 

--- a/sketch/style.css
+++ b/sketch/style.css
@@ -2030,7 +2030,7 @@ div.sharedaddy div.sd-block {
 .social-links ul a[href*='plus.google.com']:before {
     content: '\f206';
 }
-.social-links ul a[href*='pinterest.com']:before {
+.social-links ul a[href*='pinterest.']:before {
     content: '\f209';
 }
 .social-links ul a[href*='github.com']:before {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Pinterest links have dozens and dozens of TLDs, not just `.com` ones. Jetpack countered this in the last update by allowing any TLD to display the icon (Automattic/jetpack#11252). Themes should probably do the same, so I've tested this on Rebalance and Illustratr, and this should allow the Pinterest icon to display. 

There's quite a few things which should probably be updated with these social icons, for example, Path shut down a while ago. But that's a PR for another day, and there's a report of this specific issue already. 

Fixes #673
