### PR TITLE
FIX #1449: Solve primary menu display issue

### DIFF
--- a/shawburn/functions.php
+++ b/shawburn/functions.php
@@ -181,3 +181,17 @@ function shawburn_editor_styles() {
 	wp_enqueue_style( 'shawburn-editor-fonts', shawburn_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'shawburn_editor_styles' );
+
+/**
+ * Add custom body classes.
+ *
+ * @param array $classes The existing body classes.
+ * @return array $classes The updated body classes.
+ */
+function shawburn_body_classes( $classes ) {
+	if ( ! has_nav_menu( 'social' ) ) {
+		$classes[] = 'has-no-social-menu';
+	}
+	return $classes;
+}
+add_filter( 'body_class', 'shawburn_body_classes' );

--- a/shawburn/functions.php
+++ b/shawburn/functions.php
@@ -181,17 +181,3 @@ function shawburn_editor_styles() {
 	wp_enqueue_style( 'shawburn-editor-fonts', shawburn_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'shawburn_editor_styles' );
-
-/**
- * Add custom body classes.
- *
- * @param array $classes The existing body classes.
- * @return array $classes The updated body classes.
- */
-function shawburn_body_classes( $classes ) {
-	if ( ! has_nav_menu( 'social' ) ) {
-		$classes[] = 'has-no-social-menu';
-	}
-	return $classes;
-}
-add_filter( 'body_class', 'shawburn_body_classes' );

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -22,6 +22,20 @@ body {
 	}
 }
 
+.home.has-no-social-menu.hide-homepage-title {
+	.hentry .entry-content {
+		& > *:first-child {
+			&.alignfull {
+				margin-top: -#{1 * map-deep-get($config-global, "spacing", "unit")};
+
+				@include media(mobile) {
+					margin-top: -#{2 * map-deep-get($config-global, "spacing", "unit")};
+				}
+			}
+		}
+	}
+}
+
 a {
 	text-decoration: none;
 }

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -12,24 +12,10 @@ body {
 	.hentry .entry-content {
 		& > *:first-child {
 			&.alignfull {
-				margin-top: -#{2 * map-deep-get($config-global, "spacing", "unit")};
+				margin-top: -#{map-deep-get($config-global, "spacing", "unit")};
 
 				@include media(mobile) {
 					margin-top: -#{3 * map-deep-get($config-global, "spacing", "unit")};
-				}
-			}
-		}
-	}
-}
-
-.home.has-no-social-menu.hide-homepage-title {
-	.hentry .entry-content {
-		& > *:first-child {
-			&.alignfull {
-				margin-top: -#{1 * map-deep-get($config-global, "spacing", "unit")};
-
-				@include media(mobile) {
-					margin-top: -#{2 * map-deep-get($config-global, "spacing", "unit")};
 				}
 			}
 		}
@@ -41,6 +27,7 @@ a {
 }
 
 .main-navigation {
+	margin-bottom: 0;
 	text-transform: uppercase;
 }
 
@@ -149,6 +136,12 @@ hr.wp-block-separator.is-style-wide,
 .site {
 	margin: 0 auto;
 	padding: 0;
+}
+
+.site-main {
+	@include media(mobile) {
+		padding-top: #{3 * map-deep-get($config-global, "spacing", "unit")};
+	}
 }
 
 #page {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3416,6 +3416,16 @@ body {
 	}
 }
 
+.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -32px;
+	}
+}
+
 a {
 	text-decoration: none;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3407,7 +3407,7 @@ body {
 }
 
 .home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-	margin-top: -32px;
+	margin-top: -16px;
 }
 
 @media only screen and (min-width: 560px) {
@@ -3416,21 +3416,12 @@ body {
 	}
 }
 
-.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-	margin-top: -16px;
-}
-
-@media only screen and (min-width: 560px) {
-	.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-		margin-top: -32px;
-	}
-}
-
 a {
 	text-decoration: none;
 }
 
 .main-navigation {
+	margin-bottom: 0;
 	text-transform: uppercase;
 }
 
@@ -3544,6 +3535,12 @@ hr.wp-block-separator.is-style-wide,
 .site {
 	margin: 0 auto;
 	padding: 0;
+}
+
+@media only screen and (min-width: 640px) {
+	.site-main {
+		padding-top: 48px;
+	}
 }
 
 #page .entry-header,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3445,6 +3445,16 @@ body {
 	}
 }
 
+.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -32px;
+	}
+}
+
 a {
 	text-decoration: none;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3436,7 +3436,7 @@ body {
 }
 
 .home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-	margin-top: -32px;
+	margin-top: -16px;
 }
 
 @media only screen and (min-width: 560px) {
@@ -3445,21 +3445,12 @@ body {
 	}
 }
 
-.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-	margin-top: -16px;
-}
-
-@media only screen and (min-width: 560px) {
-	.home.has-no-social-menu.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
-		margin-top: -32px;
-	}
-}
-
 a {
 	text-decoration: none;
 }
 
 .main-navigation {
+	margin-bottom: 0;
 	text-transform: uppercase;
 }
 
@@ -3573,6 +3564,12 @@ hr.wp-block-separator.is-style-wide,
 .site {
 	margin: 0 auto;
 	padding: 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.site-main {
+		padding-top: 48px;
+	}
 }
 
 #page .entry-header,


### PR DESCRIPTION
Fixes #1449 

<table>
<tr>
<td>Before (Desktop):
<br><br>

![#1449 - desktop - before](https://user-images.githubusercontent.com/3323310/66060871-945d1b00-e568-11e9-9bb4-4113eb960b32.png)

</td>
<td>After (Desktop):
<br><br>

![#1449 - desktop - after](https://user-images.githubusercontent.com/3323310/66060885-9cb55600-e568-11e9-8ee0-3805e8420ea9.png)

</td>
</tr>
</table>

<table>
<tr>
<td>Before (Mobile):
<br><br>

![#1449 - mobile - before](https://user-images.githubusercontent.com/3323310/66060926-a8088180-e568-11e9-8837-b384acefecf1.png)

</td>
<td>After (Mobile):
<br><br>

![#1449 - mobile - after](https://user-images.githubusercontent.com/3323310/66060951-b191e980-e568-11e9-9d47-895814286107.png)

</td>
</tr>
</table>

@iamtakashi To fix this issue, I've introduce a new `body_class` called `has-no-social-menu` to remain backwards compatibility.

And `npm run build` resulted in many additional CSS statements, which I've excluded to keep this PR clean. You mentioned that there's work in progress to automate the generation of child theme styles anyway. Therefore, I haven't shipped these unrendered changes with this PR. 