### PR TITLE
Varia: Change nested full-width block width inside group block

### DIFF
--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -12,6 +12,7 @@
 @import "cover/editor";
 @import "heading/editor";
 @import "gallery/editor";
+@import "group/editor";
 @import "latest-posts/editor";
 @import "media-text/editor";
 @import "posts-list/editor";

--- a/varia/sass/blocks/group/_editor.scss
+++ b/varia/sass/blocks/group/_editor.scss
@@ -1,0 +1,14 @@
+.wp-block-group {
+	&.has-background {
+		padding: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+
+		@include media(mobile) {
+			padding: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+}
+
+.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+	margin: 0;
+	width: 100%;
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -388,6 +388,21 @@ object {
 	margin-bottom: 0;
 }
 
+.wp-block-group.has-background {
+	padding: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-group.has-background {
+		padding: 32px;
+	}
+}
+
+.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+	margin: 0;
+	width: 100%;
+}
+
 .wp-block-latest-posts {
 	padding-left: 0;
 }


### PR DESCRIPTION
Fixes #1394 

This PR intends to change the behaviour of the full-width block inside a group block with a background to match with the front-end.

Also, it changes the padding for a group block with a background to match with the front-end.

**Before:**
<img width="1239" alt="Screen Shot 2019-09-26 at 10 57 12" src="https://user-images.githubusercontent.com/908665/65679498-1f13b680-e04d-11e9-8a96-e9d416deb142.png">

**After:**
<img width="1239" alt="Screen Shot 2019-09-26 at 10 56 37" src="https://user-images.githubusercontent.com/908665/65679513-276bf180-e04d-11e9-9d84-548ae9ddf64d.png">
