### PR TITLE
Lodestar: Fix Cropped Gallery Block Size on Home Page

### DIFF
--- a/lodestar/assets/css/blocks.css
+++ b/lodestar/assets/css/blocks.css
@@ -80,11 +80,6 @@ body.lodestar-front-page:not(.has-sidebar) .lodestar-panel:not(.two-column) .wp-
 	height: 100% !important;
 }
 
-/* Prevent a cropped gallery block from having a distorted alignment on the home page. */
-.lodestar-intro .entry-content .wp-block-gallery.is-cropped :last-child {
-	margin-bottom: auto;
-}
-
 /*--------------------------------------------------------------
 2.0 General Block Styles
 --------------------------------------------------------------*/

--- a/lodestar/assets/css/blocks.css
+++ b/lodestar/assets/css/blocks.css
@@ -80,6 +80,11 @@ body.lodestar-front-page:not(.has-sidebar) .lodestar-panel:not(.two-column) .wp-
 	height: 100% !important;
 }
 
+/* Prevent a cropped gallery block from having a distorted alignment on the home page. */
+.lodestar-intro .entry-content .wp-block-gallery.is-cropped :last-child {
+	margin-bottom: auto;
+}
+
 /*--------------------------------------------------------------
 2.0 General Block Styles
 --------------------------------------------------------------*/

--- a/lodestar/style.css
+++ b/lodestar/style.css
@@ -1232,7 +1232,7 @@ body:not(.logged-in) .lodestar-panel .jetpack-testimonial .entry-header {
 	text-align: center;
 }
 
-.lodestar-intro .entry-content *:last-child {
+.lodestar-intro .entry-content > *:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Only the Gallery Block has the opportunity to crop images, and a margin of 0 shouldn't be applied to those blocks but only when cropped. When they're not cropped, the editor reflects an accurate version of what the theme displays. 

**Before:**

![Screenshot_20190410-130122](https://user-images.githubusercontent.com/43215253/55871060-91253b80-5b92-11e9-8a58-792ecc6071cc.jpg)

**After:**

![Screenshot_20190410-130108](https://user-images.githubusercontent.com/43215253/55871062-91253b80-5b92-11e9-9604-8c9656d7d4c2.jpg)

#### Related issue(s):

Fixes #724