### PR TITLE
Photos: Centre gallery block

### DIFF
--- a/photos/blocks.css
+++ b/photos/blocks.css
@@ -171,8 +171,8 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 /* Galleries */
-.wp-block-gallery {
-	margin-bottom: 3rem;
+figure.wp-block-gallery {
+	margin: 0 auto 3rem;
 }
 
 /* Captions */


### PR DESCRIPTION
Fixes #1506

<table>
<tr>
<td>Before:
<br><br>

![#1506 - before](https://user-images.githubusercontent.com/3323310/66467647-f957ca00-eaae-11e9-8930-c580a04dd11f.png)

</td>
<td>After:
<br><br>

![#1506 - after](https://user-images.githubusercontent.com/3323310/66467654-fc52ba80-eaae-11e9-87db-6f459cddfe5d.png)

</td>
</tr>
</table>

@iamtakashi  As `.wp-block-gallery { ... }` had been overwritten, I've increased the CSS specificity to `figure.wp-block-gallery { ... }` in addition to the CSS changes I've applied.  