### PR TITLE
Update the Modern Business footer to remove code duplication

### DIFF
--- a/modern-business/footer.php
+++ b/modern-business/footer.php
@@ -4,6 +4,10 @@
  *
  * Contains the closing of the #content div and all content after.
  *
+ * If the full site editing plugin is active then remove the widgets section,
+ * privacy policy, and navigation area in place of the footer template part
+ * that can be edited directly in the block editor.
+ *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package WordPress
@@ -15,47 +19,38 @@
 
 </div><!-- #content -->
 
-<?php
-// If FSE plugin is active, use Footer template part for content.
-if ( class_exists( 'Full_Site_Editing' ) ) : ?>
-	<footer id="colophon" class="site-footer">
-		<?php fse_get_footer(); ?>
-		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
-			<?php endif; ?>
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: WordPress. */
-				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
-				?>
-			</a>
-		</div>
-	</footer>
-<?php endif; ?>
+<footer id="colophon" class="site-footer">
+	
+	<?php 
+		if ( class_exists( 'Full_Site_Editing' ) ) {
+			fse_get_footer();
+		} else {
+			get_template_part( 'template-parts/footer/footer', 'widgets' ); 
+		}
+	?>
+	
+	<div class="site-info">
+		<?php $blog_info = get_bloginfo( 'name' ); ?>
+		
+		<?php if ( ! empty( $blog_info ) ) : ?>
+			<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
+		<?php endif; ?>
+		
+		<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
+			<?php
+			/* translators: %s: WordPress. */
+			printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
+			?>
+		</a>
 
-<?php // Otherwise we'll fall back to default Twenty Nineteen footer below. ?>
+		<?php if ( !class_exists( 'Full_Site_Editing' ) ) : ?>
 
-<?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
-	<footer id="colophon" class="site-footer">
-		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
-		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
-			<?php endif; ?>
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: WordPress. */
-				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
-				?>
-			</a>
 			<?php
 			if ( function_exists( 'the_privacy_policy_link' ) ) {
 				the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
 			}
 			?>
+
 			<?php if ( has_nav_menu( 'footer' ) ) : ?>
 				<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'twentynineteen' ); ?>">
 					<?php
@@ -69,9 +64,11 @@ if ( class_exists( 'Full_Site_Editing' ) ) : ?>
 					?>
 				</nav><!-- .footer-navigation -->
 			<?php endif; ?>
-		</div><!-- .site-info -->
-	</footer><!-- #colophon -->
-<?php endif; ?>
+
+		<?php endif; ?>
+	</div><!-- .site-info -->
+
+</footer><!-- #colophon -->
 
 </div><!-- #page -->
 


### PR DESCRIPTION
Remove code duplication and add a note about full site editing.

To test:

* Activate the theme with the full site editing plugin enabled.
* Confirm you see the following in the footer on the front end:

With FSE activated:

<img width="532" alt="Screen Shot 2019-07-18 at 5 00 16 PM" src="https://user-images.githubusercontent.com/1464705/61499845-87735700-a97d-11e9-8e35-3375f2b774c0.png">

With FSE deactivated (plus any widgets above):

<img width="503" alt="Screen Shot 2019-07-18 at 5 00 49 PM" src="https://user-images.githubusercontent.com/1464705/61499876-a245cb80-a97d-11e9-9912-2b3c0236bc1e.png">



