### PR TITLE
Independent Publisher 2:  if post word less than 250 words  post show 0 minutes time to read solved.

### DIFF
--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -129,6 +129,10 @@ function independent_publisher_2_word_count() {
 	$content = get_post_field( 'post_content', get_the_ID() );
 	$count   = str_word_count( strip_tags( $content ) );
 	$time    = $count / 250; //Roughly 250 wpm reading time
+	// if time less than 1 explicitly set to 1.
+	if( $time < 1 ) {
+		$time = 1;
+	}
 	return number_format( $time );
 }
 endif; // independent_publisher_2_word_count


### PR DESCRIPTION


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
If post word less than 250 words. Theme show 0 Minutes read time 0 is not plural.
Before:
![image](https://user-images.githubusercontent.com/17900945/62433254-87e35000-b6e8-11e9-80c9-9ab9c0ab816d.png)

_nx() function issue it assumes 0-0.9 to the plural and only 1 to single. I fixed it if the time less than 1 I explicitly set to 1.

After:
![image](https://user-images.githubusercontent.com/17900945/62433578-cdece380-b6e9-11e9-93bd-b4b4765ca58a.png)

#### Related issue(s):
https://github.com/Automattic/themes/issues/699