### PR TITLE
Full Site Editing / Varia, Maywood: Adjust the Content block vertical margins

### DIFF
--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -44,3 +44,7 @@
 		}
 	}
 }
+
+.post-content__block {
+	margin-top: -36px;
+}

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1459,6 +1459,12 @@ b, strong {
 	font-size: 21.6px;
 }
 
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
+}
+
 @media only screen and (min-width: 640px) {
 	.site-footer {
 		display: block;
@@ -1535,4 +1541,8 @@ b, strong {
 	.site-footer .main-navigation .footer-menu a {
 		font-size: 13.8px;
 	}
+}
+
+.post-content__block {
+	margin-top: -36px;
 }

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -45,6 +45,12 @@
 	}
 }
 
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20; // Minimum to appear above the Template block overlay
+}
+
 .site-footer {
 	@include media(tablet) {
 		display: block;

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -48,7 +48,11 @@
 .post-content__block {
 	margin-bottom: 160px;
 	margin-top: 36px;
-	z-index: 20; // Minimum to appear above the Template block overlay
+
+	// Minimum z-index to appear above the Template block overlay.
+	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/packages/block-editor/src/components/block-list/style.scss#L495-L496
+	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/assets/stylesheets/_z-index.scss#L8
+	z-index: 20;
 }
 
 .site-footer {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1344,6 +1344,12 @@ table th,
 	font-size: 21.6px;
 }
 
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
+}
+
 @media only screen and (min-width: 640px) {
 	.site-footer {
 		display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adjust the Content block vertical margin in the editor to look as close as possible to the front end.

![Slice](https://user-images.githubusercontent.com/2070010/64032273-009bc780-cb42-11e9-9bd4-1886ac7c37eb.png)


#### Notes:

- Varia contains the defaults for all the Varia-based themes.

- The bottom margin is not exactly the same as the front end.
This is because in the front end there is the "Edit" link in that space. I think it's not worthy to go pixel perfect in this case, and so I've just picked the multiple of 32 (for the sake of it) that looked as close as possible in Maywood.

- I've added a z-index to the Content block.
This is needed because the page title frame (or, if the title was hidden, any other block's toolbar etc.) could appear _behind_ the header Template block.

- As you might notice from the screenshot, the header spacing in Maywood is not as close as it should have been.
I've decided instead to adjust the Content top margin just enough so that the page title's permalink box is aligned with the header's overlay border.
This is not just to satisfy my pedantry, but also because while the permalink box has a background color which would cover the header content and overlay, this is not the case for the actual title textarea.
Adding a background color to the title should be avoided, because then we would need to maintain it for every theme that might have a non-white background.

#### Related issue(s):

This PR is tracked by https://github.com/Automattic/wp-calypso/issues/35870

#### Testing instructions:

- Apply this PR on an FSE site with both Varia and Maywood. If needed build Varia first and then Maywood, just in case.
- Try this with both Varia and Maywood.
- Compare the front end to the page editor, and make sure the Content block vertical margins look good (or at least, look similar to the screenshot!).