### PR TITLE
Calm Business: Make sure the first block has margin-top: 0

### DIFF
--- a/calm-business/sass/blocks/_blocks.scss
+++ b/calm-business/sass/blocks/_blocks.scss
@@ -93,6 +93,13 @@
 }
 
 /*
+ * Make sure the first block has margin-top: 0
+ */
+.entry:not(.has-post-thumbnail) .entry-content > :first-child {
+	margin-top: 0;
+}
+
+/*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
  * - helps with plugin compatibility

--- a/calm-business/sass/site/primary/_posts-and-pages.scss
+++ b/calm-business/sass/site/primary/_posts-and-pages.scss
@@ -32,11 +32,11 @@
 
 	.entry-header {
 
-		margin: calc(3 * #{ $size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+		margin: calc(3 * #{ $size__spacing-unit}) $size__spacing-unit $size__vertical-spacing-unit;
 		position: relative;
 
 		@include media(tablet) {
-			margin: calc(3 * 1rem) auto calc(1rem / 2);
+			margin: calc(3 * 1rem) auto $size__vertical-spacing-unit;
     		max-width: $size__site-tablet-content;
 		}
 
@@ -47,16 +47,16 @@
 
 	.entry-title {
 		font-size: $font__size-lg;
+		margin: 0;
+
 		@include media(tablet) {
-			margin: 32px auto;
+			margin: $size__vertical-spacing-unit auto;
 			max-width: $size__site-tablet-content;
 		}
 
 		@include media(desktop) {
 			max-width: $size__site-desktop-content;
 		}
-
-		margin: 0;
 
 		a {
 			color: inherit;

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -2380,13 +2380,13 @@ body.page .main-navigation {
 }
 
 .entry .entry-header {
-  margin: calc(3 * 1rem) 1rem 1rem;
+  margin: calc(3 * 1rem) 1rem 32px;
   position: relative;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
-    margin: calc(3 * 1rem) auto calc(1rem / 2);
+    margin: calc(3 * 1rem) auto 32px;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -986,7 +986,6 @@ form p {
 .contact-form input[type="datetime-local"],
 .contact-form input[type="color"] {
   margin-bottom: 13.6px;
-  min-width: 300px;
   min-height: 56px;
 }
 
@@ -3602,6 +3601,13 @@ body.page .main-navigation {
 }
 
 /*
+ * Make sure the first block has margin-top: 0
+ */
+.entry:not(.has-post-thumbnail) .entry-content > :first-child {
+  margin-top: 0;
+}
+
+/*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
  * - helps with plugin compatibility
@@ -4485,7 +4491,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content {
-    padding: 0 8%;
+    padding: 32px 8%;
   }
 }
 

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -3613,6 +3613,13 @@ body.page .main-navigation {
 }
 
 /*
+ * Make sure the first block has margin-top: 0
+ */
+.entry:not(.has-post-thumbnail) .entry-content > :first-child {
+  margin-top: 0;
+}
+
+/*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
  * - helps with plugin compatibility

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -2386,13 +2386,13 @@ body.page .main-navigation {
 }
 
 .entry .entry-header {
-  margin: calc(3 * 1rem) 1rem 1rem;
+  margin: calc(3 * 1rem) 1rem 32px;
   position: relative;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
-    margin: calc(3 * 1rem) auto calc(1rem / 2);
+    margin: calc(3 * 1rem) auto 32px;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes the top margin of the first child element of `.entry-content`.

#### Related issue(s):

@iamtakashi, I didn’t see an original issue for this theme, but I figured it needed the fix any way. If we don’t need it fixed in this theme, you can go ahead and close/reject this PR. See #999 for similar issue.