### PR TITLE
Temp style enhancements for Mailchimp block for all 6 style variations

### DIFF
--- a/calm-business/style-editor.css
+++ b/calm-business/style-editor.css
@@ -903,3 +903,8 @@ ul.wp-block-archives li ul,
 [data-type="core/media-text"] a {
   color: inherit;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/calm-business/style-editor.scss
+++ b/calm-business/style-editor.scss
@@ -858,3 +858,10 @@ ul.wp-block-archives,
 		color: inherit;
 	}
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/calm-business/style-jetpack.css
+++ b/calm-business/style-jetpack.css
@@ -90,3 +90,11 @@
 /**
   * Content Options
   */
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/calm-business/style-jetpack.scss
+++ b/calm-business/style-jetpack.scss
@@ -26,26 +26,26 @@
 		outline-offset: -4px;
 	}
  }
- 
+
  /**
   * Responsive Videos
   */
- 
+
  /**
   * Sharing
   */
- 
+
  .entry div.sharedaddy h3.sd-title,
  .entry h3.sd-title {
      font-family: $font__heading;
      font-weight: $font__weight_semi_bold;
      letter-spacing: normal;
  }
- 
+
  /**
   * Related Posts
   */
- 
+
  .entry #jp-relatedposts h3.jp-relatedposts-headline {
      font-family: $font__heading;
      font-weight: $font__weight_semi_bold;
@@ -53,48 +53,59 @@
          font-weight: inherit;
      }
  }
- 
+
  .entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
      font-family: $font__body;
  }
- 
+
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
  .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
      font-family: $font__body;
  }
- 
+
  /**
   * Stats
   */
- 
+
  /**
   * Comments
   */
- 
+
  /**
   * Widgets
   */
- 
+
  /* Authors Widget */
  .widget_authors > ul > li > a {
      font-family: $font__body;
  }
- 
+
  /* Display WordPress Posts */
- 
+
  /* GoodReads */
- 
+
  /* EU cookie law */
  .widget_eu_cookie_law_widget #eu-cookie-law {
      font-family: $font__body;
  }
- 
+
  /* RSS Links */
  .widget_rss_links li {
      font-family: $font__body;
  }
- 
+
  /**
   * Content Options
   */
+
+ /* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+  input[type="email"] {
+    width: 100%;
+  }
+
+  #wp-block-jetpack-mailchimp_consent-text {
+    font-size: $font__size-xs;
+  }
+}

--- a/elegant-business/style-editor.css
+++ b/elegant-business/style-editor.css
@@ -802,3 +802,8 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/elegant-business/style-editor.scss
+++ b/elegant-business/style-editor.scss
@@ -780,3 +780,10 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/elegant-business/style-jetpack.css
+++ b/elegant-business/style-jetpack.css
@@ -95,3 +95,12 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
   color: #767676;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/elegant-business/style-jetpack.scss
+++ b/elegant-business/style-jetpack.scss
@@ -111,3 +111,14 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
 	color: #767676;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+	input[type="email"] {
+		width: 100%;
+	}
+
+	#wp-block-jetpack-mailchimp_consent-text {
+		font-size: $font__size-xs;
+	}
+}

--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -794,3 +794,8 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -810,3 +810,10 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/friendly-business/style-jetpack.css
+++ b/friendly-business/style-jetpack.css
@@ -83,3 +83,12 @@
 .entry-content .contact-form label span {
   color: #0d1b24;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/friendly-business/style-jetpack.scss
+++ b/friendly-business/style-jetpack.scss
@@ -94,3 +94,14 @@
 .entry-content .contact-form label span {
 	color: $color__text-dark;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+	input[type="email"] {
+		width: 100%;
+	}
+
+	#wp-block-jetpack-mailchimp_consent-text {
+		font-size: $font__size-xs;
+	}
+}

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -831,3 +831,8 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -833,3 +833,10 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/modern-business/style-jetpack.css
+++ b/modern-business/style-jetpack.css
@@ -73,3 +73,12 @@
   color: inherit;
   font-weight: 300;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/modern-business/style-jetpack.scss
+++ b/modern-business/style-jetpack.scss
@@ -79,3 +79,14 @@
 	color: inherit;
 	font-weight: 300;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+	input[type="email"] {
+		width: 100%;
+	}
+
+	#wp-block-jetpack-mailchimp_consent-text {
+		font-size: $font__size-xs;
+	}
+}

--- a/professional-business/style-editor.css
+++ b/professional-business/style-editor.css
@@ -782,3 +782,8 @@ ul.wp-block-archives li ul,
 .wp-block[data-type="core/freeform"] .mce-btn i {
   font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/professional-business/style-editor.scss
+++ b/professional-business/style-editor.scss
@@ -786,3 +786,10 @@ ul.wp-block-archives,
 .wp-block[data-type="core/freeform"] .mce-btn i {
 	font-family: dashicons !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/professional-business/style-jetpack.css
+++ b/professional-business/style-jetpack.css
@@ -68,3 +68,11 @@
 /**
  * Content Options
  */
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/professional-business/style-jetpack.scss
+++ b/professional-business/style-jetpack.scss
@@ -78,3 +78,14 @@
 /**
  * Content Options
  */
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+	input[type="email"] {
+		width: 100%;
+	}
+
+	#wp-block-jetpack-mailchimp_consent-text {
+		font-size: $font__size-xs;
+	}
+}

--- a/sophisticated-business/style-editor.css
+++ b/sophisticated-business/style-editor.css
@@ -792,3 +792,8 @@ ul.wp-block-archives li ul,
   background-color: transparent;
   color: #fff !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp p {
+  font-size: 0.71111em;
+}

--- a/sophisticated-business/style-editor.scss
+++ b/sophisticated-business/style-editor.scss
@@ -801,3 +801,10 @@ ul.wp-block-archives,
 	background-color: transparent;
 	color: #fff !important;
 }
+
+/** === Mailchimp Block - Temp Fix === */
+.wp-block-jetpack-mailchimp {
+	p {
+		font-size: $font__size-xs;
+	}
+}

--- a/sophisticated-business/style-jetpack.css
+++ b/sophisticated-business/style-jetpack.css
@@ -110,3 +110,12 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
   color: #767676;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp input[type="email"] {
+  width: 100%;
+}
+
+.wp-block-jetpack-mailchimp #wp-block-jetpack-mailchimp_consent-text {
+  font-size: 0.71111em;
+}

--- a/sophisticated-business/style-jetpack.scss
+++ b/sophisticated-business/style-jetpack.scss
@@ -122,3 +122,14 @@ div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedp
 .contact-form label span {
 	color: #767676;
 }
+
+/* Mailchimp Block - Temp Fix */
+.wp-block-jetpack-mailchimp {
+	input[type="email"] {
+		width: 100%;
+	}
+
+	#wp-block-jetpack-mailchimp_consent-text {
+		font-size: $font__size-xs;
+	}
+}


### PR DESCRIPTION
Ideally, this should be fixed in the block itself and the Twenty Nineteen compat file in Jetpack, but we can't wait for those for Onboarding.

#### Changes proposed in this Pull Request:
* 100% width input field
* Smaller consent text

#### WIth this PR the block should look
<img width="896" alt="Screen Shot 2019-05-10 at 00 56 19" src="https://user-images.githubusercontent.com/908665/57493814-768fd080-72be-11e9-884a-db8ebb56c012.png">

#### Related issue:
See #760