### PR TITLE
Varia: Update Cover Block to work with flexible height setting in Gutenberg 6.4

### DIFF
--- a/varia/sass/blocks/cover/_config.scss
+++ b/varia/sass/blocks/cover/_config.scss
@@ -2,10 +2,9 @@
  * Cover
  */
 $config-cover: (
-	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
+	"height": 430px, // Default Cover height should match the default height in core
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "white")},
 		"background": #{map-deep-get($config-global, "color", "black")},
 	)
 );
-

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -3,7 +3,10 @@
 
 	background-color: #{map-deep-get($config-cover, "color", "background")};
 	color: #{map-deep-get($config-cover, "color", "foreground")};
-	min-height: #{map-deep-get($config-cover, "height")};
+
+	.block-library-cover__resize-container:not([style*="min-height"]) & {
+		min-height: #{map-deep-get($config-cover, "height")};
+	}
 
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -4,10 +4,6 @@
 	background-color: #{map-deep-get($config-cover, "color", "background")};
 	color: #{map-deep-get($config-cover, "color", "foreground")};
 
-	.block-library-cover__resize-container:not([style*="min-height"]) & {
-		min-height: #{map-deep-get($config-cover, "height")};
-	}
-
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text,

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -2,8 +2,11 @@
 .wp-block-cover-image {
 
 	background-color: #{map-deep-get($config-cover, "color", "background")};
-	min-height: #{map-deep-get($config-cover, "height")};
 	margin: inherit;
+
+	&:not([style*="min-height"]) {
+		min-height: #{map-deep-get($config-cover, "height")};
+	}
 
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -4,10 +4,6 @@
 	background-color: #{map-deep-get($config-cover, "color", "background")};
 	margin: inherit;
 
-	&:not([style*="min-height"]) {
-		min-height: #{map-deep-get($config-cover, "height")};
-	}
-
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {

--- a/varia/sass/child-theme/_config-child-theme-deep.scss
+++ b/varia/sass/child-theme/_config-child-theme-deep.scss
@@ -188,7 +188,7 @@ $config-button: (
  * Cover
  */
 $config-cover: (
-	"height": #{15 * map-deep-get($config-global, "spacing", "vertical")},
+	"height": 430px, // Default Cover height should match the default height in core
 	"color": (
 		"foreground": #{map-deep-get($config-global, "color", "white")},
 		"background": #{map-deep-get($config-global, "color", "black")},

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -291,7 +291,7 @@ object {
 
 .block-library-cover__resize-container:not([style*="min-height"]) .wp-block-cover, .block-library-cover__resize-container:not([style*="min-height"])
 .wp-block-cover-image {
-	min-height: 480px;
+	min-height: 430px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -286,8 +286,12 @@ object {
 .wp-block-cover-image {
 	background-color: black;
 	color: white;
-	min-height: 480px;
 	/* Treating H2 separately to account for legacy /core styles */
+}
+
+.block-library-cover__resize-container:not([style*="min-height"]) .wp-block-cover, .block-library-cover__resize-container:not([style*="min-height"])
+.wp-block-cover-image {
+	min-height: 480px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -289,11 +289,6 @@ object {
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
-.block-library-cover__resize-container:not([style*="min-height"]) .wp-block-cover, .block-library-cover__resize-container:not([style*="min-height"])
-.wp-block-cover-image {
-	min-height: 430px;
-}
-
 .wp-block-cover .wp-block-cover__inner-container,
 .wp-block-cover .wp-block-cover-image-text,
 .wp-block-cover .wp-block-cover-text,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1179,12 +1179,16 @@ input.has-focus[type="submit"],
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
-	min-height: 480px;
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */
 	/**
 	 * Block Options
 	 */
+}
+
+.wp-block-cover:not([style*="min-height"]),
+.wp-block-cover-image:not([style*="min-height"]) {
+	min-height: 480px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1188,7 +1188,7 @@ input.has-focus[type="submit"],
 
 .wp-block-cover:not([style*="min-height"]),
 .wp-block-cover-image:not([style*="min-height"]) {
-	min-height: 480px;
+	min-height: 430px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1179,12 +1179,16 @@ input.has-focus[type="submit"],
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
-	min-height: 480px;
 	margin: inherit;
 	/* Treating H2 separately to account for legacy /core styles */
 	/**
 	 * Block Options
 	 */
+}
+
+.wp-block-cover:not([style*="min-height"]),
+.wp-block-cover-image:not([style*="min-height"]) {
+	min-height: 480px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1186,11 +1186,6 @@ input.has-focus[type="submit"],
 	 */
 }
 
-.wp-block-cover:not([style*="min-height"]),
-.wp-block-cover-image:not([style*="min-height"]) {
-	min-height: 430px;
-}
-
 .wp-block-cover .wp-block-cover__inner-container,
 .wp-block-cover .wp-block-cover-image-text,
 .wp-block-cover .wp-block-cover-text,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1188,7 +1188,7 @@ input.has-focus[type="submit"],
 
 .wp-block-cover:not([style*="min-height"]),
 .wp-block-cover-image:not([style*="min-height"]) {
-	min-height: 480px;
+	min-height: 430px;
 }
 
 .wp-block-cover .wp-block-cover__inner-container,


### PR DESCRIPTION
Gutenberg 6.4 introduces a new customizable `min-height` option for the Cover Block that conflicts with the Cover Block’s `min-height` variable in Varia. To fix this, we need to revise the way the min-height works to handle 2 conditions: 

1) The heights of “Legacy” Cover Blocks that already exist should remain unchanged.
2) New Cover Blocks should respect the new `min-height` option.

#### Changes proposed in this Pull Request:

- Adapts the `min-height` CSS in Varia for the Cover Block to only apply to “legacy” Cover blocks. 
- Prevent the theme’s from conflicting with the new cover height option in the editor and the frontend.
- Sets the default `min-height` CSS to `430px` to match the default in Gutenberg.
- Does not fix this semi-related issue: https://github.com/WordPress/gutenberg/issues/17339

Going forward, Varia child-theme’s _should not_ change the `min-height` variable. Instead we should set the height in our templates directly using the new custom Cover height feature in the editor.

#### Related issue(s):

- Discovered by @danieldudzic & @iamtakashi 