### PR TITLE
Varia: Prevent list item markers from overflowing parent wrappers.

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Karla", Arial, sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/alves/style.css
+++ b/alves/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Karla", Arial, sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1603,16 +1603,17 @@ img {
 ul,
 ol {
 	font-family: "Work Sans", sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1603,16 +1603,17 @@ img {
 ul,
 ol {
 	font-family: "Work Sans", sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Source Serif Pro", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/exford/style.css
+++ b/exford/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Source Serif Pro", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/hever/style.css
+++ b/hever/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/leven/style.css
+++ b/leven/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/morden/style.css
+++ b/morden/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Lora, Baskerville, Georgia, Times, serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: Lora, Baskerville, Georgia, Times, serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Source Sans Pro", Arial, sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/stow/style.css
+++ b/stow/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Source Sans Pro", Arial, sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Lato", sans-serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1604,16 +1604,17 @@ img {
 ul,
 ol {
 	font-family: "Lato", sans-serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -1,16 +1,17 @@
 ul,
 ol {
 	font-family: #{map-deep-get($config-list, "font", "family")};
+	list-style-position: inside;
 	margin: 0 0 0 #{map-deep-get($config-global, "spacing", "unit")};
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 li > ul,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1563,6 +1563,7 @@ img {
 ul,
 ol {
 	font-family: serif;
+	list-style-position: inside;
 	margin: 0 16px 0 0;
 	padding: 0;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -1563,16 +1563,17 @@ img {
 ul,
 ol {
 	font-family: serif;
+	list-style-position: inside;
 	margin: 0 0 0 16px;
 	padding: 0;
 }
 
 ul {
-	list-style: disc;
+	list-style-type: disc;
 }
 
 ol {
-	list-style: decimal;
+	list-style-type: decimal;
 }
 
 dt {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Move list item markers “inside” list item element to prevent it from overflowing the parent wrappers.

**Before:**
![image](https://user-images.githubusercontent.com/709581/63625117-a2646700-c5cc-11e9-8a2f-1b1f99dd76ce.png)

**After:**
![image](https://user-images.githubusercontent.com/709581/63625042-692bf700-c5cc-11e9-9232-76f7292a434d.png)

#### Related issue(s):

Fixes: #1306