### PR TITLE
Fix block alignment in FSE context for friendly business

### DIFF
--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -849,17 +849,29 @@ blockquote {
   }
 }
 
+/** === Helper Functions === */
+/**
+ Given a string, $alignment, returns the nested FSE block selectors
+ required for Full Site Editing to look correct. If $alignment is given,
+ we use it to target wp-blocks with a matching data-align attribute.
+ If no alignment is given, we target the base wp-block class. In both
+ of these scenarios, we target top level blocks, and any top level blocks
+ inside one of the FSE template part blocks.
+ */
 /** === Editor Frame === */
 body {
   background: #fffdf6;
 }
 
+body .wp-block[data-type="a8c/template"],
 body .wp-block[data-align="full"] {
   width: 100%;
 }
 
 @media only screen and (min-width: 600px) {
-  body .wp-block[data-align="full"] {
+  body .wp-block[data-type="a8c/template"],
+  body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
   }
@@ -876,41 +888,63 @@ body .wp-block[data-align="full"] {
     margin-left: 0;
     margin-right: 0;
   }
-  body .wp-block[data-align="wide"] {
+  
+  body .wp-block[data-align="wide"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
-  body .wp-block[data-align="full"] {
+  body .wp-block[data-type="a8c/template"],
+  body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
     max-width: calc( 125% + 115px);
   }
-  body .wp-block[data-align="right"] {
+  
+  body .wp-block[data-align="right"],
+  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
     max-width: 125%;
   }
 }
 
 /** === Content Width === */
 .wp-block {
-  width: calc(100vw - (2 * 1rem));
-  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }
 
+
+.wp-block,
+.wp-block[data-type="a8c/post-content"] .wp-block {
+  width: calc(100vw - (2 * 1rem));
+  max-width: 100%;
+}
+
 @media only screen and (min-width: 768px) {
-  .wp-block {
+  
+  .wp-block,
+  .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .wp-block {
+  
+  .wp-block,
+  .wp-block[data-type="a8c/post-content"] .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }
 
-.wp-block .wp-block {
+
+.wp-block .wp-block,
+.wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
+  width: 100%;
+}
+
+/** === FSE Template Part Blocks === */
+.wp-block[data-type="a8c/post-content"] {
   width: 100%;
 }
 

--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -863,14 +863,14 @@ body {
   background: #fffdf6;
 }
 
-body .wp-block[data-type="a8c/template"],
 body .wp-block[data-align="full"] {
   width: 100%;
 }
 
 @media only screen and (min-width: 600px) {
-  body .wp-block[data-type="a8c/template"],
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -893,8 +893,9 @@ body .wp-block[data-align="full"] {
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
     width: 100%;
   }
-  body .wp-block[data-type="a8c/template"],
+  
   body .wp-block[data-align="full"],
+  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);

--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -870,7 +870,6 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 600px) {
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
@@ -895,7 +894,6 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/template"],
   body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -10,18 +10,40 @@ Friendly Business Editor Styles
 @import "sass/navigation/menu-main-navigation";
 @import "sass/typography/headings";
 
+/** === Helper Functions === */
+
+/**
+ Given a string, $alignment, returns the nested FSE block selectors
+ required for Full Site Editing to look correct. If $alignment is given,
+ we use it to target wp-blocks with a matching data-align attribute.
+ If no alignment is given, we target the base wp-block class. In both
+ of these scenarios, we target top level blocks, and any top level blocks
+ inside one of the FSE template part blocks.
+ */
+ @function get-block-selector($alignment) {
+	$main-block-selector: ".wp-block";
+	@if $alignment != "" {
+		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
+	}
+
+	@return "
+	  #{$main-block-selector},
+	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
+}
+
 /** === Editor Frame === */
 
 body {
 	background: $color__background-body;
 
+	.wp-block[data-type="a8c/template"],
 	.wp-block[data-align="full"] {
 		width: 100%;
 	}
 
 	@include media(mobile) {
-
-		.wp-block[data-align="full"] {
+		.wp-block[data-type="a8c/template"],
+		#{get-block-selector("full")} {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
 		}
@@ -41,18 +63,19 @@ body {
 			margin-right: 0;
 		}
 
-		.wp-block[data-align="wide"] {
+		#{get-block-selector("wide")} {
 			width: 100%;
 		}
 
-		.wp-block[data-align="full"] {
+		.wp-block[data-type="a8c/template"],
+		#{get-block-selector("full")} {
 			position: relative;
 			left: calc( -12.5% - 14px );
 			width: calc( 125% + 116px );
 			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages.
 		}
 
-		.wp-block[data-align="right"] {
+		#{get-block-selector("right")} {
 			max-width: 125%;
 		}
 	}
@@ -61,10 +84,13 @@ body {
 /** === Content Width === */
 
 .wp-block {
-	width: calc(100vw - (2 * #{$size__spacing-unit}));
-	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
+}
+
+#{get-block-selector("")} {
+	width: calc(100vw - (2 * #{$size__spacing-unit}));
+	max-width: 100%;
 
 	@include media(tablet) {
 		width: calc(8 * (100vw / 12));
@@ -79,6 +105,12 @@ body {
 		width: 100%;
 	}
 }
+
+/** === FSE Template Part Blocks === */
+.wp-block[data-type="a8c/post-content"] {
+	width: 100%;
+}
+
 
 /** === Base Typography === */
 

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -26,8 +26,14 @@ Friendly Business Editor Styles
 		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
 	}
 
+	$template-selector: "";
+	@if $alignment == "full" {
+		$template-selector: ".wp-block[data-type=\"a8c/template\"],";
+	}
+
 	@return "
 	  #{$main-block-selector},
+	  #{$template-selector}
 	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
 }
 
@@ -36,13 +42,11 @@ Friendly Business Editor Styles
 body {
 	background: $color__background-body;
 
-	.wp-block[data-type="a8c/template"],
 	.wp-block[data-align="full"] {
 		width: 100%;
 	}
 
 	@include media(mobile) {
-		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			width: calc( 100% + 90px );
 			max-width: calc( 100% + 90px );
@@ -67,7 +71,6 @@ body {
 			width: 100%;
 		}
 
-		.wp-block[data-type="a8c/template"],
 		#{get-block-selector("full")} {
 			position: relative;
 			left: calc( -12.5% - 14px );
@@ -110,7 +113,6 @@ body {
 .wp-block[data-type="a8c/post-content"] {
 	width: 100%;
 }
-
 
 /** === Base Typography === */
 

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -26,14 +26,8 @@ Friendly Business Editor Styles
 		$main-block-selector: ".wp-block[data-align=\"#{$alignment}\"]";
 	}
 
-	$template-selector: "";
-	@if $alignment == "full" {
-		$template-selector: ".wp-block[data-type=\"a8c/template\"],";
-	}
-
 	@return "
 	  #{$main-block-selector},
-	  #{$template-selector}
 	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This extends the changes proposed in https://github.com/Automattic/themes/pull/1072 to the friendly business theme. It also fixes header/footer alignment issues mentioned in the other PR which would affect themes with wide headers like this one.

#### Testing:
1. Activate the friendly business theme from this PR.
2. Also activate FSE with this companion FSE plugin PR: https://github.com/Automattic/wp-calypso/pull/34691
3. Create a new page from the pages screen.
4. Select the "small business" template
5. The full width blocks (side by side text/picture) should extend to the edge of the screen.
6. The normal paragraphs should be narrower in the middle, and most of the stuff should be centered in the middle.
7. Ultimately, the style of the post content in the page editor with FSE should look identical to how it does in the non-fse post editor, so please play around with blocks and alignments that might not be covered by this PR yet!
8. Make sure the header matches the header on the front of the site both in the header editor and in the page editor.
