### PR TITLE
Modern Business: add CSS custom properties

### DIFF
--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -315,6 +315,7 @@
 			@include button-transition;
 			border: none;
 			font-size: $font__size-sm;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			line-height: $font__line-height-heading;
 			box-sizing: border-box;
@@ -385,6 +386,7 @@
 
 		li {
 			color: $color__text-light;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
@@ -454,6 +456,7 @@
 
 	//! Verse
 	.wp-block-verse {
+		font-family: $font__body; // for browsers without CSS custom props support
 		font-family: var(--font-base, $font__body);
 		font-size: $font__size_base;
 		line-height: 1.8;
@@ -462,6 +465,7 @@
 	//! Paragraphs
 	.has-drop-cap {
 		&:not(:focus):first-letter {
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xxxl;
 			line-height: 1;
@@ -503,6 +507,7 @@
 
 		cite {
 			display: inline-block;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			line-height: 1.6;
 			text-transform: none;
@@ -831,6 +836,7 @@
 	.wp-block-gallery .blocks-gallery-image figcaption,
 	.wp-block-gallery .blocks-gallery-item figcaption {
 		font-size: $font__size-xs;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		line-height: $font__line-height-pre;
 		margin: 0;
@@ -905,6 +911,7 @@
 
 	//! File
 	.wp-block-file {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 
 		.wp-block-file__button {
@@ -914,6 +921,7 @@
 			border-radius: 5px;
 			background: $color__background-button;
 			font-size: $font__size-base;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			line-height: $font__line-height-heading;
 			text-decoration: none;
@@ -997,6 +1005,7 @@
 	.wp-block-latest-comments {
 
 		.wp-block-latest-comments__comment-meta {
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-weight: 700;
 
@@ -1212,6 +1221,7 @@
 		@include button-transition;
 		background: $color__background-button;
 		border-radius: 3px;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		padding: .05rem .4rem;
@@ -1241,6 +1251,7 @@
 		box-sizing: border-box;
 		color: $color__background-body;
 		display: inline-block;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-sm;
 		font-weight: 700;

--- a/modern-business/sass/blocks/_blocks.scss
+++ b/modern-business/sass/blocks/_blocks.scss
@@ -315,7 +315,7 @@
 			@include button-transition;
 			border: none;
 			font-size: $font__size-sm;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			line-height: $font__line-height-heading;
 			box-sizing: border-box;
 			font-weight: bold;
@@ -385,7 +385,7 @@
 
 		li {
 			color: $color__text-light;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
@@ -454,7 +454,7 @@
 
 	//! Verse
 	.wp-block-verse {
-		font-family: $font__body;
+		font-family: var(--font-base, $font__body);
 		font-size: $font__size_base;
 		line-height: 1.8;
 	}
@@ -462,7 +462,7 @@
 	//! Paragraphs
 	.has-drop-cap {
 		&:not(:focus):first-letter {
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xxxl;
 			line-height: 1;
 			font-weight: bold;
@@ -503,7 +503,7 @@
 
 		cite {
 			display: inline-block;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			line-height: 1.6;
 			text-transform: none;
 			color: $color__text-light;
@@ -831,7 +831,7 @@
 	.wp-block-gallery .blocks-gallery-image figcaption,
 	.wp-block-gallery .blocks-gallery-item figcaption {
 		font-size: $font__size-xs;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		line-height: $font__line-height-pre;
 		margin: 0;
 		padding: ( $size__spacing-unit * .5 );
@@ -905,7 +905,7 @@
 
 	//! File
 	.wp-block-file {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 
 		.wp-block-file__button {
 			display: table;
@@ -914,7 +914,7 @@
 			border-radius: 5px;
 			background: $color__background-button;
 			font-size: $font__size-base;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			line-height: $font__line-height-heading;
 			text-decoration: none;
 			font-weight: bold;
@@ -997,7 +997,7 @@
 	.wp-block-latest-comments {
 
 		.wp-block-latest-comments__comment-meta {
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-weight: 700;
 
 			.wp-block-latest-comments__comment-date {
@@ -1212,7 +1212,7 @@
 		@include button-transition;
 		background: $color__background-button;
 		border-radius: 3px;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		padding: .05rem .4rem;
 
@@ -1241,7 +1241,7 @@
 		box-sizing: border-box;
 		color: $color__background-body;
 		display: inline-block;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-sm;
 		font-weight: 700;
 		line-height: $font__line-height-heading;

--- a/modern-business/sass/blocks/_site-builder.scss
+++ b/modern-business/sass/blocks/_site-builder.scss
@@ -16,7 +16,7 @@
 
 	.site-builder__title {
 		color: $color__text-main;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		font-size: $font__size-md;
 		-webkit-font-smoothing: antialiased;

--- a/modern-business/sass/blocks/_site-builder.scss
+++ b/modern-business/sass/blocks/_site-builder.scss
@@ -16,6 +16,7 @@
 
 	.site-builder__title {
 		color: $color__text-main;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		font-size: $font__size-md;

--- a/modern-business/sass/elements/_tables.scss
+++ b/modern-business/sass/elements/_tables.scss
@@ -2,6 +2,7 @@ table {
 	margin: 0 0 $size__spacing-unit;
 	border-collapse: collapse;
 	width: 100%;
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 
 	td,

--- a/modern-business/sass/elements/_tables.scss
+++ b/modern-business/sass/elements/_tables.scss
@@ -2,7 +2,7 @@ table {
 	margin: 0 0 $size__spacing-unit;
 	border-collapse: collapse;
 	width: 100%;
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 
 	td,
 	th {

--- a/modern-business/sass/forms/_buttons.scss
+++ b/modern-business/sass/forms/_buttons.scss
@@ -10,7 +10,7 @@ input[type="submit"] {
 	border-radius: 5px;
 	box-sizing: border-box;
 	color: $color__background-body;
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 	font-size: $font__size-sm;
 	font-weight: 700;
 	line-height: $font__line-height-heading;

--- a/modern-business/sass/forms/_buttons.scss
+++ b/modern-business/sass/forms/_buttons.scss
@@ -10,6 +10,7 @@ input[type="submit"] {
 	border-radius: 5px;
 	box-sizing: border-box;
 	color: $color__background-body;
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 	font-size: $font__size-sm;
 	font-weight: 700;

--- a/modern-business/sass/media/_captions.scss
+++ b/modern-business/sass/media/_captions.scss
@@ -24,7 +24,7 @@
 .wp-caption-text {
 	color: $color__text-light;
 	font-size: $font__size-xs;
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
  	line-height: $font__line-height-pre;
  	margin: 0;
  	padding: ( $size__spacing-unit * .5 );

--- a/modern-business/sass/media/_captions.scss
+++ b/modern-business/sass/media/_captions.scss
@@ -24,6 +24,7 @@
 .wp-caption-text {
 	color: $color__text-light;
 	font-size: $font__size-xs;
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
  	line-height: $font__line-height-pre;
  	margin: 0;

--- a/modern-business/sass/media/_galleries.scss
+++ b/modern-business/sass/media/_galleries.scss
@@ -32,6 +32,7 @@
 .gallery-caption {
 	display: block;
 	font-size: $font__size-xs;
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 	line-height: $font__line-height-pre;
 	margin: 0;

--- a/modern-business/sass/media/_galleries.scss
+++ b/modern-business/sass/media/_galleries.scss
@@ -32,7 +32,7 @@
 .gallery-caption {
 	display: block;
 	font-size: $font__size-xs;
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 	line-height: $font__line-height-pre;
 	margin: 0;
 	padding: ( $size__spacing-unit * .5 );

--- a/modern-business/sass/mixins/_mixins-master.scss
+++ b/modern-business/sass/mixins/_mixins-master.scss
@@ -99,7 +99,7 @@
 	html[lang="fa-IR"] #{$wrapper_classname} *,
 	html[lang="haz"] #{$wrapper_classname} *,
 	html[lang="ps"] #{$wrapper_classname} * {
-	  font-family: Tahoma, Arial, sans-serif !important;
+	  font-family: var(--font-base, Tahoma, Arial, sans-serif !important);
 	}
 
 	/* Cyrillic */
@@ -113,22 +113,22 @@
 	html[lang="sr-RS"] #{$wrapper_classname} *,
 	html[lang="tt-RU"] #{$wrapper_classname} *,
 	html[lang="uk"] #{$wrapper_classname} * {
-	  font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important;
+	  font-family: var(--font-base, 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important);
 	}
 
 	/* Chinese (Hong Kong) */
 	html[lang="zh-HK"] #{$wrapper_classname} * {
-		font-family: -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
+		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
 	/* Chinese (Taiwan) */
 	html[lang="zh-TW"] #{$wrapper_classname} * {
-		font-family: -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
+		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
 	/* Chinese (China) */
 	html[lang="zh-CN"] #{$wrapper_classname} * {
-		font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important;
+		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
 	/* Devanagari */
@@ -136,42 +136,42 @@
 	html[lang="hi-IN"] #{$wrapper_classname} *,
 	html[lang="mr"] #{$wrapper_classname} *,
 	html[lang="ne-NP"] #{$wrapper_classname} * {
-	  font-family: Arial, sans-serif !important;
+	  font-family: var(--font-base, Arial, sans-serif !important);
 	}
 
 	/* Greek */
 	html[lang="el"] #{$wrapper_classname} * {
-	  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+	  font-family: var(--font-base, 'Helvetica Neue', Helvetica, Arial, sans-serif !important);
 	}
 
 	/* Gujarati */
 	html[lang="gu"] #{$wrapper_classname} * {
-	  font-family: Arial, sans-serif !important;
+	  font-family: var(--font-base, Arial, sans-serif !important);
 	}
 
 	/* Hebrew */
 	html[lang="he-IL"] #{$wrapper_classname} * {
-	  font-family: 'Arial Hebrew', Arial, sans-serif !important;
+	  font-family: var(--font-base, 'Arial Hebrew', Arial, sans-serif !important);
 	}
 
 	/* Japanese */
 	html[lang="ja"] #{$wrapper_classname} * {
-	  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important;
+	  font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important);
 	}
 
 	/* Korean */
 	html[lang="ko-KR"] #{$wrapper_classname} * {
-	  font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important;
+	  font-family: var(--font-base, 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important);
 	}
 
 	/* Thai */
 	html[lang="th"] #{$wrapper_classname} * {
-	  font-family: 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important;
+	  font-family: var(--font-base, 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important);
 	}
 
 	/* Vietnamese */
 	html[lang="vi"] #{$wrapper_classname} * {
-	  font-family: 'Libre Franklin', sans-serif !important;
+	  font-family: var(--font-base, 'Libre Franklin', sans-serif !important);
 	}
 }
 
@@ -195,7 +195,7 @@
 	}
 
 	ul > li > a::before {
-		font-family: $font__body;
+		font-family: var(--font-base, $font__body);
 		font-weight: normal;
 		content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
 		counter-increment: submenu

--- a/modern-business/sass/mixins/_mixins-master.scss
+++ b/modern-business/sass/mixins/_mixins-master.scss
@@ -99,6 +99,7 @@
 	html[lang="fa-IR"] #{$wrapper_classname} *,
 	html[lang="haz"] #{$wrapper_classname} *,
 	html[lang="ps"] #{$wrapper_classname} * {
+	  font-family: Tahoma, Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, Tahoma, Arial, sans-serif !important);
 	}
 
@@ -113,21 +114,25 @@
 	html[lang="sr-RS"] #{$wrapper_classname} *,
 	html[lang="tt-RU"] #{$wrapper_classname} *,
 	html[lang="uk"] #{$wrapper_classname} * {
+	  font-family: 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, sans-serif !important);
 	}
 
 	/* Chinese (Hong Kong) */
 	html[lang="zh-HK"] #{$wrapper_classname} * {
+		font-family: -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important; // for browsers without CSS custom props support
 		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang HK', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
 	/* Chinese (Taiwan) */
 	html[lang="zh-TW"] #{$wrapper_classname} * {
+		font-family: -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important; // for browsers without CSS custom props support
 		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang TC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
 	/* Chinese (China) */
 	html[lang="zh-CN"] #{$wrapper_classname} * {
+		font-family: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important; // for browsers without CSS custom props support
 		font-family: var(--font-base, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Helvetica Neue', "Microsoft YaHei New", STHeiti Light, sans-serif !important);
 	}
 
@@ -136,41 +141,49 @@
 	html[lang="hi-IN"] #{$wrapper_classname} *,
 	html[lang="mr"] #{$wrapper_classname} *,
 	html[lang="ne-NP"] #{$wrapper_classname} * {
+	  font-family: Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, Arial, sans-serif !important);
 	}
 
 	/* Greek */
 	html[lang="el"] #{$wrapper_classname} * {
+	  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Helvetica Neue', Helvetica, Arial, sans-serif !important);
 	}
 
 	/* Gujarati */
 	html[lang="gu"] #{$wrapper_classname} * {
+	  font-family: Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, Arial, sans-serif !important);
 	}
 
 	/* Hebrew */
 	html[lang="he-IL"] #{$wrapper_classname} * {
+	  font-family: 'Arial Hebrew', Arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Arial Hebrew', Arial, sans-serif !important);
 	}
 
 	/* Japanese */
 	html[lang="ja"] #{$wrapper_classname} * {
+	  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif !important);
 	}
 
 	/* Korean */
 	html[lang="ko-KR"] #{$wrapper_classname} * {
+	  font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Apple SD Gothic Neo', 'Malgun Gothic', 'Nanum Gothic', Dotum, sans-serif !important);
 	}
 
 	/* Thai */
 	html[lang="th"] #{$wrapper_classname} * {
+	  font-family: 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Sukhumvit Set', 'Helvetica Neue', helvetica, arial, sans-serif !important);
 	}
 
 	/* Vietnamese */
 	html[lang="vi"] #{$wrapper_classname} * {
+	  font-family: 'Libre Franklin', sans-serif !important; // for browsers without CSS custom props support
 	  font-family: var(--font-base, 'Libre Franklin', sans-serif !important);
 	}
 }
@@ -195,6 +208,7 @@
 	}
 
 	ul > li > a::before {
+		font-family: $font__body; // for browsers without CSS custom props support
 		font-family: var(--font-base, $font__body);
 		font-weight: normal;
 		content: "\2013\00a0" counters(submenu, "\2013\00a0", none);

--- a/modern-business/sass/navigation/_menu-main-navigation.scss
+++ b/modern-business/sass/navigation/_menu-main-navigation.scss
@@ -25,7 +25,7 @@
 		border: none;
 		padding: 0;
 		margin: 0;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		line-height: $font__line-height-heading;
 		text-decoration: none;
@@ -339,7 +339,7 @@
 		}
 
 		.sub-menu > li > a::before {
-			font-family: $font__body;
+			font-family: var(--font-base, $font__body);
 			font-weight: normal;
 			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
 			counter-increment: submenu
@@ -415,7 +415,7 @@
 		}
 
 		.sub-menu > li > a::before {
-			font-family: $font__body;
+			font-family: var(--font-base, $font__body);
 			font-weight: normal;
 			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
 			counter-increment: submenu

--- a/modern-business/sass/navigation/_menu-main-navigation.scss
+++ b/modern-business/sass/navigation/_menu-main-navigation.scss
@@ -25,6 +25,7 @@
 		border: none;
 		padding: 0;
 		margin: 0;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 		line-height: $font__line-height-heading;
@@ -339,6 +340,7 @@
 		}
 
 		.sub-menu > li > a::before {
+			font-family: $font__body; // for browsers without CSS custom props support
 			font-family: var(--font-base, $font__body);
 			font-weight: normal;
 			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
@@ -415,6 +417,7 @@
 		}
 
 		.sub-menu > li > a::before {
+			font-family: $font__body; // for browsers without CSS custom props support
 			font-family: var(--font-base, $font__body);
 			font-weight: normal;
 			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);

--- a/modern-business/sass/navigation/_next-previous.scss
+++ b/modern-business/sass/navigation/_next-previous.scss
@@ -176,6 +176,7 @@
 	.nav-next {
 		min-width: 50%;
 		width: 100%;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: bold;
 

--- a/modern-business/sass/navigation/_next-previous.scss
+++ b/modern-business/sass/navigation/_next-previous.scss
@@ -176,7 +176,7 @@
 	.nav-next {
 		min-width: 50%;
 		width: 100%;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: bold;
 
 		.secondary-text {

--- a/modern-business/sass/site/primary/_comments.scss
+++ b/modern-business/sass/site/primary/_comments.scss
@@ -128,7 +128,7 @@
 
 		.comment-body {
 			color: $color__text-light;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xs;
 			font-weight: 500;
 			margin-top: $size__spacing-unit;
@@ -144,7 +144,7 @@
 
 			.comment-edit-link {
 				color: $color__text-light;
-				font-family: $font__heading;
+				font-family: var(--font-headings, $font__heading);
 				font-weight: 500;
 			}
 		}
@@ -373,7 +373,7 @@
 
 	.comment-notes,
 	label {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		color: $color__text-light;
 	}

--- a/modern-business/sass/site/primary/_comments.scss
+++ b/modern-business/sass/site/primary/_comments.scss
@@ -128,6 +128,7 @@
 
 		.comment-body {
 			color: $color__text-light;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xs;
 			font-weight: 500;
@@ -144,6 +145,7 @@
 
 			.comment-edit-link {
 				color: $color__text-light;
+				font-family: $font__heading; // for browsers without CSS custom props support
 				font-family: var(--font-headings, $font__heading);
 				font-weight: 500;
 			}
@@ -373,6 +375,7 @@
 
 	.comment-notes,
 	label {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		color: $color__text-light;

--- a/modern-business/sass/site/secondary/_widgets.scss
+++ b/modern-business/sass/site/secondary/_widgets.scss
@@ -35,7 +35,7 @@
 
 		li {
 			color: $color__text-light;
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: 700;
 			line-height: $font__line-height-heading;
@@ -50,7 +50,7 @@
 .widget_tag_cloud {
 
 	.tagcloud {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 	}
 }

--- a/modern-business/sass/site/secondary/_widgets.scss
+++ b/modern-business/sass/site/secondary/_widgets.scss
@@ -35,6 +35,7 @@
 
 		li {
 			color: $color__text-light;
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: 700;
@@ -50,6 +51,7 @@
 .widget_tag_cloud {
 
 	.tagcloud {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 	}

--- a/modern-business/sass/typography/_copy.scss
+++ b/modern-business/sass/typography/_copy.scss
@@ -21,6 +21,7 @@ blockquote {
 	cite {
 		font-size: $font__size-xs;
 		font-style: normal;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 	}
 }

--- a/modern-business/sass/typography/_copy.scss
+++ b/modern-business/sass/typography/_copy.scss
@@ -21,7 +21,7 @@ blockquote {
 	cite {
 		font-size: $font__size-xs;
 		font-style: normal;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 	}
 }
 

--- a/modern-business/sass/typography/_headings.scss
+++ b/modern-business/sass/typography/_headings.scss
@@ -26,6 +26,7 @@ h3,
 h4,
 h5,
 h6 {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 }
 
@@ -55,6 +56,7 @@ h6 {
 }
 
 .page-title {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 

--- a/modern-business/sass/typography/_headings.scss
+++ b/modern-business/sass/typography/_headings.scss
@@ -26,7 +26,7 @@ h3,
 h4,
 h5,
 h6 {
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 }
 
 .main-navigation,
@@ -55,7 +55,7 @@ h6 {
 }
 
 .page-title {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 .site-branding,

--- a/modern-business/sass/typography/_typography.scss
+++ b/modern-business/sass/typography/_typography.scss
@@ -7,7 +7,7 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	color: $color__text-main;
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 	font-weight: 300;
 	font-size: 1em;
 	line-height: $font__line-height-body;
@@ -21,7 +21,7 @@ select,
 optgroup,
 textarea {
 	color: $color__text-main;
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 	font-weight: 300;
 	line-height: $font__line-height-body;
 	text-rendering: optimizeLegibility;

--- a/modern-business/sass/typography/_typography.scss
+++ b/modern-business/sass/typography/_typography.scss
@@ -7,6 +7,7 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	color: $color__text-main;
+	font-family: $font__body;
 	font-family: var(--font-base, $font__body);
 	font-weight: 300;
 	font-size: 1em;
@@ -21,6 +22,7 @@ select,
 optgroup,
 textarea {
 	color: $color__text-main;
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 	font-weight: 300;
 	line-height: $font__line-height-body;

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -104,6 +104,7 @@ body {
 
 body {
 	font-size: $font__size_base;
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 	line-height: $font__line-height-body;
 	color: $color__text-main;
@@ -136,6 +137,7 @@ h3,
 h4,
 h5,
 h6 {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 	font-weight: 700;
 	line-height: $font__line-height-heading;
@@ -236,6 +238,7 @@ a {
 
 figcaption,
 .gallery-caption {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 	font-size: $font__size-xs;
 	line-height: 1.6;
@@ -258,6 +261,7 @@ figcaption,
 	}
 
 	.editor-post-title__input {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 300;
 		text-align: center;
@@ -272,6 +276,7 @@ figcaption,
 /** === Default Appender === */
 
 .editor-default-block-appender .editor-default-block-appender__content {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 	font-size: $font__size_base;
 }
@@ -289,6 +294,7 @@ figcaption,
 .wp-block-paragraph {
 
 	&.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xxxl;
 		line-height: 1;
@@ -300,6 +306,7 @@ figcaption,
 /** === Table === */
 
 .wp-block-table {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 }
 
@@ -557,6 +564,7 @@ figcaption,
 
 	.wp-block-button__link {
 		line-height: 1.8;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-sm;
 		font-weight: 700;
@@ -613,6 +621,7 @@ figcaption,
 	cite,
 	footer,
 	.wp-block-quote__citation {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		line-height: 1.6;
@@ -684,6 +693,7 @@ figcaption,
 	}
 
 	.wp-block-pullquote__citation {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		line-height: 1.6;
@@ -733,6 +743,7 @@ figcaption,
 /** === File === */
 
 .wp-block-file {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-headings, $font__heading);
 
 	.wp-block-file__textlink {
@@ -834,6 +845,7 @@ ul.wp-block-archives,
 
 	li {
 		color: $color__text-light;
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 		font-weight: 700;
@@ -895,6 +907,7 @@ ul.wp-block-archives,
 .wp-block-latest-comments {
 
 	.wp-block-latest-comments__comment-meta {
+		font-family: $font__heading; // for browsers without CSS custom props support
 		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 
@@ -968,7 +981,8 @@ ul.wp-block-archives,
 .wp-caption {
 	dd {
 		color: $color__text-light;
- 		font-size: $font__size-xs;
+		font-size: $font__size-xs;
+		font-family: $font__heading; // for browsers without CSS custom props support
  		font-family: var(--font-headings, $font__heading);
  		line-height: $font__line-height-pre;
  		margin: 0;
@@ -987,6 +1001,7 @@ ul.wp-block-archives,
 		border-left: 2px solid $color__link;
 
 		cite {
+			font-family: $font__heading; // for browsers without CSS custom props support
 			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xs;
 			font-style: normal;

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -104,7 +104,7 @@ body {
 
 body {
 	font-size: $font__size_base;
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 	line-height: $font__line-height-body;
 	color: $color__text-main;
 }
@@ -136,7 +136,7 @@ h3,
 h4,
 h5,
 h6 {
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 	font-weight: 700;
 	line-height: $font__line-height-heading;
 	margin-top: 2rem;
@@ -236,7 +236,7 @@ a {
 
 figcaption,
 .gallery-caption {
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 	font-size: $font__size-xs;
 	line-height: 1.6;
 	color: $color__text-light;
@@ -258,7 +258,7 @@ figcaption,
 	}
 
 	.editor-post-title__input {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 300;
 		text-align: center;
 		font-size: $font__size-lg;
@@ -272,7 +272,7 @@ figcaption,
 /** === Default Appender === */
 
 .editor-default-block-appender .editor-default-block-appender__content {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 	font-size: $font__size_base;
 }
 
@@ -289,7 +289,7 @@ figcaption,
 .wp-block-paragraph {
 
 	&.has-drop-cap:not(:focus)::first-letter {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xxxl;
 		line-height: 1;
 		font-weight: 700;
@@ -300,7 +300,7 @@ figcaption,
 /** === Table === */
 
 .wp-block-table {
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 }
 
 /** === Cover === */
@@ -557,7 +557,7 @@ figcaption,
 
 	.wp-block-button__link {
 		line-height: 1.8;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-sm;
 		font-weight: 700;
 	}
@@ -613,7 +613,7 @@ figcaption,
 	cite,
 	footer,
 	.wp-block-quote__citation {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		line-height: 1.6;
 		color: $color__text-light;
@@ -684,7 +684,7 @@ figcaption,
 	}
 
 	.wp-block-pullquote__citation {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: $font__size-xs;
 		line-height: 1.6;
 		text-transform: none;
@@ -733,7 +733,7 @@ figcaption,
 /** === File === */
 
 .wp-block-file {
-	font-family: $font__heading;
+	font-family: var(--font-headings, $font__heading);
 
 	.wp-block-file__textlink {
 		text-decoration: underline;
@@ -834,7 +834,7 @@ ul.wp-block-archives,
 
 	li {
 		color: $color__text-light;
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 		font-weight: 700;
 		line-height: $font__line-height-heading;
@@ -895,7 +895,7 @@ ul.wp-block-archives,
 .wp-block-latest-comments {
 
 	.wp-block-latest-comments__comment-meta {
-		font-family: $font__heading;
+		font-family: var(--font-headings, $font__heading);
 		font-weight: 700;
 
 		.wp-block-latest-comments__comment-date {
@@ -969,7 +969,7 @@ ul.wp-block-archives,
 	dd {
 		color: $color__text-light;
  		font-size: $font__size-xs;
- 		font-family: $font__heading;
+ 		font-family: var(--font-headings, $font__heading);
  		line-height: $font__line-height-pre;
  		margin: 0;
  		padding: ( $size__spacing-unit * .5 );
@@ -987,7 +987,7 @@ ul.wp-block-archives,
 		border-left: 2px solid $color__link;
 
 		cite {
-			font-family: $font__heading;
+			font-family: var(--font-headings, $font__heading);
 			font-size: $font__size-xs;
 			font-style: normal;
 			line-height: 1.6;

--- a/modern-business/style-jetpack.scss
+++ b/modern-business/style-jetpack.scss
@@ -11,6 +11,7 @@
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
 	background: $color__background-button;
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 
@@ -24,16 +25,19 @@
 .entry div.sharedaddy h3.sd-title,
 .entry h3.sd-title,
 .entry #jp-relatedposts h3.jp-relatedposts-headline {
+	font-family: $font__heading; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__heading);
 }
 
 .entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 
@@ -51,6 +55,7 @@
 
 /* Authors Widget */
 .widget_authors > ul > li > a {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 
@@ -60,11 +65,13 @@
 
 /* EU cookie law */
 .widget_eu_cookie_law_widget #eu-cookie-law {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 
 /* RSS Links */
 .widget_rss_links li {
+	font-family: $font__body; // for browsers without CSS custom props support
 	font-family: var(--font-base, $font__body);
 }
 

--- a/modern-business/style-jetpack.scss
+++ b/modern-business/style-jetpack.scss
@@ -11,7 +11,7 @@
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
 	background: $color__background-button;
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 /**
@@ -24,17 +24,17 @@
 .entry div.sharedaddy h3.sd-title,
 .entry h3.sd-title,
 .entry #jp-relatedposts h3.jp-relatedposts-headline {
-	font-family: $font__heading;
+	font-family: var(--font-base, $font__heading);
 }
 
 .entry #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title,
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
 .entry #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 /**
@@ -51,7 +51,7 @@
 
 /* Authors Widget */
 .widget_authors > ul > li > a {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 /* Display WordPress Posts */
@@ -60,12 +60,12 @@
 
 /* EU cookie law */
 .widget_eu_cookie_law_widget #eu-cookie-law {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 /* RSS Links */
 .widget_rss_links li {
-	font-family: $font__body;
+	font-family: var(--font-base, $font__body);
 }
 
 /**


### PR DESCRIPTION
This adds CSS custom properties for `font-family` using the existing font as a _variable fallback_ for when the custom property is not defined.

Note that:

- I've only modified SCSS files. I'm assuming the CSS ones are generated.
- I've left a few cases untouched because they didn't use `$font__heading` or `$font__body`, but other variables such as `$font__pre` or `$font__code`. We could add support for them anyway as they'll fall back to the previous value.
- ff3d576 adds a _browser fallback_ for those that don't support custom properties.

The theme should still work as expected with this code.