### PR TITLE
Varia: Show full size featured image in single view

### DIFF
--- a/varia/inc/template-tags.php
+++ b/varia/inc/template-tags.php
@@ -212,7 +212,7 @@ if ( ! function_exists( 'varia_post_thumbnail' ) ) :
 		if ( is_singular() ) :
 			?>
 
-			<figure class="post-thumbnail responsive-max-width">
+			<figure class="post-thumbnail">
 				<?php the_post_thumbnail(); ?>
 			</figure><!-- .post-thumbnail -->
 


### PR DESCRIPTION
Assuming this wasn't intentional, this PR intends to fixes #1374 

**Before:**
![localhost_8888_wordpress__p=1518 (1)](https://user-images.githubusercontent.com/908665/64216056-31b42900-ceaf-11e9-8026-db07c5e4ac05.png)

**After:**
![localhost_8888_wordpress__p=1518](https://user-images.githubusercontent.com/908665/64216068-3f69ae80-ceaf-11e9-83b8-0e4da44a4678.png)
