### PR TITLE
Varia: Change list style position and indentation

### DIFF
--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -14,6 +14,7 @@
 @import "gallery/editor";
 @import "group/editor";
 @import "latest-posts/editor";
+@import "list/editor";
 @import "media-text/editor";
 @import "posts-list/editor";
 @import "paragraph/editor";

--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -2,6 +2,6 @@
 	ul,
 	ol {
 		margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
-		padding-left: calc(2 * #{map-deep-get($config-global, "spacing", "unit")});
+		padding-left: #{2 * map-deep-get($config-global, "spacing", "unit")};
 	}
 }

--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -2,6 +2,6 @@
 	ul,
 	ol {
 		margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
-		padding-left: #{2 * map-deep-get($config-global, "spacing", "unit")};
+		padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
 	}
 }

--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -1,0 +1,7 @@
+.block-library-list {
+	ul,
+	ol {
+		margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
+		padding-left: calc(2 * #{map-deep-get($config-global, "spacing", "unit")});
+	}
+}

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -1,9 +1,8 @@
 ul,
 ol {
 	font-family: #{map-deep-get($config-list, "font", "family")};
-	list-style-position: inside;
-	margin: 0 0 0 #{map-deep-get($config-global, "spacing", "unit")};
-	padding: 0;
+	margin: 0;
+	padding-left: calc(2 * #{map-deep-get($config-global, "spacing", "horizontal")});
 }
 
 ul {
@@ -25,5 +24,6 @@ dt {
 }
 
 dd {
-	margin: 0 0 0 #{map-deep-get($config-global, "spacing", "unit")};
+	margin: 0;
+	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
 }

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -2,7 +2,7 @@ ul,
 ol {
 	font-family: #{map-deep-get($config-list, "font", "family")};
 	margin: 0;
-	padding-left: calc(2 * #{map-deep-get($config-global, "spacing", "horizontal")});
+	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
 }
 
 ul {

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -25,5 +25,5 @@ dt {
 
 dd {
 	margin: 0;
-	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
+	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -461,7 +461,7 @@ object {
 .block-library-list ul,
 .block-library-list ol {
 	margin: 32px 0;
-	padding-left: calc(2 * 16px);
+	padding-left: 32px;
 }
 
 .wp-block-media-text .block-editor-inner-blocks {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -458,6 +458,12 @@ object {
 	margin: 0;
 }
 
+.block-library-list ul,
+.block-library-list ol {
+	margin: 32px 0;
+	padding-left: calc(2 * 16px);
+}
+
 .wp-block-media-text .block-editor-inner-blocks {
 	padding-right: 16px;
 	padding-left: 16px;

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1589,7 +1589,7 @@ ul,
 ol {
 	font-family: serif;
 	margin: 0;
-	padding-right: calc(2 * 16px);
+	padding-right: 32px;
 }
 
 ul {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1607,7 +1607,7 @@ dt {
 
 dd {
 	margin: 0;
-	padding-right: 16px;
+	padding-right: 32px;
 }
 
 .wp-block-media-text {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1588,9 +1588,8 @@ img {
 ul,
 ol {
 	font-family: serif;
-	list-style-position: inside;
-	margin: 0 16px 0 0;
-	padding: 0;
+	margin: 0;
+	padding-right: calc(2 * 16px);
 }
 
 ul {
@@ -1607,7 +1606,8 @@ dt {
 }
 
 dd {
-	margin: 0 16px 0 0;
+	margin: 0;
+	padding-right: 16px;
 }
 
 .wp-block-media-text {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1607,7 +1607,7 @@ dt {
 
 dd {
 	margin: 0;
-	padding-left: 16px;
+	padding-left: 32px;
 }
 
 .wp-block-media-text {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1589,7 +1589,7 @@ ul,
 ol {
 	font-family: serif;
 	margin: 0;
-	padding-left: calc(2 * 16px);
+	padding-left: 32px;
 }
 
 ul {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1588,9 +1588,8 @@ img {
 ul,
 ol {
 	font-family: serif;
-	list-style-position: inside;
-	margin: 0 0 0 16px;
-	padding: 0;
+	margin: 0;
+	padding-left: calc(2 * 16px);
 }
 
 ul {
@@ -1607,7 +1606,8 @@ dt {
 }
 
 dd {
-	margin: 0 0 0 16px;
+	margin: 0;
+	padding-left: 16px;
 }
 
 .wp-block-media-text {


### PR DESCRIPTION
Fixes #1441.  This should fix #1372 as well.

**After**
<img width="2556" alt="Screen Shot 2019-09-28 at 18 13 06" src="https://user-images.githubusercontent.com/908665/65820074-a5cabe00-e21c-11e9-9833-2af573e4cb4a.png">

This makes the list item indented to inside, but it's much easier to read. Eventually, we'd want to introduce a new spacing config for lists with `em` unit so it works relatively with the font size. 