### PR TITLE
FSE: Use new classnames instead of data-type selectors

### DIFF
--- a/friendly-business/package-lock.json
+++ b/friendly-business/package-lock.json
@@ -524,12 +524,12 @@
       "requires": {
         "bluebird": "3.5.3",
         "chokidar": "2.1.1",
-        "lodash": "4.17.13",
+        "lodash": "4.17.11",
         "yargs": "12.0.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -1875,7 +1875,7 @@
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.13",
+        "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
       }
     },
@@ -2683,7 +2683,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -3188,7 +3188,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       }
@@ -3514,7 +3514,7 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^7.0.0"
       },

--- a/friendly-business/style-editor.css
+++ b/friendly-business/style-editor.css
@@ -856,7 +856,7 @@ blockquote {
  we use it to target wp-blocks with a matching data-align attribute.
  If no alignment is given, we target the base wp-block class. In both
  of these scenarios, we target top level blocks, and any top level blocks
- inside one of the FSE template part blocks.
+ inside one of the FSE template blocks.
  */
 /** === Editor Frame === */
 body {
@@ -870,7 +870,7 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 600px) {
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+  body .wp-block.post-content__block .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
   }
@@ -889,12 +889,12 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="wide"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
+  body .wp-block.post-content__block .wp-block[data-align="wide"] {
     width: 100%;
   }
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+  body .wp-block.post-content__block .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
@@ -902,7 +902,7 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="right"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
+  body .wp-block.post-content__block .wp-block[data-align="right"] {
     max-width: 125%;
   }
 }
@@ -915,7 +915,7 @@ body .wp-block[data-align="full"] {
 
 
 .wp-block,
-.wp-block[data-type="a8c/post-content"] .wp-block {
+.wp-block.post-content__block .wp-block {
   width: calc(100vw - (2 * 1rem));
   max-width: 100%;
 }
@@ -923,7 +923,7 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 768px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/post-content"] .wp-block {
+  .wp-block.post-content__block .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
@@ -931,19 +931,19 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 1168px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/post-content"] .wp-block {
+  .wp-block.post-content__block .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }
 
 
 .wp-block .wp-block,
-.wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
+.wp-block.post-content__block .wp-block .wp-block {
   width: 100%;
 }
 
-/** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/post-content"] {
+/** === FSE Template Blocks === */
+.wp-block.post-content__block {
   width: 100%;
 }
 

--- a/friendly-business/style-editor.scss
+++ b/friendly-business/style-editor.scss
@@ -18,7 +18,7 @@ Friendly Business Editor Styles
  we use it to target wp-blocks with a matching data-align attribute.
  If no alignment is given, we target the base wp-block class. In both
  of these scenarios, we target top level blocks, and any top level blocks
- inside one of the FSE template part blocks.
+ inside one of the FSE template blocks.
  */
  @function get-block-selector($alignment) {
 	$main-block-selector: ".wp-block";
@@ -28,7 +28,7 @@ Friendly Business Editor Styles
 
 	@return "
 	  #{$main-block-selector},
-	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
+	  .wp-block.post-content__block #{$main-block-selector}";
 }
 
 /** === Editor Frame === */
@@ -103,8 +103,8 @@ body {
 	}
 }
 
-/** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/post-content"] {
+/** === FSE Template Blocks === */
+.wp-block.post-content__block {
 	width: 100%;
 }
 

--- a/modern-business/package-lock.json
+++ b/modern-business/package-lock.json
@@ -524,12 +524,12 @@
       "requires": {
         "bluebird": "3.5.3",
         "chokidar": "2.1.1",
-        "lodash": "4.17.13",
+        "lodash": "4.17.11",
         "yargs": "12.0.5"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -1171,24 +1171,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1198,12 +1202,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -1212,34 +1218,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1248,25 +1260,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1275,13 +1291,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1297,7 +1315,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1311,13 +1330,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1326,7 +1347,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1335,7 +1357,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1345,18 +1368,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -1364,13 +1390,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -1378,12 +1406,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -1392,7 +1422,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1401,7 +1432,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -1409,13 +1441,15 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1426,7 +1460,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1444,7 +1479,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1454,13 +1490,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1470,7 +1508,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1482,18 +1521,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -1501,19 +1543,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1523,19 +1568,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1547,7 +1595,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -1555,7 +1604,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1570,7 +1620,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1579,42 +1630,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -1624,7 +1682,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1633,7 +1692,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1641,13 +1701,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1662,13 +1724,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1677,12 +1741,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -1875,7 +1941,7 @@
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.13",
+        "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
       }
     },
@@ -2683,7 +2749,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -3188,7 +3254,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       }
@@ -3514,7 +3580,7 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^7.0.0"
       },

--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -923,7 +923,7 @@ blockquote {
  we use it to target wp-blocks with a matching data-align attribute.
  If no alignment is given, we target the base wp-block class. In both
  of these scenarios, we target top level blocks, and any top level blocks
- inside one of the FSE template part blocks.
+ inside one of the FSE template blocks.
  */
 /** === Editor Frame === */
 body {
@@ -938,7 +938,7 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 600px) {
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+  body .wp-block.post-content__block .wp-block[data-align="full"] {
     width: calc( 100% + 90px);
     max-width: calc( 100% + 90px);
   }
@@ -951,12 +951,12 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="wide"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="wide"] {
+  body .wp-block.post-content__block .wp-block[data-align="wide"] {
     width: 100%;
   }
   
   body .wp-block[data-align="full"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="full"] {
+  body .wp-block.post-content__block .wp-block[data-align="full"] {
     position: relative;
     left: calc( -12.5% - 14px);
     width: calc( 125% + 116px);
@@ -964,7 +964,7 @@ body .wp-block[data-align="full"] {
   }
   
   body .wp-block[data-align="right"],
-  body .wp-block[data-type="a8c/post-content"] .wp-block[data-align="right"] {
+  body .wp-block.post-content__block .wp-block[data-align="right"] {
     max-width: 125%;
   }
 }
@@ -972,7 +972,7 @@ body .wp-block[data-align="full"] {
 /** === Content Width === */
 
 .wp-block,
-.wp-block[data-type="a8c/post-content"] .wp-block {
+.wp-block.post-content__block .wp-block {
   width: calc(100vw - (2 * 1rem));
   max-width: 100%;
 }
@@ -980,7 +980,7 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 768px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/post-content"] .wp-block {
+  .wp-block.post-content__block .wp-block {
     width: calc(8 * (100vw / 12));
   }
 }
@@ -988,19 +988,19 @@ body .wp-block[data-align="full"] {
 @media only screen and (min-width: 1168px) {
   
   .wp-block,
-  .wp-block[data-type="a8c/post-content"] .wp-block {
+  .wp-block.post-content__block .wp-block {
     width: calc(6 * (100vw / 12 ));
   }
 }
 
 
 .wp-block .wp-block,
-.wp-block[data-type="a8c/post-content"] .wp-block .wp-block {
+.wp-block.post-content__block .wp-block .wp-block {
   width: 100%;
 }
 
-/** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/post-content"] {
+/** === FSE Template Blocks === */
+.wp-block.post-content__block {
   width: 100%;
 }
 

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -19,7 +19,7 @@ Modern Business Editor Styles
  we use it to target wp-blocks with a matching data-align attribute.
  If no alignment is given, we target the base wp-block class. In both
  of these scenarios, we target top level blocks, and any top level blocks
- inside one of the FSE template part blocks.
+ inside one of the FSE template blocks.
  */
 @function get-block-selector($alignment) {
 	$main-block-selector: ".wp-block";
@@ -29,7 +29,7 @@ Modern Business Editor Styles
 
 	@return "
 	  #{$main-block-selector},
-	  .wp-block[data-type=\"a8c/post-content\"] #{$main-block-selector}";
+	  .wp-block.post-content__block #{$main-block-selector}";
 }
 
 /** === Editor Frame === */
@@ -95,8 +95,8 @@ body {
 	}
 }
 
-/** === FSE Template Part Blocks === */
-.wp-block[data-type="a8c/post-content"] {
+/** === FSE Template Blocks === */
+.wp-block.post-content__block {
 	width: 100%;
 }
 


### PR DESCRIPTION
Affects friendly business and modern business. Also renamed one or two things to "template" from "template part".

Note that the only changes I made were in *.scss files. The .css and package lock files are autogenerated.

### Testing
1. Make sure you have both modern business and friendly business mapped to your local FSE setup
2. Make sure you have FSE active on your this site.
3. Pull this branch.
4. Activate the modern business theme.
5. Open the page editor and make sure the styles look correct. If the new selector is failing, things would be very messed up, like paragraphs in post content extending the full width of the screen.
6. Inspect the post content block and verify the style is getting applied correctly:
<img width="1255" alt="Screen Shot 2019-08-14 at 5 41 25 PM" src="https://user-images.githubusercontent.com/6265975/63065575-6722b380-bebb-11e9-88d8-91c291590747.png">

7. Inspect a block nested inside the post content block and verify the style is getting applied correctly:
<img width="1388" alt="Screen Shot 2019-08-14 at 5 40 35 PM" src="https://user-images.githubusercontent.com/6265975/63065586-73a70c00-bebb-11e9-8287-a892efacf606.png">

8. Activate the friendly business theme. Try steps 5 through 7 with it active. (Obviously most FSE functionality doesn't work with it yet, but the post content should still show up in the right format. On a local install, FSE will also stay active if the theme is unsupported, which helps test this.)

Resolves https://github.com/Automattic/wp-calypso/issues/35246 along with https://github.com/Automattic/wp-calypso/pull/35400