### PR TITLE
Adds Child Theme commands to npm run commands

### DIFF
--- a/_dsgnsystm/package.json
+++ b/_dsgnsystm/package.json
@@ -41,6 +41,6 @@
     "build:print": "node-sass print.scss print.css --output-style expanded --indent-type tab --indent-width 1 && postcss -r print.css",
     "build": "run-p \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
-    "child": "sh ../build-tools/build-child-theme.sh"
+    "child-theme": "sh ../theme-dev-utils/build-child-theme.sh"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds the ability to use the theme dev utils scripts. Specifically adds support for `npm run child-theme` to create a new child theme based on the _dsgnsystm parent theme.

#### Related issue(s):

Closes #1037 