### PR TITLE
Modern Business - FSE - align add block button to right on template editor to stop if conflicting with centred content

### DIFF
--- a/modern-business/style-editor.css
+++ b/modern-business/style-editor.css
@@ -2002,3 +2002,14 @@ ul.wp-block-archives li ul,
 .wp-block-jetpack-business-hours dd {
   margin: 0;
 }
+
+/** Align the add block button to right for FSE template editing */
+.site-footer .block-editor-block-list__block > .block-editor-block-list__insertion-point,
+.site-header .block-editor-block-list__block > .block-editor-block-list__insertion-point {
+  top: 0;
+}
+
+.site-footer .block-editor-block-list__insertion-point-inserter,
+.site-header .block-editor-block-list__insertion-point-inserter {
+  justify-content: flex-end;
+}

--- a/modern-business/style-editor.scss
+++ b/modern-business/style-editor.scss
@@ -1040,3 +1040,15 @@ ul.wp-block-archives,
 		margin: 0;
 	}
 }
+
+/** Align the add block button to right for FSE template editing */
+.site-footer,
+.site-header {
+	.block-editor-block-list__block > .block-editor-block-list__insertion-point {
+    	top: 0;
+  	}
+
+  	.block-editor-block-list__insertion-point-inserter {
+    	justify-content: flex-end;
+  	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Align the add block button to the right and drop down slightly when editing FSE template to prevent it conflicting with block selection now we have reduced block margins

#### Testing

* Build the theme and copy to your FSE test environment
* Edit the header and footer templates, but and check that the Site Title & Site Description blocks in particular are easy to select
* Also check that the Add Block floating button is still accessible to the right when needed

**Before**

![before-button](https://user-images.githubusercontent.com/3629020/63139702-51d09500-c033-11e9-986f-60a750a3e538.gif)

**After**

![after-button](https://user-images.githubusercontent.com/3629020/63139674-40878880-c033-11e9-94ee-82a5684ea742.gif)

#### Related issue(s):
Part of fix for https://github.com/Automattic/wp-calypso/issues/35421