### PR TITLE
Radcliffe 2: Fix Media & Text Block Justification

### DIFF
--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -383,6 +383,10 @@ ul.wp-block-gallery li {
 
 /* Media & Text */
 
+.wp-block-media-text .wp-block-media-text__content {
+	margin: 0;
+}
+
 .wp-block-media-text *:last-child {
 	margin-bottom: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Override the margin set from the alignwide and alignfull styles which are causing the issue. 

**Before:**

<img width="1529" alt="Screenshot 2019-04-08 at 09 09 13" src="https://user-images.githubusercontent.com/43215253/55708517-06034480-59de-11e9-80f3-3f1616131c82.png">

**After:**

<img width="1501" alt="Screenshot 2019-04-08 at 09 08 57" src="https://user-images.githubusercontent.com/43215253/55708528-0c91bc00-59de-11e9-9677-e378c7a94710.png">


#### Related issue(s):

Fixes #695