### PR TITLE
Varia: Remove auto width for image

### DIFF
--- a/varia/sass/blocks/image/_style.scss
+++ b/varia/sass/blocks/image/_style.scss
@@ -26,5 +26,4 @@ img {
 	height: auto;
 	max-width: 100%;
 	vertical-align: middle;
-	width: auto;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1446,7 +1446,6 @@ img {
 	height: auto;
 	max-width: 100%;
 	vertical-align: middle;
-	width: auto;
 }
 
 .wp-block-latest-comments {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1446,7 +1446,6 @@ img {
 	height: auto;
 	max-width: 100%;
 	vertical-align: middle;
-	width: auto;
 }
 
 .wp-block-latest-comments {


### PR DESCRIPTION
Fixes #1442 

**After:**
The size matchs in both editor and front end.

<img width="2552" alt="Screen Shot 2019-09-28 at 16 48 46" src="https://user-images.githubusercontent.com/908665/65819065-128b8b80-e210-11e9-8055-8f20681e581e.png">
