### PR TITLE
Varia: Reduce gap between header and content when homepage title is hidden.

### DIFF
--- a/varia/inc/style-wpcom.css
+++ b/varia/inc/style-wpcom.css
@@ -9,7 +9,7 @@
 	display: none;
 }
 
-.home.page.hide-homepage-title .hentry:not(.has-post-thumbnail) .entry-content > .alignfull:first-child {
+.home.page.hide-homepage-title .site-main > article > .entry-content {
 	margin-top: 0;
 }
 


### PR DESCRIPTION
Since this is for WP.com only, it's a bit awkward to test :)

Before:
<img width="916" alt="Screen Shot 2019-07-19 at 19 08 48" src="https://user-images.githubusercontent.com/908665/61580213-2d9e9880-ab07-11e9-9004-db9f385ec660.png">

After:
<img width="968" alt="Screen Shot 2019-07-19 at 19 23 35" src="https://user-images.githubusercontent.com/908665/61580214-37c09700-ab07-11e9-8326-44cc93ec4929.png">
