### PR TITLE
Modern Business: add FSE support

### DIFF
--- a/modern-business/footer.php
+++ b/modern-business/footer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * The template for displaying the footer
+ *
+ * Contains the closing of the #content div and all content after.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package WordPress
+ * @subpackage Twenty_Nineteen
+ * @since 1.0.0
+ */
+
+?>
+
+</div><!-- #content -->
+
+<?php
+// If FSE plugin is active, use Footer template part for content.
+if( defined( 'A8C_FSE_VERSION' ) ) {
+	fse_get_footer();
+}
+
+// Otherwise we'll fall back to default Twenty Nineteen footer below.
+?>
+
+<?php if( ! defined( 'A8C_FSE_VERSION' ) ) : ?>
+	<footer id="colophon" class="site-footer">
+		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
+		<div class="site-info">
+			<?php $blog_info = get_bloginfo( 'name' ); ?>
+			<?php if ( ! empty( $blog_info ) ) : ?>
+				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
+			<?php endif; ?>
+			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
+				<?php
+				/* translators: %s: WordPress. */
+				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
+				?>
+			</a>
+			<?php
+			if ( function_exists( 'the_privacy_policy_link' ) ) {
+				the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+			}
+			?>
+			<?php if ( has_nav_menu( 'footer' ) ) : ?>
+				<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'twentynineteen' ); ?>">
+					<?php
+					wp_nav_menu(
+						array(
+							'theme_location' => 'footer',
+							'menu_class'     => 'footer-menu',
+							'depth'          => 1,
+						)
+					);
+					?>
+				</nav><!-- .footer-navigation -->
+			<?php endif; ?>
+		</div><!-- .site-info -->
+	</footer><!-- #colophon -->
+<?php endif; ?>
+
+</div><!-- #page -->
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/modern-business/footer.php
+++ b/modern-business/footer.php
@@ -17,14 +17,14 @@
 
 <?php
 // If FSE plugin is active, use Footer template part for content.
-if( defined( 'A8C_FSE_VERSION' ) ) {
+if( class_exists( 'Full_Site_Editing' ) ) {
 	fse_get_footer();
 }
 
 // Otherwise we'll fall back to default Twenty Nineteen footer below.
 ?>
 
-<?php if( ! defined( 'A8C_FSE_VERSION' ) ) : ?>
+<?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
 	<footer id="colophon" class="site-footer">
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 		<div class="site-info">

--- a/modern-business/functions.php
+++ b/modern-business/functions.php
@@ -83,3 +83,15 @@ require get_stylesheet_directory() . '/inc/jetpack.php';
  * WP.com compatibility file.
  */
 require get_stylesheet_directory() . '/inc/wpcom.php';
+
+/**
+ * Full Site Editing template data population file.
+ */
+require get_stylesheet_directory() . '/inc/fse-template-data.php';
+
+function a8c_fse_insert_theme_template_data() {
+	$data_inserter = new A8C_WP_Template_Data_Inserter();
+	$data_inserter->insert_default_template_data();
+}
+
+add_action( 'after_switch_theme', 'a8c_fse_insert_theme_template_data' );

--- a/modern-business/header.php
+++ b/modern-business/header.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * The header for our theme
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package WordPress
+ * @subpackage Twenty_Nineteen
+ * @since 1.0.0
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="profile" href="https://gmpg.org/xfn/11" />
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<div id="page" class="site">
+    <a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentynineteen' ); ?></a>
+
+    <?php
+        // If FSE plugin is active, use Header template part for content.
+        if( defined( 'A8C_FSE_VERSION' ) ) {
+            fse_get_header();
+        }
+
+        // Otherwise we'll fall back to default Twenty Nineteen header below.
+    ?>
+
+    <?php if( ! defined( 'A8C_FSE_VERSION' ) ) : ?>
+
+        <header id="masthead" class="<?php echo is_singular() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header'; ?>">
+            <div class="site-branding-container">
+                <?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
+            </div><!-- .site-branding-container -->
+
+            <?php if ( is_singular() && twentynineteen_can_show_post_thumbnail() ) : ?>
+                <div class="site-featured-image">
+                    <?php
+                    twentynineteen_post_thumbnail();
+                    the_post();
+                    $discussion = ! is_page() && twentynineteen_can_show_post_thumbnail() ? twentynineteen_get_discussion_data() : null;
+
+                    $classes = 'entry-header';
+                    if ( ! empty( $discussion ) && absint( $discussion->responses ) > 0 ) {
+                        $classes = 'entry-header has-discussion';
+                    }
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+                    </div><!-- .entry-header -->
+                    <?php rewind_posts(); ?>
+                </div>
+            <?php endif; ?>
+        </header><!-- #masthead -->
+    <?php endif; ?>
+
+    <div id="content" class="site-content">

--- a/modern-business/header.php
+++ b/modern-business/header.php
@@ -26,14 +26,14 @@
 
     <?php
         // If FSE plugin is active, use Header template part for content.
-        if( defined( 'A8C_FSE_VERSION' ) ) {
+        if( class_exists( 'Full_Site_Editing' ) ) {
             fse_get_header();
         }
 
         // Otherwise we'll fall back to default Twenty Nineteen header below.
     ?>
 
-    <?php if( ! defined( 'A8C_FSE_VERSION' ) ) : ?>
+    <?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
 
         <header id="masthead" class="<?php echo is_singular() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header'; ?>">
             <div class="site-branding-container">

--- a/modern-business/inc/fse-template-data.php
+++ b/modern-business/inc/fse-template-data.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Template data inserter file.
+ *
+ * @package full-site-editing
+ */
+
+/**
+ * Class A8C_WP_Template_Data_Inserter
+ */
+class A8C_WP_Template_Data_Inserter {
+	/**
+	 * This function will be called on plugin activation hook.
+	 */
+	public function insert_default_template_data() {
+		$current_theme_name = get_option( 'stylesheet' );
+		/**
+		 * This site option will be used to indicate that template data has already been
+		 * inserted for this theme, in order to prevent this functionality from running
+		 * more than once.
+		 */
+		$fse_template_data_option = $current_theme_name . '-fse-template-data';
+
+		if ( get_option( $fse_template_data_option ) ) {
+			/*
+			 * Bail here to prevent inserting the FSE data twice for any given theme.
+			 * Multiple themes will still be able to insert different template parts.
+			 */
+			return;
+		}
+
+		$this->register_template_post_types();
+
+		$header_id = wp_insert_post(
+			[
+				'post_title'     => 'Header',
+				'post_content'   => $this->get_header_content(),
+				'post_status'    => 'publish',
+				'post_type'      => 'wp_template_part',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			]
+		);
+
+		if ( ! term_exists( "$current_theme_name-header", 'wp_template_part_type' ) ) {
+			wp_insert_term( "$current_theme_name-header", 'wp_template_part_type' );
+		}
+
+		wp_set_object_terms( $header_id, "$current_theme_name-header", 'wp_template_part_type' );
+
+		$footer_id = wp_insert_post(
+			[
+				'post_title'     => 'Footer',
+				'post_content'   => $this->get_footer_content(),
+				'post_status'    => 'publish',
+				'post_type'      => 'wp_template_part',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			]
+		);
+
+		if ( ! term_exists( "$current_theme_name-footer", 'wp_template_part_type' ) ) {
+			wp_insert_term( "$current_theme_name-footer", 'wp_template_part_type' );
+		}
+
+		wp_set_object_terms( $footer_id, "$current_theme_name-footer", 'wp_template_part_type' );
+
+		$page_template_id = wp_insert_post(
+			[
+				'post_title'     => 'Page Template',
+				'post_content'   => $this->get_template_content( $header_id, $footer_id ),
+				'post_status'    => 'publish',
+				'post_type'      => 'wp_template',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			]
+		);
+
+		if ( ! term_exists( "$current_theme_name-page-template", 'wp_template_type' ) ) {
+			wp_insert_term( "$current_theme_name-page-template", 'wp_template_type' );
+		}
+
+		wp_set_object_terms( $page_template_id, "$current_theme_name-page-template", 'wp_template_type' );
+
+		add_option( $fse_template_data_option, true );
+	}
+
+	/**
+	 * Returns default header template part content.
+	 *
+	 * @return string
+	 */
+	public function get_header_content() {
+		// TODO: replace with header blocks once they are ready.
+		return '<!-- wp:group {"className":"site-header site-branding"} -->' .
+		       '<div class="wp-block-group site-header site-branding">' .
+		       '<div class="wp-block-group__inner-container">' .
+		       '<!-- wp:a8c/site-description /-->' .
+		       '<!-- wp:a8c/site-title /-->' .
+		       '<!-- wp:a8c/navigation-menu /-->' .
+		       '</div></div>' .
+		       '<!-- /wp:group -->';
+	}
+
+	/**
+	 * Returns default footer template part content.
+	 *
+	 * @return string
+	 */
+	public function get_footer_content() {
+		return '<!-- wp:a8c/navigation-menu {\"themeLocation\":"footer"} /-->';
+	}
+
+	/**
+	 * Returns default page template content.
+	 *
+	 * @param int $header_id ID of referenced header template part CPT.
+	 * @param int $footer_id ID of referenced footer template part CPT.
+	 *
+	 * @return string
+	 */
+	public function get_template_content( $header_id, $footer_id ) {
+		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"align\":\"full\"} /-->" .
+		       '<!-- wp:a8c/post-content {"align":"full"} /-->' .
+		       "<!-- wp:a8c/template {\"templateId\":$footer_id,\"align\":\"full\"} /-->";
+	}
+
+	/**
+	 * Register post types.
+	 */
+	public function register_template_post_types() {
+		register_post_type(
+			'wp_template',
+			array(
+				'labels'                => array(
+					'name'                     => _x( 'Templates', 'post type general name', 'full-site-editing' ),
+					'singular_name'            => _x( 'Template', 'post type singular name', 'full-site-editing' ),
+					'menu_name'                => _x( 'Templates', 'admin menu', 'full-site-editing' ),
+					'name_admin_bar'           => _x( 'Template', 'add new on admin bar', 'full-site-editing' ),
+					'add_new'                  => _x( 'Add New', 'Template', 'full-site-editing' ),
+					'add_new_item'             => __( 'Add New Template', 'full-site-editing' ),
+					'new_item'                 => __( 'New Template', 'full-site-editing' ),
+					'edit_item'                => __( 'Edit Template', 'full-site-editing' ),
+					'view_item'                => __( 'View Template', 'full-site-editing' ),
+					'all_items'                => __( 'All Templates', 'full-site-editing' ),
+					'search_items'             => __( 'Search Templates', 'full-site-editing' ),
+					'not_found'                => __( 'No templates found.', 'full-site-editing' ),
+					'not_found_in_trash'       => __( 'No templates found in Trash.', 'full-site-editing' ),
+					'filter_items_list'        => __( 'Filter templates list', 'full-site-editing' ),
+					'items_list_navigation'    => __( 'Templates list navigation', 'full-site-editing' ),
+					'items_list'               => __( 'Templates list', 'full-site-editing' ),
+					'item_published'           => __( 'Template published.', 'full-site-editing' ),
+					'item_published_privately' => __( 'Template published privately.', 'full-site-editing' ),
+					'item_reverted_to_draft'   => __( 'Template reverted to draft.', 'full-site-editing' ),
+					'item_scheduled'           => __( 'Template scheduled.', 'full-site-editing' ),
+					'item_updated'             => __( 'Template updated.', 'full-site-editing' ),
+				),
+				'menu_icon'             => 'dashicons-layout',
+				'public'                => false,
+				'show_ui'               => true,
+				'show_in_menu'          => true,
+				'rewrite'               => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'templates',
+				'rest_controller_class' => 'A8C_REST_Templates_Controller',
+				'capability_type'       => 'template',
+				'capabilities'          => array(
+					// You need to be able to edit posts, in order to read templates in their raw form.
+					'read'                   => 'edit_posts',
+					// You need to be able to customize, in order to create templates.
+					'create_posts'           => 'edit_theme_options',
+					'edit_posts'             => 'edit_theme_options',
+					'delete_posts'           => 'edit_theme_options',
+					'edit_published_posts'   => 'edit_theme_options',
+					'delete_published_posts' => 'edit_theme_options',
+					'edit_others_posts'      => 'edit_theme_options',
+					'delete_others_posts'    => 'edit_theme_options',
+					'publish_posts'          => 'edit_theme_options',
+				),
+				'map_meta_cap'          => true,
+				'supports'              => array(
+					'title',
+					'editor',
+				),
+			)
+		);
+
+		register_post_type(
+			'wp_template_part',
+			array(
+				'labels'                => array(
+					'name'                     => _x( 'Template Parts', 'post type general name', 'full-site-editing' ),
+					'singular_name'            => _x( 'Template Part', 'post type singular name', 'full-site-editing' ),
+					'menu_name'                => _x( 'Template Parts', 'admin menu', 'full-site-editing' ),
+					'name_admin_bar'           => _x( 'Template Part', 'add new on admin bar', 'full-site-editing' ),
+					'add_new'                  => _x( 'Add New', 'Template Part', 'full-site-editing' ),
+					'add_new_item'             => __( 'Add New Template Part', 'full-site-editing' ),
+					'new_item'                 => __( 'New Template Part', 'full-site-editing' ),
+					'edit_item'                => __( 'Edit Template Part', 'full-site-editing' ),
+					'view_item'                => __( 'View Template Part', 'full-site-editing' ),
+					'all_items'                => __( 'All Template Parts', 'full-site-editing' ),
+					'search_items'             => __( 'Search Template Parts', 'full-site-editing' ),
+					'not_found'                => __( 'No template parts found.', 'full-site-editing' ),
+					'not_found_in_trash'       => __( 'No template parts found in Trash.', 'full-site-editing' ),
+					'filter_items_list'        => __( 'Filter template parts list', 'full-site-editing' ),
+					'items_list_navigation'    => __( 'Template parts list navigation', 'full-site-editing' ),
+					'items_list'               => __( 'Template parts list', 'full-site-editing' ),
+					'item_published'           => __( 'Template part published.', 'full-site-editing' ),
+					'item_published_privately' => __( 'Template part published privately.', 'full-site-editing' ),
+					'item_reverted_to_draft'   => __( 'Template part reverted to draft.', 'full-site-editing' ),
+					'item_scheduled'           => __( 'Template part scheduled.', 'full-site-editing' ),
+					'item_updated'             => __( 'Template part updated.', 'full-site-editing' ),
+				),
+				'menu_icon'             => 'dashicons-layout',
+				'public'                => false,
+				'show_ui'               => true,
+				'show_in_menu'          => true,
+				'rewrite'               => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'template_parts',
+				'rest_controller_class' => 'A8C_REST_Templates_Controller',
+				'capability_type'       => 'template_part',
+				'capabilities'          => array(
+					// You need to be able to edit posts, in order to read templates in their raw form.
+					'read'                   => 'edit_posts',
+					// You need to be able to customize, in order to create templates.
+					'create_posts'           => 'edit_theme_options',
+					'edit_posts'             => 'edit_theme_options',
+					'delete_posts'           => 'edit_theme_options',
+					'edit_published_posts'   => 'edit_theme_options',
+					'delete_published_posts' => 'edit_theme_options',
+					'edit_others_posts'      => 'edit_theme_options',
+					'delete_others_posts'    => 'edit_theme_options',
+					'publish_posts'          => 'edit_theme_options',
+				),
+				'map_meta_cap'          => true,
+				'supports'              => array(
+					'title',
+					'editor',
+				),
+			)
+		);
+
+		register_taxonomy(
+			'wp_template_type',
+			'wp_template',
+			array(
+				'labels'             => array(
+					'name'              => _x( 'Template Types', 'taxonomy general name', 'full-site-editing' ),
+					'singular_name'     => _x( 'Template Type', 'taxonomy singular name', 'full-site-editing' ),
+					'menu_name'         => _x( 'Template Types', 'admin menu', 'full-site-editing' ),
+					'all_items'         => __( 'All Template Types', 'full-site-editing' ),
+					'edit_item'         => __( 'Edit Template Type', 'full-site-editing' ),
+					'view_item'         => __( 'View Template Type', 'full-site-editing' ),
+					'update_item'       => __( 'Update Template Type', 'full-site-editing' ),
+					'add_new_item'      => __( 'Add New Template Type', 'full-site-editing' ),
+					'new_item_name'     => __( 'New Template Type', 'full-site-editing' ),
+					'parent_item'       => __( 'Parent Template Type', 'full-site-editing' ),
+					'parent_item_colon' => __( 'Parent Template Type:', 'full-site-editing' ),
+					'search_items'      => __( 'Search Template Types', 'full-site-editing' ),
+					'not_found'         => __( 'No template types found.', 'full-site-editing' ),
+					'back_to_items'     => __( 'Back to template types', 'full-site-editing' ),
+				),
+				'public'             => false,
+				'publicly_queryable' => true,
+				'show_ui'            => true,
+				'show_in_menu'       => false,
+				'show_in_nav_menu'   => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'template_types',
+				'show_tagcloud'      => false,
+				'show_admin_column'  => true,
+				'hierarchical'       => true,
+				'rewrite'            => false,
+				'capabilities'       => array(
+					'manage_terms' => 'edit_theme_options',
+					'edit_terms'   => 'edit_theme_options',
+					'delete_terms' => 'edit_theme_options',
+					'assign_terms' => 'edit_theme_options',
+				),
+			)
+		);
+
+		register_taxonomy(
+			'wp_template_part_type',
+			'wp_template_part',
+			array(
+				'labels'             => array(
+					'name'              => _x( 'Template Part Types', 'taxonomy general name', 'full-site-editing' ),
+					'singular_name'     => _x( 'Template Part Type', 'taxonomy singular name', 'full-site-editing' ),
+					'menu_name'         => _x( 'Template Part Types', 'admin menu', 'full-site-editing' ),
+					'all_items'         => __( 'All Template Part Types', 'full-site-editing' ),
+					'edit_item'         => __( 'Edit Template Part Type', 'full-site-editing' ),
+					'view_item'         => __( 'View Template Part Type', 'full-site-editing' ),
+					'update_item'       => __( 'Update Template Part Type', 'full-site-editing' ),
+					'add_new_item'      => __( 'Add New Template Part Type', 'full-site-editing' ),
+					'new_item_name'     => __( 'New Template Part Type', 'full-site-editing' ),
+					'parent_item'       => __( 'Parent Template Part Type', 'full-site-editing' ),
+					'parent_item_colon' => __( 'Parent Template Part Type:', 'full-site-editing' ),
+					'search_items'      => __( 'Search Template Part Types', 'full-site-editing' ),
+					'not_found'         => __( 'No template part types found.', 'full-site-editing' ),
+					'back_to_items'     => __( 'Back to template part types', 'full-site-editing' ),
+				),
+				'public'             => false,
+				'publicly_queryable' => true,
+				'show_ui'            => true,
+				'show_in_menu'       => false,
+				'show_in_nav_menu'   => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'template_part_types',
+				'show_tagcloud'      => false,
+				'show_admin_column'  => true,
+				'hierarchical'       => true,
+				'rewrite'            => false,
+				'capabilities'       => array(
+					'manage_terms' => 'edit_theme_options',
+					'edit_terms'   => 'edit_theme_options',
+					'delete_terms' => 'edit_theme_options',
+					'assign_terms' => 'edit_theme_options',
+				),
+			)
+		);
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This adds required functionality to support rendering FSE header and
footer on all site pages (static and dynamic). It's also includes the
data population functionality, which has now been removed from the plugin
and will be delegated to each theme for maximum flexibility.

#### Testing instructions:

This PR requires its FSE counterpart PR to work properly. Please follow the testing instructions provided there: https://github.com/Automattic/wp-calypso/pull/34640