### PR TITLE
Varia, Maywood: Fix FSE blocks style when inside a Cover block

### DIFF
--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -219,12 +219,12 @@ a {
 .wp-block-cover,
 .wp-block-cover-image {
 	p {
-		text-shadow: 0 0 6px #000;
+		text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
 	}
 
 	h1,h2,h3,h4,h5,h6 {
 		font-weight: 300;
-		text-shadow: 0 0 10px #000;
+		text-shadow: 0 0 10px map-deep-get($config-global, "color", "black");
 	}
 
 	@include media(desktop) {

--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -14,6 +14,14 @@
 			font-size: 16.6px;
 		}
 	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title,
+		.site-description {
+			text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
+		}
+	}
 }
 
 .site-header {

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -34,6 +34,32 @@
 		}
 	}
 
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title {
+			font-size: 20px;
+			@include media(mobile) {
+				font-size: 24px;
+			}
+
+			a {
+				text-decoration: none;
+			}
+		}
+
+		.site-description {
+			font-size: 13.8px;
+
+			@include media(mobile) {
+				font-size: 16.6px;
+			}
+		}
+
+		.main-navigation a {
+			text-decoration: none;
+		}
+	}
+
 	#colophon {
 		margin-left: auto;
 		margin-right: auto;

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1341,6 +1341,14 @@ b, strong {
 	}
 }
 
+.template-block .wp-block-cover .site-title,
+.template-block .wp-block-cover .site-description,
+.template-block .wp-block-cover-image .site-title,
+.template-block .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
 .a8c-template-editor .wp-block:not(.is-selected) [data-block] {
 	margin-bottom: 14px;
 }
@@ -1349,14 +1357,18 @@ b, strong {
 	margin-top: 14px;
 }
 
+.a8c-template-editor .wp-block-cover .site-title,
+.a8c-template-editor .wp-block-cover .site-description,
+.a8c-template-editor .wp-block-cover-image .site-title,
+.a8c-template-editor .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
 .site-header .site-title {
 	font-size: 21.6px;
 	font-weight: 700;
 	text-decoration: underline;
-}
-
-.site-header .site-title:focus {
-	color: #181818;
 }
 
 .site-header .site-description {
@@ -1510,6 +1522,16 @@ b, strong {
 	.site-header .site-description, .site-footer .site-description {
 		font-size: 16.6px;
 	}
+}
+
+.site-header .wp-block-cover .site-title,
+.site-header .wp-block-cover .site-description,
+.site-header .wp-block-cover-image .site-title,
+.site-header .wp-block-cover-image .site-description, .site-footer .wp-block-cover .site-title,
+.site-footer .wp-block-cover .site-description,
+.site-footer .wp-block-cover-image .site-title,
+.site-footer .wp-block-cover-image .site-description {
+	text-shadow: 0 0 6px black;
 }
 
 .site-header .site-title {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1075,7 +1075,7 @@ button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
-.wp-block-file__button, .a8c-posts-list__view-all {
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -1092,11 +1092,11 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after, .a8c-posts-list__view-all:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
 	height: 0;
@@ -1107,7 +1107,7 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before {
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
 
@@ -1115,7 +1115,7 @@ button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after, .a8c-posts-list__view-all:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
 
@@ -1123,15 +1123,15 @@ button:hover,
 .button:hover,
 input:hover[type="submit"],
 .wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, button:focus,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
 .button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, button.has-focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
 .has-focus.button,
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
-.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all {
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #685636;
 }
@@ -3194,30 +3194,27 @@ img#wpstats {
 }
 
 .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-	width: 100%;
-	max-width: 100%;
 	margin-right: auto;
 	margin-left: auto;
+	max-width: 100%;
+	/* Matches normal width until desktop breakpoint */
 }
 
 @media only screen and (min-width: 560px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 560px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 640px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 782px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 782px - 32px);
 	}
 }
 
@@ -3394,6 +3391,78 @@ img#wpstats {
 }
 
 /**
+<<<<<<< HEAD
+=======
+ * Cookies & Consents Banner
+ */
+body .widget_eu_cookie_law_widget {
+	background: transparent;
+	bottom: 0;
+	right: 0;
+	padding: 8px;
+	left: 0;
+}
+
+body .widget_eu_cookie_law_widget.widget.top {
+	bottom: auto;
+	top: 0;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law {
+	background: #FFFFFF;
+	border: 1px solid #CCCCCC;
+	color: #181818;
+	font-size: 0.83333rem;
+	line-height: inherit;
+	padding: 16px;
+}
+
+@media (max-width: 600px) {
+	body .widget_eu_cookie_law_widget #eu-cookie-law {
+		padding-bottom: 80px;
+	}
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative {
+	background: #181818;
+	border-color: #020202;
+	color: #FFFFFF;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept {
+	background: #FFFFFF;
+	color: #181818;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept.has-focus {
+	background: #CCCCCC;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	margin: 0;
+	margin-right: 32px;
+}
+
+@media (max-width: 600px) {
+	body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+		bottom: 16px;
+		right: 16px;
+		margin: 0;
+	}
+}
+
+body.admin-bar .widget_eu_cookie_law_widget.widget.top {
+	top: 32px;
+}
+
+@media (max-width: 782px) {
+	body.admin-bar .widget_eu_cookie_law_widget.widget.top {
+		top: 46px;
+	}
+}
+
+/**
+>>>>>>> Fix FSE blocks style when inside a Cover block
  * Mailchimp Subscription Form
  */
 .wp-block-jetpack-mailchimp p {
@@ -3641,7 +3710,7 @@ p:not(.site-title) a:hover {
 
 .wp-block-cover p,
 .wp-block-cover-image p {
-	text-shadow: 0 0 6px #000;
+	text-shadow: 0 0 6px black;
 }
 
 .wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
@@ -3652,7 +3721,7 @@ p:not(.site-title) a:hover {
 .wp-block-cover-image h5,
 .wp-block-cover-image h6 {
 	font-weight: 300;
-	text-shadow: 0 0 10px #000;
+	text-shadow: 0 0 10px black;
 }
 
 @media only screen and (min-width: 1024px) {
@@ -3866,6 +3935,40 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
 		padding: 8px;
 	}
+}
+
+.fse-enabled .wp-block-cover .site-title,
+.fse-enabled .wp-block-cover-image .site-title {
+	font-size: 20px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .wp-block-cover .site-title,
+	.fse-enabled .wp-block-cover-image .site-title {
+		font-size: 24px;
+	}
+}
+
+.fse-enabled .wp-block-cover .site-title a,
+.fse-enabled .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-enabled .wp-block-cover .site-description,
+.fse-enabled .wp-block-cover-image .site-description {
+	font-size: 13.8px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .wp-block-cover .site-description,
+	.fse-enabled .wp-block-cover-image .site-description {
+		font-size: 16.6px;
+	}
+}
+
+.fse-enabled .wp-block-cover .main-navigation a,
+.fse-enabled .wp-block-cover-image .main-navigation a {
+	text-decoration: none;
 }
 
 .fse-enabled #colophon {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3914,12 +3914,12 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-enabled.hide-homepage-title .site-header.entry-content {
+.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 	padding-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled.hide-homepage-title .site-header.entry-content {
+	.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 		padding-bottom: 48px;
 	}
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1217,6 +1217,14 @@ input.has-focus[type="submit"],
 	padding-left: 16px;
 }
 
+.wp-block-columns.alignfull:not(:first-child) {
+	margin-top: 32px;
+}
+
+.wp-block-columns.alignfull:not(:last-child) {
+	margin-bottom: 32px;
+}
+
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
@@ -3391,8 +3399,6 @@ img#wpstats {
 }
 
 /**
-<<<<<<< HEAD
-=======
  * Cookies & Consents Banner
  */
 body .widget_eu_cookie_law_widget {
@@ -3462,7 +3468,6 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
->>>>>>> Fix FSE blocks style when inside a Cover block
  * Mailchimp Subscription Form
  */
 .wp-block-jetpack-mailchimp p {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1217,6 +1217,14 @@ input.has-focus[type="submit"],
 	padding-right: 16px;
 }
 
+.wp-block-columns.alignfull:not(:first-child) {
+	margin-top: 32px;
+}
+
+.wp-block-columns.alignfull:not(:last-child) {
+	margin-bottom: 32px;
+}
+
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;
@@ -3420,8 +3428,6 @@ img#wpstats {
 }
 
 /**
-<<<<<<< HEAD
-=======
  * Cookies & Consents Banner
  */
 body .widget_eu_cookie_law_widget {
@@ -3491,7 +3497,6 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
->>>>>>> Fix FSE blocks style when inside a Cover block
  * Mailchimp Subscription Form
  */
 .wp-block-jetpack-mailchimp p {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1075,7 +1075,7 @@ button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
-.wp-block-file__button, .a8c-posts-list__view-all {
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -1092,11 +1092,11 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after, .a8c-posts-list__view-all:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
 	height: 0;
@@ -1107,7 +1107,7 @@ button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before {
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
 
@@ -1115,7 +1115,7 @@ button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after, .a8c-posts-list__view-all:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
 
@@ -1123,15 +1123,15 @@ button:hover,
 .button:hover,
 input:hover[type="submit"],
 .wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, button:focus,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
 .button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, button.has-focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
 .has-focus.button,
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
-.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all {
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #685636;
 }
@@ -3211,30 +3211,27 @@ img#wpstats {
 }
 
 .entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-	width: 100%;
-	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
+	max-width: 100%;
+	/* Matches normal width until desktop breakpoint */
 }
 
 @media only screen and (min-width: 560px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 560px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 640px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
 	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, .site-header, #colophon {
-		width: calc(calc( 782px - 32px) + 256px);
-		max-width: calc(100% - 32px);
+		max-width: calc( 782px - 32px);
 	}
 }
 
@@ -3423,6 +3420,78 @@ img#wpstats {
 }
 
 /**
+<<<<<<< HEAD
+=======
+ * Cookies & Consents Banner
+ */
+body .widget_eu_cookie_law_widget {
+	background: transparent;
+	bottom: 0;
+	left: 0;
+	padding: 8px;
+	right: 0;
+}
+
+body .widget_eu_cookie_law_widget.widget.top {
+	bottom: auto;
+	top: 0;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law {
+	background: #FFFFFF;
+	border: 1px solid #CCCCCC;
+	color: #181818;
+	font-size: 0.83333rem;
+	line-height: inherit;
+	padding: 16px;
+}
+
+@media (max-width: 600px) {
+	body .widget_eu_cookie_law_widget #eu-cookie-law {
+		padding-bottom: 80px;
+	}
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative {
+	background: #181818;
+	border-color: #020202;
+	color: #FFFFFF;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept {
+	background: #FFFFFF;
+	color: #181818;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept.has-focus {
+	background: #CCCCCC;
+}
+
+body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	margin: 0;
+	margin-left: 32px;
+}
+
+@media (max-width: 600px) {
+	body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+		bottom: 16px;
+		left: 16px;
+		margin: 0;
+	}
+}
+
+body.admin-bar .widget_eu_cookie_law_widget.widget.top {
+	top: 32px;
+}
+
+@media (max-width: 782px) {
+	body.admin-bar .widget_eu_cookie_law_widget.widget.top {
+		top: 46px;
+	}
+}
+
+/**
+>>>>>>> Fix FSE blocks style when inside a Cover block
  * Mailchimp Subscription Form
  */
 .wp-block-jetpack-mailchimp p {
@@ -3670,7 +3739,7 @@ p:not(.site-title) a:hover {
 
 .wp-block-cover p,
 .wp-block-cover-image p {
-	text-shadow: 0 0 6px #000;
+	text-shadow: 0 0 6px black;
 }
 
 .wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
@@ -3681,7 +3750,7 @@ p:not(.site-title) a:hover {
 .wp-block-cover-image h5,
 .wp-block-cover-image h6 {
 	font-weight: 300;
-	text-shadow: 0 0 10px #000;
+	text-shadow: 0 0 10px black;
 }
 
 @media only screen and (min-width: 1024px) {
@@ -3895,6 +3964,40 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
 		padding: 8px;
 	}
+}
+
+.fse-enabled .wp-block-cover .site-title,
+.fse-enabled .wp-block-cover-image .site-title {
+	font-size: 20px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .wp-block-cover .site-title,
+	.fse-enabled .wp-block-cover-image .site-title {
+		font-size: 24px;
+	}
+}
+
+.fse-enabled .wp-block-cover .site-title a,
+.fse-enabled .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-enabled .wp-block-cover .site-description,
+.fse-enabled .wp-block-cover-image .site-description {
+	font-size: 13.8px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled .wp-block-cover .site-description,
+	.fse-enabled .wp-block-cover-image .site-description {
+		font-size: 16.6px;
+	}
+}
+
+.fse-enabled .wp-block-cover .main-navigation a,
+.fse-enabled .wp-block-cover-image .main-navigation a {
+	text-decoration: none;
 }
 
 .fse-enabled #colophon {

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -10,6 +10,15 @@
 			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 		}
 	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title,
+		.site-description {
+			background: transparent;
+			color: inherit;	
+		}
+	}
 }
 
 .a8c-template-editor {
@@ -19,6 +28,16 @@
 	.wp-block:not(:first-child):not(.is-selected) [data-block] {
 		margin-top: 14px;
 	}
+
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title,
+		.site-description {
+			background: transparent;
+			color: inherit;	
+		}
+	}
 }
 
 .site-header {
@@ -26,10 +45,6 @@
 		font-size: 21.6px;
 		font-weight: 700;
 		text-decoration: underline;
-
-		&:focus {
-			color: #{map-deep-get($config-header, "branding", "color", "link")};
-		}
 	}
 
 	.site-description {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1226,6 +1226,14 @@ table th,
 	}
 }
 
+.template-block .wp-block-cover .site-title,
+.template-block .wp-block-cover .site-description,
+.template-block .wp-block-cover-image .site-title,
+.template-block .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
 .a8c-template-editor .wp-block:not(.is-selected) [data-block] {
 	margin-bottom: 14px;
 }
@@ -1234,14 +1242,18 @@ table th,
 	margin-top: 14px;
 }
 
+.a8c-template-editor .wp-block-cover .site-title,
+.a8c-template-editor .wp-block-cover .site-description,
+.a8c-template-editor .wp-block-cover-image .site-title,
+.a8c-template-editor .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
 .site-header .site-title {
 	font-size: 21.6px;
 	font-weight: 700;
 	text-decoration: underline;
-}
-
-.site-header .site-title:focus {
-	color: blue;
 }
 
 .site-header .site-description {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Themes apply some styles overrides to blocks inside Cover, for example changing the color and adding a text shadow.

* Make sure the FSE blocks (Site Title, Site Description, and Navigation Menu) look consistently when inserted inside and outside a Cover block.
* When inside a Cover block, change the color of Site Title and Site Description blocks to white, and add a text shadow. Remove the link underline from Site Title and Navigation Menu.

| | Before | After |
| - | - | - |
| Editor | <img width="943" alt="Screenshot 2019-09-24 at 11 15 10" src="https://user-images.githubusercontent.com/2070010/65506292-8a357f80-decb-11e9-8af5-3ba9a7a537d8.png"> | <img width="957" alt="Screenshot 2019-09-24 at 11 44 32" src="https://user-images.githubusercontent.com/2070010/65506297-8d307000-decb-11e9-84a9-eed289821d6f.png"> |
| Front End | <img width="1153" alt="Screenshot 2019-09-24 at 11 15 21" src="https://user-images.githubusercontent.com/2070010/65506340-a0434000-decb-11e9-91c8-3544d949d6f2.png"> | <img width="1019" alt="Screenshot 2019-09-24 at 11 44 40" src="https://user-images.githubusercontent.com/2070010/65506346-a507f400-decb-11e9-8c35-3a00ef54b9f8.png"> |

Note: I gave to the Site Title (which is rendered as a `h1`) a slightly smaller shadow compared to how it is in the front end. This is because in the editor it would be cut off by the `textarea` overflow.
I haven't found a good way to work around it, and so I just reduced the shadow blur radius so that the shadow is still visible, but the cut-off is not as annoying (you can see how it would look with the larger blur radius value in the screenshot I've used for Editor/After).


#### Testing instructions

* Update Gutenberg to 6.5 (or to master) on a FSE test site.
* Apply this PR on Varia and Maywood.
* Edit the header template: add a Cover block and move the FSE blocks inside it.
* Compare how the header looks in the header editor, in the page editor, and in the front end.
* Make sure there are no visual regressions to the FSE blocks when rendered _outside_ the Cover block.

#### Related issue(s):

Fixes https://github.com/Automattic/wp-calypso/issues/35429