### PR TITLE
Full Site Editing: Add the Header and Footer template parts to the Varia front end

### DIFF
--- a/varia/footer.php
+++ b/varia/footer.php
@@ -16,25 +16,33 @@
 	</div><!-- #content -->
 
 	<footer id="colophon" class="site-footer responsive-max-width">
-		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 		<?php
-		if ( function_exists( 'the_privacy_policy_link' ) ) {
-			the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
-		}
+			if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content.
+				$template = new A8C\FSE\WP_Template();
+				$template->output_template_content( A8C\FSE\WP_Template::FOOTER );
+			else : // Otherwise we'll fallback to the default Varia footer below.
+				get_template_part( 'template-parts/footer/footer', 'widgets' );
+				
+				if ( function_exists( 'the_privacy_policy_link' ) ) {
+					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+				}
+
+				if ( has_nav_menu( 'menu-2' ) ) : ?>
+					<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'varia' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'menu-2',
+								'menu_class'     => 'footer-menu',
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .footer-navigation -->
+				<?php endif;
+			endif;
 		?>
-		<?php if ( has_nav_menu( 'menu-2' ) ) : ?>
-			<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'varia' ); ?>">
-				<?php
-				wp_nav_menu(
-					array(
-						'theme_location' => 'menu-2',
-						'menu_class'     => 'footer-menu',
-						'depth'          => 1,
-					)
-				);
-				?>
-			</nav><!-- .footer-navigation -->
-		<?php endif; ?>
+
 		<div class="site-info">
 			<?php $blog_info = get_bloginfo( 'name' ); ?>
 			<?php if ( ! empty( $blog_info ) ) : ?>

--- a/varia/header.php
+++ b/varia/header.php
@@ -23,6 +23,17 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 
+	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
+
+		<header id="masthead" class="site-header responsive-max-width">
+			<?php
+				$template = new A8C\FSE\WP_Template();
+				$template->output_template_content( A8C\FSE\WP_Template::HEADER );
+			?>
+		</header>
+
+	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>
+
 		<header id="masthead" class="site-header responsive-max-width">
 
 			<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
@@ -66,5 +77,7 @@
 			<?php endif; ?>
 
 		</header><!-- #masthead -->
+
+	<?php endif; ?>
 
 	<div id="content" class="site-content">


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

As it was done for Modern Business, add the Full Site Editing template parts to the header and footer of the Varia theme.
They should be also inherited by the Varia children themes, such as Maywood, unless they overwrite the `header.php` and `footer.php` files.

#### Testing instructions

* Apply D31833-code and sandbox the API.
* Apply https://github.com/Automattic/wp-calypso/pull/35698 on an FSE site.
* On that site, change theme from Modern Business to Varia.
* Edit a page and make sure the template parts are still there in the editor.
* Check edit.php?post_type=wp_template and make sure that there are new Header and Footer template parts (although, virtually identical to the Modern Business ones).
* View a page in the front end. It should have the FSE Header and Footer instead of the original Varia template parts.