### PR TITLE
Full Site Editing / Varia, Maywood: Let the Editor Align the Footer Blocks

### DIFF
--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -13,4 +13,20 @@
 			}
 		}
 	}
+
+	.site-footer {
+		.wp-block-a8c-navigation-menu {
+			@include media(tablet) {
+				margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+				margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+			}
+		}
+	}
+
+	#colophon {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: none;
+		width: 100%;
+	}
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3780,6 +3780,10 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
+.fse-enabled .site-footer {
+	display: block;
+}
+
 .fse-enabled .site-footer .main-navigation {
 	display: block;
 }
@@ -3812,4 +3816,18 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-header.entry-content .main-navigation .menu-primary-container {
 		padding: 0 32px;
 	}
+}
+
+@media only screen and (min-width: 640px) {
+	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
+		margin-bottom: 21.312px;
+		margin-top: 21.312px;
+	}
+}
+
+.fse-enabled #colophon {
+	margin-right: auto;
+	margin-left: auto;
+	max-width: none;
+	width: 100%;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3809,6 +3809,10 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
+.fse-enabled .site-footer {
+	display: block;
+}
+
 .fse-enabled .site-footer .main-navigation {
 	display: block;
 }
@@ -3841,4 +3845,18 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-header.entry-content .main-navigation .menu-primary-container {
 		padding: 0 32px;
 	}
+}
+
+@media only screen and (min-width: 640px) {
+	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
+		margin-bottom: 21.312px;
+		margin-top: 21.312px;
+	}
+}
+
+.fse-enabled #colophon {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: none;
+	width: 100%;
 }

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -1,5 +1,7 @@
 .fse-enabled {
 	.site-footer {
+		display: block;
+
 		.main-navigation {
 			@extend .footer-navigation;
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -3397,6 +3397,10 @@ img#wpstats {
  * Full Site Editing
  * - Full Site Editing overrides
  */
+.fse-enabled .site-footer {
+	display: block;
+}
+
 .fse-enabled .site-footer .main-navigation {
 	display: block;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Change the default footer layout from `flex` to `block` in order to let the editor properly position and align all blocks inside the Footer template.

As a byproduct, the site info (e.g. "MAYWOOD, A WordPress.com Website.") is not inlined with the footer navigation menu as shown in the [Maywood demo](https://maywooddemo.wordpress.com/).
This is unavoidable, unless we want to add the site info as FSE block, and let the user move it as they see fit.

| | Editor | Front End |
| - | - | - |
| Before | ![Screenshot 2019-09-02 at 15 09 09](https://user-images.githubusercontent.com/2070010/64121764-ad22b700-cd97-11e9-8868-156ffa037f66.png) | ![Screenshot 2019-09-02 at 15 09 33](https://user-images.githubusercontent.com/2070010/64121863-df341900-cd97-11e9-8de3-ad729273ca25.png) |
| After | ![Slice](https://user-images.githubusercontent.com/2070010/64121791-b7dd4c00-cd97-11e9-8665-ab54a6d529c5.png) | ![localhost_short-page_](https://user-images.githubusercontent.com/2070010/64121869-e3603680-cd97-11e9-8b30-24023daa0339.png) |

#### Testing instructions

* On an FSE site apply this PR and build both Varia and Maywood.
* Activate Maywood if needed.
* Try adding some explicitly aligned blocks (e.g. Image), and change its alignment a few times.
* Check that each change looks as expected in both editor and front end (e.g. a full block should "touch" the window borders; a wide block should be wider than "normal" blocks, if there is enough horizontal space; etc.).

#### Related issue(s):

Tracked in https://github.com/Automattic/wp-calypso/issues/35870