### PR TITLE
Varia: Center image block by default.

### DIFF
--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -11,6 +11,7 @@
 @import "code/editor";
 @import "cover/editor";
 @import "heading/editor";
+@import "image/editor";
 @import "gallery/editor";
 @import "group/editor";
 @import "latest-posts/editor";

--- a/varia/sass/blocks/image/_editor.scss
+++ b/varia/sass/blocks/image/_editor.scss
@@ -1,0 +1,13 @@
+/* Center image block by default in the editor */
+
+.wp-block-image {
+	text-align: center;
+}
+
+.wp-block-image > div {
+	text-align: center;
+}
+
+[data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
+	margin:0 auto;
+}

--- a/varia/sass/blocks/image/_editor.scss
+++ b/varia/sass/blocks/image/_editor.scss
@@ -1,9 +1,5 @@
 /* Center image block by default in the editor */
 
-.wp-block-image {
-	text-align: center;
-}
-
 .wp-block-image > div {
 	text-align: center;
 }

--- a/varia/sass/blocks/image/_style.scss
+++ b/varia/sass/blocks/image/_style.scss
@@ -1,4 +1,5 @@
 .wp-block-image {
+	text-align: center;
 
 	figcaption {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -396,6 +396,19 @@ object {
 	line-height: 1.125;
 }
 
+/* Center image block by default in the editor */
+.wp-block-image {
+	text-align: center;
+}
+
+.wp-block-image > div {
+	text-align: center;
+}
+
+[data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
+	margin: 0 auto;
+}
+
 .wp-block-gallery figcaption {
 	margin-bottom: 0;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -397,10 +397,6 @@ object {
 }
 
 /* Center image block by default in the editor */
-.wp-block-image {
-	text-align: center;
-}
-
 .wp-block-image > div {
 	text-align: center;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1423,6 +1423,10 @@ h6, .h6 {
 	line-height: 1.125;
 }
 
+.wp-block-image {
+	text-align: center;
+}
+
 .wp-block-image figcaption {
 	color: #767676;
 	font-size: 0.69444rem;

--- a/varia/style.css
+++ b/varia/style.css
@@ -1423,6 +1423,10 @@ h6, .h6 {
 	line-height: 1.125;
 }
 
+.wp-block-image {
+	text-align: center;
+}
+
 .wp-block-image figcaption {
 	color: #767676;
 	font-size: 0.69444rem;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

## Changes proposed in this Pull Request: 

- Center image block by default in the editor.
- Corrects caption placement on small, resized image blocks.
- This is a temporary solution that allows images to display consistently between the editor and the frontend. The permanent solution needs to happen in Gutenberg. See here: https://github.com/WordPress/gutenberg/issues/13684

## After

**Editor** | **Frontend**
------------ | ------------
![image](https://user-images.githubusercontent.com/709581/65985602-245b7180-e450-11e9-923d-17230ace6390.png) | ![image](https://user-images.githubusercontent.com/709581/65985648-36d5ab00-e450-11e9-8836-fcf215ea1343.png)


## Related issue(s): 

Fixes #1407 