### PR TITLE
 wp_body_open() function added after body tag

### DIFF
--- a/affinity/header.php
+++ b/affinity/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'affinity' ); ?></a>
 

--- a/altofocus/header.php
+++ b/altofocus/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'altofocus' ); ?></a>
 

--- a/apostrophe-2/header.php
+++ b/apostrophe-2/header.php
@@ -16,6 +16,7 @@
 	</head>
 
 	<body <?php body_class(); ?>>
+	<?php wp_body_open(); ?>
 		<div id="page" class="hfeed site">
 
 			<header id="masthead" class="site-header" role="banner">

--- a/button-2/header.php
+++ b/button-2/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'button-2' ); ?></a>
 

--- a/canard/header.php
+++ b/canard/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'canard' ); ?></a>
 

--- a/dara/header.php
+++ b/dara/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'dara' ); ?></a>
 

--- a/dyad-2/header.php
+++ b/dyad-2/header.php
@@ -19,6 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'dyad-2' ); ?></a>
 

--- a/gazette/header.php
+++ b/gazette/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'gazette' ); ?></a>
 

--- a/illustratr/header.php
+++ b/illustratr/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 
 	<header id="masthead" class="site-header" role="banner">

--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -129,6 +129,11 @@ function independent_publisher_2_word_count() {
 	$content = get_post_field( 'post_content', get_the_ID() );
 	$count   = str_word_count( strip_tags( $content ) );
 	$time    = $count / 250; //Roughly 250 wpm reading time
+
+	// if time less than 1 explicitly set to 1.
+	if( $time < 1 ) {
+		$time = 1;
+	}
 	return number_format( $time );
 }
 endif; // independent_publisher_2_word_count

--- a/independent-publisher-2/header.php
+++ b/independent-publisher-2/header.php
@@ -18,7 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'independent-publisher-2' ); ?></a>
 

--- a/intergalactic-2/header.php
+++ b/intergalactic-2/header.php
@@ -20,6 +20,7 @@ $header = get_header_image();
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'intergalactic-2' ); ?></a>
 	<header id="masthead" class="site-header" role="banner">

--- a/ixion/header.php
+++ b/ixion/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'ixion' ); ?></a>
 

--- a/karuna/header.php
+++ b/karuna/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'karuna' ); ?></a>
 

--- a/libre-2/header.php
+++ b/libre-2/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div class="site-wrapper">
 	<div id="page" class="hfeed site">
 		<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'libre-2' ); ?></a>

--- a/libretto/header.php
+++ b/libretto/header.php
@@ -19,7 +19,7 @@
 	</head>
 
 	<body <?php body_class(); ?>>
-
+	<?php wp_body_open(); ?>
 		<header class="nav-bar">
 			<?php if ( ! is_home() ) : // On the blog index page the site title is displayed below nav-bar ?>
 			<div class="site-branding">

--- a/lodestar/header.php
+++ b/lodestar/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'lodestar' ); ?></a>
 

--- a/penscratch-2/header.php
+++ b/penscratch-2/header.php
@@ -17,6 +17,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'penscratch-2' ); ?></a>
 	<header id="masthead" class="site-header" role="banner">

--- a/photos/header.php
+++ b/photos/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'photos' ); ?></a>
 

--- a/pique/header.php
+++ b/pique/header.php
@@ -19,6 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'pique' ); ?></a>

--- a/publication/header.php
+++ b/publication/header.php
@@ -19,6 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'publication' ); ?></a>
 
 	<div id="body-wrapper" class="body-wrapper">

--- a/radcliffe-2/header.php
+++ b/radcliffe-2/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'radcliffe-2' ); ?></a>
 

--- a/rebalance/header.php
+++ b/rebalance/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'rebalance' ); ?></a>
 

--- a/scratchpad/header.php
+++ b/scratchpad/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'scratchpad' ); ?></a>
 

--- a/shoreditch/header.php
+++ b/shoreditch/header.php
@@ -18,6 +18,7 @@
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
 <?php wp_head(); ?>
+<?php wp_body_open(); ?>
 </head>
 
 <body <?php body_class(); ?>>

--- a/sketch/header.php
+++ b/sketch/header.php
@@ -18,6 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="hfeed site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'sketch' ); ?></a>
 	<header id="masthead" class="site-header" role="banner">

--- a/textbook/header.php
+++ b/textbook/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'textbook' ); ?></a>
 

--- a/toujours/header.php
+++ b/toujours/header.php
@@ -21,6 +21,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'toujours' ); ?></a>
 

--- a/varia/header.php
+++ b/varia/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Starting from WordPress 5.2 a new function is added – wp_body_open() – that is used to trigger a wp_body_open action. The intention of this action is to allow people to add things – like a <script> tag – directly inside the body of a page.

Ref: 
https://developer.wordpress.org/reference/functions/wp_body_open/
https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook/

#### Related issue(s):
