### PR TITLE
Update Modern Business to support the navigation block default menu fallback

### DIFF
--- a/modern-business/footer.php
+++ b/modern-business/footer.php
@@ -4,6 +4,10 @@
  *
  * Contains the closing of the #content div and all content after.
  *
+ * If the full site editing plugin is active then remove the widgets section,
+ * privacy policy, and navigation area in place of the footer template part
+ * that can be edited directly in the block editor.
+ *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package WordPress
@@ -15,47 +19,38 @@
 
 </div><!-- #content -->
 
-<?php
-// If FSE plugin is active, use Footer template part for content.
-if ( class_exists( 'Full_Site_Editing' ) ) : ?>
-	<footer id="colophon" class="site-footer">
-		<?php fse_get_footer(); ?>
-		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
-			<?php endif; ?>
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: WordPress. */
-				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
-				?>
-			</a>
-		</div>
-	</footer>
-<?php endif; ?>
+<footer id="colophon" class="site-footer">
+	
+	<?php 
+		if ( class_exists( 'Full_Site_Editing' ) ) {
+			fse_get_footer();
+		} else {
+			get_template_part( 'template-parts/footer/footer', 'widgets' ); 
+		}
+	?>
+	
+	<div class="site-info">
+		<?php $blog_info = get_bloginfo( 'name' ); ?>
+		
+		<?php if ( ! empty( $blog_info ) ) : ?>
+			<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
+		<?php endif; ?>
+		
+		<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
+			<?php
+			/* translators: %s: WordPress. */
+			printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
+			?>
+		</a>
 
-<?php // Otherwise we'll fall back to default Twenty Nineteen footer below. ?>
+		<?php if ( !class_exists( 'Full_Site_Editing' ) ) : ?>
 
-<?php if( ! class_exists( 'Full_Site_Editing' ) ) : ?>
-	<footer id="colophon" class="site-footer">
-		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
-		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>,
-			<?php endif; ?>
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentynineteen' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: WordPress. */
-				printf( __( 'Proudly powered by %s.', 'twentynineteen' ), 'WordPress' );
-				?>
-			</a>
 			<?php
 			if ( function_exists( 'the_privacy_policy_link' ) ) {
 				the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
 			}
 			?>
+
 			<?php if ( has_nav_menu( 'footer' ) ) : ?>
 				<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'twentynineteen' ); ?>">
 					<?php
@@ -69,9 +64,11 @@ if ( class_exists( 'Full_Site_Editing' ) ) : ?>
 					?>
 				</nav><!-- .footer-navigation -->
 			<?php endif; ?>
-		</div><!-- .site-info -->
-	</footer><!-- #colophon -->
-<?php endif; ?>
+
+		<?php endif; ?>
+	</div><!-- .site-info -->
+
+</footer><!-- #colophon -->
 
 </div><!-- #page -->
 

--- a/modern-business/sass/navigation/_menu-footer-navigation.scss
+++ b/modern-business/sass/navigation/_menu-footer-navigation.scss
@@ -20,3 +20,15 @@
 	}
 
 }
+
+footer {
+
+	.wp-block-a8c-navigation-menu {
+
+		.sub-menu {
+			visibility: hidden;
+		}
+
+	}
+
+}

--- a/modern-business/sass/navigation/_menu-main-navigation.scss
+++ b/modern-business/sass/navigation/_menu-main-navigation.scss
@@ -150,6 +150,11 @@
 					margin-right: #{1 * $size__spacing-unit};
 				}
 			}
+
+			&:last-child > a,
+			&:last-child.menu-item-has-children .submenu-expand {
+				margin-right: 0;
+			}
 		}
 	}
 

--- a/modern-business/sass/navigation/_menu-main-navigation.scss
+++ b/modern-business/sass/navigation/_menu-main-navigation.scss
@@ -139,6 +139,20 @@
 		}
 	}
 
+	.default-menu {
+		> li {
+			> a {
+				margin-right: #{1 * $size__spacing-unit};
+			}
+
+			&.menu-item-has-children {
+				> a {
+					margin-right: #{1 * $size__spacing-unit};
+				}
+			}
+		}
+	}
+
 	.sub-menu {
 
 		background-color: $color__link;

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -371,6 +371,14 @@ body.page .main-navigation {
   margin-right: 0;
 }
 
+.main-navigation .default-menu > li > a {
+  margin-right: 1rem;
+}
+
+.main-navigation .default-menu > li.menu-item-has-children > a {
+  margin-right: 1rem;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -379,6 +379,11 @@ body.page .main-navigation {
   margin-right: 1rem;
 }
 
+.main-navigation .default-menu > li:last-child > a,
+.main-navigation .default-menu > li:last-child.menu-item-has-children .submenu-expand {
+  margin-right: 0;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1142,6 +1142,11 @@ body.page .main-navigation {
   margin-left: 1rem;
 }
 
+.main-navigation .default-menu > li:last-child > a,
+.main-navigation .default-menu > li:last-child.menu-item-has-children .submenu-expand {
+  margin-left: 0;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;
@@ -1589,6 +1594,10 @@ body.page .main-navigation {
 .footer-navigation .footer-menu li {
   display: inline;
   margin-left: 1rem;
+}
+
+footer .wp-block-a8c-navigation-menu .sub-menu {
+  visibility: hidden;
 }
 
 /*--------------------------------------------------------------

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1134,6 +1134,14 @@ body.page .main-navigation {
   margin-left: 0;
 }
 
+.main-navigation .default-menu > li > a {
+  margin-left: 1rem;
+}
+
+.main-navigation .default-menu > li.menu-item-has-children > a {
+  margin-left: 1rem;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1142,6 +1142,11 @@ body.page .main-navigation {
   margin-right: 1rem;
 }
 
+.main-navigation .default-menu > li:last-child > a,
+.main-navigation .default-menu > li:last-child.menu-item-has-children .submenu-expand {
+  margin-right: 0;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;
@@ -1589,6 +1594,10 @@ body.page .main-navigation {
 .footer-navigation .footer-menu li {
   display: inline;
   margin-right: 1rem;
+}
+
+footer .wp-block-a8c-navigation-menu .sub-menu {
+  visibility: hidden;
 }
 
 /*--------------------------------------------------------------

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1134,6 +1134,14 @@ body.page .main-navigation {
   margin-right: 0;
 }
 
+.main-navigation .default-menu > li > a {
+  margin-right: 1rem;
+}
+
+.main-navigation .default-menu > li.menu-item-has-children > a {
+  margin-right: 1rem;
+}
+
 .main-navigation .sub-menu {
   background-color: #c43d80;
   color: #fff;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update Modern Business CSS to support the navigation block, and the fallback when a menu has not been created. The fallback is building a page list that utilizes the same CSS that the regular menu does:

<img width="1030" alt="Screen Shot 2019-07-19 at 8 42 55 PM" src="https://user-images.githubusercontent.com/1464705/61573559-cda3e580-aa65-11e9-9ce8-d0c712990f0f.png">

Note that the main difference is the lack of down arrow icon to denote that there are submenus. This is highlight specific to the twenty nineteen / our business themes, and not possible to replicate on the fallback menu as it is currently implemented.

#### Related issue(s):
https://github.com/Automattic/wp-calypso/pull/34796
