### PR TITLE
Update the Modern Business theme to support FSE footer

### DIFF
--- a/modern-business/inc/fse-template-data.php
+++ b/modern-business/inc/fse-template-data.php
@@ -108,7 +108,16 @@ class A8C_WP_Template_Data_Inserter {
 	 * @return string
 	 */
 	public function get_footer_content() {
-		return '<!-- wp:a8c/navigation-menu {\"themeLocation\":"footer"} /-->';
+		return '<!-- wp:group {"align":"full","className":"site-footer"} -->' .
+			   '<div class="wp-block-group alignfull site-footer">' .
+			   '<div class="wp-block-group__inner-container">' .
+			   '<!-- wp:separator {"className":"is-style-default"} -->' .
+			   '<hr class="wp-block-separator is-style-default"/>' .
+			   '<!-- /wp:separator -->' .
+			   '<!-- wp:a8c/navigation-menu /-->' .
+			   '</div>' .
+			   '</div>' .
+			   '<!-- /wp:group -->';
 	}
 
 	/**

--- a/modern-business/sass/site/footer/_site-footer.scss
+++ b/modern-business/sass/site/footer/_site-footer.scss
@@ -1,5 +1,25 @@
 /* Site footer */
 
+.site-footer {
+	padding: 1em 0;
+
+	color: $color__text-light;
+	display: flex;
+	flex-direction: column;
+	text-align: left;
+
+	@include media(tablet) {
+		margin: 0 $size__site-margins 2em;
+	}
+
+	.wp-block-separator {
+		margin: 0 0 1em;
+		background-color: $color__text-light;
+		border: 0;
+		height: 1px;
+	}
+}
+
 #colophon {
 
 	.widget-area,

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -139,6 +139,95 @@ Modern Business Editor Styles
   display: block;
 }
 
+/* Site footer */
+.site-footer {
+  padding: 1em 0;
+  color: #686868;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-footer {
+    margin: 0 calc(10% + 60px) 2em;
+  }
+}
+
+.site-footer .wp-block-separator {
+  margin: 0 0 1em;
+  background-color: #686868;
+  border: 0;
+  height: 1px;
+}
+
+#colophon .widget-area,
+#colophon .site-info {
+  margin: calc(2 * 1rem) 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  #colophon .widget-area,
+  #colophon .site-info {
+    margin: calc(3 * 1rem) auto;
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  #colophon .widget-area,
+  #colophon .site-info {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+#colophon .widget-column {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#colophon .widget-column .widget {
+  width: 100%;
+}
+
+@media only screen and (min-width: 1168px) {
+  #colophon .widget-column .widget {
+    margin-right: calc(3 * 1rem);
+    width: calc(50% - (3 * 1rem));
+  }
+}
+
+#colophon .site-info {
+  color: #686868;
+  font-weight: 300;
+}
+
+@media only screen and (min-width: 768px) {
+  #colophon .site-info {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  #colophon .site-info {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}
+
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #c43d80;
+}
+
+#colophon .site-info .imprint,
+#colophon .site-info .privacy-policy-link {
+  margin-right: 1rem;
+}
+
 /** === Main menu === */
 .main-navigation {
   display: block;

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -7,6 +7,7 @@ Modern Business Editor Styles
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";
 @import "sass/site/header/site-header";
+@import "sass/site/footer/site-footer";
 @import "sass/navigation/menu-main-navigation";
 @import "sass/typography/headings";
 

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -3197,6 +3197,27 @@ body.page .main-navigation {
 ## Footer
 --------------------------------------------------------------*/
 /* Site footer */
+.site-footer {
+  padding: 1em 0;
+  color: #686868;
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-footer {
+    margin: 1em calc(10% + 60px);
+  }
+}
+
+.site-footer .wp-block-separator {
+  margin: 0 0 1em;
+  background-color: #686868;
+  border: 0;
+  height: 1px;
+}
+
 #colophon .widget-area,
 #colophon .site-info {
   margin: calc(2 * 1rem) 1rem;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -3203,6 +3203,27 @@ body.page .main-navigation {
 ## Footer
 --------------------------------------------------------------*/
 /* Site footer */
+.site-footer {
+  padding: 1em 0;
+  color: #686868;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-footer {
+    margin: 0 calc(10% + 60px) 2em;
+  }
+}
+
+.site-footer .wp-block-separator {
+  margin: 0 0 1em;
+  background-color: #686868;
+  border: 0;
+  height: 1px;
+}
+
 #colophon .widget-area,
 #colophon .site-info {
   margin: calc(2 * 1rem) 1rem;


### PR DESCRIPTION
This updates the modern business theme to support the footer in the editor and the correct styles. The footer includes a visual separator block, and the navigation block.

<img width="1677" alt="Screen Shot 2019-07-18 at 11 58 10 AM" src="https://user-images.githubusercontent.com/1464705/61484243-58e08680-a953-11e9-884b-aa3a40f29cf1.png">

To test:

1. Activate the modern business theme from this branch
2. Delete all templates and template parts from the menus (Page Template, and Header, Footer).
3. Delete the "modern-business-fse-template-data" entry in the wp-options table.
4. Switch to a different theme, and then back to modern business.
5. Check that the footer looks like it does above, and works correctly on the front end of the site.
6. Disable the FSE plugin and check that you see equivalent to this in the footer (this message will be added to the dynamic footer in a separate PR):

<img width="800" alt="Screen Shot 2019-07-18 at 12 01 07 PM" src="https://user-images.githubusercontent.com/1464705/61484415-c7bddf80-a953-11e9-8152-eb802a7a44a0.png">

Issue for reference: https://github.com/Automattic/wp-calypso/issues/34733
