### PR TITLE
Varia: Make sure separator is always visible with background colour

### DIFF
--- a/varia/sass/blocks/separator/_editor.scss
+++ b/varia/sass/blocks/separator/_editor.scss
@@ -1,7 +1,7 @@
 .wp-block-separator,
 hr {
-    border-bottom: #{map-deep-get($config-separator, "height")} solid #{map-deep-get($config-global, "color", "border", "default")};
-    clear: both;
+	border-bottom: #{map-deep-get($config-separator, "height")} solid #{map-deep-get($config-global, "color", "border", "default")};
+	clear: both;
 
 	&[style*="text-align:right"],
 	&[style*="text-align: right"] {
@@ -19,5 +19,9 @@ hr {
 		&:before {
 			color: #{map-deep-get($config-global, "color", "border", "default")};
 		}
+	}
+
+	[class*="has-background"] & {
+		border-color: currentColor;
 	}
 }

--- a/varia/sass/blocks/separator/_editor.scss
+++ b/varia/sass/blocks/separator/_editor.scss
@@ -21,8 +21,8 @@ hr {
 		}
 	}
 
-	.has-background &,
-	[class*="background-color"] & {
+	.has-background:not(.has-background-background-color) &,
+	[class*="background-color"]:not(.has-background-background-color) & {
 		border-color: currentColor;
 	}
 }

--- a/varia/sass/blocks/separator/_editor.scss
+++ b/varia/sass/blocks/separator/_editor.scss
@@ -21,7 +21,7 @@ hr {
 		}
 	}
 
-	[class*="has-background"] & {
+	[class*="background-color"] & {
 		border-color: currentColor;
 	}
 }

--- a/varia/sass/blocks/separator/_editor.scss
+++ b/varia/sass/blocks/separator/_editor.scss
@@ -21,6 +21,7 @@ hr {
 		}
 	}
 
+	.has-background &,
 	[class*="background-color"] & {
 		border-color: currentColor;
 	}

--- a/varia/sass/blocks/separator/_style.scss
+++ b/varia/sass/blocks/separator/_style.scss
@@ -28,6 +28,7 @@ hr {
 			}
 		}
 
+		.has-background &,
 		[class*="background-color"] & {
 			border-color: currentColor;
 		}

--- a/varia/sass/blocks/separator/_style.scss
+++ b/varia/sass/blocks/separator/_style.scss
@@ -27,5 +27,9 @@ hr {
 				padding-left: #{map-deep-get($config-global, "font", "size", "sm")};
 			}
 		}
+
+		[class*="has-background"] & {
+			border-color: currentColor;
+		}
 	}
 }

--- a/varia/sass/blocks/separator/_style.scss
+++ b/varia/sass/blocks/separator/_style.scss
@@ -28,8 +28,8 @@ hr {
 			}
 		}
 
-		.has-background &,
-		[class*="background-color"] & {
+		.has-background:not(.has-background-background-color) &,
+		[class*="background-color"]:not(.has-background-background-color) & {
 			border-color: currentColor;
 		}
 	}

--- a/varia/sass/blocks/separator/_style.scss
+++ b/varia/sass/blocks/separator/_style.scss
@@ -28,7 +28,7 @@ hr {
 			}
 		}
 
-		[class*="has-background"] & {
+		[class*="background-color"] & {
 			border-color: currentColor;
 		}
 	}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -582,6 +582,11 @@ hr.is-style-dots:before {
 	color: #DDDDDD;
 }
 
+[class*="has-background"] .wp-block-separator, [class*="has-background"]
+hr {
+	border-color: currentColor;
+}
+
 table th,
 .wp-block-table th {
 	font-family: sans-serif;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -582,7 +582,10 @@ hr.is-style-dots:before {
 	color: #DDDDDD;
 }
 
-[class*="background-color"] .wp-block-separator, [class*="background-color"]
+.has-background .wp-block-separator,
+[class*="background-color"] .wp-block-separator, .has-background
+hr,
+[class*="background-color"]
 hr {
 	border-color: currentColor;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -582,10 +582,10 @@ hr.is-style-dots:before {
 	color: #DDDDDD;
 }
 
-.has-background .wp-block-separator,
-[class*="background-color"] .wp-block-separator, .has-background
+.has-background:not(.has-background-background-color) .wp-block-separator,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-separator, .has-background:not(.has-background-background-color)
 hr,
-[class*="background-color"]
+[class*="background-color"]:not(.has-background-background-color)
 hr {
 	border-color: currentColor;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -582,7 +582,7 @@ hr.is-style-dots:before {
 	color: #DDDDDD;
 }
 
-[class*="has-background"] .wp-block-separator, [class*="has-background"]
+[class*="background-color"] .wp-block-separator, [class*="background-color"]
 hr {
 	border-color: currentColor;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1887,6 +1887,7 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-right: 0.83333rem;
 }
 
+.has-background hr.wp-block-separator,
 [class*="background-color"] hr.wp-block-separator {
 	border-color: currentColor;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1887,6 +1887,10 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-right: 0.83333rem;
 }
 
+[class*="has-background"] hr.wp-block-separator {
+	border-color: currentColor;
+}
+
 .wp-block-jetpack-slideshow ul {
 	margin-right: 0;
 	margin-left: 0;

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1887,7 +1887,7 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-right: 0.83333rem;
 }
 
-[class*="has-background"] hr.wp-block-separator {
+[class*="background-color"] hr.wp-block-separator {
 	border-color: currentColor;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1887,8 +1887,8 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-right: 0.83333rem;
 }
 
-.has-background hr.wp-block-separator,
-[class*="background-color"] hr.wp-block-separator {
+.has-background:not(.has-background-background-color) hr.wp-block-separator,
+[class*="background-color"]:not(.has-background-background-color) hr.wp-block-separator {
 	border-color: currentColor;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1887,8 +1887,8 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-left: 0.83333rem;
 }
 
-.has-background hr.wp-block-separator,
-[class*="background-color"] hr.wp-block-separator {
+.has-background:not(.has-background-background-color) hr.wp-block-separator,
+[class*="background-color"]:not(.has-background-background-color) hr.wp-block-separator {
 	border-color: currentColor;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1887,6 +1887,7 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-left: 0.83333rem;
 }
 
+.has-background hr.wp-block-separator,
 [class*="background-color"] hr.wp-block-separator {
 	border-color: currentColor;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -1887,7 +1887,7 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-left: 0.83333rem;
 }
 
-[class*="has-background"] hr.wp-block-separator {
+[class*="background-color"] hr.wp-block-separator {
 	border-color: currentColor;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1887,6 +1887,10 @@ hr.wp-block-separator.is-style-dots:before {
 	padding-left: 0.83333rem;
 }
 
+[class*="has-background"] hr.wp-block-separator {
+	border-color: currentColor;
+}
+
 .wp-block-jetpack-slideshow ul {
 	margin-left: 0;
 	margin-right: 0;


### PR DESCRIPTION
Fixes #1429

**Before**
<img width="771" alt="Screen Shot 2019-09-26 at 13 05 01" src="https://user-images.githubusercontent.com/908665/65688748-8a688300-e063-11e9-90fd-1e88e2e4fc23.png">

**After**
<img width="771" alt="Screen Shot 2019-09-26 at 13 04 45" src="https://user-images.githubusercontent.com/908665/65688780-92282780-e063-11e9-8b70-2c09048073a5.png">
