### PR TITLE
Varia: Fix search page title alignment

### DIFF
--- a/varia/search.php
+++ b/varia/search.php
@@ -17,7 +17,7 @@ get_header();
 
 		<?php if ( have_posts() ) : ?>
 
-			<header class="page-header">
+			<header class="page-header responsive-max-width">
 				<?php
 				printf(
 					/* translators: 1: search result title. 2: search term. */


### PR DESCRIPTION
Fixes #1375 

Before:
![localhost_8888_wordpress__s=block (1)](https://user-images.githubusercontent.com/908665/64213103-96698680-cea3-11e9-908b-b958b8fd9ea0.png)


After:
![localhost_8888_wordpress__s=block](https://user-images.githubusercontent.com/908665/64213067-72a64080-cea3-11e9-9bb7-5b955afb849c.png)
