### PR TITLE
Modern Business: Full Site Editing - add header and footer selectors for block front end styles

### DIFF
--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -1,7 +1,8 @@
 /* !Block styles */
 
 .entry .entry-content > *,
-.entry .entry-summary > * {
+.entry .entry-summary > * 
+.site-header > *, .site-footer > * {
 	margin: $size__vertical-spacing-unit 0;
 	max-width: 100%;
 
@@ -106,7 +107,8 @@
  * - helps with plugin compatibility
  */
 .entry .entry-content,
-.entry .entry-summary {
+.entry .entry-summary,
+.site-header, .site-footer {
 
 	.entry-content,
 	.entry-summary,
@@ -123,7 +125,7 @@
 	}
 }
 
-.entry .entry-content {
+.entry .entry-content, .site-header, .site-footer {
 
 	//! Headers
 	& > h1,

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -2,7 +2,7 @@
 
 .entry .entry-content > *,
 .entry .entry-summary > * 
-.site-header > *, .site-footer > * {
+.fse-template-content > * {
 	margin: $size__vertical-spacing-unit 0;
 	max-width: 100%;
 
@@ -108,7 +108,7 @@
  */
 .entry .entry-content,
 .entry .entry-summary,
-.site-header, .site-footer {
+.fse-template-content {
 
 	.entry-content,
 	.entry-summary,
@@ -125,7 +125,7 @@
 	}
 }
 
-.entry .entry-content, .site-header, .site-footer {
+.entry .entry-content, .fse-template-content {
 
 	//! Headers
 	& > h1,

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -3588,166 +3588,184 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content > h3,
 .entry .entry-content > h4,
 .entry .entry-content > h5,
-.entry .entry-content > h6 {
+.entry .entry-content > h6, .site-header > h1,
+.site-header > h2,
+.site-header > h3,
+.site-header > h4,
+.site-header > h5,
+.site-header > h6, .site-footer > h1,
+.site-footer > h2,
+.site-footer > h3,
+.site-footer > h4,
+.site-footer > h5,
+.site-footer > h6 {
   margin: 32px auto;
   text-align: center;
 }
 
-.entry .entry-content > h2 {
+.entry .entry-content > h2, .site-header > h2, .site-footer > h2 {
   font-size: 1.125em;
   font-weight: 700;
 }
 
-.entry .entry-content p.has-background {
+.entry .entry-content p.has-background, .site-header p.has-background, .site-footer p.has-background {
   padding: 20px 30px;
 }
 
-.entry .entry-content .wp-block-audio {
+.entry .entry-content .wp-block-audio, .site-header .wp-block-audio, .site-footer .wp-block-audio {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio, .site-header .wp-block-audio audio, .site-footer .wp-block-audio audio {
   width: 100%;
 }
 
 .entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+.site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+.site-footer .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+  .site-footer .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+  .site-footer .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry .entry-content .wp-block-video video {
+.entry .entry-content .wp-block-video video, .site-header .wp-block-video video, .site-footer .wp-block-video video {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-media-text {
+.entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
   margin: 0 auto;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(odd) {
+.entry .entry-content .wp-block-media-text:nth-child(odd), .site-header .wp-block-media-text:nth-child(odd), .site-footer .wp-block-media-text:nth-child(odd) {
   background-color: #181818;
   color: #fff;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(even) {
+.entry .entry-content .wp-block-media-text:nth-child(even), .site-header .wp-block-media-text:nth-child(even), .site-footer .wp-block-media-text:nth-child(even) {
   background-color: #f2f2f2;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
   grid-area: media-text-content;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
     grid-area: media-text-media;
   }
 }
 
-.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
   padding: 8% 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
-.entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
   padding: 8%;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
   grid-area: media-text-media;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
     grid-area: media-text-content;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text {
+  .entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
     padding: 64px 0;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .site-header .wp-block-media-text .wp-block-media-text__media, .site-footer .wp-block-media-text .wp-block-media-text__media {
     margin-right: -64px;
     margin-left: 64px;
     max-width: calc( 100%);
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
-  .entry .entry-content .wp-block-media-text.alignfull {
+  .entry .entry-content .wp-block-media-text.alignfull, .site-header .wp-block-media-text.alignfull, .site-footer .wp-block-media-text.alignfull {
     margin-right: 64px;
     margin-left: 64px;
     max-width: calc( 125% + 30px);
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
     margin-left: -64px;
     margin-right: 64px;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
-.entry .entry-content .wp-block-media-text :first-child {
+.entry .entry-content .wp-block-media-text :first-child, .site-header .wp-block-media-text :first-child, .site-footer .wp-block-media-text :first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-media-text :last-child {
+.entry .entry-content .wp-block-media-text :last-child, .site-header .wp-block-media-text :last-child, .site-footer .wp-block-media-text :last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content .wp-block-media-text a,
-.entry .entry-content .wp-block-media-text a:hover {
+.entry .entry-content .wp-block-media-text a:hover, .site-header .wp-block-media-text a,
+.site-header .wp-block-media-text a:hover, .site-footer .wp-block-media-text a,
+.site-footer .wp-block-media-text a:hover {
   color: inherit;
 }
 
 @media all and (-ms-high-contrast: none) {
-  .entry .entry-content .wp-block-media-text:after {
+  .entry .entry-content .wp-block-media-text:after, .site-header .wp-block-media-text:after, .site-footer .wp-block-media-text:after {
     display: table;
     content: "";
     clear: both;
   }
-  .entry .entry-content .wp-block-media-text figure {
+  .entry .entry-content .wp-block-media-text figure, .site-header .wp-block-media-text figure, .site-footer .wp-block-media-text figure {
     float: right;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
     float: left;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .site-header .wp-block-media-text.has-media-on-the-right figure, .site-footer .wp-block-media-text.has-media-on-the-right figure {
     float: left;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     float: right;
   }
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link, .site-header .wp-block-button .wp-block-button__link, .site-footer .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
@@ -3761,34 +3779,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline: none;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .site-header .wp-block-button .wp-block-button__link:not(.has-background), .site-footer .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #c43d80;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .site-header .wp-block-button .wp-block-button__link:not(.has-text-color), .site-footer .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .site-header .wp-block-button .wp-block-button__link:hover, .site-footer .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus, .site-header .wp-block-button .wp-block-button__link:focus, .site-footer .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-header .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-footer .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .site-header .wp-block-button.is-style-outline .wp-block-button__link,
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active, .site-footer .wp-block-button.is-style-outline .wp-block-button__link,
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
@@ -3796,36 +3818,52 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #c43d80;
   border-color: currentColor;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #9e3067;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #9e3067;
 }
 
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
-.entry .entry-content .wp-block-latest-posts {
+.entry .entry-content .wp-block-latest-posts, .site-header .wp-block-archives,
+.site-header .wp-block-categories,
+.site-header .wp-block-latest-posts, .site-footer .wp-block-archives,
+.site-footer .wp-block-categories,
+.site-footer .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
 .entry .entry-content .wp-block-archives li,
 .entry .entry-content .wp-block-categories li,
-.entry .entry-content .wp-block-latest-posts li {
+.entry .entry-content .wp-block-latest-posts li, .site-header .wp-block-archives li,
+.site-header .wp-block-categories li,
+.site-header .wp-block-latest-posts li, .site-footer .wp-block-archives li,
+.site-footer .wp-block-categories li,
+.site-footer .wp-block-latest-posts li {
   color: #686868;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3838,72 +3876,86 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-categories li.menu-item-has-children,
 .entry .entry-content .wp-block-categories li:last-child,
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
-.entry .entry-content .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li:last-child, .site-header .wp-block-archives li.menu-item-has-children, .site-header .wp-block-archives li:last-child,
+.site-header .wp-block-categories li.menu-item-has-children,
+.site-header .wp-block-categories li:last-child,
+.site-header .wp-block-latest-posts li.menu-item-has-children,
+.site-header .wp-block-latest-posts li:last-child, .site-footer .wp-block-archives li.menu-item-has-children, .site-footer .wp-block-archives li:last-child,
+.site-footer .wp-block-categories li.menu-item-has-children,
+.site-footer .wp-block-categories li:last-child,
+.site-footer .wp-block-latest-posts li.menu-item-has-children,
+.site-footer .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
 .entry .entry-content .wp-block-categories li a,
-.entry .entry-content .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-latest-posts li a, .site-header .wp-block-archives li a,
+.site-header .wp-block-categories li a,
+.site-header .wp-block-latest-posts li a, .site-footer .wp-block-archives li a,
+.site-footer .wp-block-categories li a,
+.site-footer .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter, .site-header .wp-block-archives.aligncenter,
+.site-header .wp-block-categories.aligncenter, .site-footer .wp-block-archives.aligncenter,
+.site-footer .wp-block-categories.aligncenter {
   text-align: center;
 }
 
-.entry .entry-content .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
   padding-top: 24px;
 }
 
-.entry .entry-content .wp-block-categories li ul {
+.entry .entry-content .wp-block-categories li ul, .site-header .wp-block-categories li ul, .site-footer .wp-block-categories li ul {
   list-style: none;
   padding-right: 0;
 }
 
-.entry .entry-content .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
   counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a::before {
+.entry .entry-content .wp-block-categories ul > li > a::before, .site-header .wp-block-categories ul > li > a::before, .site-footer .wp-block-categories ul > li > a::before {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li, .site-header .wp-block-latest-posts.is-grid li, .site-footer .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 32px;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .site-header .wp-block-latest-posts.is-grid li a:after, .site-footer .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .site-header .wp-block-latest-posts.is-grid li:last-child, .site-footer .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .site-header .wp-block-latest-posts.is-grid li:last-child a:after, .site-footer .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted, .site-header .wp-block-preformatted, .site-footer .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-verse {
+.entry .entry-content .wp-block-verse, .site-header .wp-block-verse, .site-footer .wp-block-verse {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry .entry-content .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter, .site-header .has-drop-cap:not(:focus):first-letter, .site-footer .has-drop-cap:not(:focus):first-letter {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -3911,13 +3963,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin: 0 0 0 0.25em;
 }
 
-.entry .entry-content .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote, .site-header .wp-block-pullquote, .site-footer .wp-block-pullquote {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote, .site-header .wp-block-pullquote blockquote, .site-footer .wp-block-pullquote blockquote {
   color: #181818;
   border: none;
   margin-top: calc(3 * 32px);
@@ -3926,7 +3978,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding-right: 0;
 }
 
-.entry .entry-content .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -3934,17 +3986,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-top: 0.5em;
 }
 
-.entry .entry-content .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em, .site-header .wp-block-pullquote p em, .site-footer .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite, .site-header .wp-block-pullquote cite, .site-footer .wp-block-pullquote cite {
   display: inline-block;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -3957,36 +4009,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .site-header .wp-block-pullquote.alignleft, .site-header .wp-block-pullquote.alignright, .site-footer .wp-block-pullquote.alignleft, .site-footer .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .site-header .wp-block-pullquote.alignleft blockquote, .site-header .wp-block-pullquote.alignright blockquote, .site-footer .wp-block-pullquote.alignleft blockquote, .site-footer .wp-block-pullquote.alignright blockquote {
   margin: 32px 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .site-header .wp-block-pullquote.alignleft blockquote p:first-child, .site-header .wp-block-pullquote.alignright blockquote p:first-child, .site-footer .wp-block-pullquote.alignleft blockquote p:first-child, .site-footer .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
   background-color: #c43d80;
   padding-right: 0;
   padding-left: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
     padding-right: 10%;
     padding-left: 10%;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -3994,20 +4046,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .site-header .wp-block-pullquote.is-style-solid-color a, .site-footer .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .site-header .wp-block-pullquote.is-style-solid-color cite, .site-footer .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
   padding-right: 0;
@@ -4016,44 +4068,46 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
     margin-right: 0;
     margin-left: 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .site-header .wp-block-pullquote.is-style-solid-color.alignright, .site-header .wp-block-pullquote.is-style-solid-color.alignleft, .site-footer .wp-block-pullquote.is-style-solid-color.alignright, .site-footer .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .site-header .wp-block-pullquote.is-style-solid-color.alignfull, .site-footer .wp-block-pullquote.is-style-solid-color.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
     padding-left: calc(10% + 58px + (2 * 1rem));
   }
 }
 
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .site-header .wp-block-quote:not(.is-large), .site-header .wp-block-quote:not(.is-style-large), .site-footer .wp-block-quote:not(.is-large), .site-footer .wp-block-quote:not(.is-style-large) {
   border-color: #c43d80;
   border-width: 2px;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry .entry-content .wp-block-quote p {
+.entry .entry-content .wp-block-quote p, .site-header .wp-block-quote p, .site-footer .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry .entry-content .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite, .site-header .wp-block-quote cite, .site-footer .wp-block-quote cite {
   /*
 			 * This requires a rem-based font size calculation instead of our normal em-based one,
 			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4061,13 +4115,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
   margin: 32px auto;
   padding: 0;
   border-right: none;
 }
 
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
@@ -4075,7 +4129,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
-.entry .entry-content .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-style-large footer, .site-header .wp-block-quote.is-large cite,
+.site-header .wp-block-quote.is-large footer, .site-header .wp-block-quote.is-style-large cite,
+.site-header .wp-block-quote.is-style-large footer, .site-footer .wp-block-quote.is-large cite,
+.site-footer .wp-block-quote.is-large footer, .site-footer .wp-block-quote.is-style-large cite,
+.site-footer .wp-block-quote.is-style-large footer {
   /*
 				 * This requires a rem-based font size calculation instead of our normal em-based one,
 				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4084,30 +4142,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
     margin: 32px auto;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry .entry-content .wp-block-image {
+.entry .entry-content .wp-block-image, .site-header .wp-block-image, .site-footer .wp-block-image {
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-image img {
+.entry .entry-content .wp-block-image img, .site-header .wp-block-image img, .site-footer .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
   width: 100vw;
   max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image.alignfull img {
+  .entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
     max-width: calc( 125% + 150px);
     margin-right: auto;
     margin-left: auto;
@@ -4115,7 +4173,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image,
-.entry .entry-content .wp-block-cover {
+.entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
+.site-header .wp-block-cover, .site-footer .wp-block-cover-image,
+.site-footer .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
@@ -4123,7 +4183,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
-  .entry .entry-content .wp-block-cover {
+  .entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
+  .site-header .wp-block-cover, .site-footer .wp-block-cover-image,
+  .site-footer .wp-block-cover {
     min-height: 640px;
     padding: 1rem 10%;
   }
@@ -4134,7 +4196,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover .wp-block-cover-text {
+.entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
+.site-header .wp-block-cover-image .wp-block-cover-image-text,
+.site-header .wp-block-cover-image .wp-block-cover-text,
+.site-header .wp-block-cover .wp-block-cover__inner-container,
+.site-header .wp-block-cover .wp-block-cover-image-text,
+.site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
+.site-footer .wp-block-cover-image .wp-block-cover-image-text,
+.site-footer .wp-block-cover-image .wp-block-cover-text,
+.site-footer .wp-block-cover .wp-block-cover__inner-container,
+.site-footer .wp-block-cover .wp-block-cover-image-text,
+.site-footer .wp-block-cover .wp-block-cover-text {
   color: #fff;
   padding: 0;
   text-shadow: 0 0 12px #000;
@@ -4146,7 +4218,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
   .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text {
+  .entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
+  .site-header .wp-block-cover-image .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image .wp-block-cover-text,
+  .site-header .wp-block-cover .wp-block-cover__inner-container,
+  .site-header .wp-block-cover .wp-block-cover-image-text,
+  .site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image .wp-block-cover-text,
+  .site-footer .wp-block-cover .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover .wp-block-cover-image-text,
+  .site-footer .wp-block-cover .wp-block-cover-text {
     max-width: 100%;
   }
 }
@@ -4156,7 +4238,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text a,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container a,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text a,
-.entry .entry-content .wp-block-cover .wp-block-cover-text a {
+.entry .entry-content .wp-block-cover .wp-block-cover-text a, .site-header .wp-block-cover-image .wp-block-cover__inner-container a,
+.site-header .wp-block-cover-image .wp-block-cover-image-text a,
+.site-header .wp-block-cover-image .wp-block-cover-text a,
+.site-header .wp-block-cover .wp-block-cover__inner-container a,
+.site-header .wp-block-cover .wp-block-cover-image-text a,
+.site-header .wp-block-cover .wp-block-cover-text a, .site-footer .wp-block-cover-image .wp-block-cover__inner-container a,
+.site-footer .wp-block-cover-image .wp-block-cover-image-text a,
+.site-footer .wp-block-cover-image .wp-block-cover-text a,
+.site-footer .wp-block-cover .wp-block-cover__inner-container a,
+.site-footer .wp-block-cover .wp-block-cover-image-text a,
+.site-footer .wp-block-cover .wp-block-cover-text a {
   color: inherit;
 }
 
@@ -4171,18 +4263,44 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover h3,
 .entry .entry-content .wp-block-cover h4,
 .entry .entry-content .wp-block-cover h5,
-.entry .entry-content .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h1,
+.site-header .wp-block-cover-image h2,
+.site-header .wp-block-cover-image h3,
+.site-header .wp-block-cover-image h4,
+.site-header .wp-block-cover-image h5,
+.site-header .wp-block-cover-image h6,
+.site-header .wp-block-cover h1,
+.site-header .wp-block-cover h2,
+.site-header .wp-block-cover h3,
+.site-header .wp-block-cover h4,
+.site-header .wp-block-cover h5,
+.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h1,
+.site-footer .wp-block-cover-image h2,
+.site-footer .wp-block-cover-image h3,
+.site-footer .wp-block-cover-image h4,
+.site-footer .wp-block-cover-image h5,
+.site-footer .wp-block-cover-image h6,
+.site-footer .wp-block-cover h1,
+.site-footer .wp-block-cover h2,
+.site-footer .wp-block-cover h3,
+.site-footer .wp-block-cover h4,
+.site-footer .wp-block-cover h5,
+.site-footer .wp-block-cover h6 {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-cover-image h1,
-.entry .entry-content .wp-block-cover h1 {
+.entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
+.site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
+.site-footer .wp-block-cover h1 {
   font-size: 2.25em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h1,
-  .entry .entry-content .wp-block-cover h1 {
+  .entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
+  .site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
+  .site-footer .wp-block-cover h1 {
     font-size: 3.375em;
   }
 }
@@ -4192,7 +4310,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image h2,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
-.entry .entry-content .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
+.site-header .wp-block-cover-image .wp-block-cover-text,
+.site-header .wp-block-cover-image h2,
+.site-header .wp-block-cover .wp-block-cover-image-text,
+.site-header .wp-block-cover .wp-block-cover-text,
+.site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+.site-footer .wp-block-cover-image .wp-block-cover-text,
+.site-footer .wp-block-cover-image h2,
+.site-footer .wp-block-cover .wp-block-cover-image-text,
+.site-footer .wp-block-cover .wp-block-cover-text,
+.site-footer .wp-block-cover h2 {
   font-size: 1.6875em;
   margin: inherit;
   max-width: inherit;
@@ -4206,76 +4334,112 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image h2,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image .wp-block-cover-text,
+  .site-header .wp-block-cover-image h2,
+  .site-header .wp-block-cover .wp-block-cover-image-text,
+  .site-header .wp-block-cover .wp-block-cover-text,
+  .site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image .wp-block-cover-text,
+  .site-footer .wp-block-cover-image h2,
+  .site-footer .wp-block-cover .wp-block-cover-image-text,
+  .site-footer .wp-block-cover .wp-block-cover-text,
+  .site-footer .wp-block-cover h2 {
     font-size: 2.8125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h3,
-.entry .entry-content .wp-block-cover h3 {
+.entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
+.site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
+.site-footer .wp-block-cover h3 {
   font-size: 1.125em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h3,
-  .entry .entry-content .wp-block-cover h3 {
+  .entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
+  .site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
+  .site-footer .wp-block-cover h3 {
     font-size: 2.25em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h4,
-.entry .entry-content .wp-block-cover h4 {
+.entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
+.site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
+.site-footer .wp-block-cover h4 {
   font-size: 22px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h4,
-  .entry .entry-content .wp-block-cover h4 {
+  .entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
+  .site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
+  .site-footer .wp-block-cover h4 {
     font-size: 1.6875em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h5,
-.entry .entry-content .wp-block-cover h5 {
+.entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
+.site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
+.site-footer .wp-block-cover h5 {
   font-size: 0.88889em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h5,
-  .entry .entry-content .wp-block-cover h5 {
+  .entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
+  .site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
+  .site-footer .wp-block-cover h5 {
     font-size: 1.125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h6,
-.entry .entry-content .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
+.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
+.site-footer .wp-block-cover h6 {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h6,
-  .entry .entry-content .wp-block-cover h6 {
+  .entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
+  .site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
+  .site-footer .wp-block-cover h6 {
     font-size: 22px;
   }
 }
 
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
-.entry .entry-content .wp-block-cover.alignright {
+.entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
+.site-header .wp-block-cover.alignleft,
+.site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
+.site-footer .wp-block-cover.alignleft,
+.site-footer .wp-block-cover.alignright {
   width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
-  .entry .entry-content .wp-block-cover.alignright {
+  .entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
+  .site-header .wp-block-cover.alignleft,
+  .site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
+  .site-footer .wp-block-cover.alignleft,
+  .site-footer .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
+  .entry .entry-content .wp-block-cover.alignfull, .site-header .wp-block-cover-image.alignfull,
+  .site-header .wp-block-cover.alignfull, .site-footer .wp-block-cover-image.alignfull,
+  .site-footer .wp-block-cover.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
     padding-left: calc(10% + 58px + (2 * 1rem));
   }
@@ -4286,22 +4450,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover.alignfull h2 {
+  .entry .entry-content .wp-block-cover.alignfull h2, .site-header .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .site-header .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .site-header .wp-block-cover-image.alignfull h2,
+  .site-header .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .site-header .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .site-header .wp-block-cover.alignfull .wp-block-cover-text,
+  .site-header .wp-block-cover.alignfull h2, .site-footer .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .site-footer .wp-block-cover-image.alignfull h2,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover-text,
+  .site-footer .wp-block-cover.alignfull h2 {
     padding: 0;
   }
 }
 
-.entry .entry-content .wp-block-gallery {
+.entry .entry-content .wp-block-gallery, .site-header .wp-block-gallery, .site-footer .wp-block-gallery {
   list-style-type: none;
   padding-right: 0;
 }
 
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .site-header .wp-block-gallery .blocks-gallery-image:last-child,
+.site-header .wp-block-gallery .blocks-gallery-item:last-child, .site-footer .wp-block-gallery .blocks-gallery-image:last-child,
+.site-footer .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry .entry-content .wp-block-gallery figcaption a {
+.entry .entry-content .wp-block-gallery figcaption a, .site-header .wp-block-gallery figcaption a, .site-footer .wp-block-gallery figcaption a {
   color: #fff;
 }
 
@@ -4309,7 +4489,15 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .site-header .wp-block-audio figcaption,
+.site-header .wp-block-video figcaption,
+.site-header .wp-block-image figcaption,
+.site-header .wp-block-gallery .blocks-gallery-image figcaption,
+.site-header .wp-block-gallery .blocks-gallery-item figcaption, .site-footer .wp-block-audio figcaption,
+.site-footer .wp-block-video figcaption,
+.site-footer .wp-block-image figcaption,
+.site-footer .wp-block-gallery .blocks-gallery-image figcaption,
+.site-footer .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4319,7 +4507,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator,
-.entry .entry-content hr {
+.entry .entry-content hr, .site-header .wp-block-separator,
+.site-header hr, .site-footer .wp-block-separator,
+.site-footer hr {
   background-color: #686868;
   border: 0;
   height: 1px;
@@ -4331,26 +4521,34 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator.is-style-wide,
-.entry .entry-content hr.is-style-wide {
+.entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+.site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+.site-footer hr.is-style-wide {
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+  .site-footer hr.is-style-wide {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+  .site-footer hr.is-style-wide {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots,
-.entry .entry-content hr.is-style-dots {
+.entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+.site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+.site-footer hr.is-style-dots {
   max-width: 100%;
   background-color: inherit;
   border: inherit;
@@ -4360,20 +4558,26 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+  .site-footer hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+  .site-footer hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots:before,
-.entry .entry-content hr.is-style-dots:before {
+.entry .entry-content hr.is-style-dots:before, .site-header .wp-block-separator.is-style-dots:before,
+.site-header hr.is-style-dots:before, .site-footer .wp-block-separator.is-style-dots:before,
+.site-footer hr.is-style-dots:before {
   color: #686868;
   font-size: 1.6875em;
 }
@@ -4381,34 +4585,42 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-separator + h1:before,
 .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
-.entry .entry-content hr + h2:before {
+.entry .entry-content hr + h2:before, .site-header .wp-block-separator + h1:before,
+.site-header .wp-block-separator + h2:before,
+.site-header hr + h1:before,
+.site-header hr + h2:before, .site-footer .wp-block-separator + h1:before,
+.site-footer .wp-block-separator + h2:before,
+.site-footer hr + h1:before,
+.site-footer hr + h2:before {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer.desktop-only {
+.entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
   display: none;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-spacer.desktop-only {
+  .entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
     display: block;
   }
 }
 
-.entry .entry-content .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter, .site-header .wp-block-embed-twitter, .site-footer .wp-block-embed-twitter {
   word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,
-.entry .entry-content .wp-block-table td {
+.entry .entry-content .wp-block-table td, .site-header .wp-block-table th,
+.site-header .wp-block-table td, .site-footer .wp-block-table th,
+.site-footer .wp-block-table td {
   border-color: #686868;
 }
 
-.entry .entry-content .wp-block-file {
+.entry .entry-content .wp-block-file, .site-header .wp-block-file, .site-footer .wp-block-file {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
   border: none;
@@ -4426,85 +4638,95 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .site-header .wp-block-file .wp-block-file__button:hover, .site-footer .wp-block-file .wp-block-file__button:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus, .site-header .wp-block-file .wp-block-file__button:focus, .site-footer .wp-block-file .wp-block-file__button:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-code {
+.entry .entry-content .wp-block-code, .site-header .wp-block-code, .site-footer .wp-block-code {
   border-radius: 0;
 }
 
-.entry .entry-content .wp-block-code code {
+.entry .entry-content .wp-block-code code, .site-header .wp-block-code code, .site-footer .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns.alignfull {
+.entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
   padding-right: 1rem;
   padding-left: 1rem;
 }
 
 @media only screen and (min-width: 782px) {
-  .entry .entry-content .wp-block-columns .wp-block-column {
+  .entry .entry-content .wp-block-columns .wp-block-column, .site-header .wp-block-columns .wp-block-column, .site-footer .wp-block-columns .wp-block-column {
     margin-right: 0.5rem;
     margin-left: 0.5rem;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .site-header .wp-block-columns .wp-block-column:first-child, .site-footer .wp-block-columns .wp-block-column:first-child {
     margin-right: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .site-header .wp-block-columns .wp-block-column:last-child, .site-footer .wp-block-columns .wp-block-column:last-child {
     margin-left: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .site-header .wp-block-columns .wp-block-column > *:first-child, .site-footer .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .site-header .wp-block-columns .wp-block-column > *:last-child, .site-footer .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns.alignfull {
+  .entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
     padding-right: calc( 2 * 1rem);
     padding-left: calc( 2 * 1rem);
   }
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 700;
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment,
+.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment,
+.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color {
-  color: #fff;
+.entry .entry-content .has-light-gray-background-color, .site-header .has-primary-background-color,
+.site-header .has-secondary-background-color,
+.site-header .has-dark-gray-background-color,
+.site-header .has-light-gray-background-color, .site-footer .has-primary-background-color,
+.site-footer .has-secondary-background-color,
+.site-footer .has-dark-gray-background-color,
+.site-footer .has-light-gray-background-color {
+  color: peru;
 }
 
 .entry .entry-content .has-primary-background-color p,
@@ -4538,11 +4760,73 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-light-gray-background-color h4,
 .entry .entry-content .has-light-gray-background-color h5,
 .entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a {
+.entry .entry-content .has-light-gray-background-color a, .site-header .has-primary-background-color p,
+.site-header .has-primary-background-color h1,
+.site-header .has-primary-background-color h2,
+.site-header .has-primary-background-color h3,
+.site-header .has-primary-background-color h4,
+.site-header .has-primary-background-color h5,
+.site-header .has-primary-background-color h6,
+.site-header .has-primary-background-color a,
+.site-header .has-secondary-background-color p,
+.site-header .has-secondary-background-color h1,
+.site-header .has-secondary-background-color h2,
+.site-header .has-secondary-background-color h3,
+.site-header .has-secondary-background-color h4,
+.site-header .has-secondary-background-color h5,
+.site-header .has-secondary-background-color h6,
+.site-header .has-secondary-background-color a,
+.site-header .has-dark-gray-background-color p,
+.site-header .has-dark-gray-background-color h1,
+.site-header .has-dark-gray-background-color h2,
+.site-header .has-dark-gray-background-color h3,
+.site-header .has-dark-gray-background-color h4,
+.site-header .has-dark-gray-background-color h5,
+.site-header .has-dark-gray-background-color h6,
+.site-header .has-dark-gray-background-color a,
+.site-header .has-light-gray-background-color p,
+.site-header .has-light-gray-background-color h1,
+.site-header .has-light-gray-background-color h2,
+.site-header .has-light-gray-background-color h3,
+.site-header .has-light-gray-background-color h4,
+.site-header .has-light-gray-background-color h5,
+.site-header .has-light-gray-background-color h6,
+.site-header .has-light-gray-background-color a, .site-footer .has-primary-background-color p,
+.site-footer .has-primary-background-color h1,
+.site-footer .has-primary-background-color h2,
+.site-footer .has-primary-background-color h3,
+.site-footer .has-primary-background-color h4,
+.site-footer .has-primary-background-color h5,
+.site-footer .has-primary-background-color h6,
+.site-footer .has-primary-background-color a,
+.site-footer .has-secondary-background-color p,
+.site-footer .has-secondary-background-color h1,
+.site-footer .has-secondary-background-color h2,
+.site-footer .has-secondary-background-color h3,
+.site-footer .has-secondary-background-color h4,
+.site-footer .has-secondary-background-color h5,
+.site-footer .has-secondary-background-color h6,
+.site-footer .has-secondary-background-color a,
+.site-footer .has-dark-gray-background-color p,
+.site-footer .has-dark-gray-background-color h1,
+.site-footer .has-dark-gray-background-color h2,
+.site-footer .has-dark-gray-background-color h3,
+.site-footer .has-dark-gray-background-color h4,
+.site-footer .has-dark-gray-background-color h5,
+.site-footer .has-dark-gray-background-color h6,
+.site-footer .has-dark-gray-background-color a,
+.site-footer .has-light-gray-background-color p,
+.site-footer .has-light-gray-background-color h1,
+.site-footer .has-light-gray-background-color h2,
+.site-footer .has-light-gray-background-color h3,
+.site-footer .has-light-gray-background-color h4,
+.site-footer .has-light-gray-background-color h5,
+.site-footer .has-light-gray-background-color h6,
+.site-footer .has-light-gray-background-color a {
   color: #fff;
 }
 
-.entry .entry-content .has-white-background-color {
+.entry .entry-content .has-white-background-color, .site-header .has-white-background-color, .site-footer .has-white-background-color {
   color: #181818;
 }
 
@@ -4553,106 +4837,150 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-white-background-color h4,
 .entry .entry-content .has-white-background-color h5,
 .entry .entry-content .has-white-background-color h6,
-.entry .entry-content .has-white-background-color a {
+.entry .entry-content .has-white-background-color a, .site-header .has-white-background-color p,
+.site-header .has-white-background-color h1,
+.site-header .has-white-background-color h2,
+.site-header .has-white-background-color h3,
+.site-header .has-white-background-color h4,
+.site-header .has-white-background-color h5,
+.site-header .has-white-background-color h6,
+.site-header .has-white-background-color a, .site-footer .has-white-background-color p,
+.site-footer .has-white-background-color h1,
+.site-footer .has-white-background-color h2,
+.site-footer .has-white-background-color h3,
+.site-footer .has-white-background-color h4,
+.site-footer .has-white-background-color h5,
+.site-footer .has-white-background-color h6,
+.site-footer .has-white-background-color a {
   color: #181818;
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-header .has-primary-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-footer .has-primary-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-header .has-secondary-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-footer .has-secondary-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
   background-color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-header .has-dark-gray-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-footer .has-dark-gray-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #181818;
 }
 
 .entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-header .has-light-gray-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-footer .has-light-gray-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #686868;
 }
 
 .entry .entry-content .has-white-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-header .has-white-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-footer .has-white-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-header .has-primary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-footer .has-primary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
   color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-header .has-secondary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-footer .has-secondary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
   color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-header .has-dark-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-footer .has-dark-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
   color: #181818;
 }
 
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-header .has-light-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-footer .has-light-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
   color: #686868;
 }
 
 .entry .entry-content .has-white-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .has-white-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .has-white-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: #FFF;
 }
 
 .entry .entry-content .a8c-posts-list-item__title a,
-.entry .entry-content .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__title a,
+.site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__title a,
+.site-footer .a8c-posts-list-item__meta a {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a {
+.entry .entry-content .a8c-posts-list-item__title a, .site-header .a8c-posts-list-item__title a, .site-footer .a8c-posts-list-item__title a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus {
+.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .site-header .a8c-posts-list-item__title a:hover, .site-header .a8c-posts-list-item__title a:focus, .site-footer .a8c-posts-list-item__title a:hover, .site-footer .a8c-posts-list-item__title a:focus {
   color: #4a4a4a;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__meta a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus {
+.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .site-header .a8c-posts-list-item__meta a:hover, .site-header .a8c-posts-list-item__meta a:focus, .site-footer .a8c-posts-list-item__meta a:hover, .site-footer .a8c-posts-list-item__meta a:focus {
   color: #c43d80;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
+.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-header .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-footer .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
   color: #fff;
 }
 
-.entry .entry-content .a8c-posts-list {
+.entry .entry-content .a8c-posts-list, .site-header .a8c-posts-list, .site-footer .a8c-posts-list {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list__item:not(:first-child) {
+.entry .entry-content .a8c-posts-list__item:not(:first-child), .site-header .a8c-posts-list__item:not(:first-child), .site-footer .a8c-posts-list__item:not(:first-child) {
   margin-top: calc(6 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__featured {
+.entry .entry-content .a8c-posts-list-item__featured, .site-header .a8c-posts-list-item__featured, .site-footer .a8c-posts-list-item__featured {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__featured span {
+.entry .entry-content .a8c-posts-list-item__featured span, .site-header .a8c-posts-list-item__featured span, .site-footer .a8c-posts-list-item__featured span {
   background: #c43d80;
   color: #fff;
   display: inline-block;
@@ -4664,33 +4992,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   z-index: 1;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail, .site-header .a8c-posts-list-item__post-thumbnail, .site-footer .a8c-posts-list-item__post-thumbnail {
   margin-bottom: 32px;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail img {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .site-header .a8c-posts-list-item__post-thumbnail img, .site-footer .a8c-posts-list-item__post-thumbnail img {
   display: block;
 }
 
-.entry .entry-content .a8c-posts-list-item__title {
+.entry .entry-content .a8c-posts-list-item__title, .site-header .a8c-posts-list-item__title, .site-footer .a8c-posts-list-item__title {
   font-size: 1.6875em;
   margin: 0;
   text-align: center;
   font-weight: 300;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta {
+.entry .entry-content .a8c-posts-list-item__meta, .site-header .a8c-posts-list-item__meta, .site-footer .a8c-posts-list-item__meta {
   color: #686868;
   font-size: 0.71111em;
   font-weight: 500;
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__author {
+.entry .entry-content .a8c-posts-list-item__author, .site-header .a8c-posts-list-item__author, .site-footer .a8c-posts-list-item__author {
   margin-left: calc(.5 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link {
+.entry .entry-content .a8c-posts-list-item__edit-link, .site-header .a8c-posts-list-item__edit-link, .site-footer .a8c-posts-list-item__edit-link {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border-radius: 3px;
@@ -4699,33 +5027,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding: .05rem .4rem;
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus {
+.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .site-header .a8c-posts-list-item__edit-link:hover, .site-header .a8c-posts-list-item__edit-link:focus, .site-footer .a8c-posts-list-item__edit-link:hover, .site-footer .a8c-posts-list-item__edit-link:focus {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt {
+.entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
   margin: 0 auto;
   text-align: right;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt p {
+.entry .entry-content .a8c-posts-list-item__excerpt p, .site-header .a8c-posts-list-item__excerpt p, .site-footer .a8c-posts-list-item__excerpt p {
   margin: 32px 0;
 }
 
-.entry .entry-content .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border: none;
@@ -4743,17 +5071,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   vertical-align: bottom;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:hover {
+.entry .entry-content .a8c-posts-list__view-all:hover, .site-header .a8c-posts-list__view-all:hover, .site-footer .a8c-posts-list__view-all:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:visited {
+.entry .entry-content .a8c-posts-list__view-all:visited, .site-header .a8c-posts-list__view-all:visited, .site-footer .a8c-posts-list__view-all:visited {
   color: #fff;
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:focus {
+.entry .entry-content .a8c-posts-list__view-all:focus, .site-header .a8c-posts-list__view-all:focus, .site-footer .a8c-posts-list__view-all:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -3415,44 +3415,51 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 /* Blocks */
 /* !Block styles */
 .entry .entry-content > *,
-.entry .entry-summary > * {
+.entry .entry-summary > *
+.fse-template-content > * {
   margin: 32px 0;
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.fse-template-content > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.fse-template-content > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.fse-template-content > * {
     margin: 32px auto;
   }
 }
 
 .entry .entry-content > * > *:first-child,
-.entry .entry-summary > * > *:first-child {
+.entry .entry-summary > *
+.fse-template-content > * > *:first-child {
   margin-top: 0;
 }
 
 .entry .entry-content > * > *:last-child,
-.entry .entry-summary > * > *:last-child {
+.entry .entry-summary > *
+.fse-template-content > * > *:last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content > *.alignwide,
-.entry .entry-summary > *.alignwide {
+.entry .entry-summary > *
+.fse-template-content > *.alignwide {
   margin-right: auto;
   margin-left: auto;
   clear: both;
@@ -3460,14 +3467,16 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
-  .entry .entry-summary > *.alignwide {
+  .entry .entry-summary > *
+.fse-template-content > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
 }
 
 .entry .entry-content > *.alignfull,
-.entry .entry-summary > *.alignfull {
+.entry .entry-summary > *
+.fse-template-content > *.alignfull {
   position: relative;
   right: -1rem;
   width: calc( 100% + (2 * 1rem));
@@ -3477,7 +3486,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
-  .entry .entry-summary > *.alignfull {
+  .entry .entry-summary > *
+.fse-template-content > *.alignfull {
     margin-top: 32px;
     margin-bottom: 32px;
     right: calc( -12.5% - 75px);
@@ -3487,7 +3497,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content > *.alignleft,
-.entry .entry-summary > *.alignleft {
+.entry .entry-summary > *
+.fse-template-content > *.alignleft {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3497,14 +3508,16 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
-  .entry .entry-summary > *.alignleft {
+  .entry .entry-summary > *
+.fse-template-content > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     margin-right: calc(2 * 1rem);
   }
 }
 
 .entry .entry-content > *.alignright,
-.entry .entry-summary > *.alignright {
+.entry .entry-summary > *
+.fse-template-content > *.alignright {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3514,7 +3527,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
-  .entry .entry-summary > *.alignright {
+  .entry .entry-summary > *
+.fse-template-content > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-left: 0;
     margin-left: calc(2 * 1rem);
@@ -3522,7 +3536,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content > *.aligncenter,
-.entry .entry-summary > *.aligncenter {
+.entry .entry-summary > *
+.fse-template-content > *.aligncenter {
   margin-right: auto;
   margin-left: auto;
   /*
@@ -3535,14 +3550,16 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
-  .entry .entry-summary > *.aligncenter {
+  .entry .entry-summary > *
+.fse-template-content > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
-  .entry .entry-summary > *.aligncenter {
+  .entry .entry-summary > *
+.fse-template-content > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3564,7 +3581,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .entry,
 .entry .entry-summary .entry-content,
 .entry .entry-summary .entry-summary,
-.entry .entry-summary .entry {
+.entry .entry-summary .entry,
+.fse-template-content .entry-content,
+.fse-template-content .entry-summary,
+.fse-template-content .entry {
   margin: inherit;
   max-width: inherit;
   padding: inherit;
@@ -3576,7 +3596,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .entry,
   .entry .entry-summary .entry-content,
   .entry .entry-summary .entry-summary,
-  .entry .entry-summary .entry {
+  .entry .entry-summary .entry,
+  .fse-template-content .entry-content,
+  .fse-template-content .entry-summary,
+  .fse-template-content .entry {
     margin: inherit;
     max-width: inherit;
     padding: inherit;
@@ -3588,184 +3611,175 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content > h3,
 .entry .entry-content > h4,
 .entry .entry-content > h5,
-.entry .entry-content > h6, .site-header > h1,
-.site-header > h2,
-.site-header > h3,
-.site-header > h4,
-.site-header > h5,
-.site-header > h6, .site-footer > h1,
-.site-footer > h2,
-.site-footer > h3,
-.site-footer > h4,
-.site-footer > h5,
-.site-footer > h6 {
+.entry .entry-content > h6, .fse-template-content > h1,
+.fse-template-content > h2,
+.fse-template-content > h3,
+.fse-template-content > h4,
+.fse-template-content > h5,
+.fse-template-content > h6 {
   margin: 32px auto;
   text-align: center;
 }
 
-.entry .entry-content > h2, .site-header > h2, .site-footer > h2 {
+.entry .entry-content > h2, .fse-template-content > h2 {
   font-size: 1.125em;
   font-weight: 700;
 }
 
-.entry .entry-content p.has-background, .site-header p.has-background, .site-footer p.has-background {
+.entry .entry-content p.has-background, .fse-template-content p.has-background {
   padding: 20px 30px;
 }
 
-.entry .entry-content .wp-block-audio, .site-header .wp-block-audio, .site-footer .wp-block-audio {
+.entry .entry-content .wp-block-audio, .fse-template-content .wp-block-audio {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-audio audio, .site-header .wp-block-audio audio, .site-footer .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio, .fse-template-content .wp-block-audio audio {
   width: 100%;
 }
 
 .entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-.site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-.site-footer .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+.fse-template-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-  .site-footer .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+  .fse-template-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-  .site-footer .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+  .fse-template-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry .entry-content .wp-block-video video, .site-header .wp-block-video video, .site-footer .wp-block-video video {
+.entry .entry-content .wp-block-video video, .fse-template-content .wp-block-video video {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
+.entry .entry-content .wp-block-media-text, .fse-template-content .wp-block-media-text {
   margin: 0 auto;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(odd), .site-header .wp-block-media-text:nth-child(odd), .site-footer .wp-block-media-text:nth-child(odd) {
+.entry .entry-content .wp-block-media-text:nth-child(odd), .fse-template-content .wp-block-media-text:nth-child(odd) {
   background-color: #181818;
   color: #fff;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(even), .site-header .wp-block-media-text:nth-child(even), .site-footer .wp-block-media-text:nth-child(even) {
+.entry .entry-content .wp-block-media-text:nth-child(even), .fse-template-content .wp-block-media-text:nth-child(even) {
   background-color: #f2f2f2;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
   grid-area: media-text-content;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
     grid-area: media-text-media;
   }
 }
 
-.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull .wp-block-media-text__content {
   padding: 8% 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
-.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
   padding: 8%;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
   grid-area: media-text-media;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
     grid-area: media-text-content;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
+  .entry .entry-content .wp-block-media-text, .fse-template-content .wp-block-media-text {
     padding: 64px 0;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .site-header .wp-block-media-text .wp-block-media-text__media, .site-footer .wp-block-media-text .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .fse-template-content .wp-block-media-text .wp-block-media-text__media {
     margin-right: -64px;
     margin-left: 64px;
     max-width: calc( 100%);
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
-  .entry .entry-content .wp-block-media-text.alignfull, .site-header .wp-block-media-text.alignfull, .site-footer .wp-block-media-text.alignfull {
+  .entry .entry-content .wp-block-media-text.alignfull, .fse-template-content .wp-block-media-text.alignfull {
     margin-right: 64px;
     margin-left: 64px;
     max-width: calc( 125% + 30px);
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
     margin-left: -64px;
     margin-right: 64px;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
-.entry .entry-content .wp-block-media-text :first-child, .site-header .wp-block-media-text :first-child, .site-footer .wp-block-media-text :first-child {
+.entry .entry-content .wp-block-media-text :first-child, .fse-template-content .wp-block-media-text :first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-media-text :last-child, .site-header .wp-block-media-text :last-child, .site-footer .wp-block-media-text :last-child {
+.entry .entry-content .wp-block-media-text :last-child, .fse-template-content .wp-block-media-text :last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content .wp-block-media-text a,
-.entry .entry-content .wp-block-media-text a:hover, .site-header .wp-block-media-text a,
-.site-header .wp-block-media-text a:hover, .site-footer .wp-block-media-text a,
-.site-footer .wp-block-media-text a:hover {
+.entry .entry-content .wp-block-media-text a:hover, .fse-template-content .wp-block-media-text a,
+.fse-template-content .wp-block-media-text a:hover {
   color: inherit;
 }
 
 @media all and (-ms-high-contrast: none) {
-  .entry .entry-content .wp-block-media-text:after, .site-header .wp-block-media-text:after, .site-footer .wp-block-media-text:after {
+  .entry .entry-content .wp-block-media-text:after, .fse-template-content .wp-block-media-text:after {
     display: table;
     content: "";
     clear: both;
   }
-  .entry .entry-content .wp-block-media-text figure, .site-header .wp-block-media-text figure, .site-footer .wp-block-media-text figure {
+  .entry .entry-content .wp-block-media-text figure, .fse-template-content .wp-block-media-text figure {
     float: right;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
     float: left;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .site-header .wp-block-media-text.has-media-on-the-right figure, .site-footer .wp-block-media-text.has-media-on-the-right figure {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .fse-template-content .wp-block-media-text.has-media-on-the-right figure {
     float: left;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     float: right;
   }
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link, .site-header .wp-block-button .wp-block-button__link, .site-footer .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link, .fse-template-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
@@ -3779,38 +3793,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline: none;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .site-header .wp-block-button .wp-block-button__link:not(.has-background), .site-footer .wp-block-button .wp-block-button__link:not(.has-background) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .fse-template-content .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #c43d80;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .site-header .wp-block-button .wp-block-button__link:not(.has-text-color), .site-footer .wp-block-button .wp-block-button__link:not(.has-text-color) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .fse-template-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:hover, .site-header .wp-block-button .wp-block-button__link:hover, .site-footer .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .fse-template-content .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:focus, .site-header .wp-block-button .wp-block-button__link:focus, .site-footer .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus, .fse-template-content .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-header .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-footer .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .fse-template-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .site-header .wp-block-button.is-style-outline .wp-block-button__link,
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active, .site-footer .wp-block-button.is-style-outline .wp-block-button__link,
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link,
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
@@ -3818,52 +3830,44 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #c43d80;
   border-color: currentColor;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #9e3067;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #9e3067;
 }
 
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
-.entry .entry-content .wp-block-latest-posts, .site-header .wp-block-archives,
-.site-header .wp-block-categories,
-.site-header .wp-block-latest-posts, .site-footer .wp-block-archives,
-.site-footer .wp-block-categories,
-.site-footer .wp-block-latest-posts {
+.entry .entry-content .wp-block-latest-posts, .fse-template-content .wp-block-archives,
+.fse-template-content .wp-block-categories,
+.fse-template-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
 .entry .entry-content .wp-block-archives li,
 .entry .entry-content .wp-block-categories li,
-.entry .entry-content .wp-block-latest-posts li, .site-header .wp-block-archives li,
-.site-header .wp-block-categories li,
-.site-header .wp-block-latest-posts li, .site-footer .wp-block-archives li,
-.site-footer .wp-block-categories li,
-.site-footer .wp-block-latest-posts li {
+.entry .entry-content .wp-block-latest-posts li, .fse-template-content .wp-block-archives li,
+.fse-template-content .wp-block-categories li,
+.fse-template-content .wp-block-latest-posts li {
   color: #686868;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3876,86 +3880,79 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-categories li.menu-item-has-children,
 .entry .entry-content .wp-block-categories li:last-child,
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
-.entry .entry-content .wp-block-latest-posts li:last-child, .site-header .wp-block-archives li.menu-item-has-children, .site-header .wp-block-archives li:last-child,
-.site-header .wp-block-categories li.menu-item-has-children,
-.site-header .wp-block-categories li:last-child,
-.site-header .wp-block-latest-posts li.menu-item-has-children,
-.site-header .wp-block-latest-posts li:last-child, .site-footer .wp-block-archives li.menu-item-has-children, .site-footer .wp-block-archives li:last-child,
-.site-footer .wp-block-categories li.menu-item-has-children,
-.site-footer .wp-block-categories li:last-child,
-.site-footer .wp-block-latest-posts li.menu-item-has-children,
-.site-footer .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li:last-child, .fse-template-content .wp-block-archives li.menu-item-has-children, .fse-template-content .wp-block-archives li:last-child,
+.fse-template-content .wp-block-categories li.menu-item-has-children,
+.fse-template-content .wp-block-categories li:last-child,
+.fse-template-content .wp-block-latest-posts li.menu-item-has-children,
+.fse-template-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
 .entry .entry-content .wp-block-categories li a,
-.entry .entry-content .wp-block-latest-posts li a, .site-header .wp-block-archives li a,
-.site-header .wp-block-categories li a,
-.site-header .wp-block-latest-posts li a, .site-footer .wp-block-archives li a,
-.site-footer .wp-block-categories li a,
-.site-footer .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-latest-posts li a, .fse-template-content .wp-block-archives li a,
+.fse-template-content .wp-block-categories li a,
+.fse-template-content .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter, .site-header .wp-block-archives.aligncenter,
-.site-header .wp-block-categories.aligncenter, .site-footer .wp-block-archives.aligncenter,
-.site-footer .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter, .fse-template-content .wp-block-archives.aligncenter,
+.fse-template-content .wp-block-categories.aligncenter {
   text-align: center;
 }
 
-.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .fse-template-content .wp-block-categories ul {
   padding-top: 24px;
 }
 
-.entry .entry-content .wp-block-categories li ul, .site-header .wp-block-categories li ul, .site-footer .wp-block-categories li ul {
+.entry .entry-content .wp-block-categories li ul, .fse-template-content .wp-block-categories li ul {
   list-style: none;
   padding-right: 0;
 }
 
-.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .fse-template-content .wp-block-categories ul {
   counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a::before, .site-header .wp-block-categories ul > li > a::before, .site-footer .wp-block-categories ul > li > a::before {
+.entry .entry-content .wp-block-categories ul > li > a::before, .fse-template-content .wp-block-categories ul > li > a::before {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li, .site-header .wp-block-latest-posts.is-grid li, .site-footer .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li, .fse-template-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 32px;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .site-header .wp-block-latest-posts.is-grid li a:after, .site-footer .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .fse-template-content .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .site-header .wp-block-latest-posts.is-grid li:last-child, .site-footer .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .fse-template-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .site-header .wp-block-latest-posts.is-grid li:last-child a:after, .site-footer .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .fse-template-content .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-preformatted, .site-header .wp-block-preformatted, .site-footer .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted, .fse-template-content .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-verse, .site-header .wp-block-verse, .site-footer .wp-block-verse {
+.entry .entry-content .wp-block-verse, .fse-template-content .wp-block-verse {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry .entry-content .has-drop-cap:not(:focus):first-letter, .site-header .has-drop-cap:not(:focus):first-letter, .site-footer .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter, .fse-template-content .has-drop-cap:not(:focus):first-letter {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -3963,13 +3960,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin: 0 0 0 0.25em;
 }
 
-.entry .entry-content .wp-block-pullquote, .site-header .wp-block-pullquote, .site-footer .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote, .fse-template-content .wp-block-pullquote {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote blockquote, .site-header .wp-block-pullquote blockquote, .site-footer .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote, .fse-template-content .wp-block-pullquote blockquote {
   color: #181818;
   border: none;
   margin-top: calc(3 * 32px);
@@ -3978,7 +3975,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding-right: 0;
 }
 
-.entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p, .fse-template-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -3986,17 +3983,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-top: 0.5em;
 }
 
-.entry .entry-content .wp-block-pullquote p em, .site-header .wp-block-pullquote p em, .site-footer .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em, .fse-template-content .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p, .fse-template-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote cite, .site-header .wp-block-pullquote cite, .site-footer .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite, .fse-template-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4009,36 +4006,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .site-header .wp-block-pullquote.alignleft, .site-header .wp-block-pullquote.alignright, .site-footer .wp-block-pullquote.alignleft, .site-footer .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .fse-template-content .wp-block-pullquote.alignleft, .fse-template-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .site-header .wp-block-pullquote.alignleft blockquote, .site-header .wp-block-pullquote.alignright blockquote, .site-footer .wp-block-pullquote.alignleft blockquote, .site-footer .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .fse-template-content .wp-block-pullquote.alignleft blockquote, .fse-template-content .wp-block-pullquote.alignright blockquote {
   margin: 32px 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .site-header .wp-block-pullquote.alignleft blockquote p:first-child, .site-header .wp-block-pullquote.alignright blockquote p:first-child, .site-footer .wp-block-pullquote.alignleft blockquote p:first-child, .site-footer .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .fse-template-content .wp-block-pullquote.alignleft blockquote p:first-child, .fse-template-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color, .fse-template-content .wp-block-pullquote.is-style-solid-color {
   background-color: #c43d80;
   padding-right: 0;
   padding-left: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .fse-template-content .wp-block-pullquote.is-style-solid-color {
     padding-right: 10%;
     padding-left: 10%;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .fse-template-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -4046,20 +4043,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .fse-template-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .site-header .wp-block-pullquote.is-style-solid-color a, .site-footer .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .fse-template-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .site-header .wp-block-pullquote.is-style-solid-color cite, .site-footer .wp-block-pullquote.is-style-solid-color cite {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .fse-template-content .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
   padding-right: 0;
@@ -4068,46 +4065,45 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote {
     margin-right: 0;
     margin-left: 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .site-header .wp-block-pullquote.is-style-solid-color.alignright, .site-header .wp-block-pullquote.is-style-solid-color.alignleft, .site-footer .wp-block-pullquote.is-style-solid-color.alignright, .site-footer .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignright, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .site-header .wp-block-pullquote.is-style-solid-color.alignfull, .site-footer .wp-block-pullquote.is-style-solid-color.alignfull {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
     padding-left: calc(10% + 58px + (2 * 1rem));
   }
 }
 
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .site-header .wp-block-quote:not(.is-large), .site-header .wp-block-quote:not(.is-style-large), .site-footer .wp-block-quote:not(.is-large), .site-footer .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .fse-template-content .wp-block-quote:not(.is-large), .fse-template-content .wp-block-quote:not(.is-style-large) {
   border-color: #c43d80;
   border-width: 2px;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry .entry-content .wp-block-quote p, .site-header .wp-block-quote p, .site-footer .wp-block-quote p {
+.entry .entry-content .wp-block-quote p, .fse-template-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry .entry-content .wp-block-quote cite, .site-header .wp-block-quote cite, .site-footer .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite, .fse-template-content .wp-block-quote cite {
   /*
 			 * This requires a rem-based font size calculation instead of our normal em-based one,
 			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4115,13 +4111,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .fse-template-content .wp-block-quote.is-large, .fse-template-content .wp-block-quote.is-style-large {
   margin: 32px auto;
   padding: 0;
   border-right: none;
 }
 
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .fse-template-content .wp-block-quote.is-large p, .fse-template-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
@@ -4129,11 +4125,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
-.entry .entry-content .wp-block-quote.is-style-large footer, .site-header .wp-block-quote.is-large cite,
-.site-header .wp-block-quote.is-large footer, .site-header .wp-block-quote.is-style-large cite,
-.site-header .wp-block-quote.is-style-large footer, .site-footer .wp-block-quote.is-large cite,
-.site-footer .wp-block-quote.is-large footer, .site-footer .wp-block-quote.is-style-large cite,
-.site-footer .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-style-large footer, .fse-template-content .wp-block-quote.is-large cite,
+.fse-template-content .wp-block-quote.is-large footer, .fse-template-content .wp-block-quote.is-style-large cite,
+.fse-template-content .wp-block-quote.is-style-large footer {
   /*
 				 * This requires a rem-based font size calculation instead of our normal em-based one,
 				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4142,30 +4136,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .fse-template-content .wp-block-quote.is-large, .fse-template-content .wp-block-quote.is-style-large {
     margin: 32px auto;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .fse-template-content .wp-block-quote.is-large p, .fse-template-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry .entry-content .wp-block-image, .site-header .wp-block-image, .site-footer .wp-block-image {
+.entry .entry-content .wp-block-image, .fse-template-content .wp-block-image {
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-image img, .site-header .wp-block-image img, .site-footer .wp-block-image img {
+.entry .entry-content .wp-block-image img, .fse-template-content .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img, .fse-template-content .wp-block-image.alignfull img {
   width: 100vw;
   max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
+  .entry .entry-content .wp-block-image.alignfull img, .fse-template-content .wp-block-image.alignfull img {
     max-width: calc( 125% + 150px);
     margin-right: auto;
     margin-left: auto;
@@ -4173,9 +4167,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image,
-.entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
-.site-header .wp-block-cover, .site-footer .wp-block-cover-image,
-.site-footer .wp-block-cover {
+.entry .entry-content .wp-block-cover, .fse-template-content .wp-block-cover-image,
+.fse-template-content .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
@@ -4183,9 +4176,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
-  .entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
-  .site-header .wp-block-cover, .site-footer .wp-block-cover-image,
-  .site-footer .wp-block-cover {
+  .entry .entry-content .wp-block-cover, .fse-template-content .wp-block-cover-image,
+  .fse-template-content .wp-block-cover {
     min-height: 640px;
     padding: 1rem 10%;
   }
@@ -4196,17 +4188,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
-.site-header .wp-block-cover-image .wp-block-cover-image-text,
-.site-header .wp-block-cover-image .wp-block-cover-text,
-.site-header .wp-block-cover .wp-block-cover__inner-container,
-.site-header .wp-block-cover .wp-block-cover-image-text,
-.site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
-.site-footer .wp-block-cover-image .wp-block-cover-image-text,
-.site-footer .wp-block-cover-image .wp-block-cover-text,
-.site-footer .wp-block-cover .wp-block-cover__inner-container,
-.site-footer .wp-block-cover .wp-block-cover-image-text,
-.site-footer .wp-block-cover .wp-block-cover-text {
+.entry .entry-content .wp-block-cover .wp-block-cover-text, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container,
+.fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text,
+.fse-template-content .wp-block-cover .wp-block-cover__inner-container,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover .wp-block-cover-text {
   color: #fff;
   padding: 0;
   text-shadow: 0 0 12px #000;
@@ -4218,17 +4205,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
   .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
-  .site-header .wp-block-cover-image .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image .wp-block-cover-text,
-  .site-header .wp-block-cover .wp-block-cover__inner-container,
-  .site-header .wp-block-cover .wp-block-cover-image-text,
-  .site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image .wp-block-cover-text,
-  .site-footer .wp-block-cover .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover .wp-block-cover-image-text,
-  .site-footer .wp-block-cover .wp-block-cover-text {
+  .entry .entry-content .wp-block-cover .wp-block-cover-text, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-text,
+  .fse-template-content .wp-block-cover .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover .wp-block-cover-text {
     max-width: 100%;
   }
 }
@@ -4238,17 +4220,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text a,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container a,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text a,
-.entry .entry-content .wp-block-cover .wp-block-cover-text a, .site-header .wp-block-cover-image .wp-block-cover__inner-container a,
-.site-header .wp-block-cover-image .wp-block-cover-image-text a,
-.site-header .wp-block-cover-image .wp-block-cover-text a,
-.site-header .wp-block-cover .wp-block-cover__inner-container a,
-.site-header .wp-block-cover .wp-block-cover-image-text a,
-.site-header .wp-block-cover .wp-block-cover-text a, .site-footer .wp-block-cover-image .wp-block-cover__inner-container a,
-.site-footer .wp-block-cover-image .wp-block-cover-image-text a,
-.site-footer .wp-block-cover-image .wp-block-cover-text a,
-.site-footer .wp-block-cover .wp-block-cover__inner-container a,
-.site-footer .wp-block-cover .wp-block-cover-image-text a,
-.site-footer .wp-block-cover .wp-block-cover-text a {
+.entry .entry-content .wp-block-cover .wp-block-cover-text a, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container a,
+.fse-template-content .wp-block-cover-image .wp-block-cover-image-text a,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text a,
+.fse-template-content .wp-block-cover .wp-block-cover__inner-container a,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text a,
+.fse-template-content .wp-block-cover .wp-block-cover-text a {
   color: inherit;
 }
 
@@ -4263,44 +4240,31 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover h3,
 .entry .entry-content .wp-block-cover h4,
 .entry .entry-content .wp-block-cover h5,
-.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h1,
-.site-header .wp-block-cover-image h2,
-.site-header .wp-block-cover-image h3,
-.site-header .wp-block-cover-image h4,
-.site-header .wp-block-cover-image h5,
-.site-header .wp-block-cover-image h6,
-.site-header .wp-block-cover h1,
-.site-header .wp-block-cover h2,
-.site-header .wp-block-cover h3,
-.site-header .wp-block-cover h4,
-.site-header .wp-block-cover h5,
-.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h1,
-.site-footer .wp-block-cover-image h2,
-.site-footer .wp-block-cover-image h3,
-.site-footer .wp-block-cover-image h4,
-.site-footer .wp-block-cover-image h5,
-.site-footer .wp-block-cover-image h6,
-.site-footer .wp-block-cover h1,
-.site-footer .wp-block-cover h2,
-.site-footer .wp-block-cover h3,
-.site-footer .wp-block-cover h4,
-.site-footer .wp-block-cover h5,
-.site-footer .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h1,
+.fse-template-content .wp-block-cover-image h2,
+.fse-template-content .wp-block-cover-image h3,
+.fse-template-content .wp-block-cover-image h4,
+.fse-template-content .wp-block-cover-image h5,
+.fse-template-content .wp-block-cover-image h6,
+.fse-template-content .wp-block-cover h1,
+.fse-template-content .wp-block-cover h2,
+.fse-template-content .wp-block-cover h3,
+.fse-template-content .wp-block-cover h4,
+.fse-template-content .wp-block-cover h5,
+.fse-template-content .wp-block-cover h6 {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-cover-image h1,
-.entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
-.site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
-.site-footer .wp-block-cover h1 {
+.entry .entry-content .wp-block-cover h1, .fse-template-content .wp-block-cover-image h1,
+.fse-template-content .wp-block-cover h1 {
   font-size: 2.25em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h1,
-  .entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
-  .site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
-  .site-footer .wp-block-cover h1 {
+  .entry .entry-content .wp-block-cover h1, .fse-template-content .wp-block-cover-image h1,
+  .fse-template-content .wp-block-cover h1 {
     font-size: 3.375em;
   }
 }
@@ -4310,17 +4274,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image h2,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
-.entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
-.site-header .wp-block-cover-image .wp-block-cover-text,
-.site-header .wp-block-cover-image h2,
-.site-header .wp-block-cover .wp-block-cover-image-text,
-.site-header .wp-block-cover .wp-block-cover-text,
-.site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-.site-footer .wp-block-cover-image .wp-block-cover-text,
-.site-footer .wp-block-cover-image h2,
-.site-footer .wp-block-cover .wp-block-cover-image-text,
-.site-footer .wp-block-cover .wp-block-cover-text,
-.site-footer .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover h2, .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text,
+.fse-template-content .wp-block-cover-image h2,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover .wp-block-cover-text,
+.fse-template-content .wp-block-cover h2 {
   font-size: 1.6875em;
   margin: inherit;
   max-width: inherit;
@@ -4334,112 +4293,94 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image h2,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image .wp-block-cover-text,
-  .site-header .wp-block-cover-image h2,
-  .site-header .wp-block-cover .wp-block-cover-image-text,
-  .site-header .wp-block-cover .wp-block-cover-text,
-  .site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image .wp-block-cover-text,
-  .site-footer .wp-block-cover-image h2,
-  .site-footer .wp-block-cover .wp-block-cover-image-text,
-  .site-footer .wp-block-cover .wp-block-cover-text,
-  .site-footer .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover h2, .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-text,
+  .fse-template-content .wp-block-cover-image h2,
+  .fse-template-content .wp-block-cover .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover .wp-block-cover-text,
+  .fse-template-content .wp-block-cover h2 {
     font-size: 2.8125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h3,
-.entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
-.site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
-.site-footer .wp-block-cover h3 {
+.entry .entry-content .wp-block-cover h3, .fse-template-content .wp-block-cover-image h3,
+.fse-template-content .wp-block-cover h3 {
   font-size: 1.125em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h3,
-  .entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
-  .site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
-  .site-footer .wp-block-cover h3 {
+  .entry .entry-content .wp-block-cover h3, .fse-template-content .wp-block-cover-image h3,
+  .fse-template-content .wp-block-cover h3 {
     font-size: 2.25em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h4,
-.entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
-.site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
-.site-footer .wp-block-cover h4 {
+.entry .entry-content .wp-block-cover h4, .fse-template-content .wp-block-cover-image h4,
+.fse-template-content .wp-block-cover h4 {
   font-size: 22px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h4,
-  .entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
-  .site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
-  .site-footer .wp-block-cover h4 {
+  .entry .entry-content .wp-block-cover h4, .fse-template-content .wp-block-cover-image h4,
+  .fse-template-content .wp-block-cover h4 {
     font-size: 1.6875em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h5,
-.entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
-.site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
-.site-footer .wp-block-cover h5 {
+.entry .entry-content .wp-block-cover h5, .fse-template-content .wp-block-cover-image h5,
+.fse-template-content .wp-block-cover h5 {
   font-size: 0.88889em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h5,
-  .entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
-  .site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
-  .site-footer .wp-block-cover h5 {
+  .entry .entry-content .wp-block-cover h5, .fse-template-content .wp-block-cover-image h5,
+  .fse-template-content .wp-block-cover h5 {
     font-size: 1.125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h6,
-.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
-.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
-.site-footer .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h6,
+.fse-template-content .wp-block-cover h6 {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h6,
-  .entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
-  .site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
-  .site-footer .wp-block-cover h6 {
+  .entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h6,
+  .fse-template-content .wp-block-cover h6 {
     font-size: 22px;
   }
 }
 
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
-.entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
-.site-header .wp-block-cover.alignleft,
-.site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
-.site-footer .wp-block-cover.alignleft,
-.site-footer .wp-block-cover.alignright {
+.entry .entry-content .wp-block-cover.alignright, .fse-template-content .wp-block-cover-image.alignleft, .fse-template-content .wp-block-cover-image.alignright,
+.fse-template-content .wp-block-cover.alignleft,
+.fse-template-content .wp-block-cover.alignright {
   width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
-  .entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
-  .site-header .wp-block-cover.alignleft,
-  .site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
-  .site-footer .wp-block-cover.alignleft,
-  .site-footer .wp-block-cover.alignright {
+  .entry .entry-content .wp-block-cover.alignright, .fse-template-content .wp-block-cover-image.alignleft, .fse-template-content .wp-block-cover-image.alignright,
+  .fse-template-content .wp-block-cover.alignleft,
+  .fse-template-content .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull, .site-header .wp-block-cover-image.alignfull,
-  .site-header .wp-block-cover.alignfull, .site-footer .wp-block-cover-image.alignfull,
-  .site-footer .wp-block-cover.alignfull {
+  .entry .entry-content .wp-block-cover.alignfull, .fse-template-content .wp-block-cover-image.alignfull,
+  .fse-template-content .wp-block-cover.alignfull {
     padding-right: calc(10% + 58px + (2 * 1rem));
     padding-left: calc(10% + 58px + (2 * 1rem));
   }
@@ -4450,38 +4391,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover.alignfull h2, .site-header .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
-  .site-header .wp-block-cover-image.alignfull .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image.alignfull .wp-block-cover-text,
-  .site-header .wp-block-cover-image.alignfull h2,
-  .site-header .wp-block-cover.alignfull .wp-block-cover__inner-container,
-  .site-header .wp-block-cover.alignfull .wp-block-cover-image-text,
-  .site-header .wp-block-cover.alignfull .wp-block-cover-text,
-  .site-header .wp-block-cover.alignfull h2, .site-footer .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-text,
-  .site-footer .wp-block-cover-image.alignfull h2,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover-image-text,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover-text,
-  .site-footer .wp-block-cover.alignfull h2 {
+  .entry .entry-content .wp-block-cover.alignfull h2, .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .fse-template-content .wp-block-cover-image.alignfull h2,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .fse-template-content .wp-block-cover.alignfull h2 {
     padding: 0;
   }
 }
 
-.entry .entry-content .wp-block-gallery, .site-header .wp-block-gallery, .site-footer .wp-block-gallery {
+.entry .entry-content .wp-block-gallery, .fse-template-content .wp-block-gallery {
   list-style-type: none;
   padding-right: 0;
 }
 
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .site-header .wp-block-gallery .blocks-gallery-image:last-child,
-.site-header .wp-block-gallery .blocks-gallery-item:last-child, .site-footer .wp-block-gallery .blocks-gallery-image:last-child,
-.site-footer .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .fse-template-content .wp-block-gallery .blocks-gallery-image:last-child,
+.fse-template-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry .entry-content .wp-block-gallery figcaption a, .site-header .wp-block-gallery figcaption a, .site-footer .wp-block-gallery figcaption a {
+.entry .entry-content .wp-block-gallery figcaption a, .fse-template-content .wp-block-gallery figcaption a {
   color: #fff;
 }
 
@@ -4489,15 +4422,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .site-header .wp-block-audio figcaption,
-.site-header .wp-block-video figcaption,
-.site-header .wp-block-image figcaption,
-.site-header .wp-block-gallery .blocks-gallery-image figcaption,
-.site-header .wp-block-gallery .blocks-gallery-item figcaption, .site-footer .wp-block-audio figcaption,
-.site-footer .wp-block-video figcaption,
-.site-footer .wp-block-image figcaption,
-.site-footer .wp-block-gallery .blocks-gallery-image figcaption,
-.site-footer .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .fse-template-content .wp-block-audio figcaption,
+.fse-template-content .wp-block-video figcaption,
+.fse-template-content .wp-block-image figcaption,
+.fse-template-content .wp-block-gallery .blocks-gallery-image figcaption,
+.fse-template-content .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4507,9 +4436,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator,
-.entry .entry-content hr, .site-header .wp-block-separator,
-.site-header hr, .site-footer .wp-block-separator,
-.site-footer hr {
+.entry .entry-content hr, .fse-template-content .wp-block-separator,
+.fse-template-content hr {
   background-color: #686868;
   border: 0;
   height: 1px;
@@ -4521,34 +4449,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator.is-style-wide,
-.entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-.site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-.site-footer hr.is-style-wide {
+.entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+.fse-template-content hr.is-style-wide {
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-  .site-footer hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+  .fse-template-content hr.is-style-wide {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-  .site-footer hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+  .fse-template-content hr.is-style-wide {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots,
-.entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-.site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-.site-footer hr.is-style-dots {
+.entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+.fse-template-content hr.is-style-dots {
   max-width: 100%;
   background-color: inherit;
   border: inherit;
@@ -4558,26 +4482,23 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-  .site-footer hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+  .fse-template-content hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-  .site-footer hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+  .fse-template-content hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots:before,
-.entry .entry-content hr.is-style-dots:before, .site-header .wp-block-separator.is-style-dots:before,
-.site-header hr.is-style-dots:before, .site-footer .wp-block-separator.is-style-dots:before,
-.site-footer hr.is-style-dots:before {
+.entry .entry-content hr.is-style-dots:before, .fse-template-content .wp-block-separator.is-style-dots:before,
+.fse-template-content hr.is-style-dots:before {
   color: #686868;
   font-size: 1.6875em;
 }
@@ -4585,42 +4506,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-separator + h1:before,
 .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
-.entry .entry-content hr + h2:before, .site-header .wp-block-separator + h1:before,
-.site-header .wp-block-separator + h2:before,
-.site-header hr + h1:before,
-.site-header hr + h2:before, .site-footer .wp-block-separator + h1:before,
-.site-footer .wp-block-separator + h2:before,
-.site-footer hr + h1:before,
-.site-footer hr + h2:before {
+.entry .entry-content hr + h2:before, .fse-template-content .wp-block-separator + h1:before,
+.fse-template-content .wp-block-separator + h2:before,
+.fse-template-content hr + h1:before,
+.fse-template-content hr + h2:before {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
+.entry .entry-content .wp-block-spacer.desktop-only, .fse-template-content .wp-block-spacer.desktop-only {
   display: none;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
+  .entry .entry-content .wp-block-spacer.desktop-only, .fse-template-content .wp-block-spacer.desktop-only {
     display: block;
   }
 }
 
-.entry .entry-content .wp-block-embed-twitter, .site-header .wp-block-embed-twitter, .site-footer .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter, .fse-template-content .wp-block-embed-twitter {
   word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,
-.entry .entry-content .wp-block-table td, .site-header .wp-block-table th,
-.site-header .wp-block-table td, .site-footer .wp-block-table th,
-.site-footer .wp-block-table td {
+.entry .entry-content .wp-block-table td, .fse-template-content .wp-block-table th,
+.fse-template-content .wp-block-table td {
   border-color: #686868;
 }
 
-.entry .entry-content .wp-block-file, .site-header .wp-block-file, .site-footer .wp-block-file {
+.entry .entry-content .wp-block-file, .fse-template-content .wp-block-file {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button, .fse-template-content .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
   border: none;
@@ -4638,95 +4555,90 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button, .fse-template-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:hover, .site-header .wp-block-file .wp-block-file__button:hover, .site-footer .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .fse-template-content .wp-block-file .wp-block-file__button:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus, .site-header .wp-block-file .wp-block-file__button:focus, .site-footer .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus, .fse-template-content .wp-block-file .wp-block-file__button:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-code, .site-header .wp-block-code, .site-footer .wp-block-code {
+.entry .entry-content .wp-block-code, .fse-template-content .wp-block-code {
   border-radius: 0;
 }
 
-.entry .entry-content .wp-block-code code, .site-header .wp-block-code code, .site-footer .wp-block-code code {
+.entry .entry-content .wp-block-code code, .fse-template-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
+.entry .entry-content .wp-block-columns.alignfull, .fse-template-content .wp-block-columns.alignfull {
   padding-right: 1rem;
   padding-left: 1rem;
 }
 
 @media only screen and (min-width: 782px) {
-  .entry .entry-content .wp-block-columns .wp-block-column, .site-header .wp-block-columns .wp-block-column, .site-footer .wp-block-columns .wp-block-column {
+  .entry .entry-content .wp-block-columns .wp-block-column, .fse-template-content .wp-block-columns .wp-block-column {
     margin-right: 0.5rem;
     margin-left: 0.5rem;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .site-header .wp-block-columns .wp-block-column:first-child, .site-footer .wp-block-columns .wp-block-column:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .fse-template-content .wp-block-columns .wp-block-column:first-child {
     margin-right: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .site-header .wp-block-columns .wp-block-column:last-child, .site-footer .wp-block-columns .wp-block-column:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .fse-template-content .wp-block-columns .wp-block-column:last-child {
     margin-left: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .site-header .wp-block-columns .wp-block-column > *:first-child, .site-footer .wp-block-columns .wp-block-column > *:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .fse-template-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .site-header .wp-block-columns .wp-block-column > *:last-child, .site-footer .wp-block-columns .wp-block-column > *:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .fse-template-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
+  .entry .entry-content .wp-block-columns.alignfull, .fse-template-content .wp-block-columns.alignfull {
     padding-right: calc( 2 * 1rem);
     padding-left: calc( 2 * 1rem);
   }
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 700;
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment,
-.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment,
-.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment,
+.fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .fse-template-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color, .site-header .has-primary-background-color,
-.site-header .has-secondary-background-color,
-.site-header .has-dark-gray-background-color,
-.site-header .has-light-gray-background-color, .site-footer .has-primary-background-color,
-.site-footer .has-secondary-background-color,
-.site-footer .has-dark-gray-background-color,
-.site-footer .has-light-gray-background-color {
-  color: peru;
+.entry .entry-content .has-light-gray-background-color, .fse-template-content .has-primary-background-color,
+.fse-template-content .has-secondary-background-color,
+.fse-template-content .has-dark-gray-background-color,
+.fse-template-content .has-light-gray-background-color {
+  color: #fff;
 }
 
 .entry .entry-content .has-primary-background-color p,
@@ -4760,73 +4672,42 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-light-gray-background-color h4,
 .entry .entry-content .has-light-gray-background-color h5,
 .entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a, .site-header .has-primary-background-color p,
-.site-header .has-primary-background-color h1,
-.site-header .has-primary-background-color h2,
-.site-header .has-primary-background-color h3,
-.site-header .has-primary-background-color h4,
-.site-header .has-primary-background-color h5,
-.site-header .has-primary-background-color h6,
-.site-header .has-primary-background-color a,
-.site-header .has-secondary-background-color p,
-.site-header .has-secondary-background-color h1,
-.site-header .has-secondary-background-color h2,
-.site-header .has-secondary-background-color h3,
-.site-header .has-secondary-background-color h4,
-.site-header .has-secondary-background-color h5,
-.site-header .has-secondary-background-color h6,
-.site-header .has-secondary-background-color a,
-.site-header .has-dark-gray-background-color p,
-.site-header .has-dark-gray-background-color h1,
-.site-header .has-dark-gray-background-color h2,
-.site-header .has-dark-gray-background-color h3,
-.site-header .has-dark-gray-background-color h4,
-.site-header .has-dark-gray-background-color h5,
-.site-header .has-dark-gray-background-color h6,
-.site-header .has-dark-gray-background-color a,
-.site-header .has-light-gray-background-color p,
-.site-header .has-light-gray-background-color h1,
-.site-header .has-light-gray-background-color h2,
-.site-header .has-light-gray-background-color h3,
-.site-header .has-light-gray-background-color h4,
-.site-header .has-light-gray-background-color h5,
-.site-header .has-light-gray-background-color h6,
-.site-header .has-light-gray-background-color a, .site-footer .has-primary-background-color p,
-.site-footer .has-primary-background-color h1,
-.site-footer .has-primary-background-color h2,
-.site-footer .has-primary-background-color h3,
-.site-footer .has-primary-background-color h4,
-.site-footer .has-primary-background-color h5,
-.site-footer .has-primary-background-color h6,
-.site-footer .has-primary-background-color a,
-.site-footer .has-secondary-background-color p,
-.site-footer .has-secondary-background-color h1,
-.site-footer .has-secondary-background-color h2,
-.site-footer .has-secondary-background-color h3,
-.site-footer .has-secondary-background-color h4,
-.site-footer .has-secondary-background-color h5,
-.site-footer .has-secondary-background-color h6,
-.site-footer .has-secondary-background-color a,
-.site-footer .has-dark-gray-background-color p,
-.site-footer .has-dark-gray-background-color h1,
-.site-footer .has-dark-gray-background-color h2,
-.site-footer .has-dark-gray-background-color h3,
-.site-footer .has-dark-gray-background-color h4,
-.site-footer .has-dark-gray-background-color h5,
-.site-footer .has-dark-gray-background-color h6,
-.site-footer .has-dark-gray-background-color a,
-.site-footer .has-light-gray-background-color p,
-.site-footer .has-light-gray-background-color h1,
-.site-footer .has-light-gray-background-color h2,
-.site-footer .has-light-gray-background-color h3,
-.site-footer .has-light-gray-background-color h4,
-.site-footer .has-light-gray-background-color h5,
-.site-footer .has-light-gray-background-color h6,
-.site-footer .has-light-gray-background-color a {
+.entry .entry-content .has-light-gray-background-color a, .fse-template-content .has-primary-background-color p,
+.fse-template-content .has-primary-background-color h1,
+.fse-template-content .has-primary-background-color h2,
+.fse-template-content .has-primary-background-color h3,
+.fse-template-content .has-primary-background-color h4,
+.fse-template-content .has-primary-background-color h5,
+.fse-template-content .has-primary-background-color h6,
+.fse-template-content .has-primary-background-color a,
+.fse-template-content .has-secondary-background-color p,
+.fse-template-content .has-secondary-background-color h1,
+.fse-template-content .has-secondary-background-color h2,
+.fse-template-content .has-secondary-background-color h3,
+.fse-template-content .has-secondary-background-color h4,
+.fse-template-content .has-secondary-background-color h5,
+.fse-template-content .has-secondary-background-color h6,
+.fse-template-content .has-secondary-background-color a,
+.fse-template-content .has-dark-gray-background-color p,
+.fse-template-content .has-dark-gray-background-color h1,
+.fse-template-content .has-dark-gray-background-color h2,
+.fse-template-content .has-dark-gray-background-color h3,
+.fse-template-content .has-dark-gray-background-color h4,
+.fse-template-content .has-dark-gray-background-color h5,
+.fse-template-content .has-dark-gray-background-color h6,
+.fse-template-content .has-dark-gray-background-color a,
+.fse-template-content .has-light-gray-background-color p,
+.fse-template-content .has-light-gray-background-color h1,
+.fse-template-content .has-light-gray-background-color h2,
+.fse-template-content .has-light-gray-background-color h3,
+.fse-template-content .has-light-gray-background-color h4,
+.fse-template-content .has-light-gray-background-color h5,
+.fse-template-content .has-light-gray-background-color h6,
+.fse-template-content .has-light-gray-background-color a {
   color: #fff;
 }
 
-.entry .entry-content .has-white-background-color, .site-header .has-white-background-color, .site-footer .has-white-background-color {
+.entry .entry-content .has-white-background-color, .fse-template-content .has-white-background-color {
   color: #181818;
 }
 
@@ -4837,150 +4718,128 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-white-background-color h4,
 .entry .entry-content .has-white-background-color h5,
 .entry .entry-content .has-white-background-color h6,
-.entry .entry-content .has-white-background-color a, .site-header .has-white-background-color p,
-.site-header .has-white-background-color h1,
-.site-header .has-white-background-color h2,
-.site-header .has-white-background-color h3,
-.site-header .has-white-background-color h4,
-.site-header .has-white-background-color h5,
-.site-header .has-white-background-color h6,
-.site-header .has-white-background-color a, .site-footer .has-white-background-color p,
-.site-footer .has-white-background-color h1,
-.site-footer .has-white-background-color h2,
-.site-footer .has-white-background-color h3,
-.site-footer .has-white-background-color h4,
-.site-footer .has-white-background-color h5,
-.site-footer .has-white-background-color h6,
-.site-footer .has-white-background-color a {
+.entry .entry-content .has-white-background-color a, .fse-template-content .has-white-background-color p,
+.fse-template-content .has-white-background-color h1,
+.fse-template-content .has-white-background-color h2,
+.fse-template-content .has-white-background-color h3,
+.fse-template-content .has-white-background-color h4,
+.fse-template-content .has-white-background-color h5,
+.fse-template-content .has-white-background-color h6,
+.fse-template-content .has-white-background-color a {
   color: #181818;
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-header .has-primary-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-footer .has-primary-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .fse-template-content .has-primary-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-header .has-secondary-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-footer .has-secondary-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .fse-template-content .has-secondary-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
   background-color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-header .has-dark-gray-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-footer .has-dark-gray-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .fse-template-content .has-dark-gray-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #181818;
 }
 
 .entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-header .has-light-gray-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-footer .has-light-gray-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .fse-template-content .has-light-gray-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #686868;
 }
 
 .entry .entry-content .has-white-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-header .has-white-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-footer .has-white-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-white-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .fse-template-content .has-white-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-header .has-primary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-footer .has-primary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .fse-template-content .has-primary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
   color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-header .has-secondary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-footer .has-secondary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .fse-template-content .has-secondary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
   color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-header .has-dark-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-footer .has-dark-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .fse-template-content .has-dark-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
   color: #181818;
 }
 
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-header .has-light-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-footer .has-light-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .fse-template-content .has-light-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
   color: #686868;
 }
 
 .entry .entry-content .has-white-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .has-white-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .has-white-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .fse-template-content .has-white-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: #FFF;
 }
 
 .entry .entry-content .a8c-posts-list-item__title a,
-.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__title a,
-.site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__title a,
-.site-footer .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .fse-template-content .a8c-posts-list-item__title a,
+.fse-template-content .a8c-posts-list-item__meta a {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .fse-template-content .a8c-posts-list__view-all {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a, .site-header .a8c-posts-list-item__title a, .site-footer .a8c-posts-list-item__title a {
+.entry .entry-content .a8c-posts-list-item__title a, .fse-template-content .a8c-posts-list-item__title a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .site-header .a8c-posts-list-item__title a:hover, .site-header .a8c-posts-list-item__title a:focus, .site-footer .a8c-posts-list-item__title a:hover, .site-footer .a8c-posts-list-item__title a:focus {
+.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .fse-template-content .a8c-posts-list-item__title a:hover, .fse-template-content .a8c-posts-list-item__title a:focus {
   color: #4a4a4a;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .fse-template-content .a8c-posts-list-item__meta a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .site-header .a8c-posts-list-item__meta a:hover, .site-header .a8c-posts-list-item__meta a:focus, .site-footer .a8c-posts-list-item__meta a:hover, .site-footer .a8c-posts-list-item__meta a:focus {
+.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .fse-template-content .a8c-posts-list-item__meta a:hover, .fse-template-content .a8c-posts-list-item__meta a:focus {
   color: #c43d80;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-header .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-footer .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
+.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .fse-template-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
   color: #fff;
 }
 
-.entry .entry-content .a8c-posts-list, .site-header .a8c-posts-list, .site-footer .a8c-posts-list {
+.entry .entry-content .a8c-posts-list, .fse-template-content .a8c-posts-list {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list__item:not(:first-child), .site-header .a8c-posts-list__item:not(:first-child), .site-footer .a8c-posts-list__item:not(:first-child) {
+.entry .entry-content .a8c-posts-list__item:not(:first-child), .fse-template-content .a8c-posts-list__item:not(:first-child) {
   margin-top: calc(6 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__featured, .site-header .a8c-posts-list-item__featured, .site-footer .a8c-posts-list-item__featured {
+.entry .entry-content .a8c-posts-list-item__featured, .fse-template-content .a8c-posts-list-item__featured {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__featured span, .site-header .a8c-posts-list-item__featured span, .site-footer .a8c-posts-list-item__featured span {
+.entry .entry-content .a8c-posts-list-item__featured span, .fse-template-content .a8c-posts-list-item__featured span {
   background: #c43d80;
   color: #fff;
   display: inline-block;
@@ -4992,33 +4851,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   z-index: 1;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail, .site-header .a8c-posts-list-item__post-thumbnail, .site-footer .a8c-posts-list-item__post-thumbnail {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail, .fse-template-content .a8c-posts-list-item__post-thumbnail {
   margin-bottom: 32px;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .site-header .a8c-posts-list-item__post-thumbnail img, .site-footer .a8c-posts-list-item__post-thumbnail img {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .fse-template-content .a8c-posts-list-item__post-thumbnail img {
   display: block;
 }
 
-.entry .entry-content .a8c-posts-list-item__title, .site-header .a8c-posts-list-item__title, .site-footer .a8c-posts-list-item__title {
+.entry .entry-content .a8c-posts-list-item__title, .fse-template-content .a8c-posts-list-item__title {
   font-size: 1.6875em;
   margin: 0;
   text-align: center;
   font-weight: 300;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta, .site-header .a8c-posts-list-item__meta, .site-footer .a8c-posts-list-item__meta {
+.entry .entry-content .a8c-posts-list-item__meta, .fse-template-content .a8c-posts-list-item__meta {
   color: #686868;
   font-size: 0.71111em;
   font-weight: 500;
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__author, .site-header .a8c-posts-list-item__author, .site-footer .a8c-posts-list-item__author {
+.entry .entry-content .a8c-posts-list-item__author, .fse-template-content .a8c-posts-list-item__author {
   margin-left: calc(.5 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link, .site-header .a8c-posts-list-item__edit-link, .site-footer .a8c-posts-list-item__edit-link {
+.entry .entry-content .a8c-posts-list-item__edit-link, .fse-template-content .a8c-posts-list-item__edit-link {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border-radius: 3px;
@@ -5027,33 +4886,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding: .05rem .4rem;
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .site-header .a8c-posts-list-item__edit-link:hover, .site-header .a8c-posts-list-item__edit-link:focus, .site-footer .a8c-posts-list-item__edit-link:hover, .site-footer .a8c-posts-list-item__edit-link:focus {
+.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .fse-template-content .a8c-posts-list-item__edit-link:hover, .fse-template-content .a8c-posts-list-item__edit-link:focus {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+.entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
   margin: 0 auto;
   text-align: right;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt p, .site-header .a8c-posts-list-item__excerpt p, .site-footer .a8c-posts-list-item__excerpt p {
+.entry .entry-content .a8c-posts-list-item__excerpt p, .fse-template-content .a8c-posts-list-item__excerpt p {
   margin: 32px 0;
 }
 
-.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .fse-template-content .a8c-posts-list__view-all {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border: none;
@@ -5071,17 +4930,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   vertical-align: bottom;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:hover, .site-header .a8c-posts-list__view-all:hover, .site-footer .a8c-posts-list__view-all:hover {
+.entry .entry-content .a8c-posts-list__view-all:hover, .fse-template-content .a8c-posts-list__view-all:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:visited, .site-header .a8c-posts-list__view-all:visited, .site-footer .a8c-posts-list__view-all:visited {
+.entry .entry-content .a8c-posts-list__view-all:visited, .fse-template-content .a8c-posts-list__view-all:visited {
   color: #fff;
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:focus, .site-header .a8c-posts-list__view-all:focus, .site-footer .a8c-posts-list__view-all:focus {
+.entry .entry-content .a8c-posts-list__view-all:focus, .fse-template-content .a8c-posts-list__view-all:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -3421,44 +3421,51 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 /* Blocks */
 /* !Block styles */
 .entry .entry-content > *,
-.entry .entry-summary > * {
+.entry .entry-summary > *
+.site-header > *, .site-footer > * {
   margin: 32px 0;
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.site-header > *, .site-footer > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.site-header > *, .site-footer > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
-  .entry .entry-summary > * {
+  .entry .entry-summary > *
+.site-header > *, .site-footer > * {
     margin: 32px auto;
   }
 }
 
 .entry .entry-content > * > *:first-child,
-.entry .entry-summary > * > *:first-child {
+.entry .entry-summary > *
+.site-header > * > *:first-child, .site-footer > * > *:first-child {
   margin-top: 0;
 }
 
 .entry .entry-content > * > *:last-child,
-.entry .entry-summary > * > *:last-child {
+.entry .entry-summary > *
+.site-header > * > *:last-child, .site-footer > * > *:last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content > *.alignwide,
-.entry .entry-summary > *.alignwide {
+.entry .entry-summary > *
+.site-header > *.alignwide, .site-footer > *.alignwide {
   margin-left: auto;
   margin-right: auto;
   clear: both;
@@ -3466,14 +3473,16 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
-  .entry .entry-summary > *.alignwide {
+  .entry .entry-summary > *
+.site-header > *.alignwide, .site-footer > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
 }
 
 .entry .entry-content > *.alignfull,
-.entry .entry-summary > *.alignfull {
+.entry .entry-summary > *
+.site-header > *.alignfull, .site-footer > *.alignfull {
   position: relative;
   left: -1rem;
   width: calc( 100% + (2 * 1rem));
@@ -3483,7 +3492,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
-  .entry .entry-summary > *.alignfull {
+  .entry .entry-summary > *
+.site-header > *.alignfull, .site-footer > *.alignfull {
     margin-top: 32px;
     margin-bottom: 32px;
     left: calc( -12.5% - 75px);
@@ -3493,7 +3503,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content > *.alignleft,
-.entry .entry-summary > *.alignleft {
+.entry .entry-summary > *
+.site-header > *.alignleft, .site-footer > *.alignleft {
   /*rtl:ignore*/
   float: left;
   max-width: calc(5 * (100vw / 12));
@@ -3505,7 +3516,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
-  .entry .entry-summary > *.alignleft {
+  .entry .entry-summary > *
+.site-header > *.alignleft, .site-footer > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     /*rtl:ignore*/
     margin-right: calc(2 * 1rem);
@@ -3513,7 +3525,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content > *.alignright,
-.entry .entry-summary > *.alignright {
+.entry .entry-summary > *
+.site-header > *.alignright, .site-footer > *.alignright {
   /*rtl:ignore*/
   float: right;
   max-width: calc(5 * (100vw / 12));
@@ -3525,7 +3538,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
-  .entry .entry-summary > *.alignright {
+  .entry .entry-summary > *
+.site-header > *.alignright, .site-footer > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: 0;
     /*rtl:ignore*/
@@ -3534,7 +3548,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content > *.aligncenter,
-.entry .entry-summary > *.aligncenter {
+.entry .entry-summary > *
+.site-header > *.aligncenter, .site-footer > *.aligncenter {
   margin-left: auto;
   margin-right: auto;
   /*
@@ -3547,14 +3562,16 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
-  .entry .entry-summary > *.aligncenter {
+  .entry .entry-summary > *
+.site-header > *.aligncenter, .site-footer > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
-  .entry .entry-summary > *.aligncenter {
+  .entry .entry-summary > *
+.site-header > *.aligncenter, .site-footer > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3576,7 +3593,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .entry,
 .entry .entry-summary .entry-content,
 .entry .entry-summary .entry-summary,
-.entry .entry-summary .entry {
+.entry .entry-summary .entry,
+.site-header .entry-content,
+.site-header .entry-summary,
+.site-header .entry, .site-footer .entry-content,
+.site-footer .entry-summary,
+.site-footer .entry {
   margin: inherit;
   max-width: inherit;
   padding: inherit;
@@ -3588,7 +3610,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .entry,
   .entry .entry-summary .entry-content,
   .entry .entry-summary .entry-summary,
-  .entry .entry-summary .entry {
+  .entry .entry-summary .entry,
+  .site-header .entry-content,
+  .site-header .entry-summary,
+  .site-header .entry, .site-footer .entry-content,
+  .site-footer .entry-summary,
+  .site-footer .entry {
     margin: inherit;
     max-width: inherit;
     padding: inherit;
@@ -3600,166 +3627,184 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content > h3,
 .entry .entry-content > h4,
 .entry .entry-content > h5,
-.entry .entry-content > h6 {
+.entry .entry-content > h6, .site-header > h1,
+.site-header > h2,
+.site-header > h3,
+.site-header > h4,
+.site-header > h5,
+.site-header > h6, .site-footer > h1,
+.site-footer > h2,
+.site-footer > h3,
+.site-footer > h4,
+.site-footer > h5,
+.site-footer > h6 {
   margin: 32px auto;
   text-align: center;
 }
 
-.entry .entry-content > h2 {
+.entry .entry-content > h2, .site-header > h2, .site-footer > h2 {
   font-size: 1.125em;
   font-weight: 700;
 }
 
-.entry .entry-content p.has-background {
+.entry .entry-content p.has-background, .site-header p.has-background, .site-footer p.has-background {
   padding: 20px 30px;
 }
 
-.entry .entry-content .wp-block-audio {
+.entry .entry-content .wp-block-audio, .site-header .wp-block-audio, .site-footer .wp-block-audio {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio, .site-header .wp-block-audio audio, .site-footer .wp-block-audio audio {
   width: 100%;
 }
 
 .entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+.site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+.site-footer .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+  .site-footer .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
+  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
+  .site-footer .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry .entry-content .wp-block-video video {
+.entry .entry-content .wp-block-video video, .site-header .wp-block-video video, .site-footer .wp-block-video video {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-media-text {
+.entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
   margin: 0 auto;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(odd) {
+.entry .entry-content .wp-block-media-text:nth-child(odd), .site-header .wp-block-media-text:nth-child(odd), .site-footer .wp-block-media-text:nth-child(odd) {
   background-color: #181818;
   color: #fff;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(even) {
+.entry .entry-content .wp-block-media-text:nth-child(even), .site-header .wp-block-media-text:nth-child(even), .site-footer .wp-block-media-text:nth-child(even) {
   background-color: #f2f2f2;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
   grid-area: media-text-content;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
     grid-area: media-text-media;
   }
 }
 
-.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
   padding: 8% 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
-.entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
   padding: 8%;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
   grid-area: media-text-media;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
     grid-area: media-text-content;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text {
+  .entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
     padding: 64px 0;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .site-header .wp-block-media-text .wp-block-media-text__media, .site-footer .wp-block-media-text .wp-block-media-text__media {
     margin-left: -64px;
     margin-right: 64px;
     max-width: calc( 100%);
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
-  .entry .entry-content .wp-block-media-text.alignfull {
+  .entry .entry-content .wp-block-media-text.alignfull, .site-header .wp-block-media-text.alignfull, .site-footer .wp-block-media-text.alignfull {
     margin-left: 64px;
     margin-right: 64px;
     max-width: calc( 125% + 30px);
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
     margin-right: -64px;
     margin-left: 64px;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
-.entry .entry-content .wp-block-media-text :first-child {
+.entry .entry-content .wp-block-media-text :first-child, .site-header .wp-block-media-text :first-child, .site-footer .wp-block-media-text :first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-media-text :last-child {
+.entry .entry-content .wp-block-media-text :last-child, .site-header .wp-block-media-text :last-child, .site-footer .wp-block-media-text :last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content .wp-block-media-text a,
-.entry .entry-content .wp-block-media-text a:hover {
+.entry .entry-content .wp-block-media-text a:hover, .site-header .wp-block-media-text a,
+.site-header .wp-block-media-text a:hover, .site-footer .wp-block-media-text a,
+.site-footer .wp-block-media-text a:hover {
   color: inherit;
 }
 
 @media all and (-ms-high-contrast: none) {
-  .entry .entry-content .wp-block-media-text:after {
+  .entry .entry-content .wp-block-media-text:after, .site-header .wp-block-media-text:after, .site-footer .wp-block-media-text:after {
     display: table;
     content: "";
     clear: both;
   }
-  .entry .entry-content .wp-block-media-text figure {
+  .entry .entry-content .wp-block-media-text figure, .site-header .wp-block-media-text figure, .site-footer .wp-block-media-text figure {
     float: left;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
     float: right;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .site-header .wp-block-media-text.has-media-on-the-right figure, .site-footer .wp-block-media-text.has-media-on-the-right figure {
     float: right;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     float: left;
   }
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link, .site-header .wp-block-button .wp-block-button__link, .site-footer .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
@@ -3773,34 +3818,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline: none;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .site-header .wp-block-button .wp-block-button__link:not(.has-background), .site-footer .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #c43d80;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .site-header .wp-block-button .wp-block-button__link:not(.has-text-color), .site-footer .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .site-header .wp-block-button .wp-block-button__link:hover, .site-footer .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus, .site-header .wp-block-button .wp-block-button__link:focus, .site-footer .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-header .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-footer .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .site-header .wp-block-button.is-style-outline .wp-block-button__link,
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active, .site-footer .wp-block-button.is-style-outline .wp-block-button__link,
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
@@ -3808,36 +3857,52 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #c43d80;
   border-color: currentColor;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #9e3067;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #9e3067;
 }
 
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
-.entry .entry-content .wp-block-latest-posts {
+.entry .entry-content .wp-block-latest-posts, .site-header .wp-block-archives,
+.site-header .wp-block-categories,
+.site-header .wp-block-latest-posts, .site-footer .wp-block-archives,
+.site-footer .wp-block-categories,
+.site-footer .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
 .entry .entry-content .wp-block-archives li,
 .entry .entry-content .wp-block-categories li,
-.entry .entry-content .wp-block-latest-posts li {
+.entry .entry-content .wp-block-latest-posts li, .site-header .wp-block-archives li,
+.site-header .wp-block-categories li,
+.site-header .wp-block-latest-posts li, .site-footer .wp-block-archives li,
+.site-footer .wp-block-categories li,
+.site-footer .wp-block-latest-posts li {
   color: #686868;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3850,72 +3915,86 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-categories li.menu-item-has-children,
 .entry .entry-content .wp-block-categories li:last-child,
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
-.entry .entry-content .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li:last-child, .site-header .wp-block-archives li.menu-item-has-children, .site-header .wp-block-archives li:last-child,
+.site-header .wp-block-categories li.menu-item-has-children,
+.site-header .wp-block-categories li:last-child,
+.site-header .wp-block-latest-posts li.menu-item-has-children,
+.site-header .wp-block-latest-posts li:last-child, .site-footer .wp-block-archives li.menu-item-has-children, .site-footer .wp-block-archives li:last-child,
+.site-footer .wp-block-categories li.menu-item-has-children,
+.site-footer .wp-block-categories li:last-child,
+.site-footer .wp-block-latest-posts li.menu-item-has-children,
+.site-footer .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
 .entry .entry-content .wp-block-categories li a,
-.entry .entry-content .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-latest-posts li a, .site-header .wp-block-archives li a,
+.site-header .wp-block-categories li a,
+.site-header .wp-block-latest-posts li a, .site-footer .wp-block-archives li a,
+.site-footer .wp-block-categories li a,
+.site-footer .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter, .site-header .wp-block-archives.aligncenter,
+.site-header .wp-block-categories.aligncenter, .site-footer .wp-block-archives.aligncenter,
+.site-footer .wp-block-categories.aligncenter {
   text-align: center;
 }
 
-.entry .entry-content .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
   padding-top: 24px;
 }
 
-.entry .entry-content .wp-block-categories li ul {
+.entry .entry-content .wp-block-categories li ul, .site-header .wp-block-categories li ul, .site-footer .wp-block-categories li ul {
   list-style: none;
   padding-left: 0;
 }
 
-.entry .entry-content .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
   counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a::before {
+.entry .entry-content .wp-block-categories ul > li > a::before, .site-header .wp-block-categories ul > li > a::before, .site-footer .wp-block-categories ul > li > a::before {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li, .site-header .wp-block-latest-posts.is-grid li, .site-footer .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 32px;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .site-header .wp-block-latest-posts.is-grid li a:after, .site-footer .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .site-header .wp-block-latest-posts.is-grid li:last-child, .site-footer .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .site-header .wp-block-latest-posts.is-grid li:last-child a:after, .site-footer .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted, .site-header .wp-block-preformatted, .site-footer .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-verse {
+.entry .entry-content .wp-block-verse, .site-header .wp-block-verse, .site-footer .wp-block-verse {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry .entry-content .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter, .site-header .has-drop-cap:not(:focus):first-letter, .site-footer .has-drop-cap:not(:focus):first-letter {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -3923,13 +4002,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin: 0 0.25em 0 0;
 }
 
-.entry .entry-content .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote, .site-header .wp-block-pullquote, .site-footer .wp-block-pullquote {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote, .site-header .wp-block-pullquote blockquote, .site-footer .wp-block-pullquote blockquote {
   color: #181818;
   border: none;
   margin-top: calc(3 * 32px);
@@ -3938,7 +4017,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding-left: 0;
 }
 
-.entry .entry-content .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -3946,17 +4025,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-top: 0.5em;
 }
 
-.entry .entry-content .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em, .site-header .wp-block-pullquote p em, .site-footer .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite, .site-header .wp-block-pullquote cite, .site-footer .wp-block-pullquote cite {
   display: inline-block;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -3969,36 +4048,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .site-header .wp-block-pullquote.alignleft, .site-header .wp-block-pullquote.alignright, .site-footer .wp-block-pullquote.alignleft, .site-footer .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .site-header .wp-block-pullquote.alignleft blockquote, .site-header .wp-block-pullquote.alignright blockquote, .site-footer .wp-block-pullquote.alignleft blockquote, .site-footer .wp-block-pullquote.alignright blockquote {
   margin: 32px 0;
   padding: 0;
   text-align: left;
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .site-header .wp-block-pullquote.alignleft blockquote p:first-child, .site-header .wp-block-pullquote.alignright blockquote p:first-child, .site-footer .wp-block-pullquote.alignleft blockquote p:first-child, .site-footer .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
   background-color: #c43d80;
   padding-left: 0;
   padding-right: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
     padding-left: 10%;
     padding-right: 10%;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -4006,20 +4085,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .site-header .wp-block-pullquote.is-style-solid-color a, .site-footer .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .site-header .wp-block-pullquote.is-style-solid-color cite, .site-footer .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
   padding-left: 0;
@@ -4028,44 +4107,46 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .site-header .wp-block-pullquote.is-style-solid-color.alignright, .site-header .wp-block-pullquote.is-style-solid-color.alignleft, .site-footer .wp-block-pullquote.is-style-solid-color.alignright, .site-footer .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .site-header .wp-block-pullquote.is-style-solid-color.alignfull, .site-footer .wp-block-pullquote.is-style-solid-color.alignfull {
     padding-left: calc(10% + 58px + (2 * 1rem));
     padding-right: calc(10% + 58px + (2 * 1rem));
   }
 }
 
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .site-header .wp-block-quote:not(.is-large), .site-header .wp-block-quote:not(.is-style-large), .site-footer .wp-block-quote:not(.is-large), .site-footer .wp-block-quote:not(.is-style-large) {
   border-color: #c43d80;
   border-width: 2px;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry .entry-content .wp-block-quote p {
+.entry .entry-content .wp-block-quote p, .site-header .wp-block-quote p, .site-footer .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry .entry-content .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite, .site-header .wp-block-quote cite, .site-footer .wp-block-quote cite {
   /*
 			 * This requires a rem-based font size calculation instead of our normal em-based one,
 			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4073,13 +4154,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
   margin: 32px auto;
   padding: 0;
   border-left: none;
 }
 
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
@@ -4087,7 +4168,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
-.entry .entry-content .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-style-large footer, .site-header .wp-block-quote.is-large cite,
+.site-header .wp-block-quote.is-large footer, .site-header .wp-block-quote.is-style-large cite,
+.site-header .wp-block-quote.is-style-large footer, .site-footer .wp-block-quote.is-large cite,
+.site-footer .wp-block-quote.is-large footer, .site-footer .wp-block-quote.is-style-large cite,
+.site-footer .wp-block-quote.is-style-large footer {
   /*
 				 * This requires a rem-based font size calculation instead of our normal em-based one,
 				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4096,30 +4181,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
     margin: 32px auto;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry .entry-content .wp-block-image {
+.entry .entry-content .wp-block-image, .site-header .wp-block-image, .site-footer .wp-block-image {
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-image img {
+.entry .entry-content .wp-block-image img, .site-header .wp-block-image img, .site-footer .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
   width: 100vw;
   max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image.alignfull img {
+  .entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
     max-width: calc( 125% + 150px);
     margin-left: auto;
     margin-right: auto;
@@ -4127,7 +4212,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image,
-.entry .entry-content .wp-block-cover {
+.entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
+.site-header .wp-block-cover, .site-footer .wp-block-cover-image,
+.site-footer .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
@@ -4135,7 +4222,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
-  .entry .entry-content .wp-block-cover {
+  .entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
+  .site-header .wp-block-cover, .site-footer .wp-block-cover-image,
+  .site-footer .wp-block-cover {
     min-height: 640px;
     padding: 1rem 10%;
   }
@@ -4146,7 +4235,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover .wp-block-cover-text {
+.entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
+.site-header .wp-block-cover-image .wp-block-cover-image-text,
+.site-header .wp-block-cover-image .wp-block-cover-text,
+.site-header .wp-block-cover .wp-block-cover__inner-container,
+.site-header .wp-block-cover .wp-block-cover-image-text,
+.site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
+.site-footer .wp-block-cover-image .wp-block-cover-image-text,
+.site-footer .wp-block-cover-image .wp-block-cover-text,
+.site-footer .wp-block-cover .wp-block-cover__inner-container,
+.site-footer .wp-block-cover .wp-block-cover-image-text,
+.site-footer .wp-block-cover .wp-block-cover-text {
   color: #fff;
   padding: 0;
   text-shadow: 0 0 12px #000;
@@ -4158,7 +4257,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
   .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text {
+  .entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
+  .site-header .wp-block-cover-image .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image .wp-block-cover-text,
+  .site-header .wp-block-cover .wp-block-cover__inner-container,
+  .site-header .wp-block-cover .wp-block-cover-image-text,
+  .site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image .wp-block-cover-text,
+  .site-footer .wp-block-cover .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover .wp-block-cover-image-text,
+  .site-footer .wp-block-cover .wp-block-cover-text {
     max-width: 100%;
   }
 }
@@ -4168,7 +4277,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text a,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container a,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text a,
-.entry .entry-content .wp-block-cover .wp-block-cover-text a {
+.entry .entry-content .wp-block-cover .wp-block-cover-text a, .site-header .wp-block-cover-image .wp-block-cover__inner-container a,
+.site-header .wp-block-cover-image .wp-block-cover-image-text a,
+.site-header .wp-block-cover-image .wp-block-cover-text a,
+.site-header .wp-block-cover .wp-block-cover__inner-container a,
+.site-header .wp-block-cover .wp-block-cover-image-text a,
+.site-header .wp-block-cover .wp-block-cover-text a, .site-footer .wp-block-cover-image .wp-block-cover__inner-container a,
+.site-footer .wp-block-cover-image .wp-block-cover-image-text a,
+.site-footer .wp-block-cover-image .wp-block-cover-text a,
+.site-footer .wp-block-cover .wp-block-cover__inner-container a,
+.site-footer .wp-block-cover .wp-block-cover-image-text a,
+.site-footer .wp-block-cover .wp-block-cover-text a {
   color: inherit;
 }
 
@@ -4183,18 +4302,44 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover h3,
 .entry .entry-content .wp-block-cover h4,
 .entry .entry-content .wp-block-cover h5,
-.entry .entry-content .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h1,
+.site-header .wp-block-cover-image h2,
+.site-header .wp-block-cover-image h3,
+.site-header .wp-block-cover-image h4,
+.site-header .wp-block-cover-image h5,
+.site-header .wp-block-cover-image h6,
+.site-header .wp-block-cover h1,
+.site-header .wp-block-cover h2,
+.site-header .wp-block-cover h3,
+.site-header .wp-block-cover h4,
+.site-header .wp-block-cover h5,
+.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h1,
+.site-footer .wp-block-cover-image h2,
+.site-footer .wp-block-cover-image h3,
+.site-footer .wp-block-cover-image h4,
+.site-footer .wp-block-cover-image h5,
+.site-footer .wp-block-cover-image h6,
+.site-footer .wp-block-cover h1,
+.site-footer .wp-block-cover h2,
+.site-footer .wp-block-cover h3,
+.site-footer .wp-block-cover h4,
+.site-footer .wp-block-cover h5,
+.site-footer .wp-block-cover h6 {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-cover-image h1,
-.entry .entry-content .wp-block-cover h1 {
+.entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
+.site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
+.site-footer .wp-block-cover h1 {
   font-size: 2.25em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h1,
-  .entry .entry-content .wp-block-cover h1 {
+  .entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
+  .site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
+  .site-footer .wp-block-cover h1 {
     font-size: 3.375em;
   }
 }
@@ -4204,7 +4349,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image h2,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
-.entry .entry-content .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
+.site-header .wp-block-cover-image .wp-block-cover-text,
+.site-header .wp-block-cover-image h2,
+.site-header .wp-block-cover .wp-block-cover-image-text,
+.site-header .wp-block-cover .wp-block-cover-text,
+.site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+.site-footer .wp-block-cover-image .wp-block-cover-text,
+.site-footer .wp-block-cover-image h2,
+.site-footer .wp-block-cover .wp-block-cover-image-text,
+.site-footer .wp-block-cover .wp-block-cover-text,
+.site-footer .wp-block-cover h2 {
   font-size: 1.6875em;
   margin: inherit;
   max-width: inherit;
@@ -4218,76 +4373,112 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image h2,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image .wp-block-cover-text,
+  .site-header .wp-block-cover-image h2,
+  .site-header .wp-block-cover .wp-block-cover-image-text,
+  .site-header .wp-block-cover .wp-block-cover-text,
+  .site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image .wp-block-cover-text,
+  .site-footer .wp-block-cover-image h2,
+  .site-footer .wp-block-cover .wp-block-cover-image-text,
+  .site-footer .wp-block-cover .wp-block-cover-text,
+  .site-footer .wp-block-cover h2 {
     font-size: 2.8125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h3,
-.entry .entry-content .wp-block-cover h3 {
+.entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
+.site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
+.site-footer .wp-block-cover h3 {
   font-size: 1.125em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h3,
-  .entry .entry-content .wp-block-cover h3 {
+  .entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
+  .site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
+  .site-footer .wp-block-cover h3 {
     font-size: 2.25em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h4,
-.entry .entry-content .wp-block-cover h4 {
+.entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
+.site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
+.site-footer .wp-block-cover h4 {
   font-size: 22px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h4,
-  .entry .entry-content .wp-block-cover h4 {
+  .entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
+  .site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
+  .site-footer .wp-block-cover h4 {
     font-size: 1.6875em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h5,
-.entry .entry-content .wp-block-cover h5 {
+.entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
+.site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
+.site-footer .wp-block-cover h5 {
   font-size: 0.88889em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h5,
-  .entry .entry-content .wp-block-cover h5 {
+  .entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
+  .site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
+  .site-footer .wp-block-cover h5 {
     font-size: 1.125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h6,
-.entry .entry-content .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
+.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
+.site-footer .wp-block-cover h6 {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h6,
-  .entry .entry-content .wp-block-cover h6 {
+  .entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
+  .site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
+  .site-footer .wp-block-cover h6 {
     font-size: 22px;
   }
 }
 
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
-.entry .entry-content .wp-block-cover.alignright {
+.entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
+.site-header .wp-block-cover.alignleft,
+.site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
+.site-footer .wp-block-cover.alignleft,
+.site-footer .wp-block-cover.alignright {
   width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
-  .entry .entry-content .wp-block-cover.alignright {
+  .entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
+  .site-header .wp-block-cover.alignleft,
+  .site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
+  .site-footer .wp-block-cover.alignleft,
+  .site-footer .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
+  .entry .entry-content .wp-block-cover.alignfull, .site-header .wp-block-cover-image.alignfull,
+  .site-header .wp-block-cover.alignfull, .site-footer .wp-block-cover-image.alignfull,
+  .site-footer .wp-block-cover.alignfull {
     padding-left: calc(10% + 58px + (2 * 1rem));
     padding-right: calc(10% + 58px + (2 * 1rem));
   }
@@ -4298,22 +4489,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover.alignfull h2 {
+  .entry .entry-content .wp-block-cover.alignfull h2, .site-header .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .site-header .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .site-header .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .site-header .wp-block-cover-image.alignfull h2,
+  .site-header .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .site-header .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .site-header .wp-block-cover.alignfull .wp-block-cover-text,
+  .site-header .wp-block-cover.alignfull h2, .site-footer .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .site-footer .wp-block-cover-image.alignfull h2,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .site-footer .wp-block-cover.alignfull .wp-block-cover-text,
+  .site-footer .wp-block-cover.alignfull h2 {
     padding: 0;
   }
 }
 
-.entry .entry-content .wp-block-gallery {
+.entry .entry-content .wp-block-gallery, .site-header .wp-block-gallery, .site-footer .wp-block-gallery {
   list-style-type: none;
   padding-left: 0;
 }
 
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .site-header .wp-block-gallery .blocks-gallery-image:last-child,
+.site-header .wp-block-gallery .blocks-gallery-item:last-child, .site-footer .wp-block-gallery .blocks-gallery-image:last-child,
+.site-footer .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry .entry-content .wp-block-gallery figcaption a {
+.entry .entry-content .wp-block-gallery figcaption a, .site-header .wp-block-gallery figcaption a, .site-footer .wp-block-gallery figcaption a {
   color: #fff;
 }
 
@@ -4321,7 +4528,15 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .site-header .wp-block-audio figcaption,
+.site-header .wp-block-video figcaption,
+.site-header .wp-block-image figcaption,
+.site-header .wp-block-gallery .blocks-gallery-image figcaption,
+.site-header .wp-block-gallery .blocks-gallery-item figcaption, .site-footer .wp-block-audio figcaption,
+.site-footer .wp-block-video figcaption,
+.site-footer .wp-block-image figcaption,
+.site-footer .wp-block-gallery .blocks-gallery-image figcaption,
+.site-footer .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4331,7 +4546,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator,
-.entry .entry-content hr {
+.entry .entry-content hr, .site-header .wp-block-separator,
+.site-header hr, .site-footer .wp-block-separator,
+.site-footer hr {
   background-color: #686868;
   border: 0;
   height: 1px;
@@ -4343,26 +4560,34 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator.is-style-wide,
-.entry .entry-content hr.is-style-wide {
+.entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+.site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+.site-footer hr.is-style-wide {
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+  .site-footer hr.is-style-wide {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
+  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
+  .site-footer hr.is-style-wide {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots,
-.entry .entry-content hr.is-style-dots {
+.entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+.site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+.site-footer hr.is-style-dots {
   max-width: 100%;
   background-color: inherit;
   border: inherit;
@@ -4372,20 +4597,26 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+  .site-footer hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
+  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
+  .site-footer hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots:before,
-.entry .entry-content hr.is-style-dots:before {
+.entry .entry-content hr.is-style-dots:before, .site-header .wp-block-separator.is-style-dots:before,
+.site-header hr.is-style-dots:before, .site-footer .wp-block-separator.is-style-dots:before,
+.site-footer hr.is-style-dots:before {
   color: #686868;
   font-size: 1.6875em;
 }
@@ -4393,34 +4624,42 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-separator + h1:before,
 .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
-.entry .entry-content hr + h2:before {
+.entry .entry-content hr + h2:before, .site-header .wp-block-separator + h1:before,
+.site-header .wp-block-separator + h2:before,
+.site-header hr + h1:before,
+.site-header hr + h2:before, .site-footer .wp-block-separator + h1:before,
+.site-footer .wp-block-separator + h2:before,
+.site-footer hr + h1:before,
+.site-footer hr + h2:before {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer.desktop-only {
+.entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
   display: none;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-spacer.desktop-only {
+  .entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
     display: block;
   }
 }
 
-.entry .entry-content .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter, .site-header .wp-block-embed-twitter, .site-footer .wp-block-embed-twitter {
   word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,
-.entry .entry-content .wp-block-table td {
+.entry .entry-content .wp-block-table td, .site-header .wp-block-table th,
+.site-header .wp-block-table td, .site-footer .wp-block-table th,
+.site-footer .wp-block-table td {
   border-color: #686868;
 }
 
-.entry .entry-content .wp-block-file {
+.entry .entry-content .wp-block-file, .site-header .wp-block-file, .site-footer .wp-block-file {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
   border: none;
@@ -4438,84 +4677,94 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .site-header .wp-block-file .wp-block-file__button:hover, .site-footer .wp-block-file .wp-block-file__button:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus, .site-header .wp-block-file .wp-block-file__button:focus, .site-footer .wp-block-file .wp-block-file__button:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-code {
+.entry .entry-content .wp-block-code, .site-header .wp-block-code, .site-footer .wp-block-code {
   border-radius: 0;
 }
 
-.entry .entry-content .wp-block-code code {
+.entry .entry-content .wp-block-code code, .site-header .wp-block-code code, .site-footer .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns.alignfull {
+.entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
 @media only screen and (min-width: 782px) {
-  .entry .entry-content .wp-block-columns .wp-block-column {
+  .entry .entry-content .wp-block-columns .wp-block-column, .site-header .wp-block-columns .wp-block-column, .site-footer .wp-block-columns .wp-block-column {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .site-header .wp-block-columns .wp-block-column:first-child, .site-footer .wp-block-columns .wp-block-column:first-child {
     margin-left: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .site-header .wp-block-columns .wp-block-column:last-child, .site-footer .wp-block-columns .wp-block-column:last-child {
     margin-right: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .site-header .wp-block-columns .wp-block-column > *:first-child, .site-footer .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .site-header .wp-block-columns .wp-block-column > *:last-child, .site-footer .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns.alignfull {
+  .entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
     padding-left: calc( 2 * 1rem);
     padding-right: calc( 2 * 1rem);
   }
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 700;
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment,
+.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment,
+.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color {
+.entry .entry-content .has-light-gray-background-color, .site-header .has-primary-background-color,
+.site-header .has-secondary-background-color,
+.site-header .has-dark-gray-background-color,
+.site-header .has-light-gray-background-color, .site-footer .has-primary-background-color,
+.site-footer .has-secondary-background-color,
+.site-footer .has-dark-gray-background-color,
+.site-footer .has-light-gray-background-color {
   color: #fff;
 }
 
@@ -4550,11 +4799,73 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-light-gray-background-color h4,
 .entry .entry-content .has-light-gray-background-color h5,
 .entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a {
+.entry .entry-content .has-light-gray-background-color a, .site-header .has-primary-background-color p,
+.site-header .has-primary-background-color h1,
+.site-header .has-primary-background-color h2,
+.site-header .has-primary-background-color h3,
+.site-header .has-primary-background-color h4,
+.site-header .has-primary-background-color h5,
+.site-header .has-primary-background-color h6,
+.site-header .has-primary-background-color a,
+.site-header .has-secondary-background-color p,
+.site-header .has-secondary-background-color h1,
+.site-header .has-secondary-background-color h2,
+.site-header .has-secondary-background-color h3,
+.site-header .has-secondary-background-color h4,
+.site-header .has-secondary-background-color h5,
+.site-header .has-secondary-background-color h6,
+.site-header .has-secondary-background-color a,
+.site-header .has-dark-gray-background-color p,
+.site-header .has-dark-gray-background-color h1,
+.site-header .has-dark-gray-background-color h2,
+.site-header .has-dark-gray-background-color h3,
+.site-header .has-dark-gray-background-color h4,
+.site-header .has-dark-gray-background-color h5,
+.site-header .has-dark-gray-background-color h6,
+.site-header .has-dark-gray-background-color a,
+.site-header .has-light-gray-background-color p,
+.site-header .has-light-gray-background-color h1,
+.site-header .has-light-gray-background-color h2,
+.site-header .has-light-gray-background-color h3,
+.site-header .has-light-gray-background-color h4,
+.site-header .has-light-gray-background-color h5,
+.site-header .has-light-gray-background-color h6,
+.site-header .has-light-gray-background-color a, .site-footer .has-primary-background-color p,
+.site-footer .has-primary-background-color h1,
+.site-footer .has-primary-background-color h2,
+.site-footer .has-primary-background-color h3,
+.site-footer .has-primary-background-color h4,
+.site-footer .has-primary-background-color h5,
+.site-footer .has-primary-background-color h6,
+.site-footer .has-primary-background-color a,
+.site-footer .has-secondary-background-color p,
+.site-footer .has-secondary-background-color h1,
+.site-footer .has-secondary-background-color h2,
+.site-footer .has-secondary-background-color h3,
+.site-footer .has-secondary-background-color h4,
+.site-footer .has-secondary-background-color h5,
+.site-footer .has-secondary-background-color h6,
+.site-footer .has-secondary-background-color a,
+.site-footer .has-dark-gray-background-color p,
+.site-footer .has-dark-gray-background-color h1,
+.site-footer .has-dark-gray-background-color h2,
+.site-footer .has-dark-gray-background-color h3,
+.site-footer .has-dark-gray-background-color h4,
+.site-footer .has-dark-gray-background-color h5,
+.site-footer .has-dark-gray-background-color h6,
+.site-footer .has-dark-gray-background-color a,
+.site-footer .has-light-gray-background-color p,
+.site-footer .has-light-gray-background-color h1,
+.site-footer .has-light-gray-background-color h2,
+.site-footer .has-light-gray-background-color h3,
+.site-footer .has-light-gray-background-color h4,
+.site-footer .has-light-gray-background-color h5,
+.site-footer .has-light-gray-background-color h6,
+.site-footer .has-light-gray-background-color a {
   color: #fff;
 }
 
-.entry .entry-content .has-white-background-color {
+.entry .entry-content .has-white-background-color, .site-header .has-white-background-color, .site-footer .has-white-background-color {
   color: #181818;
 }
 
@@ -4565,106 +4876,150 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-white-background-color h4,
 .entry .entry-content .has-white-background-color h5,
 .entry .entry-content .has-white-background-color h6,
-.entry .entry-content .has-white-background-color a {
+.entry .entry-content .has-white-background-color a, .site-header .has-white-background-color p,
+.site-header .has-white-background-color h1,
+.site-header .has-white-background-color h2,
+.site-header .has-white-background-color h3,
+.site-header .has-white-background-color h4,
+.site-header .has-white-background-color h5,
+.site-header .has-white-background-color h6,
+.site-header .has-white-background-color a, .site-footer .has-white-background-color p,
+.site-footer .has-white-background-color h1,
+.site-footer .has-white-background-color h2,
+.site-footer .has-white-background-color h3,
+.site-footer .has-white-background-color h4,
+.site-footer .has-white-background-color h5,
+.site-footer .has-white-background-color h6,
+.site-footer .has-white-background-color a {
   color: #181818;
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-header .has-primary-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-footer .has-primary-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-header .has-secondary-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-footer .has-secondary-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
   background-color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-header .has-dark-gray-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-footer .has-dark-gray-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #181818;
 }
 
 .entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-header .has-light-gray-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-footer .has-light-gray-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #686868;
 }
 
 .entry .entry-content .has-white-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-header .has-white-background-color,
+.site-header .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-footer .has-white-background-color,
+.site-footer .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-header .has-primary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-footer .has-primary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
   color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-header .has-secondary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-footer .has-secondary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
   color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-header .has-dark-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-footer .has-dark-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
   color: #181818;
 }
 
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-header .has-light-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-footer .has-light-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
   color: #686868;
 }
 
 .entry .entry-content .has-white-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .has-white-color,
+.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .has-white-color,
+.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: #FFF;
 }
 
 .entry .entry-content .a8c-posts-list-item__title a,
-.entry .entry-content .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__title a,
+.site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__title a,
+.site-footer .a8c-posts-list-item__meta a {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a {
+.entry .entry-content .a8c-posts-list-item__title a, .site-header .a8c-posts-list-item__title a, .site-footer .a8c-posts-list-item__title a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus {
+.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .site-header .a8c-posts-list-item__title a:hover, .site-header .a8c-posts-list-item__title a:focus, .site-footer .a8c-posts-list-item__title a:hover, .site-footer .a8c-posts-list-item__title a:focus {
   color: #4a4a4a;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__meta a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus {
+.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .site-header .a8c-posts-list-item__meta a:hover, .site-header .a8c-posts-list-item__meta a:focus, .site-footer .a8c-posts-list-item__meta a:hover, .site-footer .a8c-posts-list-item__meta a:focus {
   color: #c43d80;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
+.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-header .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-footer .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
   color: #fff;
 }
 
-.entry .entry-content .a8c-posts-list {
+.entry .entry-content .a8c-posts-list, .site-header .a8c-posts-list, .site-footer .a8c-posts-list {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list__item:not(:first-child) {
+.entry .entry-content .a8c-posts-list__item:not(:first-child), .site-header .a8c-posts-list__item:not(:first-child), .site-footer .a8c-posts-list__item:not(:first-child) {
   margin-top: calc(6 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__featured {
+.entry .entry-content .a8c-posts-list-item__featured, .site-header .a8c-posts-list-item__featured, .site-footer .a8c-posts-list-item__featured {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__featured span {
+.entry .entry-content .a8c-posts-list-item__featured span, .site-header .a8c-posts-list-item__featured span, .site-footer .a8c-posts-list-item__featured span {
   background: #c43d80;
   color: #fff;
   display: inline-block;
@@ -4676,33 +5031,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   z-index: 1;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail, .site-header .a8c-posts-list-item__post-thumbnail, .site-footer .a8c-posts-list-item__post-thumbnail {
   margin-bottom: 32px;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail img {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .site-header .a8c-posts-list-item__post-thumbnail img, .site-footer .a8c-posts-list-item__post-thumbnail img {
   display: block;
 }
 
-.entry .entry-content .a8c-posts-list-item__title {
+.entry .entry-content .a8c-posts-list-item__title, .site-header .a8c-posts-list-item__title, .site-footer .a8c-posts-list-item__title {
   font-size: 1.6875em;
   margin: 0;
   text-align: center;
   font-weight: 300;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta {
+.entry .entry-content .a8c-posts-list-item__meta, .site-header .a8c-posts-list-item__meta, .site-footer .a8c-posts-list-item__meta {
   color: #686868;
   font-size: 0.71111em;
   font-weight: 500;
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__author {
+.entry .entry-content .a8c-posts-list-item__author, .site-header .a8c-posts-list-item__author, .site-footer .a8c-posts-list-item__author {
   margin-right: calc(.5 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link {
+.entry .entry-content .a8c-posts-list-item__edit-link, .site-header .a8c-posts-list-item__edit-link, .site-footer .a8c-posts-list-item__edit-link {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border-radius: 3px;
@@ -4711,33 +5066,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding: .05rem .4rem;
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus {
+.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .site-header .a8c-posts-list-item__edit-link:hover, .site-header .a8c-posts-list-item__edit-link:focus, .site-footer .a8c-posts-list-item__edit-link:hover, .site-footer .a8c-posts-list-item__edit-link:focus {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt {
+.entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
   margin: 0 auto;
   text-align: left;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt p {
+.entry .entry-content .a8c-posts-list-item__excerpt p, .site-header .a8c-posts-list-item__excerpt p, .site-footer .a8c-posts-list-item__excerpt p {
   margin: 32px 0;
 }
 
-.entry .entry-content .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border: none;
@@ -4755,17 +5110,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   vertical-align: bottom;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:hover {
+.entry .entry-content .a8c-posts-list__view-all:hover, .site-header .a8c-posts-list__view-all:hover, .site-footer .a8c-posts-list__view-all:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:visited {
+.entry .entry-content .a8c-posts-list__view-all:visited, .site-header .a8c-posts-list__view-all:visited, .site-footer .a8c-posts-list__view-all:visited {
   color: #fff;
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:focus {
+.entry .entry-content .a8c-posts-list__view-all:focus, .site-header .a8c-posts-list__view-all:focus, .site-footer .a8c-posts-list__view-all:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -3422,7 +3422,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 /* !Block styles */
 .entry .entry-content > *,
 .entry .entry-summary > *
-.site-header > *, .site-footer > * {
+.fse-template-content > * {
   margin: 32px 0;
   max-width: 100%;
 }
@@ -3430,7 +3430,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *
-.site-header > *, .site-footer > * {
+.fse-template-content > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3438,7 +3438,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
   .entry .entry-summary > *
-.site-header > *, .site-footer > * {
+.fse-template-content > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3446,26 +3446,26 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *
-.site-header > *, .site-footer > * {
+.fse-template-content > * {
     margin: 32px auto;
   }
 }
 
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > *
-.site-header > * > *:first-child, .site-footer > * > *:first-child {
+.fse-template-content > * > *:first-child {
   margin-top: 0;
 }
 
 .entry .entry-content > * > *:last-child,
 .entry .entry-summary > *
-.site-header > * > *:last-child, .site-footer > * > *:last-child {
+.fse-template-content > * > *:last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content > *.alignwide,
 .entry .entry-summary > *
-.site-header > *.alignwide, .site-footer > *.alignwide {
+.fse-template-content > *.alignwide {
   margin-left: auto;
   margin-right: auto;
   clear: both;
@@ -3474,7 +3474,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *
-.site-header > *.alignwide, .site-footer > *.alignwide {
+.fse-template-content > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
@@ -3482,7 +3482,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *
-.site-header > *.alignfull, .site-footer > *.alignfull {
+.fse-template-content > *.alignfull {
   position: relative;
   left: -1rem;
   width: calc( 100% + (2 * 1rem));
@@ -3493,7 +3493,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *
-.site-header > *.alignfull, .site-footer > *.alignfull {
+.fse-template-content > *.alignfull {
     margin-top: 32px;
     margin-bottom: 32px;
     left: calc( -12.5% - 75px);
@@ -3504,7 +3504,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignleft,
 .entry .entry-summary > *
-.site-header > *.alignleft, .site-footer > *.alignleft {
+.fse-template-content > *.alignleft {
   /*rtl:ignore*/
   float: left;
   max-width: calc(5 * (100vw / 12));
@@ -3517,7 +3517,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
   .entry .entry-summary > *
-.site-header > *.alignleft, .site-footer > *.alignleft {
+.fse-template-content > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     /*rtl:ignore*/
     margin-right: calc(2 * 1rem);
@@ -3526,7 +3526,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *
-.site-header > *.alignright, .site-footer > *.alignright {
+.fse-template-content > *.alignright {
   /*rtl:ignore*/
   float: right;
   max-width: calc(5 * (100vw / 12));
@@ -3539,7 +3539,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *
-.site-header > *.alignright, .site-footer > *.alignright {
+.fse-template-content > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: 0;
     /*rtl:ignore*/
@@ -3549,7 +3549,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.aligncenter,
 .entry .entry-summary > *
-.site-header > *.aligncenter, .site-footer > *.aligncenter {
+.fse-template-content > *.aligncenter {
   margin-left: auto;
   margin-right: auto;
   /*
@@ -3563,7 +3563,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *
-.site-header > *.aligncenter, .site-footer > *.aligncenter {
+.fse-template-content > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3571,7 +3571,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *
-.site-header > *.aligncenter, .site-footer > *.aligncenter {
+.fse-template-content > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3594,11 +3594,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-summary .entry-content,
 .entry .entry-summary .entry-summary,
 .entry .entry-summary .entry,
-.site-header .entry-content,
-.site-header .entry-summary,
-.site-header .entry, .site-footer .entry-content,
-.site-footer .entry-summary,
-.site-footer .entry {
+.fse-template-content .entry-content,
+.fse-template-content .entry-summary,
+.fse-template-content .entry {
   margin: inherit;
   max-width: inherit;
   padding: inherit;
@@ -3611,11 +3609,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-summary .entry-content,
   .entry .entry-summary .entry-summary,
   .entry .entry-summary .entry,
-  .site-header .entry-content,
-  .site-header .entry-summary,
-  .site-header .entry, .site-footer .entry-content,
-  .site-footer .entry-summary,
-  .site-footer .entry {
+  .fse-template-content .entry-content,
+  .fse-template-content .entry-summary,
+  .fse-template-content .entry {
     margin: inherit;
     max-width: inherit;
     padding: inherit;
@@ -3627,184 +3623,175 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content > h3,
 .entry .entry-content > h4,
 .entry .entry-content > h5,
-.entry .entry-content > h6, .site-header > h1,
-.site-header > h2,
-.site-header > h3,
-.site-header > h4,
-.site-header > h5,
-.site-header > h6, .site-footer > h1,
-.site-footer > h2,
-.site-footer > h3,
-.site-footer > h4,
-.site-footer > h5,
-.site-footer > h6 {
+.entry .entry-content > h6, .fse-template-content > h1,
+.fse-template-content > h2,
+.fse-template-content > h3,
+.fse-template-content > h4,
+.fse-template-content > h5,
+.fse-template-content > h6 {
   margin: 32px auto;
   text-align: center;
 }
 
-.entry .entry-content > h2, .site-header > h2, .site-footer > h2 {
+.entry .entry-content > h2, .fse-template-content > h2 {
   font-size: 1.125em;
   font-weight: 700;
 }
 
-.entry .entry-content p.has-background, .site-header p.has-background, .site-footer p.has-background {
+.entry .entry-content p.has-background, .fse-template-content p.has-background {
   padding: 20px 30px;
 }
 
-.entry .entry-content .wp-block-audio, .site-header .wp-block-audio, .site-footer .wp-block-audio {
+.entry .entry-content .wp-block-audio, .fse-template-content .wp-block-audio {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-audio audio, .site-header .wp-block-audio audio, .site-footer .wp-block-audio audio {
+.entry .entry-content .wp-block-audio audio, .fse-template-content .wp-block-audio audio {
   width: 100%;
 }
 
 .entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-.site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-.site-footer .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+.fse-template-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-  .site-footer .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+  .fse-template-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 
 @media only screen and (min-width: 1379px) {
   .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio, .site-header .wp-block-audio.alignleft audio,
-  .site-header .wp-block-audio.alignright audio, .site-footer .wp-block-audio.alignleft audio,
-  .site-footer .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignright audio, .fse-template-content .wp-block-audio.alignleft audio,
+  .fse-template-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
 
-.entry .entry-content .wp-block-video video, .site-header .wp-block-video video, .site-footer .wp-block-video video {
+.entry .entry-content .wp-block-video video, .fse-template-content .wp-block-video video {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
+.entry .entry-content .wp-block-media-text, .fse-template-content .wp-block-media-text {
   margin: 0 auto;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(odd), .site-header .wp-block-media-text:nth-child(odd), .site-footer .wp-block-media-text:nth-child(odd) {
+.entry .entry-content .wp-block-media-text:nth-child(odd), .fse-template-content .wp-block-media-text:nth-child(odd) {
   background-color: #181818;
   color: #fff;
 }
 
-.entry .entry-content .wp-block-media-text:nth-child(even), .site-header .wp-block-media-text:nth-child(even), .site-footer .wp-block-media-text:nth-child(even) {
+.entry .entry-content .wp-block-media-text:nth-child(even), .fse-template-content .wp-block-media-text:nth-child(even) {
   background-color: #f2f2f2;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
   grid-area: media-text-content;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__media {
     grid-area: media-text-media;
   }
 }
 
-.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull .wp-block-media-text__content {
   padding: 8% 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.alignfull.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
-.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
   padding: 8%;
 }
 
-.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+.entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
   grid-area: media-text-media;
 }
 
 @media only screen and (min-width: 600px) {
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right.is-stacked-on-mobile .wp-block-media-text__content {
     grid-area: media-text-content;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-media-text, .site-header .wp-block-media-text, .site-footer .wp-block-media-text {
+  .entry .entry-content .wp-block-media-text, .fse-template-content .wp-block-media-text {
     padding: 64px 0;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .site-header .wp-block-media-text .wp-block-media-text__media, .site-footer .wp-block-media-text .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__media, .fse-template-content .wp-block-media-text .wp-block-media-text__media {
     margin-left: -64px;
     margin-right: 64px;
     max-width: calc( 100%);
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
     padding: 0 64px 0 0;
   }
-  .entry .entry-content .wp-block-media-text.alignfull, .site-header .wp-block-media-text.alignfull, .site-footer .wp-block-media-text.alignfull {
+  .entry .entry-content .wp-block-media-text.alignfull, .fse-template-content .wp-block-media-text.alignfull {
     margin-left: 64px;
     margin-right: 64px;
     max-width: calc( 125% + 30px);
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__media {
     margin-right: -64px;
     margin-left: 64px;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     padding: 0 0 0 64px;
   }
 }
 
-.entry .entry-content .wp-block-media-text :first-child, .site-header .wp-block-media-text :first-child, .site-footer .wp-block-media-text :first-child {
+.entry .entry-content .wp-block-media-text :first-child, .fse-template-content .wp-block-media-text :first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-media-text :last-child, .site-header .wp-block-media-text :last-child, .site-footer .wp-block-media-text :last-child {
+.entry .entry-content .wp-block-media-text :last-child, .fse-template-content .wp-block-media-text :last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content .wp-block-media-text a,
-.entry .entry-content .wp-block-media-text a:hover, .site-header .wp-block-media-text a,
-.site-header .wp-block-media-text a:hover, .site-footer .wp-block-media-text a,
-.site-footer .wp-block-media-text a:hover {
+.entry .entry-content .wp-block-media-text a:hover, .fse-template-content .wp-block-media-text a,
+.fse-template-content .wp-block-media-text a:hover {
   color: inherit;
 }
 
 @media all and (-ms-high-contrast: none) {
-  .entry .entry-content .wp-block-media-text:after, .site-header .wp-block-media-text:after, .site-footer .wp-block-media-text:after {
+  .entry .entry-content .wp-block-media-text:after, .fse-template-content .wp-block-media-text:after {
     display: table;
     content: "";
     clear: both;
   }
-  .entry .entry-content .wp-block-media-text figure, .site-header .wp-block-media-text figure, .site-footer .wp-block-media-text figure {
+  .entry .entry-content .wp-block-media-text figure, .fse-template-content .wp-block-media-text figure {
     float: left;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .site-header .wp-block-media-text .wp-block-media-text__content, .site-footer .wp-block-media-text .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text .wp-block-media-text__content, .fse-template-content .wp-block-media-text .wp-block-media-text__content {
     float: right;
     width: 50%;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .site-header .wp-block-media-text.has-media-on-the-right figure, .site-footer .wp-block-media-text.has-media-on-the-right figure {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right figure, .fse-template-content .wp-block-media-text.has-media-on-the-right figure {
     float: right;
   }
-  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-header .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .site-footer .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
+  .entry .entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content, .fse-template-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content {
     float: left;
   }
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link, .site-header .wp-block-button .wp-block-button__link, .site-footer .wp-block-button .wp-block-button__link {
+.entry .entry-content .wp-block-button .wp-block-button__link, .fse-template-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
@@ -3818,38 +3805,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline: none;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .site-header .wp-block-button .wp-block-button__link:not(.has-background), .site-footer .wp-block-button .wp-block-button__link:not(.has-background) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background), .fse-template-content .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #c43d80;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .site-header .wp-block-button .wp-block-button__link:not(.has-text-color), .site-footer .wp-block-button .wp-block-button__link:not(.has-text-color) {
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color), .fse-template-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:hover, .site-header .wp-block-button .wp-block-button__link:hover, .site-footer .wp-block-button .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button .wp-block-button__link:hover, .fse-template-content .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-button .wp-block-button__link:focus, .site-header .wp-block-button .wp-block-button__link:focus, .site-footer .wp-block-button .wp-block-button__link:focus {
+.entry .entry-content .wp-block-button .wp-block-button__link:focus, .fse-template-content .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-header .wp-block-button:not(.is-style-squared) .wp-block-button__link, .site-footer .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link, .fse-template-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .site-header .wp-block-button.is-style-outline .wp-block-button__link,
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active, .site-footer .wp-block-button.is-style-outline .wp-block-button__link,
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active, .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link,
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
@@ -3857,52 +3842,44 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-header .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.site-header .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.site-footer .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #c43d80;
   border-color: currentColor;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover, .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #9e3067;
 }
 
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-header .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .site-footer .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background), .fse-template-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #9e3067;
 }
 
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
-.entry .entry-content .wp-block-latest-posts, .site-header .wp-block-archives,
-.site-header .wp-block-categories,
-.site-header .wp-block-latest-posts, .site-footer .wp-block-archives,
-.site-footer .wp-block-categories,
-.site-footer .wp-block-latest-posts {
+.entry .entry-content .wp-block-latest-posts, .fse-template-content .wp-block-archives,
+.fse-template-content .wp-block-categories,
+.fse-template-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
 
 .entry .entry-content .wp-block-archives li,
 .entry .entry-content .wp-block-categories li,
-.entry .entry-content .wp-block-latest-posts li, .site-header .wp-block-archives li,
-.site-header .wp-block-categories li,
-.site-header .wp-block-latest-posts li, .site-footer .wp-block-archives li,
-.site-footer .wp-block-categories li,
-.site-footer .wp-block-latest-posts li {
+.entry .entry-content .wp-block-latest-posts li, .fse-template-content .wp-block-archives li,
+.fse-template-content .wp-block-categories li,
+.fse-template-content .wp-block-latest-posts li {
   color: #686868;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: calc(22px * 1.125);
@@ -3915,86 +3892,79 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-categories li.menu-item-has-children,
 .entry .entry-content .wp-block-categories li:last-child,
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
-.entry .entry-content .wp-block-latest-posts li:last-child, .site-header .wp-block-archives li.menu-item-has-children, .site-header .wp-block-archives li:last-child,
-.site-header .wp-block-categories li.menu-item-has-children,
-.site-header .wp-block-categories li:last-child,
-.site-header .wp-block-latest-posts li.menu-item-has-children,
-.site-header .wp-block-latest-posts li:last-child, .site-footer .wp-block-archives li.menu-item-has-children, .site-footer .wp-block-archives li:last-child,
-.site-footer .wp-block-categories li.menu-item-has-children,
-.site-footer .wp-block-categories li:last-child,
-.site-footer .wp-block-latest-posts li.menu-item-has-children,
-.site-footer .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li:last-child, .fse-template-content .wp-block-archives li.menu-item-has-children, .fse-template-content .wp-block-archives li:last-child,
+.fse-template-content .wp-block-categories li.menu-item-has-children,
+.fse-template-content .wp-block-categories li:last-child,
+.fse-template-content .wp-block-latest-posts li.menu-item-has-children,
+.fse-template-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 
 .entry .entry-content .wp-block-archives li a,
 .entry .entry-content .wp-block-categories li a,
-.entry .entry-content .wp-block-latest-posts li a, .site-header .wp-block-archives li a,
-.site-header .wp-block-categories li a,
-.site-header .wp-block-latest-posts li a, .site-footer .wp-block-archives li a,
-.site-footer .wp-block-categories li a,
-.site-footer .wp-block-latest-posts li a {
+.entry .entry-content .wp-block-latest-posts li a, .fse-template-content .wp-block-archives li a,
+.fse-template-content .wp-block-categories li a,
+.fse-template-content .wp-block-latest-posts li a {
   text-decoration: none;
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter, .site-header .wp-block-archives.aligncenter,
-.site-header .wp-block-categories.aligncenter, .site-footer .wp-block-archives.aligncenter,
-.site-footer .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter, .fse-template-content .wp-block-archives.aligncenter,
+.fse-template-content .wp-block-categories.aligncenter {
   text-align: center;
 }
 
-.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .fse-template-content .wp-block-categories ul {
   padding-top: 24px;
 }
 
-.entry .entry-content .wp-block-categories li ul, .site-header .wp-block-categories li ul, .site-footer .wp-block-categories li ul {
+.entry .entry-content .wp-block-categories li ul, .fse-template-content .wp-block-categories li ul {
   list-style: none;
   padding-left: 0;
 }
 
-.entry .entry-content .wp-block-categories ul, .site-header .wp-block-categories ul, .site-footer .wp-block-categories ul {
+.entry .entry-content .wp-block-categories ul, .fse-template-content .wp-block-categories ul {
   counter-reset: submenu;
 }
 
-.entry .entry-content .wp-block-categories ul > li > a::before, .site-header .wp-block-categories ul > li > a::before, .site-footer .wp-block-categories ul > li > a::before {
+.entry .entry-content .wp-block-categories ul > li > a::before, .fse-template-content .wp-block-categories ul > li > a::before {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li, .site-header .wp-block-latest-posts.is-grid li, .site-footer .wp-block-latest-posts.is-grid li {
+.entry .entry-content .wp-block-latest-posts.is-grid li, .fse-template-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 32px;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .site-header .wp-block-latest-posts.is-grid li a:after, .site-footer .wp-block-latest-posts.is-grid li a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after, .fse-template-content .wp-block-latest-posts.is-grid li a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .site-header .wp-block-latest-posts.is-grid li:last-child, .site-footer .wp-block-latest-posts.is-grid li:last-child {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child, .fse-template-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
 
-.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .site-header .wp-block-latest-posts.is-grid li:last-child a:after, .site-footer .wp-block-latest-posts.is-grid li:last-child a:after {
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after, .fse-template-content .wp-block-latest-posts.is-grid li:last-child a:after {
   content: '';
 }
 
-.entry .entry-content .wp-block-preformatted, .site-header .wp-block-preformatted, .site-footer .wp-block-preformatted {
+.entry .entry-content .wp-block-preformatted, .fse-template-content .wp-block-preformatted {
   font-size: 0.71111em;
   line-height: 1.8;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-verse, .site-header .wp-block-verse, .site-footer .wp-block-verse {
+.entry .entry-content .wp-block-verse, .fse-template-content .wp-block-verse {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 22px;
   line-height: 1.8;
 }
 
-.entry .entry-content .has-drop-cap:not(:focus):first-letter, .site-header .has-drop-cap:not(:focus):first-letter, .site-footer .has-drop-cap:not(:focus):first-letter {
+.entry .entry-content .has-drop-cap:not(:focus):first-letter, .fse-template-content .has-drop-cap:not(:focus):first-letter {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
   line-height: 1;
@@ -4002,13 +3972,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin: 0 0.25em 0 0;
 }
 
-.entry .entry-content .wp-block-pullquote, .site-header .wp-block-pullquote, .site-footer .wp-block-pullquote {
+.entry .entry-content .wp-block-pullquote, .fse-template-content .wp-block-pullquote {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
 }
 
-.entry .entry-content .wp-block-pullquote blockquote, .site-header .wp-block-pullquote blockquote, .site-footer .wp-block-pullquote blockquote {
+.entry .entry-content .wp-block-pullquote blockquote, .fse-template-content .wp-block-pullquote blockquote {
   color: #181818;
   border: none;
   margin-top: calc(3 * 32px);
@@ -4017,7 +3987,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding-left: 0;
 }
 
-.entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
+.entry .entry-content .wp-block-pullquote p, .fse-template-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
@@ -4025,17 +3995,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-top: 0.5em;
 }
 
-.entry .entry-content .wp-block-pullquote p em, .site-header .wp-block-pullquote p em, .site-footer .wp-block-pullquote p em {
+.entry .entry-content .wp-block-pullquote p em, .fse-template-content .wp-block-pullquote p em {
   font-style: normal;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote p, .site-header .wp-block-pullquote p, .site-footer .wp-block-pullquote p {
+  .entry .entry-content .wp-block-pullquote p, .fse-template-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote cite, .site-header .wp-block-pullquote cite, .site-footer .wp-block-pullquote cite {
+.entry .entry-content .wp-block-pullquote cite, .fse-template-content .wp-block-pullquote cite {
   display: inline-block;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4048,36 +4018,36 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .site-header .wp-block-pullquote.alignleft, .site-header .wp-block-pullquote.alignright, .site-footer .wp-block-pullquote.alignleft, .site-footer .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright, .fse-template-content .wp-block-pullquote.alignleft, .fse-template-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .site-header .wp-block-pullquote.alignleft blockquote, .site-header .wp-block-pullquote.alignright blockquote, .site-footer .wp-block-pullquote.alignleft blockquote, .site-footer .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote, .fse-template-content .wp-block-pullquote.alignleft blockquote, .fse-template-content .wp-block-pullquote.alignright blockquote {
   margin: 32px 0;
   padding: 0;
   text-align: left;
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .site-header .wp-block-pullquote.alignleft blockquote p:first-child, .site-header .wp-block-pullquote.alignright blockquote p:first-child, .site-footer .wp-block-pullquote.alignleft blockquote p:first-child, .site-footer .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child, .fse-template-content .wp-block-pullquote.alignleft blockquote p:first-child, .fse-template-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color, .fse-template-content .wp-block-pullquote.is-style-solid-color {
   background-color: #c43d80;
   padding-left: 0;
   padding-right: 0;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .site-header .wp-block-pullquote.is-style-solid-color, .site-footer .wp-block-pullquote.is-style-solid-color {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color, .fse-template-content .wp-block-pullquote.is-style-solid-color {
     padding-left: 10%;
     padding-right: 10%;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p, .fse-template-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -4085,20 +4055,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .site-header .wp-block-pullquote.is-style-solid-color p, .site-footer .wp-block-pullquote.is-style-solid-color p {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p, .fse-template-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .site-header .wp-block-pullquote.is-style-solid-color a, .site-footer .wp-block-pullquote.is-style-solid-color a {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a, .fse-template-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .site-header .wp-block-pullquote.is-style-solid-color cite, .site-footer .wp-block-pullquote.is-style-solid-color cite {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite, .fse-template-content .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
 
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
   padding-left: 0;
@@ -4107,46 +4077,45 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .site-header .wp-block-pullquote.is-style-solid-color blockquote, .site-footer .wp-block-pullquote.is-style-solid-color blockquote {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote, .fse-template-content .wp-block-pullquote.is-style-solid-color blockquote {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .site-header .wp-block-pullquote.is-style-solid-color.alignright, .site-header .wp-block-pullquote.is-style-solid-color.alignleft, .site-footer .wp-block-pullquote.is-style-solid-color.alignright, .site-footer .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignright, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .site-header .wp-block-pullquote.is-style-solid-color.alignfull, .site-footer .wp-block-pullquote.is-style-solid-color.alignfull {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull, .fse-template-content .wp-block-pullquote.is-style-solid-color.alignfull {
     padding-left: calc(10% + 58px + (2 * 1rem));
     padding-right: calc(10% + 58px + (2 * 1rem));
   }
 }
 
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .site-header .wp-block-quote:not(.is-large), .site-header .wp-block-quote:not(.is-style-large), .site-footer .wp-block-quote:not(.is-large), .site-footer .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large), .fse-template-content .wp-block-quote:not(.is-large), .fse-template-content .wp-block-quote:not(.is-style-large) {
   border-color: #c43d80;
   border-width: 2px;
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.entry .entry-content .wp-block-quote p, .site-header .wp-block-quote p, .site-footer .wp-block-quote p {
+.entry .entry-content .wp-block-quote p, .fse-template-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
 
-.entry .entry-content .wp-block-quote cite, .site-header .wp-block-quote cite, .site-footer .wp-block-quote cite {
+.entry .entry-content .wp-block-quote cite, .fse-template-content .wp-block-quote cite {
   /*
 			 * This requires a rem-based font size calculation instead of our normal em-based one,
 			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4154,13 +4123,13 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .fse-template-content .wp-block-quote.is-large, .fse-template-content .wp-block-quote.is-style-large {
   margin: 32px auto;
   padding: 0;
   border-left: none;
 }
 
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .fse-template-content .wp-block-quote.is-large p, .fse-template-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
@@ -4168,11 +4137,9 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
-.entry .entry-content .wp-block-quote.is-style-large footer, .site-header .wp-block-quote.is-large cite,
-.site-header .wp-block-quote.is-large footer, .site-header .wp-block-quote.is-style-large cite,
-.site-header .wp-block-quote.is-style-large footer, .site-footer .wp-block-quote.is-large cite,
-.site-footer .wp-block-quote.is-large footer, .site-footer .wp-block-quote.is-style-large cite,
-.site-footer .wp-block-quote.is-style-large footer {
+.entry .entry-content .wp-block-quote.is-style-large footer, .fse-template-content .wp-block-quote.is-large cite,
+.fse-template-content .wp-block-quote.is-large footer, .fse-template-content .wp-block-quote.is-style-large cite,
+.fse-template-content .wp-block-quote.is-style-large footer {
   /*
 				 * This requires a rem-based font size calculation instead of our normal em-based one,
 				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
@@ -4181,30 +4148,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .site-header .wp-block-quote.is-large, .site-header .wp-block-quote.is-style-large, .site-footer .wp-block-quote.is-large, .site-footer .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large, .fse-template-content .wp-block-quote.is-large, .fse-template-content .wp-block-quote.is-style-large {
     margin: 32px auto;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .site-header .wp-block-quote.is-large p, .site-header .wp-block-quote.is-style-large p, .site-footer .wp-block-quote.is-large p, .site-footer .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p, .fse-template-content .wp-block-quote.is-large p, .fse-template-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
 
-.entry .entry-content .wp-block-image, .site-header .wp-block-image, .site-footer .wp-block-image {
+.entry .entry-content .wp-block-image, .fse-template-content .wp-block-image {
   max-width: 100%;
 }
 
-.entry .entry-content .wp-block-image img, .site-header .wp-block-image img, .site-footer .wp-block-image img {
+.entry .entry-content .wp-block-image img, .fse-template-content .wp-block-image img {
   display: block;
 }
 
-.entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
+.entry .entry-content .wp-block-image.alignfull img, .fse-template-content .wp-block-image.alignfull img {
   width: 100vw;
   max-width: calc( 100% + (2 * 1rem));
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image.alignfull img, .site-header .wp-block-image.alignfull img, .site-footer .wp-block-image.alignfull img {
+  .entry .entry-content .wp-block-image.alignfull img, .fse-template-content .wp-block-image.alignfull img {
     max-width: calc( 125% + 150px);
     margin-left: auto;
     margin-right: auto;
@@ -4212,9 +4179,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image,
-.entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
-.site-header .wp-block-cover, .site-footer .wp-block-cover-image,
-.site-footer .wp-block-cover {
+.entry .entry-content .wp-block-cover, .fse-template-content .wp-block-cover-image,
+.fse-template-content .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
@@ -4222,9 +4188,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
-  .entry .entry-content .wp-block-cover, .site-header .wp-block-cover-image,
-  .site-header .wp-block-cover, .site-footer .wp-block-cover-image,
-  .site-footer .wp-block-cover {
+  .entry .entry-content .wp-block-cover, .fse-template-content .wp-block-cover-image,
+  .fse-template-content .wp-block-cover {
     min-height: 640px;
     padding: 1rem 10%;
   }
@@ -4235,17 +4200,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-.entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
-.site-header .wp-block-cover-image .wp-block-cover-image-text,
-.site-header .wp-block-cover-image .wp-block-cover-text,
-.site-header .wp-block-cover .wp-block-cover__inner-container,
-.site-header .wp-block-cover .wp-block-cover-image-text,
-.site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
-.site-footer .wp-block-cover-image .wp-block-cover-image-text,
-.site-footer .wp-block-cover-image .wp-block-cover-text,
-.site-footer .wp-block-cover .wp-block-cover__inner-container,
-.site-footer .wp-block-cover .wp-block-cover-image-text,
-.site-footer .wp-block-cover .wp-block-cover-text {
+.entry .entry-content .wp-block-cover .wp-block-cover-text, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container,
+.fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text,
+.fse-template-content .wp-block-cover .wp-block-cover__inner-container,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover .wp-block-cover-text {
   color: #fff;
   padding: 0;
   text-shadow: 0 0 12px #000;
@@ -4257,17 +4217,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
   .entry .entry-content .wp-block-cover .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
-  .entry .entry-content .wp-block-cover .wp-block-cover-text, .site-header .wp-block-cover-image .wp-block-cover__inner-container,
-  .site-header .wp-block-cover-image .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image .wp-block-cover-text,
-  .site-header .wp-block-cover .wp-block-cover__inner-container,
-  .site-header .wp-block-cover .wp-block-cover-image-text,
-  .site-header .wp-block-cover .wp-block-cover-text, .site-footer .wp-block-cover-image .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image .wp-block-cover-text,
-  .site-footer .wp-block-cover .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover .wp-block-cover-image-text,
-  .site-footer .wp-block-cover .wp-block-cover-text {
+  .entry .entry-content .wp-block-cover .wp-block-cover-text, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-text,
+  .fse-template-content .wp-block-cover .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover .wp-block-cover-text {
     max-width: 100%;
   }
 }
@@ -4277,17 +4232,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text a,
 .entry .entry-content .wp-block-cover .wp-block-cover__inner-container a,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text a,
-.entry .entry-content .wp-block-cover .wp-block-cover-text a, .site-header .wp-block-cover-image .wp-block-cover__inner-container a,
-.site-header .wp-block-cover-image .wp-block-cover-image-text a,
-.site-header .wp-block-cover-image .wp-block-cover-text a,
-.site-header .wp-block-cover .wp-block-cover__inner-container a,
-.site-header .wp-block-cover .wp-block-cover-image-text a,
-.site-header .wp-block-cover .wp-block-cover-text a, .site-footer .wp-block-cover-image .wp-block-cover__inner-container a,
-.site-footer .wp-block-cover-image .wp-block-cover-image-text a,
-.site-footer .wp-block-cover-image .wp-block-cover-text a,
-.site-footer .wp-block-cover .wp-block-cover__inner-container a,
-.site-footer .wp-block-cover .wp-block-cover-image-text a,
-.site-footer .wp-block-cover .wp-block-cover-text a {
+.entry .entry-content .wp-block-cover .wp-block-cover-text a, .fse-template-content .wp-block-cover-image .wp-block-cover__inner-container a,
+.fse-template-content .wp-block-cover-image .wp-block-cover-image-text a,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text a,
+.fse-template-content .wp-block-cover .wp-block-cover__inner-container a,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text a,
+.fse-template-content .wp-block-cover .wp-block-cover-text a {
   color: inherit;
 }
 
@@ -4302,44 +4252,31 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover h3,
 .entry .entry-content .wp-block-cover h4,
 .entry .entry-content .wp-block-cover h5,
-.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h1,
-.site-header .wp-block-cover-image h2,
-.site-header .wp-block-cover-image h3,
-.site-header .wp-block-cover-image h4,
-.site-header .wp-block-cover-image h5,
-.site-header .wp-block-cover-image h6,
-.site-header .wp-block-cover h1,
-.site-header .wp-block-cover h2,
-.site-header .wp-block-cover h3,
-.site-header .wp-block-cover h4,
-.site-header .wp-block-cover h5,
-.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h1,
-.site-footer .wp-block-cover-image h2,
-.site-footer .wp-block-cover-image h3,
-.site-footer .wp-block-cover-image h4,
-.site-footer .wp-block-cover-image h5,
-.site-footer .wp-block-cover-image h6,
-.site-footer .wp-block-cover h1,
-.site-footer .wp-block-cover h2,
-.site-footer .wp-block-cover h3,
-.site-footer .wp-block-cover h4,
-.site-footer .wp-block-cover h5,
-.site-footer .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h1,
+.fse-template-content .wp-block-cover-image h2,
+.fse-template-content .wp-block-cover-image h3,
+.fse-template-content .wp-block-cover-image h4,
+.fse-template-content .wp-block-cover-image h5,
+.fse-template-content .wp-block-cover-image h6,
+.fse-template-content .wp-block-cover h1,
+.fse-template-content .wp-block-cover h2,
+.fse-template-content .wp-block-cover h3,
+.fse-template-content .wp-block-cover h4,
+.fse-template-content .wp-block-cover h5,
+.fse-template-content .wp-block-cover h6 {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-cover-image h1,
-.entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
-.site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
-.site-footer .wp-block-cover h1 {
+.entry .entry-content .wp-block-cover h1, .fse-template-content .wp-block-cover-image h1,
+.fse-template-content .wp-block-cover h1 {
   font-size: 2.25em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h1,
-  .entry .entry-content .wp-block-cover h1, .site-header .wp-block-cover-image h1,
-  .site-header .wp-block-cover h1, .site-footer .wp-block-cover-image h1,
-  .site-footer .wp-block-cover h1 {
+  .entry .entry-content .wp-block-cover h1, .fse-template-content .wp-block-cover-image h1,
+  .fse-template-content .wp-block-cover h1 {
     font-size: 3.375em;
   }
 }
@@ -4349,17 +4286,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-cover-image h2,
 .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
-.entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
-.site-header .wp-block-cover-image .wp-block-cover-text,
-.site-header .wp-block-cover-image h2,
-.site-header .wp-block-cover .wp-block-cover-image-text,
-.site-header .wp-block-cover .wp-block-cover-text,
-.site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-.site-footer .wp-block-cover-image .wp-block-cover-text,
-.site-footer .wp-block-cover-image h2,
-.site-footer .wp-block-cover .wp-block-cover-image-text,
-.site-footer .wp-block-cover .wp-block-cover-text,
-.site-footer .wp-block-cover h2 {
+.entry .entry-content .wp-block-cover h2, .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover-image .wp-block-cover-text,
+.fse-template-content .wp-block-cover-image h2,
+.fse-template-content .wp-block-cover .wp-block-cover-image-text,
+.fse-template-content .wp-block-cover .wp-block-cover-text,
+.fse-template-content .wp-block-cover h2 {
   font-size: 1.6875em;
   margin: inherit;
   max-width: inherit;
@@ -4373,112 +4305,94 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover-image h2,
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover h2, .site-header .wp-block-cover-image .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image .wp-block-cover-text,
-  .site-header .wp-block-cover-image h2,
-  .site-header .wp-block-cover .wp-block-cover-image-text,
-  .site-header .wp-block-cover .wp-block-cover-text,
-  .site-header .wp-block-cover h2, .site-footer .wp-block-cover-image .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image .wp-block-cover-text,
-  .site-footer .wp-block-cover-image h2,
-  .site-footer .wp-block-cover .wp-block-cover-image-text,
-  .site-footer .wp-block-cover .wp-block-cover-text,
-  .site-footer .wp-block-cover h2 {
+  .entry .entry-content .wp-block-cover h2, .fse-template-content .wp-block-cover-image .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image .wp-block-cover-text,
+  .fse-template-content .wp-block-cover-image h2,
+  .fse-template-content .wp-block-cover .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover .wp-block-cover-text,
+  .fse-template-content .wp-block-cover h2 {
     font-size: 2.8125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h3,
-.entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
-.site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
-.site-footer .wp-block-cover h3 {
+.entry .entry-content .wp-block-cover h3, .fse-template-content .wp-block-cover-image h3,
+.fse-template-content .wp-block-cover h3 {
   font-size: 1.125em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h3,
-  .entry .entry-content .wp-block-cover h3, .site-header .wp-block-cover-image h3,
-  .site-header .wp-block-cover h3, .site-footer .wp-block-cover-image h3,
-  .site-footer .wp-block-cover h3 {
+  .entry .entry-content .wp-block-cover h3, .fse-template-content .wp-block-cover-image h3,
+  .fse-template-content .wp-block-cover h3 {
     font-size: 2.25em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h4,
-.entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
-.site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
-.site-footer .wp-block-cover h4 {
+.entry .entry-content .wp-block-cover h4, .fse-template-content .wp-block-cover-image h4,
+.fse-template-content .wp-block-cover h4 {
   font-size: 22px;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h4,
-  .entry .entry-content .wp-block-cover h4, .site-header .wp-block-cover-image h4,
-  .site-header .wp-block-cover h4, .site-footer .wp-block-cover-image h4,
-  .site-footer .wp-block-cover h4 {
+  .entry .entry-content .wp-block-cover h4, .fse-template-content .wp-block-cover-image h4,
+  .fse-template-content .wp-block-cover h4 {
     font-size: 1.6875em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h5,
-.entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
-.site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
-.site-footer .wp-block-cover h5 {
+.entry .entry-content .wp-block-cover h5, .fse-template-content .wp-block-cover-image h5,
+.fse-template-content .wp-block-cover h5 {
   font-size: 0.88889em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h5,
-  .entry .entry-content .wp-block-cover h5, .site-header .wp-block-cover-image h5,
-  .site-header .wp-block-cover h5, .site-footer .wp-block-cover-image h5,
-  .site-footer .wp-block-cover h5 {
+  .entry .entry-content .wp-block-cover h5, .fse-template-content .wp-block-cover-image h5,
+  .fse-template-content .wp-block-cover h5 {
     font-size: 1.125em;
   }
 }
 
 .entry .entry-content .wp-block-cover-image h6,
-.entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
-.site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
-.site-footer .wp-block-cover h6 {
+.entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h6,
+.fse-template-content .wp-block-cover h6 {
   font-size: 0.71111em;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image h6,
-  .entry .entry-content .wp-block-cover h6, .site-header .wp-block-cover-image h6,
-  .site-header .wp-block-cover h6, .site-footer .wp-block-cover-image h6,
-  .site-footer .wp-block-cover h6 {
+  .entry .entry-content .wp-block-cover h6, .fse-template-content .wp-block-cover-image h6,
+  .fse-template-content .wp-block-cover h6 {
     font-size: 22px;
   }
 }
 
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
-.entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
-.site-header .wp-block-cover.alignleft,
-.site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
-.site-footer .wp-block-cover.alignleft,
-.site-footer .wp-block-cover.alignright {
+.entry .entry-content .wp-block-cover.alignright, .fse-template-content .wp-block-cover-image.alignleft, .fse-template-content .wp-block-cover-image.alignright,
+.fse-template-content .wp-block-cover.alignleft,
+.fse-template-content .wp-block-cover.alignright {
   width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
-  .entry .entry-content .wp-block-cover.alignright, .site-header .wp-block-cover-image.alignleft, .site-header .wp-block-cover-image.alignright,
-  .site-header .wp-block-cover.alignleft,
-  .site-header .wp-block-cover.alignright, .site-footer .wp-block-cover-image.alignleft, .site-footer .wp-block-cover-image.alignright,
-  .site-footer .wp-block-cover.alignleft,
-  .site-footer .wp-block-cover.alignright {
+  .entry .entry-content .wp-block-cover.alignright, .fse-template-content .wp-block-cover-image.alignleft, .fse-template-content .wp-block-cover-image.alignright,
+  .fse-template-content .wp-block-cover.alignleft,
+  .fse-template-content .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull, .site-header .wp-block-cover-image.alignfull,
-  .site-header .wp-block-cover.alignfull, .site-footer .wp-block-cover-image.alignfull,
-  .site-footer .wp-block-cover.alignfull {
+  .entry .entry-content .wp-block-cover.alignfull, .fse-template-content .wp-block-cover-image.alignfull,
+  .fse-template-content .wp-block-cover.alignfull {
     padding-left: calc(10% + 58px + (2 * 1rem));
     padding-right: calc(10% + 58px + (2 * 1rem));
   }
@@ -4489,38 +4403,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
-  .entry .entry-content .wp-block-cover.alignfull h2, .site-header .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
-  .site-header .wp-block-cover-image.alignfull .wp-block-cover-image-text,
-  .site-header .wp-block-cover-image.alignfull .wp-block-cover-text,
-  .site-header .wp-block-cover-image.alignfull h2,
-  .site-header .wp-block-cover.alignfull .wp-block-cover__inner-container,
-  .site-header .wp-block-cover.alignfull .wp-block-cover-image-text,
-  .site-header .wp-block-cover.alignfull .wp-block-cover-text,
-  .site-header .wp-block-cover.alignfull h2, .site-footer .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-image-text,
-  .site-footer .wp-block-cover-image.alignfull .wp-block-cover-text,
-  .site-footer .wp-block-cover-image.alignfull h2,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover__inner-container,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover-image-text,
-  .site-footer .wp-block-cover.alignfull .wp-block-cover-text,
-  .site-footer .wp-block-cover.alignfull h2 {
+  .entry .entry-content .wp-block-cover.alignfull h2, .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .fse-template-content .wp-block-cover-image.alignfull h2,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover__inner-container,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .fse-template-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .fse-template-content .wp-block-cover.alignfull h2 {
     padding: 0;
   }
 }
 
-.entry .entry-content .wp-block-gallery, .site-header .wp-block-gallery, .site-footer .wp-block-gallery {
+.entry .entry-content .wp-block-gallery, .fse-template-content .wp-block-gallery {
   list-style-type: none;
   padding-left: 0;
 }
 
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .site-header .wp-block-gallery .blocks-gallery-image:last-child,
-.site-header .wp-block-gallery .blocks-gallery-item:last-child, .site-footer .wp-block-gallery .blocks-gallery-image:last-child,
-.site-footer .wp-block-gallery .blocks-gallery-item:last-child {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child, .fse-template-content .wp-block-gallery .blocks-gallery-image:last-child,
+.fse-template-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
 
-.entry .entry-content .wp-block-gallery figcaption a, .site-header .wp-block-gallery figcaption a, .site-footer .wp-block-gallery figcaption a {
+.entry .entry-content .wp-block-gallery figcaption a, .fse-template-content .wp-block-gallery figcaption a {
   color: #fff;
 }
 
@@ -4528,15 +4434,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .site-header .wp-block-audio figcaption,
-.site-header .wp-block-video figcaption,
-.site-header .wp-block-image figcaption,
-.site-header .wp-block-gallery .blocks-gallery-image figcaption,
-.site-header .wp-block-gallery .blocks-gallery-item figcaption, .site-footer .wp-block-audio figcaption,
-.site-footer .wp-block-video figcaption,
-.site-footer .wp-block-image figcaption,
-.site-footer .wp-block-gallery .blocks-gallery-image figcaption,
-.site-footer .wp-block-gallery .blocks-gallery-item figcaption {
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption, .fse-template-content .wp-block-audio figcaption,
+.fse-template-content .wp-block-video figcaption,
+.fse-template-content .wp-block-image figcaption,
+.fse-template-content .wp-block-gallery .blocks-gallery-image figcaption,
+.fse-template-content .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.71111em;
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
@@ -4546,9 +4448,8 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator,
-.entry .entry-content hr, .site-header .wp-block-separator,
-.site-header hr, .site-footer .wp-block-separator,
-.site-footer hr {
+.entry .entry-content hr, .fse-template-content .wp-block-separator,
+.fse-template-content hr {
   background-color: #686868;
   border: 0;
   height: 1px;
@@ -4560,34 +4461,30 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-separator.is-style-wide,
-.entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-.site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-.site-footer hr.is-style-wide {
+.entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+.fse-template-content hr.is-style-wide {
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-  .site-footer hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+  .fse-template-content hr.is-style-wide {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
-  .entry .entry-content hr.is-style-wide, .site-header .wp-block-separator.is-style-wide,
-  .site-header hr.is-style-wide, .site-footer .wp-block-separator.is-style-wide,
-  .site-footer hr.is-style-wide {
+  .entry .entry-content hr.is-style-wide, .fse-template-content .wp-block-separator.is-style-wide,
+  .fse-template-content hr.is-style-wide {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots,
-.entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-.site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-.site-footer hr.is-style-dots {
+.entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+.fse-template-content hr.is-style-dots {
   max-width: 100%;
   background-color: inherit;
   border: inherit;
@@ -4597,26 +4494,23 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-  .site-footer hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+  .fse-template-content hr.is-style-dots {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots, .site-header .wp-block-separator.is-style-dots,
-  .site-header hr.is-style-dots, .site-footer .wp-block-separator.is-style-dots,
-  .site-footer hr.is-style-dots {
+  .entry .entry-content hr.is-style-dots, .fse-template-content .wp-block-separator.is-style-dots,
+  .fse-template-content hr.is-style-dots {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
 .entry .entry-content .wp-block-separator.is-style-dots:before,
-.entry .entry-content hr.is-style-dots:before, .site-header .wp-block-separator.is-style-dots:before,
-.site-header hr.is-style-dots:before, .site-footer .wp-block-separator.is-style-dots:before,
-.site-footer hr.is-style-dots:before {
+.entry .entry-content hr.is-style-dots:before, .fse-template-content .wp-block-separator.is-style-dots:before,
+.fse-template-content hr.is-style-dots:before {
   color: #686868;
   font-size: 1.6875em;
 }
@@ -4624,42 +4518,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .wp-block-separator + h1:before,
 .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
-.entry .entry-content hr + h2:before, .site-header .wp-block-separator + h1:before,
-.site-header .wp-block-separator + h2:before,
-.site-header hr + h1:before,
-.site-header hr + h2:before, .site-footer .wp-block-separator + h1:before,
-.site-footer .wp-block-separator + h2:before,
-.site-footer hr + h1:before,
-.site-footer hr + h2:before {
+.entry .entry-content hr + h2:before, .fse-template-content .wp-block-separator + h1:before,
+.fse-template-content .wp-block-separator + h2:before,
+.fse-template-content hr + h1:before,
+.fse-template-content hr + h2:before {
   display: none;
 }
 
-.entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
+.entry .entry-content .wp-block-spacer.desktop-only, .fse-template-content .wp-block-spacer.desktop-only {
   display: none;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-spacer.desktop-only, .site-header .wp-block-spacer.desktop-only, .site-footer .wp-block-spacer.desktop-only {
+  .entry .entry-content .wp-block-spacer.desktop-only, .fse-template-content .wp-block-spacer.desktop-only {
     display: block;
   }
 }
 
-.entry .entry-content .wp-block-embed-twitter, .site-header .wp-block-embed-twitter, .site-footer .wp-block-embed-twitter {
+.entry .entry-content .wp-block-embed-twitter, .fse-template-content .wp-block-embed-twitter {
   word-break: break-word;
 }
 
 .entry .entry-content .wp-block-table th,
-.entry .entry-content .wp-block-table td, .site-header .wp-block-table th,
-.site-header .wp-block-table td, .site-footer .wp-block-table th,
-.site-footer .wp-block-table td {
+.entry .entry-content .wp-block-table td, .fse-template-content .wp-block-table th,
+.fse-template-content .wp-block-table td {
   border-color: #686868;
 }
 
-.entry .entry-content .wp-block-file, .site-header .wp-block-file, .site-footer .wp-block-file {
+.entry .entry-content .wp-block-file, .fse-template-content .wp-block-file {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
+.entry .entry-content .wp-block-file .wp-block-file__button, .fse-template-content .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
   border: none;
@@ -4677,94 +4567,89 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-file .wp-block-file__button, .site-header .wp-block-file .wp-block-file__button, .site-footer .wp-block-file .wp-block-file__button {
+  .entry .entry-content .wp-block-file .wp-block-file__button, .fse-template-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:hover, .site-header .wp-block-file .wp-block-file__button:hover, .site-footer .wp-block-file .wp-block-file__button:hover {
+.entry .entry-content .wp-block-file .wp-block-file__button:hover, .fse-template-content .wp-block-file .wp-block-file__button:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .wp-block-file .wp-block-file__button:focus, .site-header .wp-block-file .wp-block-file__button:focus, .site-footer .wp-block-file .wp-block-file__button:focus {
+.entry .entry-content .wp-block-file .wp-block-file__button:focus, .fse-template-content .wp-block-file .wp-block-file__button:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-.entry .entry-content .wp-block-code, .site-header .wp-block-code, .site-footer .wp-block-code {
+.entry .entry-content .wp-block-code, .fse-template-content .wp-block-code {
   border-radius: 0;
 }
 
-.entry .entry-content .wp-block-code code, .site-header .wp-block-code code, .site-footer .wp-block-code code {
+.entry .entry-content .wp-block-code code, .fse-template-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
+.entry .entry-content .wp-block-columns.alignfull, .fse-template-content .wp-block-columns.alignfull {
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
 @media only screen and (min-width: 782px) {
-  .entry .entry-content .wp-block-columns .wp-block-column, .site-header .wp-block-columns .wp-block-column, .site-footer .wp-block-columns .wp-block-column {
+  .entry .entry-content .wp-block-columns .wp-block-column, .fse-template-content .wp-block-columns .wp-block-column {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .site-header .wp-block-columns .wp-block-column:first-child, .site-footer .wp-block-columns .wp-block-column:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:first-child, .fse-template-content .wp-block-columns .wp-block-column:first-child {
     margin-left: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .site-header .wp-block-columns .wp-block-column:last-child, .site-footer .wp-block-columns .wp-block-column:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column:last-child, .fse-template-content .wp-block-columns .wp-block-column:last-child {
     margin-right: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .site-header .wp-block-columns .wp-block-column > *:first-child, .site-footer .wp-block-columns .wp-block-column > *:first-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child, .fse-template-content .wp-block-columns .wp-block-column > *:first-child {
     margin-top: 0;
   }
-  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .site-header .wp-block-columns .wp-block-column > *:last-child, .site-footer .wp-block-columns .wp-block-column > *:last-child {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child, .fse-template-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns.alignfull, .site-header .wp-block-columns.alignfull, .site-footer .wp-block-columns.alignfull {
+  .entry .entry-content .wp-block-columns.alignfull, .fse-template-content .wp-block-columns.alignfull {
     padding-left: calc( 2 * 1rem);
     padding-right: calc( 2 * 1rem);
   }
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 700;
 }
 
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: 300;
 }
 
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-header .wp-block-latest-comments .wp-block-latest-comments__comment,
-.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.site-header .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .site-footer .wp-block-latest-comments .wp-block-latest-comments__comment,
-.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-date,
-.site-footer .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p, .fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment,
+.fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.fse-template-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
 
-.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-header .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .site-footer .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date, .fse-template-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
 }
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color, .site-header .has-primary-background-color,
-.site-header .has-secondary-background-color,
-.site-header .has-dark-gray-background-color,
-.site-header .has-light-gray-background-color, .site-footer .has-primary-background-color,
-.site-footer .has-secondary-background-color,
-.site-footer .has-dark-gray-background-color,
-.site-footer .has-light-gray-background-color {
+.entry .entry-content .has-light-gray-background-color, .fse-template-content .has-primary-background-color,
+.fse-template-content .has-secondary-background-color,
+.fse-template-content .has-dark-gray-background-color,
+.fse-template-content .has-light-gray-background-color {
   color: #fff;
 }
 
@@ -4799,73 +4684,42 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-light-gray-background-color h4,
 .entry .entry-content .has-light-gray-background-color h5,
 .entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a, .site-header .has-primary-background-color p,
-.site-header .has-primary-background-color h1,
-.site-header .has-primary-background-color h2,
-.site-header .has-primary-background-color h3,
-.site-header .has-primary-background-color h4,
-.site-header .has-primary-background-color h5,
-.site-header .has-primary-background-color h6,
-.site-header .has-primary-background-color a,
-.site-header .has-secondary-background-color p,
-.site-header .has-secondary-background-color h1,
-.site-header .has-secondary-background-color h2,
-.site-header .has-secondary-background-color h3,
-.site-header .has-secondary-background-color h4,
-.site-header .has-secondary-background-color h5,
-.site-header .has-secondary-background-color h6,
-.site-header .has-secondary-background-color a,
-.site-header .has-dark-gray-background-color p,
-.site-header .has-dark-gray-background-color h1,
-.site-header .has-dark-gray-background-color h2,
-.site-header .has-dark-gray-background-color h3,
-.site-header .has-dark-gray-background-color h4,
-.site-header .has-dark-gray-background-color h5,
-.site-header .has-dark-gray-background-color h6,
-.site-header .has-dark-gray-background-color a,
-.site-header .has-light-gray-background-color p,
-.site-header .has-light-gray-background-color h1,
-.site-header .has-light-gray-background-color h2,
-.site-header .has-light-gray-background-color h3,
-.site-header .has-light-gray-background-color h4,
-.site-header .has-light-gray-background-color h5,
-.site-header .has-light-gray-background-color h6,
-.site-header .has-light-gray-background-color a, .site-footer .has-primary-background-color p,
-.site-footer .has-primary-background-color h1,
-.site-footer .has-primary-background-color h2,
-.site-footer .has-primary-background-color h3,
-.site-footer .has-primary-background-color h4,
-.site-footer .has-primary-background-color h5,
-.site-footer .has-primary-background-color h6,
-.site-footer .has-primary-background-color a,
-.site-footer .has-secondary-background-color p,
-.site-footer .has-secondary-background-color h1,
-.site-footer .has-secondary-background-color h2,
-.site-footer .has-secondary-background-color h3,
-.site-footer .has-secondary-background-color h4,
-.site-footer .has-secondary-background-color h5,
-.site-footer .has-secondary-background-color h6,
-.site-footer .has-secondary-background-color a,
-.site-footer .has-dark-gray-background-color p,
-.site-footer .has-dark-gray-background-color h1,
-.site-footer .has-dark-gray-background-color h2,
-.site-footer .has-dark-gray-background-color h3,
-.site-footer .has-dark-gray-background-color h4,
-.site-footer .has-dark-gray-background-color h5,
-.site-footer .has-dark-gray-background-color h6,
-.site-footer .has-dark-gray-background-color a,
-.site-footer .has-light-gray-background-color p,
-.site-footer .has-light-gray-background-color h1,
-.site-footer .has-light-gray-background-color h2,
-.site-footer .has-light-gray-background-color h3,
-.site-footer .has-light-gray-background-color h4,
-.site-footer .has-light-gray-background-color h5,
-.site-footer .has-light-gray-background-color h6,
-.site-footer .has-light-gray-background-color a {
+.entry .entry-content .has-light-gray-background-color a, .fse-template-content .has-primary-background-color p,
+.fse-template-content .has-primary-background-color h1,
+.fse-template-content .has-primary-background-color h2,
+.fse-template-content .has-primary-background-color h3,
+.fse-template-content .has-primary-background-color h4,
+.fse-template-content .has-primary-background-color h5,
+.fse-template-content .has-primary-background-color h6,
+.fse-template-content .has-primary-background-color a,
+.fse-template-content .has-secondary-background-color p,
+.fse-template-content .has-secondary-background-color h1,
+.fse-template-content .has-secondary-background-color h2,
+.fse-template-content .has-secondary-background-color h3,
+.fse-template-content .has-secondary-background-color h4,
+.fse-template-content .has-secondary-background-color h5,
+.fse-template-content .has-secondary-background-color h6,
+.fse-template-content .has-secondary-background-color a,
+.fse-template-content .has-dark-gray-background-color p,
+.fse-template-content .has-dark-gray-background-color h1,
+.fse-template-content .has-dark-gray-background-color h2,
+.fse-template-content .has-dark-gray-background-color h3,
+.fse-template-content .has-dark-gray-background-color h4,
+.fse-template-content .has-dark-gray-background-color h5,
+.fse-template-content .has-dark-gray-background-color h6,
+.fse-template-content .has-dark-gray-background-color a,
+.fse-template-content .has-light-gray-background-color p,
+.fse-template-content .has-light-gray-background-color h1,
+.fse-template-content .has-light-gray-background-color h2,
+.fse-template-content .has-light-gray-background-color h3,
+.fse-template-content .has-light-gray-background-color h4,
+.fse-template-content .has-light-gray-background-color h5,
+.fse-template-content .has-light-gray-background-color h6,
+.fse-template-content .has-light-gray-background-color a {
   color: #fff;
 }
 
-.entry .entry-content .has-white-background-color, .site-header .has-white-background-color, .site-footer .has-white-background-color {
+.entry .entry-content .has-white-background-color, .fse-template-content .has-white-background-color {
   color: #181818;
 }
 
@@ -4876,150 +4730,128 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .has-white-background-color h4,
 .entry .entry-content .has-white-background-color h5,
 .entry .entry-content .has-white-background-color h6,
-.entry .entry-content .has-white-background-color a, .site-header .has-white-background-color p,
-.site-header .has-white-background-color h1,
-.site-header .has-white-background-color h2,
-.site-header .has-white-background-color h3,
-.site-header .has-white-background-color h4,
-.site-header .has-white-background-color h5,
-.site-header .has-white-background-color h6,
-.site-header .has-white-background-color a, .site-footer .has-white-background-color p,
-.site-footer .has-white-background-color h1,
-.site-footer .has-white-background-color h2,
-.site-footer .has-white-background-color h3,
-.site-footer .has-white-background-color h4,
-.site-footer .has-white-background-color h5,
-.site-footer .has-white-background-color h6,
-.site-footer .has-white-background-color a {
+.entry .entry-content .has-white-background-color a, .fse-template-content .has-white-background-color p,
+.fse-template-content .has-white-background-color h1,
+.fse-template-content .has-white-background-color h2,
+.fse-template-content .has-white-background-color h3,
+.fse-template-content .has-white-background-color h4,
+.fse-template-content .has-white-background-color h5,
+.fse-template-content .has-white-background-color h6,
+.fse-template-content .has-white-background-color a {
   color: #181818;
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-header .has-primary-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .site-footer .has-primary-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color, .fse-template-content .has-primary-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-header .has-secondary-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .site-footer .has-secondary-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color, .fse-template-content .has-secondary-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
   background-color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-header .has-dark-gray-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .site-footer .has-dark-gray-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color, .fse-template-content .has-dark-gray-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #181818;
 }
 
 .entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-header .has-light-gray-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .site-footer .has-light-gray-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color, .fse-template-content .has-light-gray-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #686868;
 }
 
 .entry .entry-content .has-white-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-header .has-white-background-color,
-.site-header .wp-block-pullquote.is-style-solid-color.has-white-background-color, .site-footer .has-white-background-color,
-.site-footer .wp-block-pullquote.is-style-solid-color.has-white-background-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color, .fse-template-content .has-white-background-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-header .has-primary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .site-footer .has-primary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p, .fse-template-content .has-primary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
   color: #c43d80;
 }
 
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-header .has-secondary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .site-footer .has-secondary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p, .fse-template-content .has-secondary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
   color: #9e3067;
 }
 
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-header .has-dark-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .site-footer .has-dark-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p, .fse-template-content .has-dark-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
   color: #181818;
 }
 
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-header .has-light-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .site-footer .has-light-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p, .fse-template-content .has-light-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
   color: #686868;
 }
 
 .entry .entry-content .has-white-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-header .has-white-color,
-.site-header .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .site-footer .has-white-color,
-.site-footer .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color, .fse-template-content .has-white-color,
+.fse-template-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: #FFF;
 }
 
 .entry .entry-content .a8c-posts-list-item__title a,
-.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__title a,
-.site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__title a,
-.site-footer .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .fse-template-content .a8c-posts-list-item__title a,
+.fse-template-content .a8c-posts-list-item__meta a {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .fse-template-content .a8c-posts-list__view-all {
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a, .site-header .a8c-posts-list-item__title a, .site-footer .a8c-posts-list-item__title a {
+.entry .entry-content .a8c-posts-list-item__title a, .fse-template-content .a8c-posts-list-item__title a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .site-header .a8c-posts-list-item__title a:hover, .site-header .a8c-posts-list-item__title a:focus, .site-footer .a8c-posts-list-item__title a:hover, .site-footer .a8c-posts-list-item__title a:focus {
+.entry .entry-content .a8c-posts-list-item__title a:hover, .entry .entry-content .a8c-posts-list-item__title a:focus, .fse-template-content .a8c-posts-list-item__title a:hover, .fse-template-content .a8c-posts-list-item__title a:focus {
   color: #4a4a4a;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a, .site-header .a8c-posts-list-item__meta a, .site-footer .a8c-posts-list-item__meta a {
+.entry .entry-content .a8c-posts-list-item__meta a, .fse-template-content .a8c-posts-list-item__meta a {
   color: inherit;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .site-header .a8c-posts-list-item__meta a:hover, .site-header .a8c-posts-list-item__meta a:focus, .site-footer .a8c-posts-list-item__meta a:hover, .site-footer .a8c-posts-list-item__meta a:focus {
+.entry .entry-content .a8c-posts-list-item__meta a:hover, .entry .entry-content .a8c-posts-list-item__meta a:focus, .fse-template-content .a8c-posts-list-item__meta a:hover, .fse-template-content .a8c-posts-list-item__meta a:focus {
   color: #c43d80;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-header .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .site-footer .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
+.entry .entry-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a, .fse-template-content .a8c-posts-list-item__meta .a8c-posts-list-item__edit-link a {
   color: #fff;
 }
 
-.entry .entry-content .a8c-posts-list, .site-header .a8c-posts-list, .site-footer .a8c-posts-list {
+.entry .entry-content .a8c-posts-list, .fse-template-content .a8c-posts-list {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list__item:not(:first-child), .site-header .a8c-posts-list__item:not(:first-child), .site-footer .a8c-posts-list__item:not(:first-child) {
+.entry .entry-content .a8c-posts-list__item:not(:first-child), .fse-template-content .a8c-posts-list__item:not(:first-child) {
   margin-top: calc(6 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__featured, .site-header .a8c-posts-list-item__featured, .site-footer .a8c-posts-list-item__featured {
+.entry .entry-content .a8c-posts-list-item__featured, .fse-template-content .a8c-posts-list-item__featured {
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__featured span, .site-header .a8c-posts-list-item__featured span, .site-footer .a8c-posts-list-item__featured span {
+.entry .entry-content .a8c-posts-list-item__featured span, .fse-template-content .a8c-posts-list-item__featured span {
   background: #c43d80;
   color: #fff;
   display: inline-block;
@@ -5031,33 +4863,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   z-index: 1;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail, .site-header .a8c-posts-list-item__post-thumbnail, .site-footer .a8c-posts-list-item__post-thumbnail {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail, .fse-template-content .a8c-posts-list-item__post-thumbnail {
   margin-bottom: 32px;
 }
 
-.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .site-header .a8c-posts-list-item__post-thumbnail img, .site-footer .a8c-posts-list-item__post-thumbnail img {
+.entry .entry-content .a8c-posts-list-item__post-thumbnail img, .fse-template-content .a8c-posts-list-item__post-thumbnail img {
   display: block;
 }
 
-.entry .entry-content .a8c-posts-list-item__title, .site-header .a8c-posts-list-item__title, .site-footer .a8c-posts-list-item__title {
+.entry .entry-content .a8c-posts-list-item__title, .fse-template-content .a8c-posts-list-item__title {
   font-size: 1.6875em;
   margin: 0;
   text-align: center;
   font-weight: 300;
 }
 
-.entry .entry-content .a8c-posts-list-item__meta, .site-header .a8c-posts-list-item__meta, .site-footer .a8c-posts-list-item__meta {
+.entry .entry-content .a8c-posts-list-item__meta, .fse-template-content .a8c-posts-list-item__meta {
   color: #686868;
   font-size: 0.71111em;
   font-weight: 500;
   text-align: center;
 }
 
-.entry .entry-content .a8c-posts-list-item__author, .site-header .a8c-posts-list-item__author, .site-footer .a8c-posts-list-item__author {
+.entry .entry-content .a8c-posts-list-item__author, .fse-template-content .a8c-posts-list-item__author {
   margin-right: calc(.5 * 1rem);
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link, .site-header .a8c-posts-list-item__edit-link, .site-footer .a8c-posts-list-item__edit-link {
+.entry .entry-content .a8c-posts-list-item__edit-link, .fse-template-content .a8c-posts-list-item__edit-link {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border-radius: 3px;
@@ -5066,33 +4898,33 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   padding: .05rem .4rem;
 }
 
-.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .site-header .a8c-posts-list-item__edit-link:hover, .site-header .a8c-posts-list-item__edit-link:focus, .site-footer .a8c-posts-list-item__edit-link:hover, .site-footer .a8c-posts-list-item__edit-link:focus {
+.entry .entry-content .a8c-posts-list-item__edit-link:hover, .entry .entry-content .a8c-posts-list-item__edit-link:focus, .fse-template-content .a8c-posts-list-item__edit-link:hover, .fse-template-content .a8c-posts-list-item__edit-link:focus {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+.entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
   margin: 0 auto;
   text-align: left;
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
 
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .a8c-posts-list-item__excerpt, .site-header .a8c-posts-list-item__excerpt, .site-footer .a8c-posts-list-item__excerpt {
+  .entry .entry-content .a8c-posts-list-item__excerpt, .fse-template-content .a8c-posts-list-item__excerpt {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
-.entry .entry-content .a8c-posts-list-item__excerpt p, .site-header .a8c-posts-list-item__excerpt p, .site-footer .a8c-posts-list-item__excerpt p {
+.entry .entry-content .a8c-posts-list-item__excerpt p, .fse-template-content .a8c-posts-list-item__excerpt p {
   margin: 32px 0;
 }
 
-.entry .entry-content .a8c-posts-list__view-all, .site-header .a8c-posts-list__view-all, .site-footer .a8c-posts-list__view-all {
+.entry .entry-content .a8c-posts-list__view-all, .fse-template-content .a8c-posts-list__view-all {
   transition: background 150ms ease-in-out;
   background: #c43d80;
   border: none;
@@ -5110,17 +4942,17 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   vertical-align: bottom;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:hover, .site-header .a8c-posts-list__view-all:hover, .site-footer .a8c-posts-list__view-all:hover {
+.entry .entry-content .a8c-posts-list__view-all:hover, .fse-template-content .a8c-posts-list__view-all:hover {
   background: #9e3067;
   cursor: pointer;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:visited, .site-header .a8c-posts-list__view-all:visited, .site-footer .a8c-posts-list__view-all:visited {
+.entry .entry-content .a8c-posts-list__view-all:visited, .fse-template-content .a8c-posts-list__view-all:visited {
   color: #fff;
   text-decoration: none;
 }
 
-.entry .entry-content .a8c-posts-list__view-all:focus, .site-header .a8c-posts-list__view-all:focus, .site-footer .a8c-posts-list__view-all:focus {
+.entry .entry-content .a8c-posts-list__view-all:focus, .fse-template-content .a8c-posts-list__view-all:focus {
   background: #9e3067;
   outline: thin dotted;
   outline-offset: -4px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add  `.fse-template-content` class to block styles in order to apply the correct front end block styles to the FSE header and footer content.

#### Testing
- Check out https://github.com/Automattic/wp-calypso/pull/35154 in your FSE test environment
- Build theme and copy or link to local FSE install
- Add a Paragraph block to the Header and Footer template parts and set the background colour to one of the primary colours
- View the page in the front end and check that the blocks have a background colour

**Before**

<img width="534" alt="before" src="https://user-images.githubusercontent.com/3629020/62341603-1369af00-b538-11e9-8108-95633455e74d.png">

**After**

<img width="519" alt="after" src="https://user-images.githubusercontent.com/3629020/62341613-1cf31700-b538-11e9-9d65-f6e237322f8e.png">

#### Related issue(s): 
https://github.com/Automattic/wp-calypso/issues/35058
https://github.com/Automattic/wp-calypso/pull/35154
