### PR TITLE
Redhill: Fix fonts in editor to match the frontend

### DIFF
--- a/redhill/sass/style-child-theme-editor.scss
+++ b/redhill/sass/style-child-theme-editor.scss
@@ -19,6 +19,11 @@
  */
 @import "../../_dsgnsystm/sass/base/editor";
 
+// Reset the font-family override on html to make editor fonts match front-end
+ html {
+	font-family: #{map-deep-get($config-global, "font", "family", "primary")};
+}
+
 /**
  * Elements
  * - Styles for basic HTML elemants

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -196,6 +196,10 @@ a {
 	cursor: pointer;
 }
 
+html {
+	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+}
+
 /**
  * Elements
  * - Styles for basic HTML elemants

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1232,6 +1232,21 @@ input[type="submit"].has-focus,
 	padding: 0;
 }
 
+.wp-block-cover h2.has-text-align-left,
+.wp-block-cover-image h2.has-text-align-left {
+	text-align: right;
+}
+
+.wp-block-cover h2.has-text-align-center,
+.wp-block-cover-image h2.has-text-align-center {
+	text-align: center;
+}
+
+.wp-block-cover h2.has-text-align-right,
+.wp-block-cover-image h2.has-text-align-right {
+	text-align: left;
+}
+
 .wp-block-cover.alignleft, .wp-block-cover.alignright,
 .wp-block-cover-image.alignleft,
 .wp-block-cover-image.alignright {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Fixes the editor fonts so that they appear in the editor the same way they do on the frontend.
- This was achieved by adding some “Extra” css to the child-theme editor stylesheet.
- Also recompiles the RTL stylesheet to match with changes to master

**Before**

![image](https://user-images.githubusercontent.com/709581/61474751-4405f200-a957-11e9-9535-28ee5f17b980.png)

**After**

![image](https://user-images.githubusercontent.com/709581/61474600-ff7a5680-a956-11e9-8c88-a9c1a126dd4f.png)

#### Related issue(s):

This issue was discovered by @thomasguillot via Slack. 