### PR TITLE
affinity: wp_body_open() function added after body tag

### DIFF
--- a/affinity/header.php
+++ b/affinity/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'affinity' ); ?></a>
 

--- a/altofocus/header.php
+++ b/altofocus/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'altofocus' ); ?></a>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Starting from WordPress 5.2 a new function is added – wp_body_open() – that is used to trigger a wp_body_open action. The intention of this action is to allow people to add things – like a <script> tag – directly inside the body of a page.

Ref: 
https://developer.wordpress.org/reference/functions/wp_body_open/
https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook/

#### Related issue(s):

