### PR TITLE
Apostrophe 2: Offer an Option to Display a Mobile Social Menu

### DIFF
--- a/apostrophe-2/functions.php
+++ b/apostrophe-2/functions.php
@@ -293,6 +293,10 @@ function apostrophe_2_body_class( $classes ) {
 		$classes[] = 'apostrophe-2-no-sidebar';
 	}
 
+	if ( function_exists( 'jetpack_social_menu' ) && get_theme_mod( 'apostrophe_2_mobile_social' ) == 1 ) {
+		$classes[] = 'show-mobile-social-menu';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'apostrophe_2_body_class' );

--- a/apostrophe-2/inc/customizer.php
+++ b/apostrophe-2/inc/customizer.php
@@ -28,8 +28,8 @@ function apostrophe_2_customize_register( $wp_customize ) {
 
 		$wp_customize->add_control( 'apostrophe_2_mobile_social', array(
   			'type' => 'checkbox',
-  			'section' => 'nav_menu[2]',
-  			'label' => __( 'Display social menu on mobile devices' ),
+  			'section' => 'jetpack_content_options',
+  			'label' => __( 'Display social menu on mobile devices', 'apostrophe-2' ),
 		) );
 	}	
 }

--- a/apostrophe-2/inc/customizer.php
+++ b/apostrophe-2/inc/customizer.php
@@ -14,6 +14,18 @@ function apostrophe_2_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
+	
+	if ( function_exists( 'jetpack_social_menu' ) ) {
+		$wp_customize->add_setting( 'apostrophe_2_mobile_social', array(
+  			'capability' => 'edit_theme_options',
+		) );
+
+		$wp_customize->add_control( 'apostrophe_2_mobile_social', array(
+  			'type' => 'checkbox',
+  			'section' => 'nav_menu[2]',
+  			'label' => __( 'Display social menu on mobile devices' ),
+		) );
+	}	
 }
 add_action( 'customize_register', 'apostrophe_2_customize_register' );
 

--- a/apostrophe-2/inc/customizer.php
+++ b/apostrophe-2/inc/customizer.php
@@ -15,9 +15,15 @@ function apostrophe_2_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
 	
+	function apostrophe_2_sanitize_checkbox( $checked ){ 
+            return ( ( isset( $checked ) && true == $checked ) ? true : false );
+        }
+	
 	if ( function_exists( 'jetpack_social_menu' ) ) {
 		$wp_customize->add_setting( 'apostrophe_2_mobile_social', array(
   			'capability' => 'edit_theme_options',
+			'transport' => 'refresh',
+			'sanitize_callback'  => 'apostrophe_2_sanitize_checkbox',
 		) );
 
 		$wp_customize->add_control( 'apostrophe_2_mobile_social', array(

--- a/apostrophe-2/inc/jetpack.php
+++ b/apostrophe-2/inc/jetpack.php
@@ -61,23 +61,13 @@ function apostrophe_2_has_post_thumbnail( $post = null ) {
 }
 
 /**
- * Return early if Social Menu is not available and check if it should be displayed on mobile.
+ * Return early if Social Menu is not available.
  */
 function apostrophe_2_social_menu() {
 	if ( ! function_exists( 'jetpack_social_menu' ) ) {
 		return;
-	} 
-	
-	if ( function_exists( 'jetpack_social_menu' ) && ( get_theme_mod( 'apostrophe_2_mobile_social' ) == 0 )) {
+	} else {
 		jetpack_social_menu();
-	} 
-	
-	if ( function_exists( 'jetpack_social_menu' ) && ( get_theme_mod( 'apostrophe_2_mobile_social' ) == 1 ) ) {
-	?>
-		<div class="social-mobile-menu">
-			<?php jetpack_social_menu(); ?>
-		</div>
-	<?php
 	}
 }
 

--- a/apostrophe-2/inc/jetpack.php
+++ b/apostrophe-2/inc/jetpack.php
@@ -61,13 +61,23 @@ function apostrophe_2_has_post_thumbnail( $post = null ) {
 }
 
 /**
- * Return early if Social Menu is not available.
+ * Return early if Social Menu is not available and check if it should be displayed on mobile.
  */
 function apostrophe_2_social_menu() {
 	if ( ! function_exists( 'jetpack_social_menu' ) ) {
 		return;
-	} else {
+	} 
+	
+	if ( function_exists( 'jetpack_social_menu' ) && ( get_theme_mod( 'apostrophe_2_mobile_social' ) == 0 )) {
 		jetpack_social_menu();
+	} 
+	
+	if ( function_exists( 'jetpack_social_menu' ) && ( get_theme_mod( 'apostrophe_2_mobile_social' ) == 1 ) ) {
+	?>
+		<div class="social-mobile-menu">
+			<?php jetpack_social_menu(); ?>
+		</div>
+	<?php
 	}
 }
 

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -2776,7 +2776,7 @@ Primarily mobile devices and super-small tablets.
 	}
 	
 	/* Display the social menu if the user requests it */
-	.social-mobile-menu .jetpack-social-navigation {
+	.show-mobile-social-menu .jetpack-social-navigation {
     		display: block;
     		position: absolute;
     		top: 0;
@@ -2785,7 +2785,7 @@ Primarily mobile devices and super-small tablets.
    		width: 80%;
 	}
   
- 	.social-mobile-menu .jetpack-social-navigation ul li a {
+ 	.show-mobile-social-menu .jetpack-social-navigation ul li a {
      		margin-right: 10px;
     		padding: 0.75rem 0 1.5rem;
    		line-height: 45px;

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -2691,6 +2691,7 @@ Primarily mobile devices and super-small tablets.
 
 	.main-navigation {
 		margin: 10px 0 20px;
+		position: relative;
 	}
 
 	.main-navigation .menu-toggle {
@@ -2772,6 +2773,23 @@ Primarily mobile devices and super-small tablets.
 
 	.apostrophe-2-navigation .dropdown-toggle {
 		display: block;
+	}
+	
+	/* Display the social menu if the user requests it */
+	.social-mobile-menu .jetpack-social-navigation {
+    		display: block;
+    		position: absolute;
+    		top: 0;
+    		right: 0;
+		min-width: 5%;
+   		max-width: 80%;
+    		height: 50px;
+	}
+  
+ 	.social-mobile-menu .jetpack-social-navigation ul li a {
+     		margin-right: 2em;
+    		padding: 0.75rem 0 1.5rem;
+   		line-height: 45px;
 	}
 
 	/* Use a slightly smaller font size for titles */

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -2781,13 +2781,12 @@ Primarily mobile devices and super-small tablets.
     		position: absolute;
     		top: 0;
     		right: 0;
-		min-width: 5%;
-   		max-width: 80%;
-    		height: 50px;
+		height: 50px;
+   		width: 80%;
 	}
   
  	.social-mobile-menu .jetpack-social-navigation ul li a {
-     		margin-right: 2em;
+     		margin-right: 10px;
     		padding: 0.75rem 0 1.5rem;
    		line-height: 45px;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

It's my understanding that changes cannot be made which will affect all sites in risk of it being unwelcome by some users, however the menu on mobile devices with Apostrophe 2 uses a fraction of the space, and it seems very reasonable for users to want to display their social menu in the remaining space.

As such, this offers an option in the Customizer to do so. This will only appear after a social menu has been created.

<img width="296" alt="Screenshot 2019-04-21 at 21 12 36" src="https://user-images.githubusercontent.com/43215253/56475080-60d77a00-647b-11e9-9f86-43e97c0bcc57.png">

If checked, then the social menu will appear on mobile devices. If unchecked, it won't (which is what currently happens now in all cases).

<img width="467" alt="Screenshot 2019-04-21 at 21 17 21" src="https://user-images.githubusercontent.com/43215253/56475090-7a78c180-647b-11e9-9bbf-4060e3729efe.png">

#### Related issue(s):

Resolves #628 
