### PR TITLE
FSE - remove 100% in figure to allow centre alignment on smaller screens

### DIFF
--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -1912,6 +1912,10 @@ ul.wp-block-archives li ul,
   margin-right: auto;
 }
 
+.block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] > .block-editor-block-list__block-edit figure.fse-site-logo {
+  width: inherit;
+}
+
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -942,6 +942,15 @@ ul.wp-block-archives,
     }
 }
 
+/* Remove 100% width on figure to center align logo in editor on smaller screens */
+.block-editor-block-list__layout  {
+    .block-editor-block-list__block[data-align="full"] > .block-editor-block-list__block-edit  {
+	    figure.fse-site-logo {
+	        width: inherit;
+        }
+	}
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Removes the 100% width alignment on site-logo figure which is stopping site logo centre aligning on smaller screens

#### Test instructions:

* Checkout this patch, rebuild the modern-business theme and copy to FSE test environment
* When editing a page check that the site logo remains centre aligned in the header template block even on small screens.

**before**

<img width="499" alt="Screen Shot 2019-08-12 at 4 32 23 PM" src="https://user-images.githubusercontent.com/3629020/62845975-a963bd80-bd20-11e9-89cd-fc3e01dbe5c0.png">

**after**

<img width="502" alt="Screen Shot 2019-08-12 at 4 31 46 PM" src="https://user-images.githubusercontent.com/3629020/62845983-b7194300-bd20-11e9-8fdb-0414e69a1916.png">

#### Related issue(s):
Fixes https://github.com/Automattic/wp-calypso/issues/35245