### PR TITLE
Modern Business: FSE - fix footer alignment in front end

### DIFF
--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -1265,7 +1265,7 @@
 	}
 }
 
-.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+.fse-enabled .site-footer {
 	
 	padding: $size__spacing-unit $size__vertical-spacing-unit;
 	

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -1267,3 +1267,12 @@
 		}
 	}
 }
+
+.fse-enabled .site-footer {
+	.wp-block-a8c-navigation-menu, .wp-block-separator {
+		margin: 15px 0;
+	}
+	.site-info {
+		text-align: center;
+	}
+}

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -1282,9 +1282,15 @@
 		margin: $size__vertical-spacing-unit 0;
 		text-align: left;
 	}
-	.wp-block-separator, .wp-block-button {
+	
+	.wp-block-button, p {
 		margin: 15px 0;
 	}
+
+	.wp-block-separator {
+		margin: 16px 0;
+	}
+
 	&#colophon .site-info {
 		text-align: left;
 		margin: 0;

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -1270,7 +1270,7 @@
 
 .fse-enabled .site-footer {
 	.wp-block-a8c-navigation-menu, .wp-block-separator {
-		margin: 15px 0;
+		margin: 15px;
 	}
 	.site-info {
 		text-align: center;

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -2,8 +2,7 @@
 
 .entry .entry-content > *,
 .entry .entry-summary > *, 
-.fse-enabled .site-header > *,
-.fse-enabled .site-footer > * {
+.fse-enabled .site-header > * {
 	margin: $size__vertical-spacing-unit 0;
 	max-width: 100%;
 
@@ -110,9 +109,7 @@
  * - helps with plugin compatibility
  */
 .entry .entry-content,
-.entry .entry-summary,
-.fse-enabled .site-header,
-.fse-enabled .site-footer {
+.entry .entry-summary {
 
 	.entry-content,
 	.entry-summary,
@@ -1268,11 +1265,28 @@
 	}
 }
 
-.fse-enabled .site-footer {
-	.wp-block-a8c-navigation-menu, .wp-block-separator {
-		margin: 15px;
+.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+	
+	padding: $size__spacing-unit $size__vertical-spacing-unit;
+	
+	@include media(tablet) {
+		padding: $size__spacing-unit 0;
 	}
-	.site-info {
-		text-align: center;
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		margin: $size__vertical-spacing-unit 0;
+		text-align: left;
+	}
+	.wp-block-separator, .wp-block-button {
+		margin: 15px 0;
+	}
+	&#colophon .site-info {
+		text-align: left;
+		margin: 0;
 	}
 }

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -1933,6 +1933,15 @@ ul.wp-block-archives li ul,
   width: calc( 125% + 111px);
 }
 
+.site-footer h1,
+.site-footer h2,
+.site-footer h3,
+.site-footer h4,
+.site-footer h5,
+.site-footer h6 {
+  text-align: left;
+}
+
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -1942,6 +1942,10 @@ ul.wp-block-archives li ul,
   text-align: left;
 }
 
+.site-footer .wp-block-separator {
+  margin: 16px 0;
+}
+
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -972,6 +972,9 @@ ul.wp-block-archives,
 	h6 {
 		text-align: left;
 	}
+	.wp-block-separator {
+		margin: 16px 0;
+	}
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -956,10 +956,22 @@ ul.wp-block-archives,
 	max-width: calc( 125% + 114px );
 	width: calc( 125% + 114px );
 }
+
 .template-block.site-header .wp-block[data-align="full"] {
 	left: calc( -12.5% - 9px );
 	max-width: calc( 125% + 111px );
 	width: calc( 125% + 111px );
+}
+
+.site-footer {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		text-align: left;
+	}
 }
 
 /** === Classic Editor === */

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -5602,7 +5602,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
-  margin: 15px 0;
+  margin: 15px;
 }
 
 .fse-enabled .site-footer .site-info {

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -5572,12 +5572,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
-.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+.fse-enabled .site-footer {
   padding: 1rem 32px;
 }
 
 @media only screen and (min-width: 768px) {
-  .fse-enabled .site-footer, .post-type-wp_template .site-footer {
+  .fse-enabled .site-footer {
     padding: 1rem 0;
   }
 }
@@ -5587,25 +5587,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .fse-enabled .site-footer h3,
 .fse-enabled .site-footer h4,
 .fse-enabled .site-footer h5,
-.fse-enabled .site-footer h6, .post-type-wp_template .site-footer h1,
-.post-type-wp_template .site-footer h2,
-.post-type-wp_template .site-footer h3,
-.post-type-wp_template .site-footer h4,
-.post-type-wp_template .site-footer h5,
-.post-type-wp_template .site-footer h6 {
+.fse-enabled .site-footer h6 {
   margin: 32px 0;
   text-align: right;
 }
 
-.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p, .post-type-wp_template .site-footer .wp-block-button, .post-type-wp_template .site-footer p {
+.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p {
   margin: 15px 0;
 }
 
-.fse-enabled .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-separator {
+.fse-enabled .site-footer .wp-block-separator {
   margin: 16px 0;
 }
 
-.fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {
+.fse-enabled .site-footer#colophon .site-info {
   text-align: right;
   margin: 0;
 }

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -3433,8 +3433,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 /* !Block styles */
 .entry .entry-content > *,
 .entry .entry-summary > *,
-.fse-enabled .site-header > *,
-.fse-enabled .site-footer > * {
+.fse-enabled .site-header > * {
   margin: 32px 0;
   max-width: 100%;
 }
@@ -3442,8 +3441,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3451,8 +3449,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3460,30 +3457,26 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     margin: 32px auto;
   }
 }
 
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > * > *:first-child,
-.fse-enabled .site-header > * > *:first-child,
-.fse-enabled .site-footer > * > *:first-child {
+.fse-enabled .site-header > * > *:first-child {
   margin-top: 0;
 }
 
 .entry .entry-content > * > *:last-child,
 .entry .entry-summary > * > *:last-child,
-.fse-enabled .site-header > * > *:last-child,
-.fse-enabled .site-footer > * > *:last-child {
+.fse-enabled .site-header > * > *:last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content > *.alignwide,
 .entry .entry-summary > *.alignwide,
-.fse-enabled .site-header > *.alignwide,
-.fse-enabled .site-footer > *.alignwide {
+.fse-enabled .site-header > *.alignwide {
   margin-right: auto;
   margin-left: auto;
   clear: both;
@@ -3492,8 +3485,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide,
-  .fse-enabled .site-header > *.alignwide,
-  .fse-enabled .site-footer > *.alignwide {
+  .fse-enabled .site-header > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
@@ -3501,8 +3493,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull,
-.fse-enabled .site-header > *.alignfull,
-.fse-enabled .site-footer > *.alignfull {
+.fse-enabled .site-header > *.alignfull {
   position: relative;
   right: -1rem;
   width: calc( 100% + (2 * 1rem));
@@ -3513,8 +3504,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull,
-  .fse-enabled .site-header > *.alignfull,
-  .fse-enabled .site-footer > *.alignfull {
+  .fse-enabled .site-header > *.alignfull {
     margin-top: 32px;
     margin-bottom: 32px;
     right: calc( -12.5% - 75px);
@@ -3525,8 +3515,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignleft,
 .entry .entry-summary > *.alignleft,
-.fse-enabled .site-header > *.alignleft,
-.fse-enabled .site-footer > *.alignleft {
+.fse-enabled .site-header > *.alignleft {
   float: left;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3537,8 +3526,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
   .entry .entry-summary > *.alignleft,
-  .fse-enabled .site-header > *.alignleft,
-  .fse-enabled .site-footer > *.alignleft {
+  .fse-enabled .site-header > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     margin-right: calc(2 * 1rem);
   }
@@ -3546,8 +3534,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright,
-.fse-enabled .site-header > *.alignright,
-.fse-enabled .site-footer > *.alignright {
+.fse-enabled .site-header > *.alignright {
   float: right;
   max-width: calc(5 * (100vw / 12));
   margin-top: 0;
@@ -3558,8 +3545,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright,
-  .fse-enabled .site-header > *.alignright,
-  .fse-enabled .site-footer > *.alignright {
+  .fse-enabled .site-header > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-left: 0;
     margin-left: calc(2 * 1rem);
@@ -3568,8 +3554,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.aligncenter,
 .entry .entry-summary > *.aligncenter,
-.fse-enabled .site-header > *.aligncenter,
-.fse-enabled .site-footer > *.aligncenter {
+.fse-enabled .site-header > *.aligncenter {
   margin-right: auto;
   margin-left: auto;
   /*
@@ -3583,8 +3568,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
-  .fse-enabled .site-header > *.aligncenter,
-  .fse-enabled .site-footer > *.aligncenter {
+  .fse-enabled .site-header > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3592,8 +3576,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
-  .fse-enabled .site-header > *.aligncenter,
-  .fse-enabled .site-footer > *.aligncenter {
+  .fse-enabled .site-header > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3617,13 +3600,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .entry,
 .entry .entry-summary .entry-content,
 .entry .entry-summary .entry-summary,
-.entry .entry-summary .entry,
-.fse-enabled .site-header .entry-content,
-.fse-enabled .site-header .entry-summary,
-.fse-enabled .site-header .entry,
-.fse-enabled .site-footer .entry-content,
-.fse-enabled .site-footer .entry-summary,
-.fse-enabled .site-footer .entry {
+.entry .entry-summary .entry {
   margin: inherit;
   max-width: inherit;
   padding: inherit;
@@ -3635,13 +3612,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .entry,
   .entry .entry-summary .entry-content,
   .entry .entry-summary .entry-summary,
-  .entry .entry-summary .entry,
-  .fse-enabled .site-header .entry-content,
-  .fse-enabled .site-header .entry-summary,
-  .fse-enabled .site-header .entry,
-  .fse-enabled .site-footer .entry-content,
-  .fse-enabled .site-footer .entry-summary,
-  .fse-enabled .site-footer .entry {
+  .entry .entry-summary .entry {
     margin: inherit;
     max-width: inherit;
     padding: inherit;
@@ -5601,12 +5572,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
-.fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
-  margin: 15px;
+.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+  padding: 1rem 32px;
 }
 
-.fse-enabled .site-footer .site-info {
-  text-align: center;
+@media only screen and (min-width: 768px) {
+  .fse-enabled .site-footer, .post-type-wp_template .site-footer {
+    padding: 1rem 0;
+  }
+}
+
+.fse-enabled .site-footer h1,
+.fse-enabled .site-footer h2,
+.fse-enabled .site-footer h3,
+.fse-enabled .site-footer h4,
+.fse-enabled .site-footer h5,
+.fse-enabled .site-footer h6, .post-type-wp_template .site-footer h1,
+.post-type-wp_template .site-footer h2,
+.post-type-wp_template .site-footer h3,
+.post-type-wp_template .site-footer h4,
+.post-type-wp_template .site-footer h5,
+.post-type-wp_template .site-footer h6 {
+  margin: 32px 0;
+  text-align: right;
+}
+
+.fse-enabled .site-footer .wp-block-separator, .fse-enabled .site-footer .wp-block-button, .post-type-wp_template .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-button {
+  margin: 15px 0;
+}
+
+.fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {
+  text-align: right;
+  margin: 0;
 }
 
 /* Site Builder */

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -5597,8 +5597,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   text-align: right;
 }
 
-.fse-enabled .site-footer .wp-block-separator, .fse-enabled .site-footer .wp-block-button, .post-type-wp_template .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-button {
+.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p, .post-type-wp_template .site-footer .wp-block-button, .post-type-wp_template .site-footer p {
   margin: 15px 0;
+}
+
+.fse-enabled .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-separator {
+  margin: 16px 0;
 }
 
 .fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -5601,6 +5601,14 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
+.fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
+  margin: 15px 0;
+}
+
+.fse-enabled .site-footer .site-info {
+  text-align: center;
+}
+
 /* Site Builder */
 /* !Site Builder styles */
 .entry .entry-content .site-builder__header {

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -3439,8 +3439,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 /* !Block styles */
 .entry .entry-content > *,
 .entry .entry-summary > *,
-.fse-enabled .site-header > *,
-.fse-enabled .site-footer > * {
+.fse-enabled .site-header > * {
   margin: 32px 0;
   max-width: 100%;
 }
@@ -3448,8 +3447,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3457,8 +3455,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3466,30 +3463,26 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
-  .fse-enabled .site-header > *,
-  .fse-enabled .site-footer > * {
+  .fse-enabled .site-header > * {
     margin: 32px auto;
   }
 }
 
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > * > *:first-child,
-.fse-enabled .site-header > * > *:first-child,
-.fse-enabled .site-footer > * > *:first-child {
+.fse-enabled .site-header > * > *:first-child {
   margin-top: 0;
 }
 
 .entry .entry-content > * > *:last-child,
 .entry .entry-summary > * > *:last-child,
-.fse-enabled .site-header > * > *:last-child,
-.fse-enabled .site-footer > * > *:last-child {
+.fse-enabled .site-header > * > *:last-child {
   margin-bottom: 0;
 }
 
 .entry .entry-content > *.alignwide,
 .entry .entry-summary > *.alignwide,
-.fse-enabled .site-header > *.alignwide,
-.fse-enabled .site-footer > *.alignwide {
+.fse-enabled .site-header > *.alignwide {
   margin-left: auto;
   margin-right: auto;
   clear: both;
@@ -3498,8 +3491,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide,
-  .fse-enabled .site-header > *.alignwide,
-  .fse-enabled .site-footer > *.alignwide {
+  .fse-enabled .site-header > *.alignwide {
     width: 100%;
     max-width: 100%;
   }
@@ -3507,8 +3499,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull,
-.fse-enabled .site-header > *.alignfull,
-.fse-enabled .site-footer > *.alignfull {
+.fse-enabled .site-header > *.alignfull {
   position: relative;
   left: -1rem;
   width: calc( 100% + (2 * 1rem));
@@ -3519,8 +3510,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull,
-  .fse-enabled .site-header > *.alignfull,
-  .fse-enabled .site-footer > *.alignfull {
+  .fse-enabled .site-header > *.alignfull {
     margin-top: 32px;
     margin-bottom: 32px;
     left: calc( -12.5% - 75px);
@@ -3531,8 +3521,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignleft,
 .entry .entry-summary > *.alignleft,
-.fse-enabled .site-header > *.alignleft,
-.fse-enabled .site-footer > *.alignleft {
+.fse-enabled .site-header > *.alignleft {
   /*rtl:ignore*/
   float: left;
   max-width: calc(5 * (100vw / 12));
@@ -3545,8 +3534,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
   .entry .entry-summary > *.alignleft,
-  .fse-enabled .site-header > *.alignleft,
-  .fse-enabled .site-footer > *.alignleft {
+  .fse-enabled .site-header > *.alignleft {
     max-width: calc(4 * (100vw / 12));
     /*rtl:ignore*/
     margin-right: calc(2 * 1rem);
@@ -3555,8 +3543,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright,
-.fse-enabled .site-header > *.alignright,
-.fse-enabled .site-footer > *.alignright {
+.fse-enabled .site-header > *.alignright {
   /*rtl:ignore*/
   float: right;
   max-width: calc(5 * (100vw / 12));
@@ -3569,8 +3556,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright,
-  .fse-enabled .site-header > *.alignright,
-  .fse-enabled .site-footer > *.alignright {
+  .fse-enabled .site-header > *.alignright {
     max-width: calc(4 * (100vw / 12));
     margin-right: 0;
     /*rtl:ignore*/
@@ -3580,8 +3566,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 
 .entry .entry-content > *.aligncenter,
 .entry .entry-summary > *.aligncenter,
-.fse-enabled .site-header > *.aligncenter,
-.fse-enabled .site-footer > *.aligncenter {
+.fse-enabled .site-header > *.aligncenter {
   margin-left: auto;
   margin-right: auto;
   /*
@@ -3595,8 +3580,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
-  .fse-enabled .site-header > *.aligncenter,
-  .fse-enabled .site-footer > *.aligncenter {
+  .fse-enabled .site-header > *.aligncenter {
     max-width: calc(8 * (100vw / 12) - 28px);
   }
 }
@@ -3604,8 +3588,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
-  .fse-enabled .site-header > *.aligncenter,
-  .fse-enabled .site-footer > *.aligncenter {
+  .fse-enabled .site-header > *.aligncenter {
     max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
@@ -3629,13 +3612,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .entry .entry-content .entry,
 .entry .entry-summary .entry-content,
 .entry .entry-summary .entry-summary,
-.entry .entry-summary .entry,
-.fse-enabled .site-header .entry-content,
-.fse-enabled .site-header .entry-summary,
-.fse-enabled .site-header .entry,
-.fse-enabled .site-footer .entry-content,
-.fse-enabled .site-footer .entry-summary,
-.fse-enabled .site-footer .entry {
+.entry .entry-summary .entry {
   margin: inherit;
   max-width: inherit;
   padding: inherit;
@@ -3647,13 +3624,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   .entry .entry-content .entry,
   .entry .entry-summary .entry-content,
   .entry .entry-summary .entry-summary,
-  .entry .entry-summary .entry,
-  .fse-enabled .site-header .entry-content,
-  .fse-enabled .site-header .entry-summary,
-  .fse-enabled .site-header .entry,
-  .fse-enabled .site-footer .entry-content,
-  .fse-enabled .site-footer .entry-summary,
-  .fse-enabled .site-footer .entry {
+  .entry .entry-summary .entry {
     margin: inherit;
     max-width: inherit;
     padding: inherit;
@@ -5613,12 +5584,38 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
-.fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
-  margin: 15px;
+.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+  padding: 1rem 32px;
 }
 
-.fse-enabled .site-footer .site-info {
-  text-align: center;
+@media only screen and (min-width: 768px) {
+  .fse-enabled .site-footer, .post-type-wp_template .site-footer {
+    padding: 1rem 0;
+  }
+}
+
+.fse-enabled .site-footer h1,
+.fse-enabled .site-footer h2,
+.fse-enabled .site-footer h3,
+.fse-enabled .site-footer h4,
+.fse-enabled .site-footer h5,
+.fse-enabled .site-footer h6, .post-type-wp_template .site-footer h1,
+.post-type-wp_template .site-footer h2,
+.post-type-wp_template .site-footer h3,
+.post-type-wp_template .site-footer h4,
+.post-type-wp_template .site-footer h5,
+.post-type-wp_template .site-footer h6 {
+  margin: 32px 0;
+  text-align: left;
+}
+
+.fse-enabled .site-footer .wp-block-separator, .fse-enabled .site-footer .wp-block-button, .post-type-wp_template .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-button {
+  margin: 15px 0;
+}
+
+.fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {
+  text-align: left;
+  margin: 0;
 }
 
 /* Site Builder */

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -5609,8 +5609,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   text-align: left;
 }
 
-.fse-enabled .site-footer .wp-block-separator, .fse-enabled .site-footer .wp-block-button, .post-type-wp_template .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-button {
+.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p, .post-type-wp_template .site-footer .wp-block-button, .post-type-wp_template .site-footer p {
   margin: 15px 0;
+}
+
+.fse-enabled .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-separator {
+  margin: 16px 0;
 }
 
 .fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -5614,7 +5614,7 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 }
 
 .fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
-  margin: 15px 0;
+  margin: 15px;
 }
 
 .fse-enabled .site-footer .site-info {

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -5613,6 +5613,14 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
+.fse-enabled .site-footer .wp-block-a8c-navigation-menu, .fse-enabled .site-footer .wp-block-separator {
+  margin: 15px 0;
+}
+
+.fse-enabled .site-footer .site-info {
+  text-align: center;
+}
+
 /* Site Builder */
 /* !Site Builder styles */
 .entry .entry-content .site-builder__header {

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -5584,12 +5584,12 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
   outline-offset: -4px;
 }
 
-.fse-enabled .site-footer, .post-type-wp_template .site-footer {
+.fse-enabled .site-footer {
   padding: 1rem 32px;
 }
 
 @media only screen and (min-width: 768px) {
-  .fse-enabled .site-footer, .post-type-wp_template .site-footer {
+  .fse-enabled .site-footer {
     padding: 1rem 0;
   }
 }
@@ -5599,25 +5599,20 @@ footer .wp-block-a8c-navigation-menu .sub-menu {
 .fse-enabled .site-footer h3,
 .fse-enabled .site-footer h4,
 .fse-enabled .site-footer h5,
-.fse-enabled .site-footer h6, .post-type-wp_template .site-footer h1,
-.post-type-wp_template .site-footer h2,
-.post-type-wp_template .site-footer h3,
-.post-type-wp_template .site-footer h4,
-.post-type-wp_template .site-footer h5,
-.post-type-wp_template .site-footer h6 {
+.fse-enabled .site-footer h6 {
   margin: 32px 0;
   text-align: left;
 }
 
-.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p, .post-type-wp_template .site-footer .wp-block-button, .post-type-wp_template .site-footer p {
+.fse-enabled .site-footer .wp-block-button, .fse-enabled .site-footer p {
   margin: 15px 0;
 }
 
-.fse-enabled .site-footer .wp-block-separator, .post-type-wp_template .site-footer .wp-block-separator {
+.fse-enabled .site-footer .wp-block-separator {
   margin: 16px 0;
 }
 
-.fse-enabled .site-footer#colophon .site-info, .post-type-wp_template .site-footer#colophon .site-info {
+.fse-enabled .site-footer#colophon .site-info {
   text-align: left;
   margin: 0;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Add css to left align the footer separator and nav menu to match the editor styling

### Testing

* Build modern business and apply to FSE test environment
* Check that the the horizontal alignment of any block added to the footer matches across the page view, template edit view and the front end.
* Check that side padding is adding correctly on smaller screens to stop blocks being pushed hard against the edge

**notes:** 

* This issue occurred in both local and WP.com Simple sites. I have tested in Sandboxed simple site  - feel free to double check the fix in both also.
* Vertical alignment is still not perfect between these views, but close!

**Before**

<img width="1900" alt="before-footer-space" src="https://user-images.githubusercontent.com/3629020/63072125-453a3700-bf76-11e9-8183-73b9c030aa12.png">


**After**

<img width="1894" alt="footer-space-after" src="https://user-images.githubusercontent.com/3629020/63072131-4e2b0880-bf76-11e9-9579-8caac96ed998.png">

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/35389