### PR TITLE
Varia: Update Cover Block default background-color and text color 

### DIFF
--- a/brompton/sass/_config-child-theme-deep.scss
+++ b/brompton/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 18 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{18 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/brompton/sass/_config-child-theme-deep.scss
+++ b/brompton/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 18 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/coutoire/sass/_config-child-theme-deep.scss
+++ b/coutoire/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/coutoire/sass/_config-child-theme-deep.scss
+++ b/coutoire/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/exford/sass/_config-child-theme-deep.scss
+++ b/exford/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/exford/sass/_config-child-theme-deep.scss
+++ b/exford/sass/_config-child-theme-deep.scss
@@ -188,7 +188,11 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
+	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/hever/sass/_config-child-theme-deep.scss
+++ b/hever/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/hever/sass/_config-child-theme-deep.scss
+++ b/hever/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/leven/sass/_config-child-theme-deep.scss
+++ b/leven/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/leven/sass/_config-child-theme-deep.scss
+++ b/leven/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/morden/sass/_config-child-theme-deep.scss
+++ b/morden/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/morden/sass/_config-child-theme-deep.scss
+++ b/morden/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/redhill/sass/_config-child-theme-deep.scss
+++ b/redhill/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 18 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{18 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/redhill/sass/_config-child-theme-deep.scss
+++ b/redhill/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 18 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/rockfield/sass/_config-child-theme-deep.scss
+++ b/rockfield/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": 90vh,
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/stow/sass/_config-child-theme-deep.scss
+++ b/stow/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/stow/sass/_config-child-theme-deep.scss
+++ b/stow/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/stratford/sass/_config-child-theme-deep.scss
+++ b/stratford/sass/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
+		"background": #{map-deep-get($config-global, "color", "foreground", "default")},
+	)
 );
 
 /**

--- a/stratford/sass/_config-child-theme-deep.scss
+++ b/stratford/sass/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "background", "default")},
 		"background": #{map-deep-get($config-global, "color", "foreground", "default")},

--- a/varia/sass/blocks/cover/_config.scss
+++ b/varia/sass/blocks/cover/_config.scss
@@ -3,5 +3,9 @@
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "white")},
+		"background": #{map-deep-get($config-global, "color", "black")},
+	)
 );
 

--- a/varia/sass/blocks/cover/_config.scss
+++ b/varia/sass/blocks/cover/_config.scss
@@ -2,7 +2,7 @@
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "white")},
 		"background": #{map-deep-get($config-global, "color", "black")},

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -7,7 +7,8 @@
 
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
-	.wp-block-cover-text {
+	.wp-block-cover-text,
+	.block-editor-block-list__block {
 		color: #{map-deep-get($config-cover, "color", "foreground")};
 
 		a {

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -1,13 +1,14 @@
 .wp-block-cover,
 .wp-block-cover-image {
 
-	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
+	background-color: #{map-deep-get($config-cover, "color", "background")};
+	color: #{map-deep-get($config-cover, "color", "foreground")};
 	min-height: #{map-deep-get($config-cover, "height")};
 
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {
-		color: #{map-deep-get($config-global, "color", "background", "default")};
+		color: #{map-deep-get($config-cover, "color", "foreground")};
 
 		a {
 			color: currentColor;

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -1,14 +1,14 @@
 .wp-block-cover,
 .wp-block-cover-image {
 
-	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
+	background-color: #{map-deep-get($config-cover, "color", "background")};
 	min-height: #{map-deep-get($config-cover, "height")};
 	margin: inherit;
 
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {
-		color: #{map-deep-get($config-global, "color", "background", "default")};
+		color: #{map-deep-get($config-cover, "color", "foreground")};
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
 

--- a/varia/sass/child-theme/_config-child-theme-deep.scss
+++ b/varia/sass/child-theme/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "white")},
 		"background": #{map-deep-get($config-global, "color", "black")},

--- a/varia/sass/child-theme/_config-child-theme-deep.scss
+++ b/varia/sass/child-theme/_config-child-theme-deep.scss
@@ -189,6 +189,10 @@ $config-button: (
  */
 $config-cover: (
 	"height": calc( 15 * #{map-deep-get($config-global, "spacing", "vertical")} ),
+	"color": (
+		"foreground": #{map-deep-get($config-global, "color", "white")},
+		"background": #{map-deep-get($config-global, "color", "black")},
+	)
 );
 
 /**

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -283,7 +283,8 @@ object {
 
 .wp-block-cover,
 .wp-block-cover-image {
-	background-color: #444444;
+	background-color: black;
+	color: white;
 	min-height: 480px;
 	/* Treating H2 separately to account for legacy /core styles */
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -292,18 +292,22 @@ object {
 .wp-block-cover .wp-block-cover__inner-container,
 .wp-block-cover .wp-block-cover-image-text,
 .wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
-.wp-block-cover-image .wp-block-cover-text {
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
 	color: white;
 }
 
 .wp-block-cover .wp-block-cover__inner-container a,
 .wp-block-cover .wp-block-cover-image-text a,
 .wp-block-cover .wp-block-cover-text a,
+.wp-block-cover .block-editor-block-list__block a,
 .wp-block-cover-image .wp-block-cover__inner-container a,
 .wp-block-cover-image .wp-block-cover-image-text a,
-.wp-block-cover-image .wp-block-cover-text a {
+.wp-block-cover-image .wp-block-cover-text a,
+.wp-block-cover-image .block-editor-block-list__block a {
 	color: currentColor;
 }
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -284,7 +284,7 @@ object {
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: #444444;
-	min-height: calc( 15 * 32px);
+	min-height: 480px;
 	/* Treating H2 separately to account for legacy /core styles */
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1172,7 +1172,7 @@ input.has-focus[type="submit"],
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
-	min-height: calc( 15 * 32px);
+	min-height: 480px;
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */
 	/**

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1171,7 +1171,7 @@ input.has-focus[type="submit"],
 
 .wp-block-cover,
 .wp-block-cover-image {
-	background-color: #444444;
+	background-color: black;
 	min-height: calc( 15 * 32px);
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */

--- a/varia/style.css
+++ b/varia/style.css
@@ -1172,7 +1172,7 @@ input.has-focus[type="submit"],
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
-	min-height: calc( 15 * 32px);
+	min-height: 480px;
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */
 	/**

--- a/varia/style.css
+++ b/varia/style.css
@@ -1171,7 +1171,7 @@ input.has-focus[type="submit"],
 
 .wp-block-cover,
 .wp-block-cover-image {
-	background-color: #444444;
+	background-color: black;
 	min-height: calc( 15 * 32px);
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Set default Cover Block colors to `background: #000` and `color: #FFF`. 
- Remove `calc()` from Cover Block height so we get `height: 480px` instead of `height: calc(15 * 32px)`.
- Update Cover Block config file to include background and foreground color overrides for easier child-theming
- Updates the `$config-cover` array in starter child-theme to include the new colors variables. 
- Updates the `$config-cover` array for all launched Varia child themes to prevent errors when recompiling after this merges.

#### Related issue(s):

Fixes: #1274 