### PR TITLE
Independent Publisher 2: Changed display mode of summary tag

### DIFF
--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -80,9 +80,12 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
+}
+
+summary {
+	display: list-item;
 }
 
 audio,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
By default the `<summary>` tag displays black triangle.
Due to inconsistent behavior between browsers, by design Firefox does not show the triangle when summary's `display` mode is set to `block`. To show the triangle summary should be displayed as a `list-item`. The behavior is discribed in [Firefox documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#Default_style). This pull request brings consistency back.

#### Related issue(s):
None