### PR TITLE
FSE: Add line height to site description block to prevent jump

### DIFF
--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -1840,9 +1840,10 @@ ul.wp-block-archives li ul,
 }
 
 /** === Site Description Block === */
-.wp-block-a8c-site-description {
+.wp-block-a8c-site-description, .wp-block-a8c-site-description:focus {
   text-align: center;
   margin: 0;
+  line-height: 0.8em;
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -910,8 +910,13 @@ ul.wp-block-archives,
 /** === Site Description Block === */
 
 .wp-block-a8c-site-description {
-	text-align: center;
-	margin: 0;
+	&,&:focus {
+		text-align: center;
+		margin: 0;
+		// Line height rounded up from the description text-size set in style.css.
+		// It needs to be a bit larger to prevent text from getting cropped on top.
+		line-height: 0.8em;
+	}
 }
 
 /** === Classic Editor === */


### PR DESCRIPTION
Previously, the block would jump around. This makes those consistent and makes sure that they are also applied during block focus.

**Before:**
![jumpy block](https://user-images.githubusercontent.com/191598/61888695-feef3c00-aed1-11e9-922e-ad1ae1a3c82e.gif)

**After:**
![2019-08-02 10 00 54](https://user-images.githubusercontent.com/6265975/62386417-a391ff00-b50c-11e9-9e82-5737a2ce82ea.gif)

#### Changes proposed in this Pull Request:
- Make sure site description styles are also applied to `:focus` of block
- Add line height to prevent the block from jumping around in the editor. The value (0.8em) is rounded up from the actual text size value (0.71111em) to make sure that the tops of characters do not get cut off.

#### Testing:
- You'll want your local FSE setup to be good to go. 
- Map the theme location to your testing environment. Using docker, you can add it as a volume.
- Make sure you have the modern business theme activated.
- Open the site header template part editor
- Click into the site description block. The position of the text should not move whatsoever, even on the first time.
- Type text into the site description block, click out of the block, and click back into the block. The position of the text should not change.
- Select some other blocks then select the site description block again. Make sure the text doesn't move around.

#### Related issue(s):
Resolves https://github.com/Automattic/wp-calypso/issues/34886

For followup: this may also need fixed for all other FSE themes.