### PR TITLE
All style variations: Add a utility css class for spacer block

### DIFF
--- a/calm-business/sass/blocks/_blocks.scss
+++ b/calm-business/sass/blocks/_blocks.scss
@@ -710,6 +710,17 @@
 		}
 	}
 
+	//! Spacer
+	.wp-block-spacer {
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
+	}
+
 	//! Twitter Embed
 	.wp-block-embed-twitter {
 		word-break: break-word;

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -4230,6 +4230,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -4242,6 +4242,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/elegant-business/sass/blocks/_blocks.scss
+++ b/elegant-business/sass/blocks/_blocks.scss
@@ -680,10 +680,15 @@
 		}
 	}
 
-	//! Separator
+	//! Spacer
 	.wp-block-spacer {
-		margin-bottom: $size__vertical-spacing-unit;
-		margin-top: $size__vertical-spacing-unit;
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
 	}
 
 	//! Twitter Embed

--- a/elegant-business/style-rtl.css
+++ b/elegant-business/style-rtl.css
@@ -4105,9 +4105,14 @@ body.page .main-navigation {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer {
-  margin-bottom: 32px;
-  margin-top: 32px;
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
 }
 
 .entry .entry-content .wp-block-embed-twitter {

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -4117,9 +4117,14 @@ body.page .main-navigation {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer {
-  margin-bottom: 32px;
-  margin-top: 32px;
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
 }
 
 .entry .entry-content .wp-block-embed-twitter {

--- a/friendly-business/sass/blocks/_blocks.scss
+++ b/friendly-business/sass/blocks/_blocks.scss
@@ -635,6 +635,17 @@
 		}
 	}
 
+	//! Spacer
+	.wp-block-spacer {
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
+	}
+
 	//! Twitter Embed
 	.wp-block-embed-twitter {
 		word-break: break-word;

--- a/friendly-business/style-rtl.css
+++ b/friendly-business/style-rtl.css
@@ -3988,6 +3988,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/friendly-business/style.css
+++ b/friendly-business/style.css
@@ -4000,6 +4000,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -805,6 +805,17 @@
 		}
 	}
 
+	//! Spacer
+	.wp-block-spacer {
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
+	}
+
 	//! Twitter Embed
 	.wp-block-embed-twitter {
 		word-break: break-word;

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -4255,6 +4255,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -4267,6 +4267,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/professional-business/sass/blocks/_blocks.scss
+++ b/professional-business/sass/blocks/_blocks.scss
@@ -681,6 +681,17 @@
 		}
 	}
 
+	//! Spacer
+	.wp-block-spacer {
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
+	}
+
 	//! Twitter Embed
 	.wp-block-embed-twitter {
 		word-break: break-word;

--- a/professional-business/style-rtl.css
+++ b/professional-business/style-rtl.css
@@ -4134,6 +4134,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -4146,6 +4146,16 @@ body.page .main-navigation {
   display: none;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/sophisticated-business/sass/blocks/_blocks.scss
+++ b/sophisticated-business/sass/blocks/_blocks.scss
@@ -746,6 +746,17 @@
 		}
 	}
 
+	//! Spacer
+	.wp-block-spacer {
+		&.desktop-only {
+			display: none;
+
+			@include media(tablet) {
+				display: block;
+			}
+		}
+	}
+
 	//! Twitter Embed
 	.wp-block-embed-twitter {
 		word-break: break-word;

--- a/sophisticated-business/style-rtl.css
+++ b/sophisticated-business/style-rtl.css
@@ -4158,6 +4158,16 @@ body.page .main-navigation {
   padding-right: 0.88889em;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -4170,6 +4170,16 @@ body.page .main-navigation {
   padding-left: 0.88889em;
 }
 
+.entry .entry-content .wp-block-spacer.desktop-only {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-spacer.desktop-only {
+    display: block;
+  }
+}
+
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }


### PR DESCRIPTION
Fixes #746 

It might not ideal to add our own utility class for a space block, but until when we have wpcom stylesheet, we can leave it here.

Testing:
* Add a spacer block to a page.
* Add a css class`desktop-only` to the block.
* View it with under 786px viewport.