### PR TITLE
Varia: Add posts list block support

### DIFF
--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -14,6 +14,7 @@
 @import "gallery/editor";
 @import "latest-posts/editor";
 @import "media-text/editor";
+@import "posts-list/editor";
 @import "pullquote/editor";
 @import "quote/editor";
 @import "separator/editor";

--- a/varia/sass/blocks/_imports.scss
+++ b/varia/sass/blocks/_imports.scss
@@ -22,6 +22,7 @@
 @import "list/style";
 @import "media-text/style";
 @import "paragraph/style";
+@import "posts-list/style";
 @import "pullquote/style";
 @import "quote/style";
 @import "separator/style";

--- a/varia/sass/blocks/button/_style.scss
+++ b/varia/sass/blocks/button/_style.scss
@@ -1,9 +1,10 @@
-button,
-.button,
-input[type="submit"],
-.wp-block-button__link,
-.wp-block-file__button {
-
+/**
+ * Placeholder button style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+%button-style {
 	@include crop-text(map-deep-get($config-button, "font", "line-height"));
 	color: #{map-deep-get($config-button, "color", "text")};
 	cursor: pointer;
@@ -21,6 +22,15 @@ input[type="submit"],
 		color: #{map-deep-get($config-button, "color", "text-hover")};
 		background-color: #{map-deep-get($config-button, "color", "background-hover")};
 	}
+}
+
+button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button {
+	// Extend button style
+	@extend %button-style;
 }
 
 /**

--- a/varia/sass/blocks/image/_style.scss
+++ b/varia/sass/blocks/image/_style.scss
@@ -11,7 +11,7 @@
 }
 
 img {
-	width: auto;
+	height: auto;
 	vertical-align: middle;
 	max-width: 100%;
 }

--- a/varia/sass/blocks/posts-list/_editor.scss
+++ b/varia/sass/blocks/posts-list/_editor.scss
@@ -1,0 +1,3 @@
+.a8c-posts-list {
+	padding-left: 0;
+}

--- a/varia/sass/blocks/posts-list/_style.scss
+++ b/varia/sass/blocks/posts-list/_style.scss
@@ -1,31 +1,38 @@
-.a8c-posts-list {
-	margin-left: 0;
-	.a8c-posts-list__listing {
-		list-style: none;
-		margin: 0;
-		padding: 0;
+.a8c-posts-list__listing {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.a8c-posts-list-item__featured span {
+	color: #{map-deep-get($config-global, "color", "background")};
+	background-color: #{map-deep-get($config-global, "color", "primary", "default")};
+	font-family: #{map-deep-get($config-global, "font", "family", "primary")};
+	font-weight: bold;
+	font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+	line-height: 1;
+	padding: calc(0.5 * #{map-deep-get($config-global, "spacing", "unit")}) calc(0.66 * #{map-deep-get($config-global, "spacing", "unit")} );
+}
+
+.a8c-posts-list__item {
+	display: block;
+
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+	margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+
+	&:first-child {
+		margin-top: 0;
 	}
 
-	.a8c-posts-list__item {
-		display: block;
-
-		.a8c-posts-list-item__meta {
-			color: #{map-deep-get($config-global, "color", "foreground", "light")};
-			font-size: #{map-deep-get($config-global, "font", "size", "xs")};
-			line-height: #{map-deep-get($config-global, "font", "line-height", "body")};
-		}
-
-		.a8c-posts-list-item__excerpt {
-			font-size: #{map-deep-get($config-global, "font", "size", "sm")};
-			line-height: #{map-deep-get($config-global, "font", "line-height", "body")};
-			margin: 0;
-		}
+	&:last-child {
+		margin-bottom: 0;
 	}
 
-	& > li {
-		/* Vertical margins logic */
-		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
-		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+	.entry > * {
+		/* Vertical margins logic between post details */
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+		margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
 
 		&:first-child {
 			margin-top: 0;
@@ -36,11 +43,21 @@
 		}
 	}
 
-	& > li > a {
-		font-family: #{map-deep-get($config-heading, "font", "family")};
-		font-size: #{map-deep-get($config-heading, "font", "size", "h4")};
-		font-weight: #{map-deep-get($config-heading, "font", "weight")};
-		line-height: #{map-deep-get($config-heading, "font", "line-height", "h4")};
+	.a8c-posts-list-item__meta {
+		color: #{map-deep-get($config-global, "color", "foreground", "light")};
+		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
+		a {
+			color: currentColor;
+
+			&:hover,
+			&:active {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
 	}
-		
+
+	.a8c-posts-list-item__edit-link {
+		margin-left: #{map-deep-get($config-global, "spacing", "unit")};
+	}
 }

--- a/varia/sass/blocks/posts-list/_style.scss
+++ b/varia/sass/blocks/posts-list/_style.scss
@@ -2,6 +2,10 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
+
+	&:not(:last-child) {
+		margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+	}
 }
 
 .a8c-posts-list-item__featured span {
@@ -60,4 +64,10 @@
 	.a8c-posts-list-item__edit-link {
 		margin-left: #{map-deep-get($config-global, "spacing", "unit")};
 	}
+}
+
+.a8c-posts-list__view-all {
+	// Extend button style
+	@extend %button-style;
+	display: inline-block;
 }

--- a/varia/sass/blocks/posts-list/_style.scss
+++ b/varia/sass/blocks/posts-list/_style.scss
@@ -1,0 +1,46 @@
+.a8c-posts-list {
+	margin-left: 0;
+	.a8c-posts-list__listing {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.a8c-posts-list__item {
+		display: block;
+
+		.a8c-posts-list-item__meta {
+			color: #{map-deep-get($config-global, "color", "foreground", "light")};
+			font-size: #{map-deep-get($config-global, "font", "size", "xs")};
+			line-height: #{map-deep-get($config-global, "font", "line-height", "body")};
+		}
+
+		.a8c-posts-list-item__excerpt {
+			font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+			line-height: #{map-deep-get($config-global, "font", "line-height", "body")};
+			margin: 0;
+		}
+	}
+
+	& > li {
+		/* Vertical margins logic */
+		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	& > li > a {
+		font-family: #{map-deep-get($config-heading, "font", "family")};
+		font-size: #{map-deep-get($config-heading, "font", "size", "h4")};
+		font-weight: #{map-deep-get($config-heading, "font", "weight")};
+		line-height: #{map-deep-get($config-heading, "font", "line-height", "h4")};
+	}
+		
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -394,6 +394,10 @@ object {
 	color: currentColor;
 }
 
+.a8c-posts-list {
+	padding-left: 0;
+}
+
 .wp-block-pullquote {
 	padding: calc( 3 * 16px) 0;
 	margin-left: 0;

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1021,11 +1021,17 @@ object {
 	min-width: 300px;
 }
 
+/**
+ * Placeholder button style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
-.wp-block-file__button {
+.wp-block-file__button, .a8c-posts-list__view-all {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -1038,15 +1044,15 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before, button:after,
+button:before,
 .button:before,
-.button:after,
 input[type="submit"]:before,
-input[type="submit"]:after,
 .wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, button:after,
+.button:after,
+input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:before,
-.wp-block-file__button:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after {
 	content: '';
 	display: block;
 	height: 0;
@@ -1057,7 +1063,7 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before {
+.wp-block-file__button:before, .a8c-posts-list__view-all:before {
 	margin-bottom: -0.12em;
 }
 
@@ -1065,23 +1071,23 @@ button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after {
 	margin-top: -0.11em;
 }
 
-button:hover, button:focus, button.has-focus,
+button:hover,
 .button:hover,
-.button:focus,
-.button.has-focus,
-input[type="submit"]:hover,
-input[type="submit"]:focus,
-input[type="submit"].has-focus,
+input:hover[type="submit"],
 .wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-button__link.has-focus,
-.wp-block-file__button:hover,
-.wp-block-file__button:focus,
-.wp-block-file__button.has-focus {
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all {
 	color: white;
 	background-color: indigo;
 }
@@ -1569,6 +1575,10 @@ p.has-background {
 	padding: 0;
 }
 
+.a8c-posts-list__listing:not(:last-child) {
+	margin-bottom: calc(3 * 32px);
+}
+
 .a8c-posts-list-item__featured span {
 	color: white;
 	background-color: blue;
@@ -1623,6 +1633,10 @@ p.has-background {
 
 .a8c-posts-list__item .a8c-posts-list-item__edit-link {
 	margin-right: 16px;
+}
+
+.a8c-posts-list__view-all {
+	display: inline-block;
 }
 
 .wp-block-pullquote {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1371,7 +1371,7 @@ h6, .h6 {
 }
 
 img {
-	width: auto;
+	height: auto;
 	vertical-align: middle;
 	max-width: 100%;
 }
@@ -1560,6 +1560,68 @@ dd {
 
 p.has-background {
 	padding: 16px 16px;
+}
+
+.a8c-posts-list__listing {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.a8c-posts-list-item__featured span {
+	color: white;
+	background-color: blue;
+	font-family: sans-serif;
+	font-weight: bold;
+	font-size: 0.83333rem;
+	line-height: 1;
+	padding: calc(0.5 * 16px) calc(0.66 * 16px);
+}
+
+.a8c-posts-list__item {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.a8c-posts-list__item:first-child {
+	margin-top: 0;
+}
+
+.a8c-posts-list__item:last-child {
+	margin-bottom: 0;
+}
+
+.a8c-posts-list__item .entry > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.a8c-posts-list__item .entry > *:first-child {
+	margin-top: 0;
+}
+
+.a8c-posts-list__item .entry > *:last-child {
+	margin-bottom: 0;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta a {
+	color: currentColor;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta a:hover, .a8c-posts-list__item .a8c-posts-list-item__meta a:active {
+	color: indigo;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__edit-link {
+	margin-right: 16px;
 }
 
 .wp-block-pullquote {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1722,6 +1722,11 @@ hr.is-style-dots:before {
 	padding-right: 0.83333rem;
 }
 
+.wp-block-jetpack-slideshow ul {
+	margin-right: 0;
+	margin-left: 0;
+}
+
 .wp-block-spacer {
 	display: block;
 	margin-bottom: 0;

--- a/varia/style.css
+++ b/varia/style.css
@@ -1562,6 +1562,53 @@ p.has-background {
 	padding: 16px 16px;
 }
 
+.a8c-posts-list {
+	margin-left: 0;
+}
+
+.a8c-posts-list .a8c-posts-list__listing {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.a8c-posts-list .a8c-posts-list__item {
+	display: block;
+}
+
+.a8c-posts-list .a8c-posts-list__item .a8c-posts-list-item__meta {
+	color: #767676;
+	font-size: 0.69444rem;
+	line-height: 1.78;
+}
+
+.a8c-posts-list .a8c-posts-list__item .a8c-posts-list-item__excerpt {
+	font-size: 0.83333rem;
+	line-height: 1.78;
+	margin: 0;
+}
+
+.a8c-posts-list > li {
+	/* Vertical margins logic */
+	margin-top: 32px;
+	margin-bottom: 32px;
+}
+
+.a8c-posts-list > li:first-child {
+	margin-top: 0;
+}
+
+.a8c-posts-list > li:last-child {
+	margin-bottom: 0;
+}
+
+.a8c-posts-list > li > a {
+	font-family: sans-serif;
+	font-size: 1.728rem;
+	font-weight: bold;
+	line-height: 1.125;
+}
+
 .wp-block-pullquote {
 	padding: calc( 3 * 16px) 0;
 	margin-left: 0;

--- a/varia/style.css
+++ b/varia/style.css
@@ -1371,7 +1371,7 @@ h6, .h6 {
 }
 
 img {
-	width: auto;
+	height: auto;
 	vertical-align: middle;
 	max-width: 100%;
 }
@@ -1562,51 +1562,66 @@ p.has-background {
 	padding: 16px 16px;
 }
 
-.a8c-posts-list {
-	margin-left: 0;
-}
-
-.a8c-posts-list .a8c-posts-list__listing {
+.a8c-posts-list__listing {
 	list-style: none;
 	margin: 0;
 	padding: 0;
 }
 
-.a8c-posts-list .a8c-posts-list__item {
-	display: block;
-}
-
-.a8c-posts-list .a8c-posts-list__item .a8c-posts-list-item__meta {
-	color: #767676;
-	font-size: 0.69444rem;
-	line-height: 1.78;
-}
-
-.a8c-posts-list .a8c-posts-list__item .a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__featured span {
+	color: white;
+	background-color: blue;
+	font-family: sans-serif;
+	font-weight: bold;
 	font-size: 0.83333rem;
-	line-height: 1.78;
-	margin: 0;
+	line-height: 1;
+	padding: calc(0.5 * 16px) calc(0.66 * 16px);
 }
 
-.a8c-posts-list > li {
-	/* Vertical margins logic */
-	margin-top: 32px;
-	margin-bottom: 32px;
+.a8c-posts-list__item {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
 }
 
-.a8c-posts-list > li:first-child {
+.a8c-posts-list__item:first-child {
 	margin-top: 0;
 }
 
-.a8c-posts-list > li:last-child {
+.a8c-posts-list__item:last-child {
 	margin-bottom: 0;
 }
 
-.a8c-posts-list > li > a {
-	font-family: sans-serif;
-	font-size: 1.728rem;
-	font-weight: bold;
-	line-height: 1.125;
+.a8c-posts-list__item .entry > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.a8c-posts-list__item .entry > *:first-child {
+	margin-top: 0;
+}
+
+.a8c-posts-list__item .entry > *:last-child {
+	margin-bottom: 0;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta a {
+	color: currentColor;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta a:hover, .a8c-posts-list__item .a8c-posts-list-item__meta a:active {
+	color: indigo;
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__edit-link {
+	margin-left: 16px;
 }
 
 .wp-block-pullquote {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1021,11 +1021,17 @@ object {
 	min-width: 300px;
 }
 
+/**
+ * Placeholder button style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
-.wp-block-file__button {
+.wp-block-file__button, .a8c-posts-list__view-all {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -1038,15 +1044,15 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before, button:after,
+button:before,
 .button:before,
-.button:after,
 input[type="submit"]:before,
-input[type="submit"]:after,
 .wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, button:after,
+.button:after,
+input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:before,
-.wp-block-file__button:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after {
 	content: '';
 	display: block;
 	height: 0;
@@ -1057,7 +1063,7 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before {
+.wp-block-file__button:before, .a8c-posts-list__view-all:before {
 	margin-bottom: -0.12em;
 }
 
@@ -1065,23 +1071,23 @@ button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after {
 	margin-top: -0.11em;
 }
 
-button:hover, button:focus, button.has-focus,
+button:hover,
 .button:hover,
-.button:focus,
-.button.has-focus,
-input[type="submit"]:hover,
-input[type="submit"]:focus,
-input[type="submit"].has-focus,
+input:hover[type="submit"],
 .wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-button__link.has-focus,
-.wp-block-file__button:hover,
-.wp-block-file__button:focus,
-.wp-block-file__button.has-focus {
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all {
 	color: white;
 	background-color: indigo;
 }
@@ -1569,6 +1575,10 @@ p.has-background {
 	padding: 0;
 }
 
+.a8c-posts-list__listing:not(:last-child) {
+	margin-bottom: calc(3 * 32px);
+}
+
 .a8c-posts-list-item__featured span {
 	color: white;
 	background-color: blue;
@@ -1623,6 +1633,10 @@ p.has-background {
 
 .a8c-posts-list__item .a8c-posts-list-item__edit-link {
 	margin-left: 16px;
+}
+
+.a8c-posts-list__view-all {
+	display: inline-block;
 }
 
 .wp-block-pullquote {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a default styles and variables to the a8c Posts List block. 

- Optimize selector nesting
- Add style for `featured` span to match archives
- Add vertical spacing to match index/archives
- Add link color to meta data and clean up spacing
- Use small font-size in meta data'
- Also fixes a [responsive image bug](https://github.com/Automattic/themes/compare/varia_add_posts_list_block_support?expand=1#diff-480b74bc7d291227b08c24b6af8b67e4R13), originally reported here: #1085 

#### Related issue(s):

Fixes: #1097 

## Merging note:

Once this PR is merged, we’ll need to re-build all child themes based on Varia, so that they _automatically_ adopt these new styles. 