### PR TITLE
Full Site Editing / Varia, Maywood: Fix incorrect content positioning when the homepage title is hidden

### DIFF
--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -13,7 +13,7 @@
 			}
 		}
 	}
-	&.hide-homepage-title .site-header.entry-content {
+	&.home.page.hide-homepage-title .site-header.entry-content {
 		padding-bottom: $spacing_vertical;
 		@include media(mobile) {
 			padding-bottom: #{1.5 * $spacing_vertical};

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -13,6 +13,12 @@
 			}
 		}
 	}
+	&.hide-homepage-title .site-header.entry-content {
+		padding-bottom: $spacing_vertical;
+		@include media(mobile) {
+			padding-bottom: #{1.5 * $spacing_vertical};
+		}
+	}
 
 	.site-footer {
 		.wp-block-a8c-navigation-menu {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3396,6 +3396,37 @@ img#wpstats {
 }
 
 /**
+ * Mailchimp Subscription Form
+ */
+.wp-block-jetpack-mailchimp p {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-mailchimp p {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-mailchimp p:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-mailchimp p:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-jetpack-mailchimp input[type=email] {
+	width: 100%;
+}
+
+#wp-block-jetpack-mailchimp_consent-text {
+	font-size: 0.83333rem;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**
@@ -3813,6 +3844,16 @@ p:not(.site-title) a:hover {
 @media only screen and (max-width: 559px) {
 	.fse-enabled .site-header.entry-content .main-navigation > div {
 		padding: 0 32px;
+	}
+}
+
+.fse-enabled.hide-homepage-title .site-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.hide-homepage-title .site-header.entry-content {
+		padding-bottom: 48px;
 	}
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3425,6 +3425,37 @@ img#wpstats {
 }
 
 /**
+ * Mailchimp Subscription Form
+ */
+.wp-block-jetpack-mailchimp p {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-mailchimp p {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-mailchimp p:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-mailchimp p:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-jetpack-mailchimp input[type=email] {
+	width: 100%;
+}
+
+#wp-block-jetpack-mailchimp_consent-text {
+	font-size: 0.83333rem;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**
@@ -3842,6 +3873,16 @@ p:not(.site-title) a:hover {
 @media only screen and (max-width: 559px) {
 	.fse-enabled .site-header.entry-content .main-navigation > div {
 		padding: 0 32px;
+	}
+}
+
+.fse-enabled.hide-homepage-title .site-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.hide-homepage-title .site-header.entry-content {
+		padding-bottom: 48px;
 	}
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3876,12 +3876,12 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-enabled.hide-homepage-title .site-header.entry-content {
+.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 	padding-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled.hide-homepage-title .site-header.entry-content {
+	.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 		padding-bottom: 48px;
 	}
 }

--- a/varia/inc/style-editor-wpcom.css
+++ b/varia/inc/style-editor-wpcom.css
@@ -1,0 +1,7 @@
+.hide-homepage-title .editor-styles-wrapper .post-content__block .editor-post-title {
+	display: none;
+}
+
+.hide-homepage-title .editor-styles-wrapper .post-content__block {
+  margin-top: -16px;
+}

--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -105,3 +105,21 @@ function varia_wpcom_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'varia_wpcom_body_classes' );
+
+/**
+ * Adds custom classes to the admin body classes.
+ *
+ * @param string $classes Classes for the body element.
+ * @return string
+ */
+function varia_wpcom_admin_body_classes( $classes ) {
+	$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
+	$hide = get_theme_mod( 'hide_front_page_title', false );
+
+	if ( $is_block_editor_screen && true === $hide ) {
+		$classes .= ' hide-homepage-title';
+	}
+
+	return $classes;
+}
+add_filter( 'admin_body_class', 'varia_wpcom_admin_body_classes' );

--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -123,3 +123,11 @@ function varia_wpcom_admin_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'admin_body_class', 'varia_wpcom_admin_body_classes' );
+
+/**
+ * Enqueue our WP.com styles for the block editor.
+ */
+function varia_wpcom_editor_scripts() {
+	wp_enqueue_style( 'varia-wpcom-editor-style', get_template_directory_uri() . '/inc/style-editor-wpcom.css', array(), '20190906' );
+}
+add_action( 'enqueue_block_editor_assets', 'varia_wpcom_editor_scripts' );

--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -113,10 +113,12 @@ add_filter( 'body_class', 'varia_wpcom_body_classes' );
  * @return string
  */
 function varia_wpcom_admin_body_classes( $classes ) {
+	global $post;
 	$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
 	$hide = get_theme_mod( 'hide_front_page_title', false );
+	$front_page = (int) get_option( 'page_on_front' );
 
-	if ( $is_block_editor_screen && true === $hide ) {
+	if ( $is_block_editor_screen && $front_page === $post->ID && true === $hide ) {
 		$classes .= ' hide-homepage-title';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

On WPCOM, Varia adds an option, which defaults to true, to hide the page title of the homepage.
I didn't know about it, and my tests on a local install of course didn't have this option.

* Add the `.hide-homepage-title` class to the block editor body as well.
* Enqueue a new stylesheet on the block editor that hides the homepage title and reposition the Post Content block.
* Restore the header's bottom padding on the front end's homepage when the page title is hidden.

| | Before | After |
| - | - | - |
| Editor | ![Screenshot 2019-09-06 at 16 05 42](https://user-images.githubusercontent.com/2070010/64438567-3e5b9b80-d0c0-11e9-9847-7f7b0eee7290.png) | ![Screenshot 2019-09-06 at 15 45 02](https://user-images.githubusercontent.com/2070010/64438430-005e7780-d0c0-11e9-9b4f-b8572c114888.png) |
| Front End | ![Screenshot 2019-09-06 at 16 05 24](https://user-images.githubusercontent.com/2070010/64438568-3e5b9b80-d0c0-11e9-88d6-ee9fe65a6053.png) | ![Screenshot 2019-09-06 at 15 44 43](https://user-images.githubusercontent.com/2070010/64438414-f8063c80-d0bf-11e9-837c-49b76eb075c9.png) |

#### Notes:

I haven't found a better solution for this than to add a new stylesheet to the block editor on WPCOM.
This is because I believe there is no way in PHP to add CSS classes to the `editor-styles-wrapper` component, which is automagically considered the `style-editor.css` body.
So, the approach here is to add `.hide-homepage-title` to the actual editor page body, and manually enqueue the stylesheet that repositions title and content in FSE.
This manually enqueued stylesheet is not automagically parsed by WP, and so it is able to target the page body instead of just `.editor-styles-wrapper`.

Let me know if you think there's a better way that:
- Doesn't entail modifying to the plugin: theme options shouldn't be its concern!
- Adding unnecessary JS to the theme (e.g. to use the `editor.BlockListBlock` filter).

#### Testing instructions:

* Sandbox an FSE site using Maywood.
* Copy the files modified by this PR into the sandbox `wp-content/themes/pub/`.
* Make sure the "Hide homepage title" option (in the customizer, accessible at `/customize/{ siteFragment }` or `/wp-admin/customize.php`, homepage settings) is enabled.
* Open the front end, and make sure the page title is hidden and there is enough space between the header and the content.
* Edit the front end page, and make sure the title is hidden, and there is a reasonable space between header and content block.
* Repeat the test on a different page, and make sure the title is visible, and the spaces look fine.
* Disable the "Hide homepage title" option.
* Repeat the test: this time the front page should look exactly the same as any other page.

#### Related issue(s):

Fixes https://github.com/Automattic/wp-calypso/issues/36021