### PR TITLE
Varia: Update Cover Block for Gutenberg 6.2

### DIFF
--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -79,7 +79,7 @@
 	}
 
 	&.alignwide {
-		// Make sure nested blocks respects .alignwide utility classes.
+		// Make sure nested blocks respect .alignwide utility classes.
 		& > .wp-block-cover__inner-container > .alignwide {
 			@extend %responsive-width-wide;
 		}
@@ -91,7 +91,7 @@
 	}
 
 	&.alignfull {
-		// Make sure nested blocks respects .alignwide utility classes.
+		// Make sure nested blocks respect .alignwide utility classes.
 		& > .wp-block-cover__inner-container > .alignwide {
 			@extend %responsive-width-wide;
 		}

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -75,6 +75,19 @@
 		.wp-block-cover-image-text,
 		.wp-block-cover-text {
 			@extend %responsive-align-container;
+
+			// Make sure nested block respects .alignwide utility classes.
+			& > .alignwide {
+				@extend %responsive-width-wide;
+				clear: both;
+			}
+
+			// Make sure nested block respect .alignfull utility classes.
+			& > .alignfull {
+				@extend %responsive-width-full;
+				clear: both;
+			}
+
 		}
 	}
 

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -75,18 +75,30 @@
 		.wp-block-cover-image-text,
 		.wp-block-cover-text {
 			@extend %responsive-align-container;
+		}
+	}
 
-			// Make sure nested block respects .alignwide utility classes.
-			& > .alignwide {
-				@extend %responsive-width-wide;
-				clear: both;
-			}
+	&.alignwide {
+		// Make sure nested blocks respects .alignwide utility classes.
+		& > .wp-block-cover__inner-container > .alignwide {
+			@extend %responsive-width-wide;
+		}
 
-			// Make sure nested block respect .alignfull utility classes.
-			& > .alignfull {
-				@extend %responsive-width-full;
-				clear: both;
-			}
+		// Make sure nested blocks respect .alignfull utility classes.
+		& > .wp-block-cover__inner-container > .alignfull {
+			@extend %responsive-width-wide;
+		}
+	}
+
+	&.alignfull {
+		// Make sure nested blocks respects .alignwide utility classes.
+		& > .wp-block-cover__inner-container > .alignwide {
+			@extend %responsive-width-wide;
+		}
+
+		// Make sure nested blocks respect .alignfull utility classes.
+		& > .wp-block-cover__inner-container > .alignfull {
+			@extend %responsive-width-full;
 		}
 	}
 

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -87,7 +87,6 @@
 				@extend %responsive-width-full;
 				clear: both;
 			}
-
 		}
 	}
 

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -18,8 +18,8 @@
 		}
 
 		& > * {
-			margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
-			margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+			margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+			margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
 
 			&:first-child {
 				margin-top: 0;

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -16,6 +16,19 @@
 		a {
 			color: currentColor;
 		}
+
+		& > * {
+			margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+			margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+
+			&:first-child {
+				margin-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	/* Treating H2 separately to account for legacy /core styles */

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1258,6 +1258,34 @@ input.has-focus[type="submit"],
 	width: 100%;
 }
 
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide {
+	clear: both;
+}
+
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull {
+	clear: both;
+}
+
 .wp-block-cover.has-left-content, .wp-block-cover.has-right-content,
 .wp-block-cover-image.has-left-content,
 .wp-block-cover-image.has-right-content {
@@ -2958,7 +2986,17 @@ img#wpstats {
 	}
 }
 
-.wp-block-group.alignwide .alignwide,
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 .wp-block-group.alignwide .alignfull,
 .wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 	margin-right: calc( -0.25 * ( 100vw - 100% ));
@@ -2968,7 +3006,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 560px - 32px) ));
@@ -2979,7 +3027,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 640px - 32px) ));
@@ -2990,7 +3048,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 782px - 32px) ));
@@ -3001,7 +3069,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: -128px;
@@ -3012,7 +3090,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: -128px;
@@ -3022,7 +3110,17 @@ img#wpstats {
 	}
 }
 
-.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 	margin-right: calc( -0.5 * ( 100vw - 100% ));
 	margin-left: calc( -0.5 * ( 100vw - 100% ));
 	width: calc( 100% + (0.5 * 2) * ( 100vw - 100% ));
@@ -3030,7 +3128,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		width: calc( calc( 560px - 32px) + (0.5 * 2) * ( 100vw - calc( 560px - 32px) ));
@@ -3039,7 +3147,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		width: calc( calc( 640px - 32px) + (0.5 * 2) * ( 100vw - calc( 640px - 32px) ));
@@ -3048,7 +3166,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3057,7 +3185,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3066,7 +3204,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1258,34 +1258,6 @@ input.has-focus[type="submit"],
 	width: 100%;
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide {
-	clear: both;
-}
-
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull {
-	clear: both;
-}
-
 .wp-block-cover.has-left-content, .wp-block-cover.has-right-content,
 .wp-block-cover-image.has-left-content,
 .wp-block-cover-image.has-right-content {
@@ -2986,17 +2958,10 @@ img#wpstats {
 	}
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 .wp-block-group.alignwide .alignfull,
 .wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 	margin-right: calc( -0.25 * ( 100vw - 100% ));
@@ -3006,17 +2971,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 560px - 32px) ));
@@ -3027,17 +2985,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 640px - 32px) ));
@@ -3048,17 +2999,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.25 * ( 100vw - calc( 782px - 32px) ));
@@ -3069,17 +3013,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: -128px;
@@ -3090,17 +3027,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-right: -128px;
@@ -3110,17 +3040,8 @@ img#wpstats {
 	}
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 	margin-right: calc( -0.5 * ( 100vw - 100% ));
 	margin-left: calc( -0.5 * ( 100vw - 100% ));
 	width: calc( 100% + (0.5 * 2) * ( 100vw - 100% ));
@@ -3128,17 +3049,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		width: calc( calc( 560px - 32px) + (0.5 * 2) * ( 100vw - calc( 560px - 32px) ));
@@ -3147,17 +3059,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		width: calc( calc( 640px - 32px) + (0.5 * 2) * ( 100vw - calc( 640px - 32px) ));
@@ -3166,17 +3069,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3185,17 +3079,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3204,17 +3089,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1195,8 +1195,8 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover__inner-container > *,
 .wp-block-cover-image .wp-block-cover-image-text > *,
 .wp-block-cover-image .wp-block-cover-text > * {
-	margin-top: 32px;
-	margin-bottom: 32px;
+	margin-top: 16px;
+	margin-bottom: 16px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container > *:first-child,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1189,6 +1189,34 @@ input.has-focus[type="submit"],
 	color: currentColor;
 }
 
+.wp-block-cover .wp-block-cover__inner-container > *,
+.wp-block-cover .wp-block-cover-image-text > *,
+.wp-block-cover .wp-block-cover-text > *,
+.wp-block-cover-image .wp-block-cover__inner-container > *,
+.wp-block-cover-image .wp-block-cover-image-text > *,
+.wp-block-cover-image .wp-block-cover-text > * {
+	margin-top: 32px;
+	margin-bottom: 32px;
+}
+
+.wp-block-cover .wp-block-cover__inner-container > *:first-child,
+.wp-block-cover .wp-block-cover-image-text > *:first-child,
+.wp-block-cover .wp-block-cover-text > *:first-child,
+.wp-block-cover-image .wp-block-cover__inner-container > *:first-child,
+.wp-block-cover-image .wp-block-cover-image-text > *:first-child,
+.wp-block-cover-image .wp-block-cover-text > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-cover .wp-block-cover__inner-container > *:last-child,
+.wp-block-cover .wp-block-cover-image-text > *:last-child,
+.wp-block-cover .wp-block-cover-text > *:last-child,
+.wp-block-cover-image .wp-block-cover__inner-container > *:last-child,
+.wp-block-cover-image .wp-block-cover-image-text > *:last-child,
+.wp-block-cover-image .wp-block-cover-text > *:last-child {
+	margin-bottom: 0;
+}
+
 .wp-block-cover h2,
 .wp-block-cover-image h2 {
 	font-size: 2.48832rem;

--- a/varia/style.css
+++ b/varia/style.css
@@ -1258,6 +1258,34 @@ input.has-focus[type="submit"],
 	width: 100%;
 }
 
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide {
+	clear: both;
+}
+
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull {
+	clear: both;
+}
+
 .wp-block-cover.has-left-content, .wp-block-cover.has-right-content,
 .wp-block-cover-image.has-left-content,
 .wp-block-cover-image.has-right-content {
@@ -2963,7 +2991,17 @@ img#wpstats {
 	}
 }
 
-.wp-block-group.alignwide .alignwide,
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 .wp-block-group.alignwide .alignfull,
 .wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 	margin-left: calc( -0.25 * ( 100vw - 100% ));
@@ -2973,7 +3011,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 560px - 32px) ));
@@ -2984,7 +3032,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 640px - 32px) ));
@@ -2995,7 +3053,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 782px - 32px) ));
@@ -3006,7 +3074,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: -128px;
@@ -3017,7 +3095,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: -128px;
@@ -3027,7 +3115,17 @@ img#wpstats {
 	}
 }
 
-.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 	margin-left: calc( -0.5 * ( 100vw - 100% ));
 	margin-right: calc( -0.5 * ( 100vw - 100% ));
 	width: calc( 100% + (0.5 * 2) * ( 100vw - 100% ));
@@ -3035,7 +3133,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		width: calc( calc( 560px - 32px) + (0.5 * 2) * ( 100vw - calc( 560px - 32px) ));
@@ -3044,7 +3152,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		width: calc( calc( 640px - 32px) + (0.5 * 2) * ( 100vw - calc( 640px - 32px) ));
@@ -3053,7 +3171,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3062,7 +3190,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3071,7 +3209,17 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
+	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));

--- a/varia/style.css
+++ b/varia/style.css
@@ -1258,34 +1258,6 @@ input.has-focus[type="submit"],
 	width: 100%;
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide {
-	clear: both;
-}
-
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull {
-	clear: both;
-}
-
 .wp-block-cover.has-left-content, .wp-block-cover.has-right-content,
 .wp-block-cover-image.has-left-content,
 .wp-block-cover-image.has-right-content {
@@ -2991,17 +2963,10 @@ img#wpstats {
 	}
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 .wp-block-group.alignwide .alignfull,
 .wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 	margin-left: calc( -0.25 * ( 100vw - 100% ));
@@ -3011,17 +2976,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 560px - 32px) ));
@@ -3032,17 +2990,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 640px - 32px) ));
@@ -3053,17 +3004,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.25 * ( 100vw - calc( 782px - 32px) ));
@@ -3074,17 +3018,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: -128px;
@@ -3095,17 +3032,10 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignwide, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignwide,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignwide, .wp-block-group.alignwide .alignwide,
+	.wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignwide, .wp-block-cover.alignwide > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignwide > .wp-block-cover__inner-container > .alignfull, .wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignwide,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignwide, .wp-block-group.alignwide .alignwide,
 	.wp-block-group.alignwide .alignfull,
 	.wp-block-group.alignfull .alignwide, .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 		margin-left: -128px;
@@ -3115,17 +3045,8 @@ img#wpstats {
 	}
 }
 
-.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 	margin-left: calc( -0.5 * ( 100vw - 100% ));
 	margin-right: calc( -0.5 * ( 100vw - 100% ));
 	width: calc( 100% + (0.5 * 2) * ( 100vw - 100% ));
@@ -3133,17 +3054,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 560px - 32px) ));
 		width: calc( calc( 560px - 32px) + (0.5 * 2) * ( 100vw - calc( 560px - 32px) ));
@@ -3152,17 +3064,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 640px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 640px - 32px) ));
 		width: calc( calc( 640px - 32px) + (0.5 * 2) * ( 100vw - calc( 640px - 32px) ));
@@ -3171,17 +3074,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 782px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3190,17 +3084,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1024px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));
@@ -3209,17 +3094,8 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 1280px) {
-	.wp-block-cover.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignwide .wp-block-cover-text > .alignfull, .wp-block-cover.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover.alignfull .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignwide .wp-block-cover-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover__inner-container > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-image-text > .alignfull,
-	.wp-block-cover-image.alignfull .wp-block-cover-text > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.wp-block-cover.alignfull > .wp-block-cover__inner-container > .alignfull,
+	.wp-block-cover-image.alignfull > .wp-block-cover__inner-container > .alignfull, .wp-block-group.alignfull .alignfull, .entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		margin-right: calc( -0.5 * ( 100vw - calc( 782px - 32px) ));
 		width: calc( calc( 782px - 32px) + (0.5 * 2) * ( 100vw - calc( 782px - 32px) ));

--- a/varia/style.css
+++ b/varia/style.css
@@ -1195,8 +1195,8 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover__inner-container > *,
 .wp-block-cover-image .wp-block-cover-image-text > *,
 .wp-block-cover-image .wp-block-cover-text > * {
-	margin-top: 32px;
-	margin-bottom: 32px;
+	margin-top: 16px;
+	margin-bottom: 16px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container > *:first-child,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1189,6 +1189,34 @@ input.has-focus[type="submit"],
 	color: currentColor;
 }
 
+.wp-block-cover .wp-block-cover__inner-container > *,
+.wp-block-cover .wp-block-cover-image-text > *,
+.wp-block-cover .wp-block-cover-text > *,
+.wp-block-cover-image .wp-block-cover__inner-container > *,
+.wp-block-cover-image .wp-block-cover-image-text > *,
+.wp-block-cover-image .wp-block-cover-text > * {
+	margin-top: 32px;
+	margin-bottom: 32px;
+}
+
+.wp-block-cover .wp-block-cover__inner-container > *:first-child,
+.wp-block-cover .wp-block-cover-image-text > *:first-child,
+.wp-block-cover .wp-block-cover-text > *:first-child,
+.wp-block-cover-image .wp-block-cover__inner-container > *:first-child,
+.wp-block-cover-image .wp-block-cover-image-text > *:first-child,
+.wp-block-cover-image .wp-block-cover-text > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-cover .wp-block-cover__inner-container > *:last-child,
+.wp-block-cover .wp-block-cover-image-text > *:last-child,
+.wp-block-cover .wp-block-cover-text > *:last-child,
+.wp-block-cover-image .wp-block-cover__inner-container > *:last-child,
+.wp-block-cover-image .wp-block-cover-image-text > *:last-child,
+.wp-block-cover-image .wp-block-cover-text > *:last-child {
+	margin-bottom: 0;
+}
+
 .wp-block-cover h2,
 .wp-block-cover-image h2 {
 	font-size: 2.48832rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Cover Block has no restrictions on which Blocks can be contained within the Block. It now supports pretty much all Blocks. 

#### Related issue(s):

Discovered when Gutenberg was updated recently.

#### To Do
- [x] Add uniform spacing between any elements contained within cover blocks.
- [x] Test Responsive behaviors with nested complex blocks like Columns, Media&Text, and Cover within Cover.
- [x] Test `.alignwide/full` on both the Cover block itself and any blocks contained within it that use `.alignwide/full`. Make sure it works as expected. 

#### Before:
![image](https://user-images.githubusercontent.com/709581/62583676-2d302c80-b87f-11e9-93e9-7c09311fc0e7.png)

#### After:
![image](https://user-images.githubusercontent.com/709581/62583641-007c1500-b87f-11e9-96fe-fd1facfda036.png)