### PR TITLE
Modern Business: Add editor palette support to the functions.php

### DIFF
--- a/modern-business/functions.php
+++ b/modern-business/functions.php
@@ -16,21 +16,53 @@ if ( ! function_exists( 'modern_business_setup' ) ) :
 	 * as indicating support for post thumbnails.
 	 */
 	function modern_business_setup() {
-	    /**
-	     * Add support for core custom logo.
-	     *
-	     * @link https://codex.wordpress.org/Theme_Logo
-	     */
-	    add_theme_support(
-	        'custom-logo',
-	        array(
-	            'height'      => 128,
-	            'width'       => 128,
-	            'flex-width'  => true,
-	            'flex-height' => false,
-	            'header-text' => array( 'site-title' ),
-	        )
-	    );
+		/**
+		 * Add support for core custom logo.
+		 *
+		 * @link https://codex.wordpress.org/Theme_Logo
+		 */
+		add_theme_support(
+				'custom-logo',
+				array(
+						'height'      => 128,
+						'width'       => 128,
+						'flex-width'  => true,
+						'flex-height' => false,
+						'header-text' => array( 'site-title' ),
+				)
+		);
+
+		// Editor color palette.
+		add_theme_support(
+			'editor-color-palette',
+			array(
+				array(
+					'name'  => __( 'Primary', 'modern-business' ),
+					'slug'  => 'primary',
+					'color' => '#c43d80', // $color__link
+				),
+				array(
+					'name'  => __( 'Secondary', 'modern-business' ),
+					'slug'  => 'secondary',
+					'color' => '#9e3067', // $color__border-link-hover
+				),
+				array(
+					'name'  => __( 'Dark Gray', 'modern-business' ),
+					'slug'  => 'dark-gray',
+					'color' => '#181818', // $color__text-main
+				),
+				array(
+					'name'  => __( 'Light Gray', 'modern-business' ),
+					'slug'  => 'light-gray',
+					'color' => '#686868', // $color__text-light
+				),
+				array(
+					'name'  => __( 'White', 'modern-business' ),
+					'slug'  => 'white',
+					'color' => '#FFF',
+				),
+			)
+		);
 	}
 endif; // modern_business_setup
 add_action( 'after_setup_theme', 'modern_business_setup', 30 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Editor color palettes require two parts to work:
- One in PHP where we define the colors names and codes, which is used by the editor.
- One in CSS where we assign styles to the classes automagically generated by the editor.

Modern Business only has the CSS part, while inheriting the PHP one from Twenty Nineteen.
This means that, for example, the Primary color is blue in the editor (as defined by [Twenty Nineteen `functions.php`](https://github.com/WordPress/twentynineteen/blob/e74d348ab9cfc6ad46bdf33f691611930c39e944/functions.php#L141-L171)), and pink on the front-end (as defined by [Modern Business CSS](https://github.com/Automattic/themes/blob/0afe9f26f9b91d3710fa5a9d32ac5b1d9a8210ce/modern-business/sass/blocks/_blocks.scss#L1045-L1098)).

* Add the `editor-color-palette` theme support to Modern Business, overriding the Twenty Nineteen one, to display the correct custom colors in the editor.

| Before | After | Front end (unchanged) |
| - | - | - |
| ![Screenshot 2019-08-02 at 13 20 07](https://user-images.githubusercontent.com/2070010/62369928-101af700-b529-11e9-9201-4fe8c774a688.png) | ![Screenshot 2019-08-02 at 13 21 16](https://user-images.githubusercontent.com/2070010/62369943-1c9f4f80-b529-11e9-9eb4-8c811af9ecea.png) | ![Screenshot 2019-08-02 at 13 20 47](https://user-images.githubusercontent.com/2070010/62369949-20cb6d00-b529-11e9-9002-4d922ae1e2d1.png) |