### PR TITLE
Libretto: Hide Mobile Site Title if Selected

### DIFF
--- a/libretto/inc/custom-header.php
+++ b/libretto/inc/custom-header.php
@@ -46,6 +46,7 @@ if ( ! function_exists( 'libretto_header_style' ) ) :
 		<style type="text/css">
 		<?php if ( 'blank' === $header_text_color ) : // Hide text if user has set to hide ?>
 			.site-title,
+			.mobile-site-title,
 			.site-description {
 				position: absolute;
 				clip: rect(1px, 1px, 1px, 1px);


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adds the selector of the mobile site title to be hidden when selected to be so in the Customiser.

## Current (checkbox ticked or not) 

![Screenshot_20190409-111320](https://user-images.githubusercontent.com/43215253/55784353-13413180-5ab9-11e9-9020-5a72166fa3f6.jpg)

## Proposed (checkbox ticked only) 

![Screenshot_20190409-111301](https://user-images.githubusercontent.com/43215253/55784372-1e945d00-5ab9-11e9-8a71-95032767408f.jpg)

#### Related issue(s):

Fixes #480