### PR TITLE
dsgnsystm: Adds height: auto

### DIFF
--- a/_dsgnsystm/sass/blocks/image/_style.scss
+++ b/_dsgnsystm/sass/blocks/image/_style.scss
@@ -12,6 +12,7 @@
 
 img {
 	width: auto;
+	height: auto;
 	vertical-align: middle;
 	max-width: 100%;
 }


### PR DESCRIPTION
On my test site, I noticed my (very large) images were vertically stretched. This seemed to do the trick for me.

#### Changes proposed in this Pull Request:
* Added `height: auto` to the img block elenet
