### PR TITLE
Varia: Revising #1122 again

### DIFF
--- a/varia/sass/blocks/media-text/_editor.scss
+++ b/varia/sass/blocks/media-text/_editor.scss
@@ -1,8 +1,10 @@
 .wp-block-media-text {
 
-	.block-editor-inner-blocks {
-		a {
-			color: currentColor;
+	&[style*="background-color"]:not(.has-background-background-color) {
+		.block-editor-inner-blocks {
+			a {
+				color: currentColor;
+			}
 		}
 	}
 }

--- a/varia/sass/blocks/media-text/_style.scss
+++ b/varia/sass/blocks/media-text/_style.scss
@@ -17,9 +17,14 @@
 				margin-bottom: 0;
 			}
 		}
+	}
 
-		a {
-			color: currentColor;
+	&[class*="background-color"]:not(.has-background-background-color),
+	&[style*="background-color"] {
+		.wp-block-media-text__content {
+			a {
+				color: currentColor;
+			}
 		}
 	}
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -394,7 +394,7 @@ object {
 	padding-left: 0;
 }
 
-.wp-block-media-text .block-editor-inner-blocks a {
+.wp-block-media-text[style*="background-color"]:not(.has-background-background-color) .block-editor-inner-blocks a {
 	color: currentColor;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1544,7 +1544,7 @@ dd {
 	margin-bottom: 0;
 }
 
-.wp-block-media-text .wp-block-media-text__content a {
+.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
 	color: currentColor;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1544,7 +1544,7 @@ dd {
 	margin-bottom: 0;
 }
 
-.wp-block-media-text .wp-block-media-text__content a {
+.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
 	color: currentColor;
 }
 


### PR DESCRIPTION
Have links inherit the color only when the block (Media & Text or Paragrpah) are using a background color

#### Changes proposed in this Pull Request:

This splits the commits at #1122 into two separate PRs. This one provides a fix for Varia.

#### Related issue(s):

Fixes #1113 for Varia