### PR TITLE
Varia: Remove unnecessary paddings from quote block

### DIFF
--- a/varia/sass/blocks/quote/_editor.scss
+++ b/varia/sass/blocks/quote/_editor.scss
@@ -13,7 +13,7 @@
 	&.is-large,
 	&.is-style-large {
 		border: none;
-		padding: 0 #{map-deep-get($config-global, "spacing", "horizontal")};
+		padding: 0;
 
 		p {
 			font-family: #{map-deep-get($config-quote, "font", "family")};

--- a/varia/sass/blocks/quote/_style.scss
+++ b/varia/sass/blocks/quote/_style.scss
@@ -2,7 +2,7 @@
 
 	border-left-color: #{map-deep-get($config-global, "color", "primary", "default")};
 	margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
-	padding: 0 #{map-deep-get($config-global, "spacing", "horizontal")};
+	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
 
 	& > * {
 		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
@@ -52,6 +52,7 @@
 		/* Resetting margins to match _block-container.scss */
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+		padding: 0;
 
 		p {
 			font-size: #{map-deep-get($config-heading, "font", "size", "h3")};

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -572,7 +572,7 @@ p.has-background:not(.has-background-background-color) a {
 
 .wp-block-quote.is-large, .wp-block-quote.is-style-large {
 	border: none;
-	padding: 0 16px;
+	padding: 0;
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1806,7 +1806,7 @@ p.has-background {
 .wp-block-quote {
 	border-right-color: blue;
 	margin: 32px 0;
-	padding: 0 16px;
+	padding-right: 16px;
 	/**
 	 * Block Options
 	 */
@@ -1869,6 +1869,7 @@ p.has-background {
 	/* Resetting margins to match _block-container.scss */
 	margin-top: 32px;
 	margin-bottom: 32px;
+	padding: 0;
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1806,7 +1806,7 @@ p.has-background {
 .wp-block-quote {
 	border-left-color: blue;
 	margin: 32px 0;
-	padding: 0 16px;
+	padding-left: 16px;
 	/**
 	 * Block Options
 	 */
@@ -1869,6 +1869,7 @@ p.has-background {
 	/* Resetting margins to match _block-container.scss */
 	margin-top: 32px;
 	margin-bottom: 32px;
+	padding: 0;
 }
 
 .wp-block-quote.is-style-large p, .wp-block-quote.is-large p {


### PR DESCRIPTION
Fixes #1292 

**After**
<img width="807" alt="Screen Shot 2019-09-27 at 16 56 04" src="https://user-images.githubusercontent.com/908665/65783468-c117c980-e147-11e9-9ae6-47d278fb55e8.png">
