### PR TITLE
FIX #1409: Limit Gravatar size

### DIFF
--- a/varia/sass/components/comments/_comments.scss
+++ b/varia/sass/components/comments/_comments.scss
@@ -96,6 +96,8 @@
 			display: block;
 			position: absolute;
 			right: 0;
+			height: $avatar-size;
+			width: $avatar-size;
 
 			@include media(mobile) {
 				margin-right: #{map-deep-get($config-global, "spacing", "horizontal")};

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2937,6 +2937,8 @@ table th,
 	display: block;
 	position: absolute;
 	left: 0;
+	height: 32px;
+	width: 32px;
 }
 
 @media only screen and (min-width: 560px) {

--- a/varia/style.css
+++ b/varia/style.css
@@ -2954,6 +2954,8 @@ table th,
 	display: block;
 	position: absolute;
 	right: 0;
+	height: 32px;
+	width: 32px;
 }
 
 @media only screen and (min-width: 560px) {


### PR DESCRIPTION
Fixes #1409 

Before the fix, all Gravatars were visible in their original size. This PR ensures that the Gravatars are visible with a maximum height of 32px.

<table>
<tr>
<td>Before I:
<br><br>

![#1409 - before I](https://user-images.githubusercontent.com/3323310/65873325-fc670200-e3ac-11e9-887a-5ff8c150d5c0.png)

</td>
<td>Before II:
<br><br>

![#1409 - before II](https://user-images.githubusercontent.com/3323310/65873333-025ce300-e3ad-11e9-8ae3-6036898539bd.png)

</td>
<td>After:
<br><br>

![#1409 - after](https://user-images.githubusercontent.com/3323310/65873334-06890080-e3ad-11e9-9d0a-4c6dfa4c3366.png)

</td>
</tr>
</table>

While  #1409 affects the `Morden` theme, this PR contains the styles of its parent theme `Varia`  as according to https://github.com/Automattic/themes/pull/1455#issuecomment-536551295 the process should be automated in a way that styles of child themes are created automatically.