### PR TITLE
Radcliffe 2: Fix Error Warning with Blocks CSS File

### DIFF
--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -213,8 +213,6 @@ ul.wp-block-gallery li {
 
 /* Audio */
 
-.wp-block-audio {}
-
 .wp-block-audio audio {
 	display: block;
 	min-width: 270px;
@@ -456,12 +454,6 @@ ul.wp-block-gallery li {
 }
 
 /* Latest Comments */
-
-.wp-block-latest-comments.not(.alignwide),
-.wp-block-latest-comments.not(.alignfull) {
-	margin-left: 0;
-	margin-right: 0;
-}
 
 .wp-block-latest-comments__comment,
 .wp-block-latest-comments__comment-date {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I noticed due to #717 an incredibly minor issue with the blocks file on Radcliffe 2, the screenshots show it best. This PR also cleans up a bit of styling for the audio block. 

### Current (when editing files) 

![Screenshot_20190408-214602](https://user-images.githubusercontent.com/43215253/55755959-5c0cd200-5a48-11e9-80f8-a3d354ff8006.jpg)

### With a correct :not selector (broken, they should be different alignments) 

<img width="1360" alt="Screenshot_2019-04-08_at_09 13 16" src="https://user-images.githubusercontent.com/43215253/55756003-7941a080-5a48-11e9-8aae-b2d6be69e3fa.png">

### With no Latest Comments Margin Adjusting 

<img width="1518" alt="Screenshot_2019-04-08_at_09 13 29" src="https://user-images.githubusercontent.com/43215253/55756087-9f674080-5a48-11e9-8d7d-e444df6aab5c.png">

Note how the widths are different, as they should be. 