### PR TITLE
Modern business: Disable nav menu order if FSE is enabled

### DIFF
--- a/modern-business/sass/navigation/_menu-main-navigation.scss
+++ b/modern-business/sass/navigation/_menu-main-navigation.scss
@@ -6,6 +6,11 @@
 	margin-top: #{0.6 * $size__spacing-unit};
 	order: 3;
 
+	body.fse-enabled & {
+		// With FSE, we want the placement of the nav menu to be set in gutenberg:
+		order: initial;
+	}
+
 	body.page & {
 		display: block;
 	}

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -258,6 +258,10 @@ Modern Business Editor Styles
 	 */
 }
 
+body.fse-enabled .main-navigation {
+  order: initial;
+}
+
 body.page .main-navigation {
   display: block;
 }

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1012,6 +1012,10 @@ a:focus {
 	 */
 }
 
+body.fse-enabled .main-navigation {
+  order: initial;
+}
+
 body.page .main-navigation {
   display: block;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1012,6 +1012,10 @@ a:focus {
 	 */
 }
 
+body.fse-enabled .main-navigation {
+  order: initial;
+}
+
 body.page .main-navigation {
   display: block;
 }


### PR DESCRIPTION
Since we set the order of footer/header elements (like nav) in Gutenberg, we don't want the stylesheet to override it. The order property was causing the footer nav menu in FSE to show up at very bottom of the page, even if the user changed its order.

#### Changes proposed in this Pull Request:
- If the body has the `.fse-enabled` selector, reset the order property.

#### Testing instructions:
0. If the PR following has not been merged yet, pull the changes in https://github.com/Automattic/wp-calypso/pull/35209 and run it for FSE in your local install.
1. Pull this PR and make sure you have modern business mapped to your local install.
1. Edit the footer template. Move (or insert if you don't have it) the nav menu block to the top of the footer area.
2. Previously, the nav menu would have still shown up at the bottom of the footer. (See issue below.) Verify that it is showing up at the top of the footer now.
3. Change the order of the nav menu to go somewhere else. Verify that the order of the content in the template editor still matches the order of the content on the front end.
4. For safety's sake, verify that the nav block in the header still matches the order it has in the editor.

#### Related issue(s):
Fixes https://github.com/Automattic/wp-calypso/issues/35204

#### Next Steps:
The default footer content has a TON of stuff which we don't have in our FSE footer. We need to replicate some of that footer content (i.e. the WP attribution) for use in FSE. Plus, the default footer nav menu is a different style.