### PR TITLE
FSE: add fse theme support flag

### DIFF
--- a/maywood/functions.php
+++ b/maywood/functions.php
@@ -99,6 +99,9 @@ if ( ! function_exists( 'maywood_setup' ) ) :
 				),
 			)
 		);
+
+		// Enable Full Site Editing
+		add_theme_support( 'full-site-editing');
 	}
 endif;
 add_action( 'after_setup_theme', 'maywood_setup', 12 );

--- a/modern-business/functions.php
+++ b/modern-business/functions.php
@@ -63,6 +63,9 @@ if ( ! function_exists( 'modern_business_setup' ) ) :
 				),
 			)
 		);
+		
+		// Enable Full Site Editing
+		add_theme_support( 'full-site-editing');
 	}
 endif; // modern_business_setup
 add_action( 'after_setup_theme', 'modern_business_setup', 30 );

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -194,7 +194,6 @@ if ( ! function_exists( 'varia_setup' ) ) :
 
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
-		
 	}
 endif;
 add_action( 'after_setup_theme', 'varia_setup' );

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -194,6 +194,10 @@ if ( ! function_exists( 'varia_setup' ) ) :
 
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
+
+		// Enable Full Site Editing
+		add_theme_support( 'full-site-editing');
+		
 	}
 endif;
 add_action( 'after_setup_theme', 'varia_setup' );

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -194,9 +194,6 @@ if ( ! function_exists( 'varia_setup' ) ) :
 
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
-
-		// Enable Full Site Editing
-		add_theme_support( 'full-site-editing');
 		
 	}
 endif;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add add_theme_support( 'full-site-editing') to each of the FSE themes so this can be used instead of a whitelist in the FSE plugin

Testing instructions at https://github.com/Automattic/wp-calypso/pull/35856