### PR TITLE
Full Site Editing: restore site info when rendering the footer

### DIFF
--- a/modern-business/footer.php
+++ b/modern-business/footer.php
@@ -17,12 +17,25 @@
 
 <?php
 // If FSE plugin is active, use Footer template part for content.
-if( class_exists( 'Full_Site_Editing' ) ) {
-	fse_get_footer();
-}
+if ( class_exists( 'Full_Site_Editing' ) ) : ?>
+	<footer id="colophon" class="site-footer">
+		<?php fse_get_footer(); ?>
+		<div class="site-info">
+			<?php $blog_info = get_bloginfo( 'name' ); ?>
+			<?php if ( ! empty( $blog_info ) ) : ?>
+				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
+			<?php endif; ?>
+			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
+				<?php
+				/* translators: %s: WordPress. */
+				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
+				?>
+			</a>
+		</div>
+	</footer>
+<?php endif; ?>
 
-// Otherwise we'll fall back to default Twenty Nineteen footer below.
-?>
+<?php // Otherwise we'll fall back to default Twenty Nineteen footer below. ?>
 
 <?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
 	<footer id="colophon" class="site-footer">

--- a/modern-business/header.php
+++ b/modern-business/header.php
@@ -24,14 +24,14 @@
 <div id="page" class="site">
     <a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentynineteen' ); ?></a>
 
-    <?php
-        // If FSE plugin is active, use Header template part for content.
-        if( class_exists( 'Full_Site_Editing' ) ) {
-            fse_get_header();
-        }
+    <?php // If FSE plugin is active, use Header template part for content. ?>
+    <?php if( class_exists( 'Full_Site_Editing' ) ) : ?>
+        <header id="masthead" class="<?php echo is_singular() && twentynineteen_can_show_post_thumbnail() ? 'site-header featured-image' : 'site-header'; ?>">
+            <?php fse_get_header(); ?>
+        </header>
+    <?php endif; ?>
 
-        // Otherwise we'll fall back to default Twenty Nineteen header below.
-    ?>
+    <?php // Otherwise we'll fall back to default Twenty Nineteen header below. ?>
 
     <?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
 

--- a/modern-business/sass/site/footer/_site-footer.scss
+++ b/modern-business/sass/site/footer/_site-footer.scss
@@ -9,7 +9,7 @@
 	text-align: left;
 
 	@include media(tablet) {
-		margin: 0 $size__site-margins 2em;
+		margin: 0 $size__site-margins;
 	}
 
 	.wp-block-separator {
@@ -27,7 +27,7 @@
 		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) auto;
+			margin: 0 $size__site-margins;
 			max-width: $size__site-tablet-content;
 		}
 

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -150,7 +150,7 @@ Modern Business Editor Styles
 
 @media only screen and (min-width: 768px) {
   .site-footer {
-    margin: 0 calc(10% + 60px) 2em;
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -169,7 +169,7 @@ Modern Business Editor Styles
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    margin: calc(3 * 1rem) auto;
+    margin: 0 calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -3207,7 +3207,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-footer {
-    margin: 1em calc(10% + 60px);
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -3226,7 +3226,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    margin: calc(3 * 1rem) auto;
+    margin: 0 calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -3213,7 +3213,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-footer {
-    margin: 0 calc(10% + 60px) 2em;
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -3232,7 +3232,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    margin: calc(3 * 1rem) auto;
+    margin: 0 calc(10% + 60px);
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Shows the default site info line after the footer template part
content. Also adds header and footer tags to corresponding template
parts to bring them closer to overall theme's structure.

Fixes https://github.com/Automattic/wp-calypso/issues/34754
Fixes https://github.com/Automattic/wp-calypso/issues/34423

#### Testing instructions

1. Enable latest versions of FSE plugin and Modern Business theme on your test site.
2. Verify that rendered pages show the following text after the FSE footer:

`[Site Name], Proudly powered by WordPress`
