### PR TITLE
Canard: Fix Sub-Menu Overlap

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -3349,7 +3349,7 @@ a {
 		margin-top: -60px;
 	}
 	.blog .hentry:first-of-type {
-		margin-top: 0;
+		margin: 0;
 		position: relative;
 		bottom: 60px;
 		z-index: -1;

--- a/canard/style.css
+++ b/canard/style.css
@@ -3345,9 +3345,14 @@ a {
 		padding-top: 60px;
 	}
 	.archive .hentry:first-of-type,
-	.blog .hentry:first-of-type,
 	.search .hentry:first-of-type {
 		margin-top: -60px;
+	}
+	.blog .hentry:first-of-type {
+		margin-top: 0;
+		position: relative;
+		bottom: 60px;
+		z-index: -1;
 	}
 	.page .entry-footer {
 		margin-bottom: 30px;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Avoids using a negative margin for the blog page, it's fine for the other ones as there's a title in the way. This approach should hopefully prevent an overlap:

<img width="580" alt="Screenshot 2019-04-08 at 08 38 19" src="https://user-images.githubusercontent.com/43215253/55706676-b15dca80-59d9-11e9-876d-c363d176cfbf.png">

But look completely identical to current:

<img width="667" alt="Screenshot 2019-04-08 at 08 39 38" src="https://user-images.githubusercontent.com/43215253/55706751-e10cd280-59d9-11e9-9855-d62233189574.png">

#### Related issue(s):

Fixes #682