### PR TITLE
Shoreditch: Ensure Site Header isn't Overlapped

### DIFF
--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -938,7 +938,7 @@ label {
 	-ms-flex-wrap: wrap;
 	flex-wrap: wrap;
 	position: relative;
-	z-index: 1;
+	z-index: 9999;
 }
 
 .site-branding {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This increases the z-index of the `site-header-wrapper` class. Two is enough to override the Slideshow Block, but I suspect there's several other cases where this issue can occur, so 9999 seems like a safe value as I don't think that the site header should ever be hidden. 

**Before:**

<img width="303" alt="Screenshot 2019-07-07 at 13 42 49" src="https://user-images.githubusercontent.com/43215253/60768587-7bee7900-a0bd-11e9-887b-f5ca1a454969.png">

**After:**

<img width="560" alt="Screenshot 2019-07-07 at 13 43 09" src="https://user-images.githubusercontent.com/43215253/60768589-814bc380-a0bd-11e9-98ae-bfe500cd3ea0.png">

#### Related issue(s):

Fixes #1053