### PR TITLE
FSE / Modern Business: Fix full width blocks in the header template part

### DIFF
--- a/modern-business/sass/site/header/_site-header.scss
+++ b/modern-business/sass/site/header/_site-header.scss
@@ -34,6 +34,10 @@
 	}
 }
 
+.fse-enabled .site-header .wp-block-image.alignfull {
+	max-width: inherit;
+}
+
 // Site branding
 
 .site-branding {

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -48,6 +48,10 @@ Modern Business Editor Styles
   margin-right: auto;
 }
 
+.fse-enabled .site-header .wp-block-image.alignfull {
+  max-width: inherit;
+}
+
 .site-branding {
   color: #686868;
   display: flex;
@@ -1912,8 +1916,21 @@ ul.wp-block-archives li ul,
   margin-right: auto;
 }
 
+/* Remove 100% width on figure to center align logo in editor on smaller screens */
 .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] > .block-editor-block-list__block-edit figure.fse-site-logo {
   width: inherit;
+}
+
+.site-header .wp-block[data-align="full"] {
+  left: calc( -12.5% - 12px);
+  max-width: calc( 125% + 114px);
+  width: calc( 125% + 114px);
+}
+
+.template-block.site-header .wp-block[data-align="full"] {
+  left: calc( -12.5% - 9px);
+  max-width: calc( 125% + 111px);
+  width: calc( 125% + 111px);
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -944,11 +944,22 @@ ul.wp-block-archives,
 
 /* Remove 100% width on figure to center align logo in editor on smaller screens */
 .block-editor-block-list__layout  {
-    .block-editor-block-list__block[data-align="full"] > .block-editor-block-list__block-edit  {
-	    figure.fse-site-logo {
-	        width: inherit;
-        }
+	.block-editor-block-list__block[data-align="full"] > .block-editor-block-list__block-edit  {
+		figure.fse-site-logo {
+			width: inherit;
+		}
 	}
+}
+
+.site-header .wp-block[data-align="full"] {
+	left: calc( -12.5% - 12px );
+	max-width: calc( 125% + 114px );
+	width: calc( 125% + 114px );
+}
+.template-block.site-header .wp-block[data-align="full"] {
+	left: calc( -12.5% - 9px );
+	max-width: calc( 125% + 111px );
+	width: calc( 125% + 111px );
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -1955,6 +1955,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-left: auto;
 }
 
+.fse-enabled .site-header .wp-block-image.alignfull {
+  max-width: inherit;
+}
+
 .site-branding {
   color: #686868;
   display: flex;

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1961,6 +1961,10 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   margin-right: auto;
 }
 
+.fse-enabled .site-header .wp-block-image.alignfull {
+  max-width: inherit;
+}
+
 .site-branding {
   color: #686868;
   display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adjust the `alignfull` blocks width and positioning when rendered in the header template part to be properly full-width.

| | Before | After |
| - | - | - |
| Template Editor | ![Screenshot 2019-08-12 at 17 36 06](https://user-images.githubusercontent.com/2070010/62881627-1af33a00-bd28-11e9-9fc6-2645d6cd971b.png) | ![Screenshot 2019-08-12 at 17 32 14](https://user-images.githubusercontent.com/2070010/62881651-2ba3b000-bd28-11e9-878d-5cbb455023f0.png) |
| Page Editor | ![Screenshot 2019-08-12 at 17 34 14](https://user-images.githubusercontent.com/2070010/62881681-3d855300-bd28-11e9-9159-c0a33c54d894.png) | ![Screenshot 2019-08-12 at 17 31 59](https://user-images.githubusercontent.com/2070010/62881732-555cd700-bd28-11e9-8f17-24f9b364cfd0.png) |
| Front End | ![Screenshot 2019-08-12 at 17 36 22](https://user-images.githubusercontent.com/2070010/62881768-67d71080-bd28-11e9-8cfe-0a5f1419ce74.png) | ![Screenshot 2019-08-12 at 17 32 25](https://user-images.githubusercontent.com/2070010/62881779-702f4b80-bd28-11e9-8778-d4f84226fefb.png) |

Note: the Pullquote block is not 100% identical between editor and front end, but that's a fix for another time, less relevant, and would likely involve checking all blocks anyway.

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/35260
