### PR TITLE
AltoFocus: Navigation Links "New Tab" Feature Fixed

### DIFF
--- a/altofocus/assets/js/navigation.js
+++ b/altofocus/assets/js/navigation.js
@@ -79,7 +79,7 @@
 		});
 
 		// Close expanded sub-menus when clicking links
-		container.find( 'a' ).click( function( e ) {
+		container.find( "a:not([target='_blank'])" ).click( function( e ) {
 
 			var _this         = $( this ),
 				anchor        = _this.attr( 'href' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
I've changed something so that the window.location doesn't work for links with target=_blank.

#### Related issue(s):
#1213 