### PR TITLE
FIX #1409: Limit gravatar size

### DIFF
--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2927,6 +2927,7 @@ table th,
 	display: block;
 	position: absolute;
 	left: 0;
+	height: 32px;
 }
 
 @media only screen and (min-width: 560px) {

--- a/morden/style.css
+++ b/morden/style.css
@@ -2944,6 +2944,7 @@ table th,
 	display: block;
 	position: absolute;
 	right: 0;
+	height: 32px;
 }
 
 @media only screen and (min-width: 560px) {


### PR DESCRIPTION
Fixes #1409

Before the fix, all Gravatars were visible in their original size. This PR ensures that the Gravatars are visible with a maximum height of 32px.

<table>
<tr>
<td>Before I:
<br><br>

![#1409 - before I](https://user-images.githubusercontent.com/3323310/65873325-fc670200-e3ac-11e9-887a-5ff8c150d5c0.png)

</td>
<td>Before II:
<br><br>

![#1409 - before II](https://user-images.githubusercontent.com/3323310/65873333-025ce300-e3ad-11e9-8ae3-6036898539bd.png)

</td>
<td>After:
<br><br>

![#1409 - after](https://user-images.githubusercontent.com/3323310/65873334-06890080-e3ad-11e9-9d0a-4c6dfa4c3366.png)

</td>
</tr>
</table>