### PR TITLE
Sophisticated Business: Fixing font-weight for legacy cover block

### DIFF
--- a/sophisticated-business/sass/blocks/_blocks.scss
+++ b/sophisticated-business/sass/blocks/_blocks.scss
@@ -568,6 +568,7 @@
 		.wp-block-cover-text,
 		h2 {
 			font-size: $font__size-xl;
+			font-weight: 700;
 			margin: inherit;
 			max-width: inherit;
 			text-align: inherit;

--- a/sophisticated-business/style-rtl.css
+++ b/sophisticated-business/style-rtl.css
@@ -3929,6 +3929,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-size: 2.25em;
+  font-weight: 700;
   margin: inherit;
   max-width: inherit;
   text-align: inherit;

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -3941,6 +3941,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-size: 2.25em;
+  font-weight: 700;
   margin: inherit;
   max-width: inherit;
   text-align: inherit;


### PR DESCRIPTION
Fixes font weight for legacy Cover block classes: `.wp-block-cover-text` and `.wp-block-cover-image-text`.

#### Related issue(s):

#803 