### PR TITLE
Lodestar: gallery block margin issue

### DIFF
--- a/lodestar/style.css
+++ b/lodestar/style.css
@@ -1232,7 +1232,7 @@ body:not(.logged-in) .lodestar-panel .jetpack-testimonial .entry-header {
 	text-align: center;
 }
 
-.lodestar-intro .entry-content *:last-child {
+.lodestar-intro .entry-content > *:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This solves the bottom-margin issue with the gallery block on the front page of Lodestar. The theme wants to set a margin-bottom for the last item in the entry-content to be 0, but doesn't account for the block editor. This PR fixes this by limiting this rule to the last direct descendent of the entry-content.

#### Related issue(s):
https://github.com/Automattic/themes/issues/724