### PR TITLE
Full Site Editing / Varia, Maywood: Update the navigation menu 

### DIFF
--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -55,6 +55,7 @@
 			text-decoration: none;
 			@include media(mobile-only) {
 				font-size: 13.8px;
+				padding: 0 8px;
 			}
 		}
 	}

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -8,7 +8,7 @@
 		width: 100%;
 
 		@include media(mobile-only) {
-			.main-navigation .menu-primary-container {
+			.main-navigation > div {
 				padding: 0 32px;
 			}
 		}
@@ -19,6 +19,11 @@
 			@include media(tablet) {
 				margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
 				margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+			}
+			@include media(mobile) {
+				.footer-menu a {
+					padding: 8px;
+				}
 			}
 		}
 	}

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1481,7 +1481,7 @@ b, strong {
 }
 
 @media only screen and (max-width: 559px) {
-	.site-footer .main-navigation .menu-primary-container {
+	.site-footer .main-navigation > div {
 		display: block;
 	}
 	.site-footer .main-navigation li {
@@ -1556,6 +1556,7 @@ b, strong {
 @media only screen and (max-width: 559px) {
 	.site-footer .main-navigation .footer-menu a {
 		font-size: 13.8px;
+		padding: 0 8px;
 	}
 }
 

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1896,23 +1896,17 @@ p.has-background {
 }
 
 hr {
-	border-bottom-color: #CCCCCC;
-	border-bottom-width: 2px;
+	border-bottom: 2px solid #CCCCCC;
 	clear: both;
 	margin-right: auto;
 	margin-left: auto;
 }
 
 hr.wp-block-separator {
-	border-bottom-color: #CCCCCC;
+	border-bottom: 2px solid #CCCCCC;
 	/**
 		 * Block Options
 		 */
-}
-
-hr.wp-block-separator.is-style-wide {
-	border-bottom-color: #CCCCCC;
-	border-bottom-width: 2px;
 }
 
 hr.wp-block-separator.is-style-dots:before {
@@ -3794,7 +3788,7 @@ p:not(.site-title) a:hover {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation .menu-primary-container {
+	.fse-enabled .site-footer .main-navigation > div {
 		display: block;
 	}
 	.fse-enabled .site-footer .main-navigation li {
@@ -3813,7 +3807,7 @@ p:not(.site-title) a:hover {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-header.entry-content .main-navigation .menu-primary-container {
+	.fse-enabled .site-header.entry-content .main-navigation > div {
 		padding: 0 32px;
 	}
 }
@@ -3822,6 +3816,12 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
 		margin-bottom: 21.312px;
 		margin-top: 21.312px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
+		padding: 8px;
 	}
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1896,23 +1896,17 @@ p.has-background {
 }
 
 hr {
-	border-bottom-color: #CCCCCC;
-	border-bottom-width: 2px;
+	border-bottom: 2px solid #CCCCCC;
 	clear: both;
 	margin-left: auto;
 	margin-right: auto;
 }
 
 hr.wp-block-separator {
-	border-bottom-color: #CCCCCC;
+	border-bottom: 2px solid #CCCCCC;
 	/**
 		 * Block Options
 		 */
-}
-
-hr.wp-block-separator.is-style-wide {
-	border-bottom-color: #CCCCCC;
-	border-bottom-width: 2px;
 }
 
 hr.wp-block-separator.is-style-dots:before {
@@ -3823,7 +3817,7 @@ p:not(.site-title) a:hover {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation .menu-primary-container {
+	.fse-enabled .site-footer .main-navigation > div {
 		display: block;
 	}
 	.fse-enabled .site-footer .main-navigation li {
@@ -3842,7 +3836,7 @@ p:not(.site-title) a:hover {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-header.entry-content .main-navigation .menu-primary-container {
+	.fse-enabled .site-header.entry-content .main-navigation > div {
 		padding: 0 32px;
 	}
 }
@@ -3851,6 +3845,12 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
 		margin-bottom: 21.312px;
 		margin-top: 21.312px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
+		padding: 8px;
 	}
 }
 

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -71,7 +71,7 @@
 		}
 
 		@include media(mobile-only) {
-			.menu-primary-container {
+			> div {
 				display: block;
 			}
 			li {

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -13,7 +13,7 @@
 			}
 
 			@include media(mobile-only) {
-				.menu-primary-container {
+				> div {
 					display: block;
 				}
 				li {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1366,7 +1366,7 @@ table th,
 }
 
 @media only screen and (max-width: 559px) {
-	.site-footer .main-navigation .menu-primary-container {
+	.site-footer .main-navigation > div {
 		display: block;
 	}
 	.site-footer .main-navigation li {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3376,7 +3376,7 @@ img#wpstats {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation .menu-primary-container {
+	.fse-enabled .site-footer .main-navigation > div {
 		display: block;
 	}
 	.fse-enabled .site-footer .main-navigation li {

--- a/varia/style.css
+++ b/varia/style.css
@@ -3405,7 +3405,7 @@ img#wpstats {
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation .menu-primary-container {
+	.fse-enabled .site-footer .main-navigation > div {
 		display: block;
 	}
 	.fse-enabled .site-footer .main-navigation li {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Change how the SCSS targets the Navigation block in Full Site Editing after the changes in https://github.com/Automattic/wp-calypso/pull/35998.
* Make the footer menu items padding consistent.

Note: some CSS changes here are unbuilt leftovers from other commits. Please only review the SCSS files.

Instructions and screenshots: see https://github.com/Automattic/wp-calypso/pull/35998

#### Related issue(s):

Requires https://github.com/Automattic/wp-calypso/pull/35998
Tracked by https://github.com/Automattic/wp-calypso/issues/35870