### PR TITLE
Independent Publisher 2: Fix Menu Toggle Colour not Changing

### DIFF
--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -836,8 +836,7 @@ input::-moz-focus-inner {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 	font-size: 17px;
 	font-weight: bold;
-	line-height: 1;
-	color: #a4a4a4;
+	line-height: 1;	
 	border: solid 2px currentColor;
 	border-radius: 4px;
 	background: none;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The more specific colour being set is overriding the colour of the buttons that change with different palettes. Removing this fixed colour ensures that palettes effect the mobile menu toggle too. 

Notice how the menu toggle has a different colour with this PR:

<img width="669" alt="Screenshot_2019-04-07_at_18 18 18" src="https://user-images.githubusercontent.com/43215253/55687715-0660f880-5968-11e9-98d1-16130b2e9a6e.png">
<img width="681" alt="Screenshot_2019-04-07_at_18 18 26" src="https://user-images.githubusercontent.com/43215253/55687716-06f98f00-5968-11e9-84a7-fa4c8ff37552.png">

Currently, they're identical regardless of palette. 

#### Related issue(s):

Fixes #711
