### PR TITLE
Full Site Editing / Varia, Maywood: Center the site info

### DIFF
--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3799,6 +3799,10 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.fse-enabled .site-footer .site-info {
+	text-align: center;
+}
+
 .fse-enabled .site-header.entry-content {
 	margin-bottom: 0;
 	max-width: 100%;

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3828,6 +3828,10 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.fse-enabled .site-footer .site-info {
+	text-align: center;
+}
+
 .fse-enabled .site-header.entry-content {
 	margin-bottom: 0;
 	max-width: 100%;

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -25,5 +25,9 @@
 				}
 			}
 		}
+
+		.site-info {
+			text-align: center;
+		}
 	}
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3386,3 +3386,7 @@ img#wpstats {
 		display: none;
 	}
 }
+
+.fse-enabled .site-footer .site-info {
+	text-align: center;
+}

--- a/varia/style.css
+++ b/varia/style.css
@@ -3415,3 +3415,7 @@ img#wpstats {
 		display: none;
 	}
 }
+
+.fse-enabled .site-footer .site-info {
+	text-align: center;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* On FSE sites with FSE enabled, center the site info element after the footer template.

![Screenshot 2019-09-05 at 15 04 35](https://user-images.githubusercontent.com/2070010/64349242-827e6b80-cfee-11e9-94ff-cfa7955cffed.png)

Note: some CSS changes here are unbuilt leftovers from other commits. Please only review the SCSS files.

#### Related issue(s):

Tracked by Automattic/wp-calypso#35870