### PR TITLE
Modern Business: Set editor background color for FSE

### DIFF
--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -924,6 +924,7 @@ blockquote {
 /** === Editor Frame === */
 body {
   font-weight: 300;
+  background: #fff;
 }
 
 body .wp-block[data-align="full"] {

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -33,9 +33,11 @@ Modern Business Editor Styles
 }
 
 /** === Editor Frame === */
-
+// Targets just the editor frame area, not outside it.
+// See https://github.com/WordPress/gutenberg/blob/0ad0414e7a469254ef1ad105fdcf14248a986686/docs/designers-developers/developers/themes/theme-support.md#editor-styles
 body {
 	font-weight: 300;
+	background: $color__background-body;
 
 	.wp-block[data-align="full"] {
 		width: 100%;

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -4649,17 +4649,29 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-left,
-.entry .entry-content .wp-block-cover h2.has-text-align-left {
+.entry .entry-content .wp-block-cover h2.has-text-align-left,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-left,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-left,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-left,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-left {
   text-align: right;
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-center,
-.entry .entry-content .wp-block-cover h2.has-text-align-center {
+.entry .entry-content .wp-block-cover h2.has-text-align-center,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-center,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-center,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-center,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-center {
   text-align: center;
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-right,
-.entry .entry-content .wp-block-cover h2.has-text-align-right {
+.entry .entry-content .wp-block-cover h2.has-text-align-right,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-right,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-right,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-right,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-right {
   text-align: left;
 }
 

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -4661,17 +4661,29 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-left,
-.entry .entry-content .wp-block-cover h2.has-text-align-left {
+.entry .entry-content .wp-block-cover h2.has-text-align-left,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-left,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-left,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-left,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-left {
   text-align: left;
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-center,
-.entry .entry-content .wp-block-cover h2.has-text-align-center {
+.entry .entry-content .wp-block-cover h2.has-text-align-center,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-center,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-center,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-center,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-center {
   text-align: center;
 }
 
 .entry .entry-content .wp-block-cover-image h2.has-text-align-right,
-.entry .entry-content .wp-block-cover h2.has-text-align-right {
+.entry .entry-content .wp-block-cover h2.has-text-align-right,
+.fse-enabled .site-header .wp-block-cover-image h2.has-text-align-right,
+.fse-enabled .site-header .wp-block-cover h2.has-text-align-right,
+.fse-enabled .site-footer .wp-block-cover-image h2.has-text-align-right,
+.fse-enabled .site-footer .wp-block-cover h2.has-text-align-right {
   text-align: right;
 }
 


### PR DESCRIPTION
Handle background color of editor for FSE. I thought one would just add `.editor-styles-wrapper`, but it turns out that Gutenberg automagically prefixes every selector inside the editor stylesheet! So to target the background of the editor, you actually use `body`. See more info on that [here](https://github.com/WordPress/gutenberg/blob/0ad0414e7a469254ef1ad105fdcf14248a986686/docs/designers-developers/developers/themes/theme-support.md#editor-styles). 

## Testing:
0. Use this FSE PR on your local setup: https://github.com/Automattic/wp-calypso/pull/35235
1. Pull this branch and make sure you have modern business mapped to your local setup.
2. Open the page editor and the template editor.
3. The background color of each should be `#fff` as set by the theme.
4. Change the background property to `blue`. ([here](https://github.com/Automattic/themes/pull/1219/files#diff-5a116bd4bbf0de8a39434744a50c9dc9R40))
5. In `themes/modern-business` run `npm i && npm run build` to update the CSS.
6. Verify that the editor background color is now blue. This is just to make sure the selector is getting applied, since the default color in FSE is also set to white.

Resolves #35117. A task has been added to the overall theme issues to bring this support to them as well, so we don't need that issue. I'll link to this PR so that people can see what to do for it.