### PR TITLE
Varia: Add basic styling support for Full Site Editing

### DIFF
--- a/varia/footer.php
+++ b/varia/footer.php
@@ -15,7 +15,7 @@
 
 	</div><!-- #content -->
 
-	<footer id="colophon" class="site-footer responsive-max-width">
+	<footer id="colophon" class="site-footer <?php echo class_exists( 'A8C\FSE\WP_Template' ) ? 'entry-content' : 'responsive-max-width'; ?>">
 		<?php
 			if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content.
 				$template = new A8C\FSE\WP_Template();

--- a/varia/header.php
+++ b/varia/header.php
@@ -25,7 +25,7 @@
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
-		<header id="masthead" class="site-header responsive-max-width">
+		<header id="masthead" class="site-header entry-content">
 			<?php
 				$template = new A8C\FSE\WP_Template();
 				$template->output_template_content( A8C\FSE\WP_Template::HEADER );

--- a/varia/header.php
+++ b/varia/header.php
@@ -25,13 +25,11 @@
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
-		<header id="masthead" class="site-header entry-content">
-			<div class="site-branding">
-				<?php
-					$template = new A8C\FSE\WP_Template();
-					$template->output_template_content( A8C\FSE\WP_Template::HEADER );
-				?>
-			</div>
+		<header id="masthead" class="site-header site-branding entry-content">
+			<?php
+				$template = new A8C\FSE\WP_Template();
+				$template->output_template_content( A8C\FSE\WP_Template::HEADER );
+			?>
 		</header>
 
 	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>

--- a/varia/header.php
+++ b/varia/header.php
@@ -26,10 +26,12 @@
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
 		<header id="masthead" class="site-header entry-content">
-			<?php
-				$template = new A8C\FSE\WP_Template();
-				$template->output_template_content( A8C\FSE\WP_Template::HEADER );
-			?>
+			<div class="site-branding">
+				<?php
+					$template = new A8C\FSE\WP_Template();
+					$template->output_template_content( A8C\FSE\WP_Template::HEADER );
+				?>
+			</div>
 		</header>
 
 	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -1,0 +1,2 @@
+@import "../components/header/header";
+@import "../components/footer/footer";

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -5,11 +5,20 @@
 	.site-header,
 	.site-footer {
 		padding: #{map-deep-get($config-global, "spacing", "unit")};
-	
+
 		@include media(mobile) {
 			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 		}
-	}	
+	}
+}
+
+.a8c-template-editor {
+	.wp-block:not(.is-selected) [data-block] {
+		margin-bottom: 14px;
+	}
+	.wp-block:not(:first-child):not(.is-selected) [data-block] {
+		margin-top: 14px;
+	}
 }
 
 .site-header {
@@ -17,16 +26,16 @@
 		font-size: 21.6px;
 		font-weight: 700;
 		text-decoration: underline;
-	
+
 		&:focus {
 			color: #{map-deep-get($config-header, "branding", "color", "link")};
 		}
 	}
-	
+
 	.site-description {
 		font-size: 15px;
 	}
-	
+
 	.main-navigation a {
 		font-size: 21.6px;
 	}

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -31,3 +31,9 @@
 		font-size: 21.6px;
 	}
 }
+
+.site-footer {
+	@include media(tablet) {
+		display: block;
+	}
+}

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -1,2 +1,22 @@
 @import "../components/header/header";
 @import "../components/footer/footer";
+
+.site-header {
+	.site-title {
+		font-size: 21.6px;
+		font-weight: 700;
+		text-decoration: underline;
+	
+		&:focus {
+			color: #{map-deep-get($config-header, "branding", "color", "link")};
+		}
+	}
+	
+	.site-description {
+		font-size: 15px;
+	}
+	
+	.main-navigation a {
+		font-size: 21.6px;
+	}
+}

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -4,10 +4,10 @@
 .template-block {
 	.site-header,
 	.site-footer {
-		padding: map-deep-get($config-global, "spacing", "unit") 0;
+		padding: #{map-deep-get($config-global, "spacing", "unit")} 0;
 	
 		@include media(mobile) {
-			padding: map-deep-get($config-global, "spacing", "vertical") 0;
+			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 		}
 	}	
 }
@@ -35,5 +35,26 @@
 .site-footer {
 	@include media(tablet) {
 		display: block;
+	}
+}
+
+.main-navigation {
+	@include media(mobile-only) {
+		background-color: #{map-deep-get($config-button, "color", "background")};
+		border-radius: #{map-deep-get($config-button, "border-radius")};
+		color: #{map-deep-get($config-button, "color", "text")};
+		display: inline-block;
+		font-family: #{map-deep-get($config-button, "font", "family")};
+		font-size: 18px;
+		font-weight: #{map-deep-get($config-button, "font", "weight")};
+		line-height: #{map-deep-get($config-button, "font", "line-height")};
+		padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
+
+		&:before {
+			content: "Menu";
+		}
+		&:after {
+			content: "+";
+		}
 	}
 }

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -1,6 +1,17 @@
 @import "../components/header/header";
 @import "../components/footer/footer";
 
+.template-block {
+	.site-header,
+	.site-footer {
+		padding: map-deep-get($config-global, "spacing", "unit") 0;
+	
+		@include media(mobile) {
+			padding: map-deep-get($config-global, "spacing", "vertical") 0;
+		}
+	}	
+}
+
 .site-header {
 	.site-title {
 		font-size: 21.6px;

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -4,7 +4,7 @@
 .template-block {
 	.site-header,
 	.site-footer {
-		padding: #{map-deep-get($config-global, "spacing", "unit")} 0;
+		padding: #{map-deep-get($config-global, "spacing", "unit")};
 	
 		@include media(mobile) {
 			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1231,3 +1231,9 @@ table th,
 .site-header .main-navigation a {
 	font-size: 21.6px;
 }
+
+@media only screen and (min-width: 640px) {
+	.site-footer {
+		display: block;
+	}
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1201,3 +1201,21 @@ table th,
 .footer-navigation .footer-menu a:hover {
 	color: indigo;
 }
+
+.site-header .site-title {
+	font-size: 21.6px;
+	font-weight: 700;
+	text-decoration: underline;
+}
+
+.site-header .site-title:focus {
+	color: blue;
+}
+
+.site-header .site-description {
+	font-size: 15px;
+}
+
+.site-header .main-navigation a {
+	font-size: 21.6px;
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1204,7 +1204,7 @@ table th,
 
 .template-block .site-header,
 .template-block .site-footer {
-	padding: 16px 0;
+	padding: 16px;
 }
 
 @media only screen and (min-width: 560px) {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1202,6 +1202,18 @@ table th,
 	color: indigo;
 }
 
+.template-block .site-header,
+.template-block .site-footer {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .site-header,
+	.template-block .site-footer {
+		padding: 32px 0;
+	}
+}
+
 .site-header .site-title {
 	font-size: 21.6px;
 	font-weight: 700;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1237,3 +1237,23 @@ table th,
 		display: block;
 	}
 }
+
+@media only screen and (max-width: 559px) {
+	.main-navigation {
+		background-color: blue;
+		border-radius: 9px;
+		color: white;
+		display: inline-block;
+		font-family: sans-serif;
+		font-size: 18px;
+		font-weight: bold;
+		line-height: 1;
+		padding: 16px 16px;
+	}
+	.main-navigation:before {
+		content: "Menu";
+	}
+	.main-navigation:after {
+		content: "+";
+	}
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1214,6 +1214,14 @@ table th,
 	}
 }
 
+.a8c-template-editor .wp-block:not(.is-selected) [data-block] {
+	margin-bottom: 14px;
+}
+
+.a8c-template-editor .wp-block:not(:first-child):not(.is-selected) [data-block] {
+	margin-top: 14px;
+}
+
 .site-header .site-title {
 	font-size: 21.6px;
 	font-weight: 700;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -823,4 +824,380 @@ table th,
 
 .padding-left-default {
 	padding-left: 32px !important;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.site-branding {
+	color: #444444;
+}
+
+.site-title {
+	color: blue;
+	font-family: sans-serif;
+	font-size: 1.2rem;
+	letter-spacing: normal;
+	line-height: 1;
+}
+
+.site-title a {
+	color: currentColor;
+	font-weight: bold;
+}
+
+.site-title a:link, .site-title a:visited {
+	color: currentColor;
+}
+
+.site-title a:hover {
+	color: indigo;
+}
+
+.site-description {
+	color: currentColor;
+	font-family: serif;
+	font-size: 0.83333rem;
+}
+
+.main-navigation {
+	color: #444444;
+}
+
+.main-navigation > div {
+	display: none;
+}
+
+.main-navigation #toggle-menu {
+	display: inline-block;
+	margin: 0;
+}
+
+.main-navigation #toggle:checked ~ div {
+	display: block;
+}
+
+.main-navigation #toggle:focus + #toggle-menu {
+	background-color: indigo;
+	outline: inherit;
+	text-decoration: underline;
+}
+
+.main-navigation .dropdown-icon.close {
+	display: none;
+}
+
+.main-navigation #toggle:checked + #toggle-menu .open {
+	display: none;
+}
+
+.main-navigation #toggle:checked + #toggle-menu .close {
+	display: inline;
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation > div {
+		display: block;
+	}
+	.main-navigation #toggle-menu {
+		display: none;
+	}
+	.main-navigation > div > ul > li > ul {
+		display: none;
+	}
+}
+
+.main-navigation > div > ul {
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	max-width: none;
+	position: relative;
+	/* Sub-menus Flyout */
+}
+
+.main-navigation > div > ul li {
+	display: block;
+	position: relative;
+	width: 100%;
+	z-index: 1;
+}
+
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation > div > ul li {
+		display: inherit;
+		width: inherit;
+		/* Submenu display */
+	}
+	.main-navigation > div > ul li:hover > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li ul:hover,
+	.main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+	.main-navigation > div > ul li:hover > ul,
+	.main-navigation > div > ul li:focus-within > ul,
+	.main-navigation > div > ul li ul:hover,
+	.main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation > div > ul > li > a {
+		line-height: 1;
+	}
+	.main-navigation > div > ul > li > a:before, .main-navigation > div > ul > li > a:after {
+		content: '';
+		display: block;
+		height: 0;
+		width: 0;
+	}
+	.main-navigation > div > ul > li > a:before {
+		margin-bottom: -0.12em;
+	}
+	.main-navigation > div > ul > li > a:after {
+		margin-top: -0.11em;
+	}
+	.main-navigation > div > ul > li:first-of-type > a {
+		padding-left: 0;
+	}
+	.main-navigation > div > ul > li:last-of-type > a {
+		padding-right: 0;
+	}
+}
+
+.main-navigation > div > ul > li > .sub-menu {
+	margin: 0;
+	position: relative;
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation > div > ul > li > .sub-menu {
+		background: white;
+		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
+		left: 0;
+		top: 100%;
+		min-width: max-content;
+		opacity: 0;
+		position: absolute;
+		transition: all 0.5s ease;
+		visibility: hidden;
+	}
+}
+
+.main-navigation > div > ul > li > .sub-menu .sub-menu {
+	width: 100%;
+}
+
+.main-navigation a {
+	color: blue;
+	display: block;
+	font-family: sans-serif;
+	font-size: 1.2rem;
+	font-weight: bold;
+	padding: 8px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation a {
+		padding: 16px;
+	}
+}
+
+.main-navigation a:link, .main-navigation a:visited {
+	color: blue;
+}
+
+.main-navigation a:hover {
+	color: indigo;
+}
+
+.main-navigation .sub-menu {
+	list-style: none;
+	margin-left: 0;
+	/* Reset the counter for each UL */
+	counter-reset: nested-list;
+}
+
+.main-navigation .sub-menu .menu-item a {
+	padding-top: 8px;
+	padding-bottom: 8px;
+}
+
+.main-navigation .sub-menu .menu-item a::before {
+	/* Increment the dashes */
+	counter-increment: nested-list;
+	/* Insert dashes with spaces in between */
+	content: "– " counters(nested-list, "– ", none);
+}
+
+@media only screen and (min-width: 560px) {
+	.main-navigation > div > ul > .menu-item-has-children > a::after {
+		content: "\00a0\25BC";
+		display: inline-block;
+		font-size: 0.69444rem;
+		height: inherit;
+		width: inherit;
+	}
+}
+
+.main-navigation .hide-visually {
+	position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0 !important;
+	border: 0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+}
+
+.social-navigation > div > ul {
+	align-content: center;
+	display: flex;
+	list-style: none;
+	margin: 0;
+}
+
+.social-navigation > div > ul > li:first-of-type > a {
+	padding-left: 0;
+}
+
+.social-navigation > div > ul > li:last-of-type > a {
+	padding-right: 0;
+}
+
+.social-navigation a {
+	color: blue;
+	display: inline-block;
+	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
+}
+
+.social-navigation a:hover {
+	color: indigo;
+}
+
+.social-navigation svg {
+	fill: currentColor;
+	vertical-align: middle;
+}
+
+.site-footer {
+	overflow: hidden;
+}
+
+@media only screen and (min-width: 640px) {
+	.site-footer {
+		align-items: flex-end;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+	}
+}
+
+.site-info {
+	color: #767676;
+	font-family: sans-serif;
+	font-size: 0.83333rem;
+}
+
+@media only screen and (min-width: 640px) {
+	.site-info {
+		order: 1;
+		flex: 1 0 50%;
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
+.site-info .site-name {
+	font-weight: bold;
+}
+
+.site-info a {
+	color: currentColor;
+}
+
+.site-info a:link, .site-info a:visited {
+	color: currentColor;
+}
+
+.site-info a:hover {
+	color: indigo;
+}
+
+.footer-navigation {
+	display: inline;
+}
+
+@media only screen and (min-width: 640px) {
+	.footer-navigation {
+		flex: 1 0 50%;
+		order: 2;
+		margin-top: 0;
+		margin-bottom: 0;
+		text-align: right;
+	}
+}
+
+.footer-navigation > div {
+	display: inline;
+}
+
+.footer-navigation .footer-menu {
+	color: #767676;
+	margin: 0;
+	padding-left: 0;
+}
+
+@media only screen and (min-width: 640px) {
+	.footer-navigation .footer-menu {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+	}
+}
+
+.footer-navigation .footer-menu > li {
+	display: inline;
+}
+
+.footer-navigation .footer-menu > li:first-of-type > a {
+	padding-left: 0;
+}
+
+.footer-navigation .footer-menu > li:last-of-type {
+	padding-right: 0;
+}
+
+.footer-navigation .footer-menu a {
+	font-family: sans-serif;
+	font-size: 0.83333rem;
+	font-weight: bold;
+	padding: 16px;
+	color: currentColor;
+}
+
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
+	color: currentColor;
+}
+
+.footer-navigation .footer-menu a:hover {
+	color: indigo;
 }

--- a/varia/style-editor.scss
+++ b/varia/style-editor.scss
@@ -28,3 +28,9 @@
  *   spacing with CSS-variables overrides
  */
 @import "sass/blocks/editor";
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "sass/full-site-editing/editor";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add the header and footer styles to `style-editor.scss`.
* Add the `.entry-content` class to the header and footer when in FSE context.
* Add some styles overrides for the FSE blocks in the header template.
* Adjust the Template block paddings.
* Stop `display: flex;` the footer to avoid incorrect positioning of the footer blocks.
* Add a responsive version of the main navigation, as featured in Varia and most Varia-based themes.

#### Screenshots and testing instructions

Please head over https://github.com/Automattic/wp-calypso/pull/35821