### PR TITLE
Temp. fix for Jetpack Business Hours Block style for all 6 style variations

### DIFF
--- a/calm-business/style-editor.css
+++ b/calm-business/style-editor.css
@@ -903,3 +903,19 @@ ul.wp-block-archives li ul,
 [data-type="core/media-text"] a {
   color: inherit;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/calm-business/style-editor.scss
+++ b/calm-business/style-editor.scss
@@ -858,3 +858,22 @@ ul.wp-block-archives,
 		color: inherit;
 	}
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/calm-business/style-jetpack.css
+++ b/calm-business/style-jetpack.css
@@ -90,3 +90,20 @@
 /**
   * Content Options
   */
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/calm-business/style-jetpack.scss
+++ b/calm-business/style-jetpack.scss
@@ -26,26 +26,26 @@
 		outline-offset: -4px;
 	}
  }
- 
+
  /**
   * Responsive Videos
   */
- 
+
  /**
   * Sharing
   */
- 
+
  .entry div.sharedaddy h3.sd-title,
  .entry h3.sd-title {
      font-family: $font__heading;
      font-weight: $font__weight_semi_bold;
      letter-spacing: normal;
  }
- 
+
  /**
   * Related Posts
   */
- 
+
  .entry #jp-relatedposts h3.jp-relatedposts-headline {
      font-family: $font__heading;
      font-weight: $font__weight_semi_bold;
@@ -53,48 +53,69 @@
          font-weight: inherit;
      }
  }
- 
+
  .entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
      font-family: $font__body;
  }
- 
+
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
      font-family: $font__body;
  }
- 
+
  /**
   * Stats
   */
- 
+
  /**
   * Comments
   */
- 
+
  /**
   * Widgets
   */
- 
+
  /* Authors Widget */
  .widget_authors > ul > li > a {
      font-family: $font__body;
  }
- 
+
  /* Display WordPress Posts */
- 
+
  /* GoodReads */
- 
+
  /* EU cookie law */
  .widget_eu_cookie_law_widget #eu-cookie-law {
      font-family: $font__body;
  }
- 
+
  /* RSS Links */
  .widget_rss_links li {
      font-family: $font__body;
  }
- 
+
  /**
   * Content Options
   */
+
+ /**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+  dt,
+  dd {
+    float: left;
+  }
+
+  dt {
+    clear: both;
+    margin-right: ( $size__spacing-unit * .5 );
+  }
+
+  dd {
+    margin: 0;
+  }
+}

--- a/elegant-business/style-editor.css
+++ b/elegant-business/style-editor.css
@@ -802,3 +802,19 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/elegant-business/style-editor.scss
+++ b/elegant-business/style-editor.scss
@@ -780,3 +780,22 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/elegant-business/style-jetpack.css
+++ b/elegant-business/style-jetpack.css
@@ -95,3 +95,21 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
   color: #767676;
 }
+
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/elegant-business/style-jetpack.scss
+++ b/elegant-business/style-jetpack.scss
@@ -111,3 +111,24 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
 	color: #767676;
 }
+
+/**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -794,3 +794,19 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -810,3 +810,22 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/friendly-business/style-jetpack.css
+++ b/friendly-business/style-jetpack.css
@@ -83,3 +83,21 @@
 .entry-content .contact-form label span {
   color: #0d1b24;
 }
+
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/friendly-business/style-jetpack.scss
+++ b/friendly-business/style-jetpack.scss
@@ -94,3 +94,24 @@
 .entry-content .contact-form label span {
 	color: $color__text-dark;
 }
+
+/**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -831,3 +831,19 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -833,3 +833,22 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/modern-business/style-jetpack.css
+++ b/modern-business/style-jetpack.css
@@ -73,3 +73,21 @@
   color: inherit;
   font-weight: 300;
 }
+
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/modern-business/style-jetpack.scss
+++ b/modern-business/style-jetpack.scss
@@ -79,3 +79,24 @@
 	color: inherit;
 	font-weight: 300;
 }
+
+/**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/professional-business/style-editor.css
+++ b/professional-business/style-editor.css
@@ -782,3 +782,19 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/professional-business/style-editor.scss
+++ b/professional-business/style-editor.scss
@@ -786,3 +786,23 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}
+

--- a/professional-business/style-jetpack.css
+++ b/professional-business/style-jetpack.css
@@ -68,3 +68,20 @@
 /**
  * Content Options
  */
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/professional-business/style-jetpack.scss
+++ b/professional-business/style-jetpack.scss
@@ -78,3 +78,24 @@
 /**
  * Content Options
  */
+
+/**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/sophisticated-business/style-editor.css
+++ b/sophisticated-business/style-editor.css
@@ -792,3 +792,19 @@ ul.wp-block-archives li ul,
   background-color: transparent;
   color: #fff !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+.wp-block-jetpack-business-hours dt,
+.wp-block-jetpack-business-hours dd {
+  float: left;
+}
+
+.wp-block-jetpack-business-hours dt {
+  clear: both;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.wp-block-jetpack-business-hours dd {
+  margin: 0;
+}

--- a/sophisticated-business/style-editor.scss
+++ b/sophisticated-business/style-editor.scss
@@ -801,3 +801,22 @@ ul.wp-block-archives,
 	background-color: transparent;
 	color: #fff !important;
 }
+
+/** === Business Hours Block - Temp Fix === */
+
+.wp-block-jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		font-weight: bold;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}

--- a/sophisticated-business/style-jetpack.css
+++ b/sophisticated-business/style-jetpack.css
@@ -110,3 +110,21 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
   color: #767676;
 }
+
+/**
+ * Blocks
+ */
+/* Business Hours - Temp Fix */
+.jetpack-business-hours dt,
+.jetpack-business-hours dd {
+  float: left;
+}
+
+.jetpack-business-hours dt {
+  clear: both;
+  margin-right: 0.5rem;
+}
+
+.jetpack-business-hours dd {
+  margin: 0;
+}

--- a/sophisticated-business/style-jetpack.scss
+++ b/sophisticated-business/style-jetpack.scss
@@ -122,3 +122,24 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
 	color: #767676;
 }
+
+/**
+ * Blocks
+ */
+
+/* Business Hours - Temp Fix */
+.jetpack-business-hours {
+	dt,
+	dd {
+		float: left;
+	}
+
+	dt {
+		clear: both;
+		margin-right: ( $size__spacing-unit * .5 );
+	}
+
+	dd {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Ideally, this simple style fix should be added to the block itself, but we can't wait for the fix to land in WP.com for Onboarding.

We should remove this when the style is added in the block and becomes available in WP.com.

#### With this PR the block should look like this:
<img width="420" alt="Screen Shot 2019-05-09 at 22 21 52" src="https://user-images.githubusercontent.com/908665/57487598-ec893d00-72a8-11e9-8c55-3f06c87182d9.png">


#### Related issue(s):
Fixes: #757

