### PR TITLE
Full Site Editing: Fix post content nested block alignment on modern business

### DIFF
--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -811,14 +811,14 @@ body {
   font-weight: 300;
 }
 
-body .wp-block[data-type="a8c/template"],
 body .wp-block[data-align="full"] {
   width: 100%;
 }
 
 @media only screen and (min-width: 600px) {
-  body .wp-block[data-type="a8c/template"],
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -835,8 +835,9 @@ body .wp-block[data-align="full"] {
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
-  body .wp-block[data-type="a8c/template"],
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -797,6 +797,15 @@ blockquote {
   }
 }
 
+/** === Helper Functions === */
+/**
+ Given a string, $alignment, returns the nested FSE block selectors
+ required for Full Site Editing to look correct. If $alignment is given,
+ we use it to target wp-blocks with a matching data-align attribute.
+ If no alignment is given, we target the base wp-block class. In both
+ of these scenarios, we target top level blocks, and any top level blocks
+ inside one of the FSE template part blocks.
+ */
 /** === Editor Frame === */
 body {
   font-weight: 300;
@@ -807,7 +816,9 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 600px) {
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"] .wp-block[data-align="full"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -819,50 +830,65 @@ body .wp-block[data-align="full"] {
     max-width: 80%;
     margin: 0 10%;
   }
+  
   body .wp-block[data-align="wide"],
+  body .wp-block[data-type="a8c/template"] .wp-block[data-align="wide"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"] .wp-block[data-align="full"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
     max-width: calc( 125% + 115px);
   }
+  
   body .wp-block[data-align="right"],
+  body .wp-block[data-type="a8c/template"] .wp-block[data-align="right"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
     max-width: 125%;
   }
 }
 
 /** === Content Width === */
+
 .wp-block,
+.wp-block[data-type="a8c/template"] .wp-block,
 .wp-block[data-type="a8c/post-content"] .wp-block {
   width: calc(100vw - (2 * 1rem));
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
+  
   .wp-block,
+  .wp-block[data-type="a8c/template"] .wp-block,
   .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
 
 @media only screen and (min-width: 1168px) {
+  
   .wp-block,
+  .wp-block[data-type="a8c/template"] .wp-block,
   .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }
 
+
 .wp-block .wp-block,
+.wp-block[data-type="a8c/template"] .wp-block .wp-block,
 .wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
   width: 100%;
 }
 
-/** === FSE Post Content Block Override === */
+/** === FSE Template Part Blocks === */
+.wp-block[data-type="a8c/template"],
 .wp-block[data-type="a8c/post-content"] {
   width: 100%;
 }

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -811,14 +811,14 @@ body {
   font-weight: 300;
 }
 
+body .wp-block[data-type="a8c/template"],
 body .wp-block[data-align="full"] {
   width: 100%;
 }
 
 @media only screen and (min-width: 600px) {
-  
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"] .wp-block[data-align="full"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -832,13 +832,11 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="wide"],
-  body .wp-block[data-type="a8c/template"] .wp-block[data-align="wide"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
-  
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"] .wp-block[data-align="full"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
@@ -847,7 +845,6 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="right"],
-  body .wp-block[data-type="a8c/template"] .wp-block[data-align="right"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
     max-width: 125%;
   }
@@ -856,7 +853,6 @@ body .wp-block[data-align="full"] {
 /** === Content Width === */
 
 .wp-block,
-.wp-block[data-type="a8c/template"] .wp-block,
 .wp-block[data-type="a8c/post-content"] .wp-block {
   width: calc(100vw - (2 * 1rem));
   max-width: 100%;
@@ -865,7 +861,6 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 768px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/template"] .wp-block,
   .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(8 * (100vw / 12));
   }
@@ -874,7 +869,6 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 1168px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/template"] .wp-block,
   .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
@@ -882,13 +876,11 @@ body .wp-block[data-align="full"] {
 
 
 .wp-block .wp-block,
-.wp-block[data-type="a8c/template"] .wp-block .wp-block,
 .wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
   width: 100%;
 }
 
 /** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/template"],
 .wp-block[data-type="a8c/post-content"] {
   width: 100%;
 }

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -807,7 +807,8 @@ body .wp-block[data-align="full"] {
 }
 
 @media only screen and (min-width: 600px) {
-  body .wp-block[data-align="full"] {
+  body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
   }
@@ -818,39 +819,51 @@ body .wp-block[data-align="full"] {
     max-width: 80%;
     margin: 0 10%;
   }
-  body .wp-block[data-align="wide"] {
+  body .wp-block[data-align="wide"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
-  body .wp-block[data-align="full"] {
+  body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
     max-width: calc( 125% + 115px);
   }
-  body .wp-block[data-align="right"] {
+  body .wp-block[data-align="right"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
     max-width: 125%;
   }
 }
 
 /** === Content Width === */
-.wp-block {
+.wp-block,
+.wp-block[data-type="a8c/post-content"] .wp-block {
   width: calc(100vw - (2 * 1rem));
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block {
+  .wp-block,
+  .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .wp-block {
+  .wp-block,
+  .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }
 
-.wp-block .wp-block {
+.wp-block .wp-block,
+.wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
+  width: 100%;
+}
+
+/** === FSE Post Content Block Override === */
+.wp-block[data-type="a8c/post-content"] {
   width: 100%;
 }
 

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -818,7 +818,6 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 600px) {
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -837,7 +836,6 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -28,7 +28,6 @@ Modern Business Editor Styles
 
 	@return "
 	  #{$main-block-selector},
-	  .wp-block[data-type=\"a8c/template\"] #{$main-block-selector},
 	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
 }
 
@@ -37,12 +36,14 @@ Modern Business Editor Styles
 body {
 	font-weight: 300;
 
+	.wp-block[data-type="a8c/template"],
 	.wp-block[data-align="full"] {
 		width: 100%;
 	}
 
 	@include media(mobile) {
 
+		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
@@ -60,6 +61,7 @@ body {
 			width: 100%;
 		}
 
+		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			position: relative;
 			left: calc( -12.5% - 14px );
@@ -94,7 +96,6 @@ body {
 }
 
 /** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/template"],
 .wp-block[data-type="a8c/post-content"] {
 	width: 100%;
 }

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -10,6 +10,28 @@ Modern Business Editor Styles
 @import "sass/navigation/menu-main-navigation";
 @import "sass/typography/headings";
 
+/** === Helper Functions === */
+
+/**
+ Given a string, $alignment, returns the nested FSE block selectors
+ required for Full Site Editing to look correct. If $alignment is given,
+ we use it to target wp-blocks with a matching data-align attribute.
+ If no alignment is given, we target the base wp-block class. In both
+ of these scenarios, we target top level blocks, and any top level blocks
+ inside one of the FSE template part blocks.
+ */
+@function get-block-selector($alignment) {
+	$main-block-selector: ".wp-block";
+	@if $alignment != "" {
+		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
+	}
+
+	@return "
+	  #{$main-block-selector},
+	  .wp-block[data-type=\"a8c/template\"] #{$main-block-selector},
+	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
+}
+
 /** === Editor Frame === */
 
 body {
@@ -21,8 +43,7 @@ body {
 
 	@include media(mobile) {
 
-		.wp-block[data-align="full"],
-		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+		#{get-block-selector("full")} {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
 		}
@@ -35,21 +56,18 @@ body {
 			margin: 0 10%;
 		}
 
-		.wp-block[data-align="wide"],
-		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
+		#{get-block-selector("wide")} {
 			width: 100%;
 		}
 
-		.wp-block[data-align="full"],
-		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+		#{get-block-selector("full")} {
 			position: relative;
 			left: calc( -12.5% - 14px );
 			width: calc( 125% + 116px );
 			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages.
 		}
 
-		.wp-block[data-align="right"],
-		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
+		#{get-block-selector("right")}  {
 			max-width: 125%;
 		}
 	}
@@ -57,8 +75,7 @@ body {
 
 /** === Content Width === */
 
-.wp-block,
-.wp-block[data-type="a8c/post-content"] .wp-block {
+#{get-block-selector("")} {
 	width: calc(100vw - (2 * #{$size__spacing-unit}));
 	max-width: 100%;
 
@@ -76,7 +93,8 @@ body {
 	}
 }
 
-/** === FSE Post Content Block Override === */
+/** === FSE Template Part Blocks === */
+.wp-block[data-type="a8c/template"],
 .wp-block[data-type="a8c/post-content"] {
 	width: 100%;
 }

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -21,7 +21,8 @@ body {
 
 	@include media(mobile) {
 
-		.wp-block[data-align="full"] {
+		.wp-block[data-align="full"],
+		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
 		}
@@ -34,18 +35,21 @@ body {
 			margin: 0 10%;
 		}
 
-		.wp-block[data-align="wide"] {
+		.wp-block[data-align="wide"],
+		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
 			width: 100%;
 		}
 
-		.wp-block[data-align="full"] {
+		.wp-block[data-align="full"],
+		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
 			position: relative;
 			left: calc( -12.5% - 14px );
 			width: calc( 125% + 116px );
 			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages.
 		}
 
-		.wp-block[data-align="right"] {
+		.wp-block[data-align="right"],
+		.wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
 			max-width: 125%;
 		}
 	}
@@ -53,7 +57,8 @@ body {
 
 /** === Content Width === */
 
-.wp-block {
+.wp-block,
+.wp-block[data-type="a8c/post-content"] .wp-block {
 	width: calc(100vw - (2 * #{$size__spacing-unit}));
 	max-width: 100%;
 
@@ -69,6 +74,11 @@ body {
 	.wp-block {
 		width: 100%;
 	}
+}
+
+/** === FSE Post Content Block Override === */
+.wp-block[data-type="a8c/post-content"] {
+	width: 100%;
 }
 
 /** === Base Typography === */

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -26,14 +26,8 @@ Modern Business Editor Styles
 		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
 	}
 
-	$template-selector: "";
-	@if $alignment == "full" {
-		$template-selector: ".wp-block[data-type=\"a8c/template\"],";
-	}
-
 	@return "
 	  #{$main-block-selector},
-	  #{$template-selector}
 	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
 }
 

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -26,8 +26,14 @@ Modern Business Editor Styles
 		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
 	}
 
+	$template-selector: "";
+	@if $alignment == "full" {
+		$template-selector: ".wp-block[data-type=\"a8c/template\"],";
+	}
+
 	@return "
 	  #{$main-block-selector},
+	  #{$template-selector}
 	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
 }
 
@@ -36,14 +42,12 @@ Modern Business Editor Styles
 body {
 	font-weight: 300;
 
-	.wp-block[data-type="a8c/template"],
 	.wp-block[data-align="full"] {
 		width: 100%;
 	}
 
 	@include media(mobile) {
 
-		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
@@ -61,7 +65,6 @@ body {
 			width: 100%;
 		}
 
-		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			position: relative;
 			left: calc( -12.5% - 14px );


### PR DESCRIPTION
- Make the post content block 100% width. As a result, the post content block takes up the same area that the post editor container takes up without the post content block. This is important because the theme styles do alignment of blocks based on the style of outer 
- Allow nested blocks inside the post content block to maintain the default alignment styles for top level blocks. Previously, they were targeted as 2nd level blocks, and were thus being set to a much wider width.

I did this by targeting `.wp-block[data-type="a8c/post-content"]` because we need to set the width of the outer block container. Additionally, I needed to override the default block alignment styles for 2nd level blocks inside the , so I used `.wp-block[data-type="a8c/post-content"] .wp-block` to target those. I tried using `.post-content-block .wp-block` but it didn't appear to override the styles, so I had to stick with the data type selector.

#### Testing:
1. Activate the modern business theme from this PR.
2. Also activate FSE with this companion FSE plugin PR (alternatively, just turn off full width alignment on the page content block): https://github.com/Automattic/wp-calypso/pull/34691
3. Create a new page from the pages screen.
4. Select the "portfolio" template
5. The full width blocks (gallery & video) should extend to the edge of the screen.
6. The normal paragraphs should be narrower in the middle.
7. Ultimately, the style of the post content should look identical to how it does in the non-fse post editor, so please play around with blocks and alignments that might not be covered by this PR yet!

_Update: Testing for template part blocks_
1. Activate this theme update.
1. In the page editor, select the header template part block and turn off full width alignment. _I'll be opening a PR soon which disables alignment on template part blocks, which has the same effect._
3. Make sure that the style of the Modern Business header is still looking correct.
4. Find a block like the gallery insert it into the header, setting it to full width. Save the update and go back to the page editor. That new block should extend screen to screen. 

#### Follow up tasks:
- [x] Make sure the header/footer styles are updated to work with alignment disabled.
* Make the same changes to the other 2019 child themes (will be followup PRs so long as this approach is viable.)

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/34558