### PR TITLE
Fix a template conflict issue with modern business

### DIFF
--- a/modern-business/inc/fse-template-data.php
+++ b/modern-business/inc/fse-template-data.php
@@ -129,9 +129,9 @@ class A8C_WP_Template_Data_Inserter {
 	 * @return string
 	 */
 	public function get_template_content( $header_id, $footer_id ) {
-		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"align\":\"full\"} /-->" .
-		       '<!-- wp:a8c/post-content {"align":"full"} /-->' .
-		       "<!-- wp:a8c/template {\"templateId\":$footer_id,\"align\":\"full\"} /-->";
+		return "<!-- wp:a8c/template {\"templateId\":$header_id} /-->" .
+		       '<!-- wp:a8c/post-content /-->' .
+		       "<!-- wp:a8c/template {\"templateId\":$footer_id} /-->";
 	}
 
 	/**


### PR DESCRIPTION
**DO NOT MERGE**: Requires https://github.com/Automattic/wp-calypso/pull/34797

We disabled alignment settings for the blocks, but the template content function here still has alignment in it. This produces a template conflict warning in the editor:
<img width="832" alt="Screen Shot 2019-07-19 at 4 32 31 PM" src="https://user-images.githubusercontent.com/6265975/61570623-d59e5e00-aa42-11e9-95c1-9e895dd5890d.png">

### Changes proposed in this Pull Request:
- Remove alignment attributes from template part blocks in `get_template_content`

### Testing:
1. Have the `master` copy of this theme running.
2. This is going to be odd, but use your local FSE environment for this. Make sure you have master up to date, and **comment out** a line of code. You can find it here: `/wp-calypso/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js`. You want to comment out the line `import './template-validity-override';`, and make sure that you have the FSE watch command running.
3. Go to a page in the FSE editor on your local install. You **should** see an error like "the content of your post doesn't match the template..." if you have the master copy of the theme running with the suppression code commented out.
4. Now, pull this branch/PR
3. To get the new code to show up, you'll want to delete the existing template parts and templates and then deactivate modern business. Then to make sure that when you reactivate modern business that it repopulates everything, you may need to comment out the line in `inc/fse-template-data` where it bails to prevent multiple insertions. (line 29).
5. Then reactivate modern business
6. Go to that same page in the FSE editor. You should no longer see the error.