### PR TITLE
Calm Business: Fix Wide Separator Block

### DIFF
--- a/calm-business/style-editor.css
+++ b/calm-business/style-editor.css
@@ -626,6 +626,11 @@ hr:after {
   max-width: 3.25em;
 }
 
+.wp-block-separator.is-style-wide:after,
+hr.is-style-wide:after {
+  max-width: none;
+}
+
 @media only screen and (min-width: 768px) {
   .wp-block-separator.is-style-wide,
   hr.is-style-wide {

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -4167,6 +4167,11 @@ body.page .main-navigation {
   max-width: 100%;
 }
 
+.entry .entry-content .wp-block-separator.is-style-wide:after,
+.entry .entry-content hr.is-style-wide:after {
+  max-width: none;
+}
+
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Overrides the theme's own max-width of the :after for just the wide separator block

<img width="1374" alt="Screenshot 2019-05-01 at 17 52 53" src="https://user-images.githubusercontent.com/43215253/57029628-35524d80-6c3a-11e9-8bda-c11b55371b64.png">

#### Related issue(s):

Fixes #762 and fixes #751