### PR TITLE
Full Site Editing / Maywood: Add responsive style to the FSE blocks

### DIFF
--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -1,14 +1,28 @@
 @import "../../varia/sass/full-site-editing/editor";
 
+.site-header, .site-footer {
+	.site-title {
+		font-size: 20px;
+		@include media(mobile) {
+			font-size: 24px;
+		}
+	}
+
+	.site-description {
+		font-size: 13.8px;
+		@include media(mobile) {
+			font-size: 16.6px;
+		}
+	}
+}
+
 .site-header {
 	.site-title {
-		font-size: 24px;
 		text-align: center;
 		text-decoration: none;
 	}
 
 	.site-description{
-		font-size: 16.6px;
 		text-align: center;
 	}
 
@@ -25,12 +39,13 @@
 }
 
 .site-footer {
+	.site-title {
+		font-weight: 700;
+	}
+
 	.main-navigation .footer-menu {
-		justify-content: flex-start;
-		
-		@include media(mobile) {
-			justify-content: center;
-		}
+		justify-content: center;
+
 		@include media(tablet) {
 			justify-content: flex-end;
 		}

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1492,14 +1492,32 @@ b, strong {
 	}
 }
 
+.site-header .site-title, .site-footer .site-title {
+	font-size: 20px;
+}
+
+@media only screen and (min-width: 560px) {
+	.site-header .site-title, .site-footer .site-title {
+		font-size: 24px;
+	}
+}
+
+.site-header .site-description, .site-footer .site-description {
+	font-size: 13.8px;
+}
+
+@media only screen and (min-width: 560px) {
+	.site-header .site-description, .site-footer .site-description {
+		font-size: 16.6px;
+	}
+}
+
 .site-header .site-title {
-	font-size: 24px;
 	text-align: center;
 	text-decoration: none;
 }
 
 .site-header .site-description {
-	font-size: 16.6px;
 	text-align: center;
 }
 
@@ -1516,14 +1534,12 @@ b, strong {
 	text-decoration: none;
 }
 
-.site-footer .main-navigation .footer-menu {
-	justify-content: flex-start;
+.site-footer .site-title {
+	font-weight: 700;
 }
 
-@media only screen and (min-width: 560px) {
-	.site-footer .main-navigation .footer-menu {
-		justify-content: center;
-	}
+.site-footer .main-navigation .footer-menu {
+	justify-content: center;
 }
 
 @media only screen and (min-width: 640px) {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3368,6 +3368,10 @@ img#wpstats {
  * Full Site Editing
  * - Full Site Editing overrides
  */
+.fse-enabled .site-footer {
+	display: block;
+}
+
 .fse-enabled .site-footer .main-navigation {
 	display: block;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

| Front End | Editor Before | Editor After |
| - | - | - |
| ![Screenshot 2019-09-02 at 18 41 05](https://user-images.githubusercontent.com/2070010/64129429-d3565000-cdb3-11e9-8361-aef07a0f7ec1.png)|  ![Screenshot 2019-09-02 at 18 41 14](https://user-images.githubusercontent.com/2070010/64129417-ba4d9f00-cdb3-11e9-84b7-9f68dec9ac0c.png) | ![Screenshot 2019-09-02 at 18 54 14](https://user-images.githubusercontent.com/2070010/64129432-d8b39a80-cdb3-11e9-9f39-9bc68c2acd41.png) |



#### Related issue(s):

Tracked in https://github.com/Automattic/wp-calypso/issues/35870