### PR TITLE
Varia: Remove featured image support for Pages

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'varia_setup' ) ) :
 		 *
 		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
 		 */
-		add_theme_support( 'post-thumbnails' );
+		add_theme_support( 'post-thumbnails', array( 'post' ) );
 		set_post_thumbnail_size( 1568, 9999 );
 
 		// This theme uses wp_nav_menu() in two locations.


### PR DESCRIPTION
After some further discussion, we decided to go in the opposite of the direction of the solution suggested in #1452 for a couple of reasons: 

1. A featured image on a Page is _not_ currently displayed anywhere in Varia based themes. Some users may have had featured images on Pages before switching to a Varia, so if we add support their sites may be disrupted with new featured images that they’ll have to remove page-by-page. 
2. We want to ultimately push customers toward editing with Gutenberg more directly and right now they’re isn’t a _direct_ way to control how or when they appear. 

More background info here: https://github.com/Automattic/themes/issues/1443#issuecomment-536743360

#### Changes proposed in this Pull Request:

- Remove featured image support for Pages and only allow them for Posts.

#### Related issue(s):
#1452 
Fixes #1443 #1461