### PR TITLE
Fix #1505: Rockfield: long username overlaps comments

### DIFF
--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -449,6 +449,14 @@ table,
 	}
 }
 
+.comment-author {
+	.fn {
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+		hyphens: auto;
+	}
+}
+
 @include media(tablet) {
 	.comment-meta {
 		border-right: 1px solid #{map-deep-get($config-global, "color", "border", "default")};

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2946,19 +2946,19 @@ table th,
 	margin-bottom: 32px;
 }
 
-.children {
+.comment-list .children {
 	list-style: none;
 	padding-right: 16px;
 }
 
-.children > li {
+.comment-list .children > li {
 	border-top: 1px solid #E0E0E0;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.children {
+	.comment-list .children {
 		padding-right: 32px;
 	}
 }
@@ -3990,6 +3990,15 @@ table th,
 .comment-respond .form-submit {
 	display: flex;
 	justify-content: center;
+}
+
+.comment-author .fn {
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	-webkit-hyphens: auto;
+	-ms-hyphens: auto;
+	-moz-hyphens: auto;
+	hyphens: auto;
 }
 
 @media only screen and (min-width: 640px) {

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2963,19 +2963,19 @@ table th,
 	margin-bottom: 32px;
 }
 
-.children {
+.comment-list .children {
 	list-style: none;
 	padding-left: 16px;
 }
 
-.children > li {
+.comment-list .children > li {
 	border-top: 1px solid #E0E0E0;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.children {
+	.comment-list .children {
 		padding-left: 32px;
 	}
 }
@@ -4019,6 +4019,12 @@ table th,
 .comment-respond .form-submit {
 	display: flex;
 	justify-content: center;
+}
+
+.comment-author .fn {
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	hyphens: auto;
 }
 
 @media only screen and (min-width: 640px) {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This is a CSS implementation but most of browsers today don't support hyphens quite well. So, it defaults to word breaking.


#### Related issue(s):
#1505 This commit should fix the issue with "Rockfield: long username overlaps comments"
