### PR TITLE
FSE: Modern business - add site logo placeholder to header template

### DIFF
--- a/modern-business/inc/fse-template-data.php
+++ b/modern-business/inc/fse-template-data.php
@@ -134,7 +134,6 @@ class A8C_WP_Templates_Data_Inserter {
 		add_option( $fse_template_data_option, true );
 	}
 
-	
 	/**
 	 * Register post types.
 	 */

--- a/modern-business/inc/fse-template-data.php
+++ b/modern-business/inc/fse-template-data.php
@@ -134,6 +134,7 @@ class A8C_WP_Templates_Data_Inserter {
 		add_option( $fse_template_data_option, true );
 	}
 
+	
 	/**
 	 * Register post types.
 	 */

--- a/modern-business/sass/site/header/_site-header.scss
+++ b/modern-business/sass/site/header/_site-header.scss
@@ -26,6 +26,7 @@
 	}
 
 	.fse-site-logo {
+		margin-bottom: 0;
         img {
 			margin-left: auto;
 			margin-right: auto;

--- a/modern-business/sass/site/header/_site-header.scss
+++ b/modern-business/sass/site/header/_site-header.scss
@@ -27,7 +27,7 @@
 
 	.fse-site-logo {
 		margin-bottom: 0;
-        img {
+		img {
 			margin-left: auto;
 			margin-right: auto;
 		}

--- a/modern-business/sass/site/header/_site-header.scss
+++ b/modern-business/sass/site/header/_site-header.scss
@@ -24,6 +24,13 @@
 			margin-bottom: 2rem;
 		}
 	}
+
+	.fse-site-logo {
+        img {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 }
 
 // Site branding

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -39,6 +39,11 @@ Modern Business Editor Styles
   }
 }
 
+.site-header .fse-site-logo img {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .site-branding {
   color: #686868;
   display: flex;
@@ -1844,6 +1849,13 @@ ul.wp-block-archives li ul,
   text-align: center;
   margin: 0;
   line-height: 0.8em;
+}
+
+/** === Site Logo Block === */
+.wp-block-a8c-site-logo .components-placeholder.block-editor-media-placeholder {
+  width: 380px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -39,6 +39,10 @@ Modern Business Editor Styles
   }
 }
 
+.site-header .fse-site-logo {
+  margin-bottom: 0;
+}
+
 .site-header .fse-site-logo img {
   margin-left: auto;
   margin-right: auto;

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -1856,7 +1856,7 @@ ul.wp-block-archives li ul,
 }
 
 /** === Site Logo Block === */
-.wp-block-a8c-site-logo .components-placeholder.block-editor-media-placeholder {
+.template__site-logo .components-placeholder.block-editor-media-placeholder {
   width: 380px;
   margin-left: auto;
   margin-right: auto;

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -920,7 +920,7 @@ ul.wp-block-archives,
 }
 
 /** === Site Logo Block === */
-.wp-block-a8c-site-logo {
+.template__site-logo {
 	.components-placeholder.block-editor-media-placeholder {
 		width: 380px;
 		margin-left: auto;

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -919,6 +919,15 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Site Logo Block === */
+.wp-block-a8c-site-logo {
+	.components-placeholder.block-editor-media-placeholder {
+		width: 380px;
+		margin-left: auto;
+        margin-right: auto;
+    }
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1942,6 +1942,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   }
 }
 
+.site-header .fse-site-logo img {
+  margin-right: auto;
+  margin-left: auto;
+}
+
 .site-branding {
   color: #686868;
   display: flex;

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1942,6 +1942,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   }
 }
 
+.site-header .fse-site-logo {
+  margin-bottom: 0;
+}
+
 .site-header .fse-site-logo img {
   margin-right: auto;
   margin-left: auto;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1948,6 +1948,11 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   }
 }
 
+.site-header .fse-site-logo img {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .site-branding {
   color: #686868;
   display: flex;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1948,6 +1948,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   }
 }
 
+.site-header .fse-site-logo {
+  margin-bottom: 0;
+}
+
 .site-header .fse-site-logo img {
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add a site logo placeholder to the FSE header template along with relevant editor and front end styles

#### Testing instructions

* Build Modern Business theme and copy to  FSE test environment, and then follow test instructions at https://github.com/Automattic/wp-calypso/pull/35152

#### Related issue(s):

https://github.com/Automattic/wp-calypso/pull/35152
https://github.com/Automattic/wp-calypso/issues/35124