### PR TITLE
Varia: Add more specificity to the `.children` selector for comments …

### DIFF
--- a/varia/sass/components/comments/_comments.scss
+++ b/varia/sass/components/comments/_comments.scss
@@ -56,7 +56,7 @@
 	}
 }
 
-.children {
+.comment-list .children {
 	list-style: none;
 	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2905,19 +2905,19 @@ table th,
 	margin-bottom: 32px;
 }
 
-.children {
+.comment-list .children {
 	list-style: none;
 	padding-right: 16px;
 }
 
-.children > li {
+.comment-list .children > li {
 	border-top: 1px solid #DDDDDD;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.children {
+	.comment-list .children {
 		padding-right: 32px;
 	}
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -2922,19 +2922,19 @@ table th,
 	margin-bottom: 32px;
 }
 
-.children {
+.comment-list .children {
 	list-style: none;
 	padding-left: 16px;
 }
 
-.children > li {
+.comment-list .children > li {
 	border-top: 1px solid #DDDDDD;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.children {
+	.comment-list .children {
 		padding-left: 32px;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Add more specificity to the `.children` selector to make it only effect comments. This will prevent conflicts with other nested lists that also happen to use the `.children` selector. 

#### Related issue(s):

Discovered while testing the Categories Widget Block with the nested option turned on.