### PR TITLE
FIX #1396: Align more block

### DIFF
--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2723,7 +2723,7 @@ table th,
 }
 
 .entry-content .more-link {
-	display: inline;
+	display: block;
 	color: inherit;
 }
 

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2740,7 +2740,7 @@ table th,
 }
 
 .entry-content .more-link {
-	display: inline;
+	display: block;
 	color: inherit;
 }
 


### PR DESCRIPTION
Fixes #1396

@iamtakashi It seems that in #1420 you've only changed the stylesheets of `Varia` but missed to render the stylesheets for the child theme `Rockfield` which comes with its own stylesheets inherited by its parent theme.😀

I just rendered the stylesheets for `Rockfield` with this PR. I also saw that there are much more changes in the stylesheets when running `npm build` and `npm run build:rtl`. 

<table>
<tr>
<td>Before:
<br><br>

![#1396 - before](https://user-images.githubusercontent.com/3323310/65876359-4357f600-e3b3-11e9-91a7-f2f81deb52c9.png)

</td>
<td>After:
<br><br>

![#1396 - after](https://user-images.githubusercontent.com/3323310/65876365-46eb7d00-e3b3-11e9-8311-7a4ddefab5e8.png)

</td>
</tr>
</table>