### PR TITLE
Dyad 2: Fix Misleading Tagline Setting

### DIFF
--- a/dyad-2/inc/customizer.php
+++ b/dyad-2/inc/customizer.php
@@ -14,6 +14,7 @@ function dyad_2_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
+	$wp_customize->get_control( 'display_header_text' )->label = __( 'Display Site Title', 'dyad-2' );
 }
 add_action( 'customize_register', 'dyad_2_customize_register' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Updates the label causing confusion, as the site description cannot be hidden on Dyad 2

<img width="297" alt="Screenshot 2019-03-31 at 21 06 07" src="https://user-images.githubusercontent.com/43215253/55294360-1ec99400-53f9-11e9-8d3c-c96bf334b1c8.png">

#### Related issue(s):

Fixes #540 

cc @alaczek 