### PR TITLE
Varia: Improve spacer blocks on Mobile

### DIFF
--- a/varia/sass/abstracts/_mixins.scss
+++ b/varia/sass/abstracts/_mixins.scss
@@ -5,7 +5,7 @@
 @mixin media( $res ) {
 
 	@if mobile-only == $res {
-		@media only screen and (max-width: calc(map-deep-get($config-global, "breakpoint", "sm") - 1)) {
+		@media only screen and (max-width: #{map-deep-get($config-global, "breakpoint", "sm") - 1}) {
 			@content;
 		}
 	}

--- a/varia/sass/blocks/spacer/_style.scss
+++ b/varia/sass/blocks/spacer/_style.scss
@@ -1,6 +1,12 @@
 .wp-block-spacer {
 	display: block;
 	// Remove vertical margins
-	margin-bottom: 0;
-	margin-top: 0;
+	margin-bottom: 0 !important;
+	margin-top: 0 !important;
+
+	@include media(mobile-only) {
+		&[style] {
+			height: map-deep-get($config-global, "spacing", "unit") !important;
+		}
+	}
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1810,8 +1810,14 @@ hr.is-style-dots:before {
 
 .wp-block-spacer {
 	display: block;
-	margin-bottom: 0;
-	margin-top: 0;
+	margin-bottom: 0 !important;
+	margin-top: 0 !important;
+}
+
+@media only screen and (max-width: 559px) {
+	.wp-block-spacer[style] {
+		height: 32px !important;
+	}
 }
 
 table,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1816,7 +1816,7 @@ hr.is-style-dots:before {
 
 @media only screen and (max-width: 559px) {
 	.wp-block-spacer[style] {
-		height: 32px !important;
+		height: 16px !important;
 	}
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1810,8 +1810,14 @@ hr.is-style-dots:before {
 
 .wp-block-spacer {
 	display: block;
-	margin-bottom: 0;
-	margin-top: 0;
+	margin-bottom: 0 !important;
+	margin-top: 0 !important;
+}
+
+@media only screen and (max-width: 559px) {
+	.wp-block-spacer[style] {
+		height: 16px !important;
+	}
 }
 
 table,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR limits the spacer-block to a 16px height (to match mobile vertical margins). This might be a bit aggressive and may not expected, but it does greatly improve the scrolling experience on mobile for the templates I tried this with. When we need to, we can use empty new lines in text areas in our templates to `fake` a taller spacer area on mobile, if needed.

This PR also forces zero vertical margins on mobile screens, which is also aggressive (as it uses `!important`) but still necessary to maintain consistency. 

#### Before: Varied spacer heights makes for a lot of awkward empty spaces.

![varia-spacers-before](https://user-images.githubusercontent.com/709581/61832608-b2f3b700-ae3f-11e9-8d50-bc0d281b9ce1.gif)

#### After: Consistent 16px for _all_ spacers makes the layout feel more natural and considered.

![varia-spacers-after](https://user-images.githubusercontent.com/709581/61832750-1f6eb600-ae40-11e9-9da6-9eb0949d428c.gif)

#### Related issue(s):

Discovered while testing locally. 