### PR TITLE
Varia: Make sure elements inside cover block is always visible

### DIFF
--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -9,10 +9,20 @@
 	.wp-block-cover-image-text,
 	.wp-block-cover-text,
 	.block-editor-block-list__block {
-		color: #{map-deep-get($config-cover, "color", "foreground")};
+		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
 
 		a {
 			color: currentColor;
+		}
+	}
+
+	/* default & custom background-color */
+	&:not([class*='background-color']){
+		.wp-block-cover__inner-container,
+		.wp-block-cover-image-text,
+		.wp-block-cover-text,
+		.block-editor-block-list__block {
+			color: #{map-deep-get($config-cover, "color", "foreground")};
 		}
 	}
 

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -8,12 +8,21 @@
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {
-		color: #{map-deep-get($config-cover, "color", "foreground")};
+		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
 
 		a {
 			color: currentColor;
+		}
+	}
+
+	/* default & custom background-color */
+	&:not([class*='background-color']){
+		.wp-block-cover__inner-container,
+		.wp-block-cover-image-text,
+		.wp-block-cover-text {
+			color: #{map-deep-get($config-cover, "color", "foreground")};
 		}
 	}
 
@@ -41,7 +50,7 @@
 
 	.wp-block-cover__inner-container {
 
-		width: calc(100% - #{ 2 * map-deep-get($config-global, "spacing", "vertical") };
+		width: calc(100% - #{ 2 * map-deep-get($config-global, "spacing", "vertical") });
 
 		& > * {
 			margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -287,6 +287,7 @@ object {
 	background-color: black;
 	color: white;
 	min-height: 480px;
+	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -298,7 +299,7 @@ object {
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text,
 .wp-block-cover-image .block-editor-block-list__block {
-	color: white;
+	color: currentColor;
 }
 
 .wp-block-cover .wp-block-cover__inner-container a,
@@ -310,6 +311,17 @@ object {
 .wp-block-cover-image .wp-block-cover-text a,
 .wp-block-cover-image .block-editor-block-list__block a {
 	color: currentColor;
+}
+
+.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
+	color: white;
 }
 
 .wp-block-cover h2,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1189,6 +1189,7 @@ input.has-focus[type="submit"],
 	background-color: black;
 	min-height: 480px;
 	margin: inherit;
+	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 	/**
 	 * Block Options
@@ -1201,7 +1202,7 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text {
-	color: white;
+	color: currentColor;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
@@ -1213,6 +1214,15 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover-image-text a,
 .wp-block-cover-image .wp-block-cover-text a {
 	color: currentColor;
+}
+
+.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text {
+	color: white;
 }
 
 .wp-block-cover h2,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1189,6 +1189,7 @@ input.has-focus[type="submit"],
 	background-color: black;
 	min-height: 480px;
 	margin: inherit;
+	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 	/**
 	 * Block Options
@@ -1201,7 +1202,7 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text {
-	color: white;
+	color: currentColor;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
@@ -1213,6 +1214,15 @@ input.has-focus[type="submit"],
 .wp-block-cover-image .wp-block-cover-image-text a,
 .wp-block-cover-image .wp-block-cover-text a {
 	color: currentColor;
+}
+
+.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
+.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text {
+	color: white;
 }
 
 .wp-block-cover h2,


### PR DESCRIPTION
Fixes #1435 

**After:**
<img width="768" alt="Screen Shot 2019-09-26 at 19 52 58" src="https://user-images.githubusercontent.com/908665/65716544-48593480-e097-11e9-8bf8-9bd1f21b4edf.png">
_(The separator in the screenshot above should be fixed in #1430)_

**Testing instructions:**
1. Have a cover block with a very light overlay colour
2. Verify the text colour is in a dark colour that are set in `/sass/blocks/utilities/_style.scss`