### PR TITLE
Full Site Editing: Stop using theme classes for template parts

### DIFF
--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -230,7 +230,9 @@ a {
 	@include media(desktop) {
 		min-height: #{20 * map-deep-get($config-global, "spacing", "vertical")};
 
-		h1 {
+		// Prevent overruling the user defined font size value set inside Gutenberg
+		// for Full Site Editing's Site Title block.
+		h1:not(.site-title) {
 			font-size: #{map-deep-get($config-global, "font", "size", "xxxxl")};
 		}
 

--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -8,6 +8,17 @@
 	.main-navigation a {
 		text-decoration: none;
 	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title {
+			font-weight: #{map-deep-get($config-heading, "font", "weight")};
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
 }
 
 .post-content__block {

--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -1,6 +1,6 @@
 @import "../../varia/sass/full-site-editing/editor";
 
-.fse-template {
+.fse-template-part {
 	.has-normal-font-size {
 		font-size: map-deep-get($config-global, "font", "size", "md");
 	}

--- a/maywood/sass/_full-site-editing-editor.scss
+++ b/maywood/sass/_full-site-editing-editor.scss
@@ -1,66 +1,12 @@
 @import "../../varia/sass/full-site-editing/editor";
 
-.site-header, .site-footer {
-	.site-title {
-		font-size: 20px;
-		@include media(mobile) {
-			font-size: 24px;
-		}
+.fse-template {
+	.has-normal-font-size {
+		font-size: map-deep-get($config-global, "font", "size", "md");
 	}
 
-	.site-description {
-		font-size: 13.8px;
-		@include media(mobile) {
-			font-size: 16.6px;
-		}
-	}
-
-	.wp-block-cover,
-	.wp-block-cover-image {
-		.site-title,
-		.site-description {
-			text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
-		}
-	}
-}
-
-.site-header {
-	.site-title {
+	.main-navigation a {
 		text-decoration: none;
-	}
-
-	.main-navigation {
-		text-align: center;
-		ul {
-			justify-content: center;
-			a {
-				font-size: 20px;
-				text-decoration: none;
-			}
-		}
-	}
-}
-
-.site-footer {
-	.site-title {
-		font-weight: 700;
-	}
-
-	.main-navigation .footer-menu {
-		justify-content: center;
-
-		@include media(tablet) {
-			justify-content: flex-end;
-		}
-
-		a {
-			font-size: 16.6px;
-			text-decoration: none;
-			@include media(mobile-only) {
-				font-size: 13.8px;
-				padding: 0 8px;
-			}
-		}
 	}
 }
 

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -7,7 +7,7 @@
 	}
 }
 
-.fse-template {
+.fse-template-part {
 	.main-navigation a {
 		text-decoration: none;
 	}

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -1,69 +1,22 @@
 @import "../../varia/sass/full-site-editing/imports";
 
-.fse-enabled {
-	.site-header.entry-content {
-		margin-bottom: 0;
-		max-width: 100%;
-		padding: 0;
-		width: 100%;
-
-		@include media(mobile-only) {
-			.main-navigation > div {
-				padding: 0 32px;
-			}
-		}
+.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+	padding-bottom: $spacing_vertical;
+	@include media(mobile) {
+		padding-bottom: #{1.5 * $spacing_vertical};
 	}
-	&.home.page.hide-homepage-title .site-header.entry-content {
-		padding-bottom: $spacing_vertical;
-		@include media(mobile) {
-			padding-bottom: #{1.5 * $spacing_vertical};
-		}
+}
+
+.fse-template {
+	.main-navigation a {
+		text-decoration: none;
 	}
+	
+	@include media(mobile-only) {
+		max-width: calc( 100% - #{ $spacing_vertical } );
 
-	.site-footer {
-		.wp-block-a8c-navigation-menu {
-			@include media(tablet) {
-				margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
-				margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
-			}
-			@include media(mobile) {
-				.footer-menu a {
-					padding: 8px;
-				}
-			}
+		.main-navigation > div {
+			padding: 0 32px;
 		}
-	}
-
-	.wp-block-cover,
-	.wp-block-cover-image {
-		.site-title {
-			font-size: 20px;
-			@include media(mobile) {
-				font-size: 24px;
-			}
-
-			a {
-				text-decoration: none;
-			}
-		}
-
-		.site-description {
-			font-size: 13.8px;
-
-			@include media(mobile) {
-				font-size: 16.6px;
-			}
-		}
-
-		.main-navigation a {
-			text-decoration: none;
-		}
-	}
-
-	#colophon {
-		margin-left: auto;
-		margin-right: auto;
-		max-width: none;
-		width: 100%;
 	}
 }

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -1,6 +1,6 @@
 @import "../../varia/sass/full-site-editing/imports";
 
-.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
 	padding-bottom: $spacing_vertical;
 	@include media(mobile) {
 		padding-bottom: #{1.5 * $spacing_vertical};

--- a/maywood/sass/_full-site-editing.scss
+++ b/maywood/sass/_full-site-editing.scss
@@ -19,4 +19,15 @@
 			padding: 0 32px;
 		}
 	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title a {
+			text-decoration: none;
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
 }

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -93,4 +93,4 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * Full Site Editing
  * - Full Site Editing overrides
  */
- @import "full-site-editing";
+@import "full-site-editing";

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1079,107 +1079,11 @@ b, strong {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-.site-header .main-navigation button,
-.site-header .main-navigation .button,
-.site-header .main-navigation input[type="submit"],
-.site-header .main-navigation .wp-block-button__link,
-.site-header .main-navigation .wp-block-file__button {
-	line-height: 1;
-	color: white;
-	cursor: pointer;
-	font-weight: 700;
-	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 0.83333rem;
-	background-color: #897248;
-	border-radius: 5px;
-	border-width: 0;
-	padding: 16px 16px;
-}
-
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before, .site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
-	content: '';
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before {
-	margin-bottom: -0.12em;
-}
-
-.site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
-	margin-top: -0.11em;
-}
-
-.site-header .main-navigation button:hover,
-.site-header .main-navigation .button:hover,
-.site-header .main-navigation input:hover[type="submit"],
-.site-header .main-navigation .wp-block-button__link:hover,
-.site-header .main-navigation .wp-block-file__button:hover, .site-header .main-navigation button:focus,
-.site-header .main-navigation .button:focus,
-.site-header .main-navigation input:focus[type="submit"],
-.site-header .main-navigation .wp-block-button__link:focus,
-.site-header .main-navigation .wp-block-file__button:focus, .site-header .main-navigation button.has-focus,
-.site-header .main-navigation .has-focus.button,
-.site-header .main-navigation input.has-focus[type="submit"],
-.site-header .main-navigation .has-focus.wp-block-button__link,
-.site-header .main-navigation .has-focus.wp-block-file__button {
-	color: white;
-	background-color: #685636;
-}
-
-/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-.site-branding {
-	color: #686868;
-}
-
-.site-title {
-	color: #181818;
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	letter-spacing: normal;
-	line-height: 1;
-}
-
-.site-title a {
-	color: currentColor;
-	font-weight: 700;
-}
-
-.site-title a:link, .site-title a:visited {
-	color: currentColor;
-}
-
-.site-title a:hover {
-	color: #897248;
+@media (min-width: 600px) {
+	.a8c-template-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .template-block .fse-template-part {
@@ -1221,11 +1125,7 @@ b, strong {
 	margin: 0;
 }
 
-<<<<<<< HEAD
-.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
-=======
 .fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
->>>>>>> Temporary fix for missing alert colors in Maywood
 	display: block;
 }
 
@@ -1248,7 +1148,7 @@ b, strong {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div {
+	.fse-template-part .main-navigation > div {
 		display: inline-block;
 	}
 	.fse-template-part .main-navigation #toggle-menu {
@@ -1428,259 +1328,57 @@ b, strong {
 	font-size: 1rem;
 }
 
-.social-navigation > div > ul {
-	align-content: center;
-	display: flex;
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-}
-
-.social-navigation > div > ul > li:first-of-type > a {
-	padding-left: 0;
-}
-
-.social-navigation > div > ul > li:last-of-type > a {
-	padding-right: 0;
-}
-
-.social-navigation a {
-	color: #181818;
-	display: inline-block;
-	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
-}
-
-.social-navigation a:hover {
-	color: #897248;
-}
-
-.social-navigation svg {
-	fill: currentColor;
-	vertical-align: middle;
-}
-
-.site-footer {
-	overflow: hidden;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-footer {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-	}
-}
-
-.site-info {
-	color: #686868;
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 0.83333rem;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-info {
-		order: 1;
-		flex: 1 0 50%;
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-}
-
-.site-info .site-name {
-	font-weight: bold;
-}
-
-.site-info a {
-	color: currentColor;
-}
-
-.site-info a:link, .site-info a:visited {
-	color: currentColor;
-}
-
-.site-info a:hover {
-	color: #685636;
-}
-
-.footer-navigation, .site-footer .main-navigation {
-	display: inline;
-}
-
-@media only screen and (min-width: 640px) {
-	.footer-navigation, .site-footer .main-navigation {
-		flex: 1 0 50%;
-		order: 2;
-		margin-top: 0;
-		margin-bottom: 0;
-		text-align: right;
-	}
-}
-
-.footer-navigation > div, .site-footer .main-navigation > div {
-	display: inline;
-}
-
-.footer-navigation .footer-menu, .site-footer .main-navigation .footer-menu {
-	color: #686868;
-	margin: 0;
-	padding-left: 0;
-}
-
-@media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .site-footer .main-navigation .footer-menu {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
-}
-
-.footer-navigation .footer-menu > li, .site-footer .main-navigation .footer-menu > li {
-	display: inline;
-}
-
-.footer-navigation .footer-menu > li:first-of-type > a, .site-footer .main-navigation .footer-menu > li:first-of-type > a {
-	padding-left: 0;
-}
-
-.footer-navigation .footer-menu > li:last-of-type, .site-footer .main-navigation .footer-menu > li:last-of-type {
-	padding-right: 0;
-}
-
-.footer-navigation .footer-menu a, .site-footer .main-navigation .footer-menu a {
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-weight: 700;
-	padding: 8px;
-	color: currentColor;
-}
-
-.footer-navigation .footer-menu a:link, .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .site-footer .main-navigation .footer-menu a:visited {
-	color: currentColor;
-}
-
-.footer-navigation .footer-menu a:hover, .site-footer .main-navigation .footer-menu a:hover {
-	color: #685636;
-}
-
-body:not(.fse-enabled) .footer-menu a {
-	font-size: 0.83333rem;
-}
-
-.template-block .site-header,
-.template-block .site-footer {
-	padding: 16px;
-}
-
-@media only screen and (min-width: 560px) {
-	.template-block .site-header,
-	.template-block .site-footer {
-		padding: 32px 0;
-	}
-}
-
-.template-block .wp-block-cover .site-title,
-.template-block .wp-block-cover .site-description,
-.template-block .wp-block-cover-image .site-title,
-.template-block .wp-block-cover-image .site-description {
-	background: transparent;
-	color: inherit;
-}
-
-.a8c-template-editor .wp-block-cover .site-title,
-.a8c-template-editor .wp-block-cover .site-description,
-.a8c-template-editor .wp-block-cover-image .site-title,
-.a8c-template-editor .wp-block-cover-image .site-description {
-	background: transparent;
-	color: inherit;
-}
-
-.site-header .site-title {
-	font-size: 21.6px;
-	font-weight: 700;
-	text-decoration: underline;
-}
-
-.site-header .site-description {
-	font-size: 15px;
-}
-
-.site-header .main-navigation {
+.fse-template-part .main-navigation {
+	text-align: center;
 	/**
- * Button
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
  */
 	/**
- * Block Options
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
  */
 }
 
-.site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link {
-	color: #897248;
-	background: transparent;
-	border: 2px solid currentcolor;
-	padding: 14px 16px;
+.fse-template-part .main-navigation .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #897248;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
-.site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:focus, .site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
-	color: #685636;
-}
-
-.site-header .main-navigation .wp-block-button.is-style-squared .wp-block-button__link {
-	border-radius: 0;
-}
-
-.post-content__block {
-	margin-bottom: 160px;
-	margin-top: 36px;
-	z-index: 20;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-footer {
-		display: block;
-	}
-}
-
-.site-footer .main-navigation {
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
+	content: '';
 	display: block;
+	height: 0;
+	width: 0;
 }
 
-.site-footer .main-navigation .footer-menu {
-	color: inherit;
+.fse-template-part .main-navigation .button:before {
+	margin-bottom: -0.12em;
 }
 
-.site-footer .main-navigation > div {
-	display: block;
+.fse-template-part .main-navigation .button:after {
+	margin-top: -0.11em;
 }
 
-.site-footer .main-navigation .hide-visually,
-.site-footer .main-navigation #toggle-menu {
-	display: none;
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+	color: white;
+	background-color: #685636;
 }
 
-@media only screen and (max-width: 559px) {
-	.site-footer .main-navigation > div {
-		display: block;
-	}
-	.site-footer .main-navigation li {
-		width: auto;
-	}
-	.site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.site-header .site-title.has-background,
-.site-header .site-description.has-background,
-.site-footer .site-title.has-background,
-.site-footer .site-description.has-background {
-	border-radius: 0;
-	padding: 16px;
-}
-
-.site-header .main-navigation .main-menu.footer-menu li a,
-.site-footer .main-navigation .main-menu.footer-menu li a {
+.fse-template-part .main-navigation .main-menu.footer-menu li a {
 	font-size: inherit;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1188,23 +1188,29 @@ b, strong {
 	font-family: var(--font-base, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 }
 
-body:not(.fse-enabled) .site-title {
-	font-size: 1.2rem;
+@media only screen and (min-width: 560px) {
+	.template-block .fse-template {
+		padding: 32px 0;
+	}
 }
 
-body:not(.fse-enabled) .site-description {
-	font-size: 0.83333rem;
+.fse-template .wp-block-cover .site-title,
+.fse-template .wp-block-cover .site-description,
+.fse-template .wp-block-cover-image .site-title,
+.fse-template .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
 }
 
-.main-navigation {
+.fse-template .main-navigation {
 	color: #181818;
 }
 
-.main-navigation > div {
+.fse-template .main-navigation > div {
 	display: none;
 }
 
-.main-navigation #toggle-menu {
+.fse-template .main-navigation #toggle-menu {
 	display: inline-block;
 	margin: 0;
 }
@@ -1213,21 +1219,21 @@ body:not(.fse-enabled) .site-description {
 	display: block;
 }
 
-.main-navigation #toggle:focus + #toggle-menu {
+.fse-template .main-navigation #toggle:focus + #toggle-menu {
 	background-color: #897248;
 	outline: inherit;
 	text-decoration: underline;
 }
 
-.main-navigation .dropdown-icon.close {
+.fse-template .main-navigation .dropdown-icon.close {
 	display: none;
 }
 
-.main-navigation #toggle:checked + #toggle-menu .open {
+.fse-template .main-navigation #toggle:checked + #toggle-menu .open {
 	display: none;
 }
 
-.main-navigation #toggle:checked + #toggle-menu .close {
+.fse-template .main-navigation #toggle:checked + #toggle-menu .close {
 	display: inline;
 }
 
@@ -1235,15 +1241,15 @@ body:not(.fse-enabled) .site-description {
 	.main-navigation > div {
 		display: inline-block;
 	}
-	.main-navigation #toggle-menu {
+	.fse-template .main-navigation #toggle-menu {
 		display: none;
 	}
-	.main-navigation > div > ul > li > ul {
+	.fse-template .main-navigation > div > ul > li > ul {
 		display: none;
 	}
 }
 
-.main-navigation > div > ul {
+.fse-template .main-navigation > div > ul {
 	display: flex;
 	flex-wrap: wrap;
 	list-style: none;
@@ -1254,45 +1260,45 @@ body:not(.fse-enabled) .site-description {
 	/* Sub-menus Flyout */
 }
 
-.main-navigation > div > ul ul {
+.fse-template .main-navigation > div > ul ul {
 	padding-left: 0;
 }
 
-.main-navigation > div > ul li {
+.fse-template .main-navigation > div > ul li {
 	display: block;
 	position: relative;
 	width: 100%;
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
+.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul li {
+	.fse-template .main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
 	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
+	.fse-template .main-navigation > div > ul li:hover > ul,
+	.fse-template .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template .main-navigation > div > ul li ul:hover,
+	.fse-template .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
 	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li:focus-within > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
+	.fse-template .main-navigation > div > ul li:hover > ul,
+	.fse-template .main-navigation > div > ul li:focus-within > ul,
+	.fse-template .main-navigation > div > ul li ul:hover,
+	.fse-template .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
@@ -1300,36 +1306,36 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > li > a {
+	.fse-template .main-navigation > div > ul > li > a {
 		line-height: 1;
 	}
-	.main-navigation > div > ul > li > a:before, .main-navigation > div > ul > li > a:after {
+	.fse-template .main-navigation > div > ul > li > a:before, .fse-template .main-navigation > div > ul > li > a:after {
 		content: '';
 		display: block;
 		height: 0;
 		width: 0;
 	}
-	.main-navigation > div > ul > li > a:before {
+	.fse-template .main-navigation > div > ul > li > a:before {
 		margin-bottom: -0.12em;
 	}
-	.main-navigation > div > ul > li > a:after {
+	.fse-template .main-navigation > div > ul > li > a:after {
 		margin-top: -0.11em;
 	}
-	.main-navigation > div > ul > li:first-of-type > a {
+	.fse-template .main-navigation > div > ul > li:first-of-type > a {
 		padding-left: 0;
 	}
-	.main-navigation > div > ul > li:last-of-type > a {
+	.fse-template .main-navigation > div > ul > li:last-of-type > a {
 		padding-right: 0;
 	}
 }
 
-.main-navigation > div > ul > li > .sub-menu {
+.fse-template .main-navigation > div > ul > li > .sub-menu {
 	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > li > .sub-menu {
+	.fse-template .main-navigation > div > ul > li > .sub-menu {
 		background: #FFFFFF;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.1);
 		left: 0;
@@ -1342,11 +1348,11 @@ body:not(.fse-enabled) .site-description {
 	}
 }
 
-.main-navigation > div > ul > li > .sub-menu .sub-menu {
+.fse-template .main-navigation > div > ul > li > .sub-menu .sub-menu {
 	width: 100%;
 }
 
-.main-navigation a {
+.fse-template .main-navigation a {
 	color: #181818;
 	display: block;
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -1356,32 +1362,32 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation a {
+	.fse-template .main-navigation a {
 		padding: 8px;
 	}
 }
 
-.main-navigation a:link, .main-navigation a:visited {
+.fse-template .main-navigation a:link, .fse-template .main-navigation a:visited {
 	color: #181818;
 }
 
-.main-navigation a:hover {
+.fse-template .main-navigation a:hover {
 	color: #897248;
 }
 
-.main-navigation .sub-menu {
+.fse-template .main-navigation .sub-menu {
 	list-style: none;
 	margin-left: 0;
 	/* Reset the counter for each UL */
 	counter-reset: nested-list;
 }
 
-.main-navigation .sub-menu .menu-item a {
+.fse-template .main-navigation .sub-menu .menu-item a {
 	padding-top: 4px;
 	padding-bottom: 4px;
 }
 
-.main-navigation .sub-menu .menu-item a::before {
+.fse-template .main-navigation .sub-menu .menu-item a::before {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
@@ -1389,7 +1395,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > .menu-item-has-children > a::after {
+	.fse-template .main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
 		font-size: 0.69444rem;
@@ -1398,7 +1404,7 @@ body:not(.fse-enabled) .site-description {
 	}
 }
 
-.main-navigation .hide-visually {
+.fse-template .main-navigation .hide-visually {
 	position: absolute !important;
 	clip: rect(1px, 1px, 1px, 1px);
 	padding: 0 !important;
@@ -1408,7 +1414,7 @@ body:not(.fse-enabled) .site-description {
 	overflow: hidden;
 }
 
-body:not(.fse-enabled) .main-navigation a {
+.fse-template body:not(.fse-enabled) .main-navigation a {
 	font-size: 1rem;
 }
 
@@ -1668,108 +1674,43 @@ body:not(.fse-enabled) .footer-menu a {
 	font-size: inherit;
 }
 
-.site-header .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after,
-.site-footer .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+.fse-template .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
 
-.site-header .main-navigation .has-text-color > .main-menu.footer-menu > li > a,
-.site-footer .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.site-header .main-navigation .has-text-align-left > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.site-header .main-navigation .has-text-align-center > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.site-header .main-navigation .has-text-align-right > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.site-header .main-navigation .has-background > .main-menu.footer-menu,
-.site-footer .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px;
 }
 
-.site-header .site-title, .site-footer .site-title {
-	font-size: 20px;
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
 }
 
-@media only screen and (min-width: 560px) {
-	.site-header .site-title, .site-footer .site-title {
-		font-size: 24px;
-	}
+.fse-template .has-normal-font-size {
+	font-size: 1.2rem;
 }
 
-.site-header .site-description, .site-footer .site-description {
-	font-size: 13.8px;
-}
-
-@media only screen and (min-width: 560px) {
-	.site-header .site-description, .site-footer .site-description {
-		font-size: 16.6px;
-	}
-}
-
-.site-header .wp-block-cover .site-title,
-.site-header .wp-block-cover .site-description,
-.site-header .wp-block-cover-image .site-title,
-.site-header .wp-block-cover-image .site-description, .site-footer .wp-block-cover .site-title,
-.site-footer .wp-block-cover .site-description,
-.site-footer .wp-block-cover-image .site-title,
-.site-footer .wp-block-cover-image .site-description {
-	text-shadow: 0 0 6px black;
-}
-
-.site-header .site-title {
+.fse-template .main-navigation a {
 	text-decoration: none;
-}
-
-.site-header .main-navigation {
-	text-align: center;
-}
-
-.site-header .main-navigation ul {
-	justify-content: center;
-}
-
-.site-header .main-navigation ul a {
-	font-size: 20px;
-	text-decoration: none;
-}
-
-.site-footer .site-title {
-	font-weight: 700;
-}
-
-.site-footer .main-navigation .footer-menu {
-	justify-content: center;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-footer .main-navigation .footer-menu {
-		justify-content: flex-end;
-	}
-}
-
-.site-footer .main-navigation .footer-menu a {
-	font-size: 16.6px;
-	text-decoration: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.site-footer .main-navigation .footer-menu a {
-		font-size: 13.8px;
-		padding: 0 8px;
-	}
 }
 
 .post-content__block {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1192,6 +1192,10 @@ b, strong {
 	}
 }
 
+.template-block .fse-template-part figure.fse-site-logo {
+	width: auto;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1732,6 +1732,16 @@ body:not(.fse-enabled) .footer-menu a {
 	text-decoration: none;
 }
 
+.fse-template .wp-block-cover .site-title,
+.fse-template .wp-block-cover-image .site-title {
+	font-weight: 700;
+}
+
+.fse-template .wp-block-cover .has-background,
+.fse-template .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
 .post-content__block {
 	margin-top: -36px;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1182,10 +1182,8 @@ b, strong {
 	color: #897248;
 }
 
-.site-description {
-	color: currentColor;
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-base, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+.template-block .fse-template {
+	padding: 16px;
 }
 
 @media only screen and (min-width: 560px) {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1221,7 +1221,11 @@ b, strong {
 	margin: 0;
 }
 
+<<<<<<< HEAD
 .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+=======
+.fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+>>>>>>> Temporary fix for missing alert colors in Maywood
 	display: block;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1202,6 +1202,10 @@ b, strong {
 	color: inherit;
 }
 
+.fse-template .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	width: auto;
+}
+
 .fse-template .main-navigation {
 	color: #181818;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1182,37 +1182,37 @@ b, strong {
 	color: #897248;
 }
 
-.template-block .fse-template {
+.template-block .fse-template-part {
 	padding: 16px;
 }
 
 @media only screen and (min-width: 560px) {
-	.template-block .fse-template {
+	.template-block .fse-template-part {
 		padding: 32px 0;
 	}
 }
 
-.fse-template .wp-block-cover .site-title,
-.fse-template .wp-block-cover .site-description,
-.fse-template .wp-block-cover-image .site-title,
-.fse-template .wp-block-cover-image .site-description {
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover .site-description,
+.fse-template-part .wp-block-cover-image .site-title,
+.fse-template-part .wp-block-cover-image .site-description {
 	background: transparent;
 	color: inherit;
 }
 
-.fse-template .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 
-.fse-template .main-navigation {
+.fse-template-part .main-navigation {
 	color: #181818;
 }
 
-.fse-template .main-navigation > div {
+.fse-template-part .main-navigation > div {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle-menu {
+.fse-template-part .main-navigation #toggle-menu {
 	display: inline-block;
 	margin: 0;
 }
@@ -1221,21 +1221,21 @@ b, strong {
 	display: block;
 }
 
-.fse-template .main-navigation #toggle:focus + #toggle-menu {
+.fse-template-part .main-navigation #toggle:focus + #toggle-menu {
 	background-color: #897248;
 	outline: inherit;
 	text-decoration: underline;
 }
 
-.fse-template .main-navigation .dropdown-icon.close {
+.fse-template-part .main-navigation .dropdown-icon.close {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle:checked + #toggle-menu .open {
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .open {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle:checked + #toggle-menu .close {
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .close {
 	display: inline;
 }
 
@@ -1243,15 +1243,15 @@ b, strong {
 	.main-navigation > div {
 		display: inline-block;
 	}
-	.fse-template .main-navigation #toggle-menu {
+	.fse-template-part .main-navigation #toggle-menu {
 		display: none;
 	}
-	.fse-template .main-navigation > div > ul > li > ul {
+	.fse-template-part .main-navigation > div > ul > li > ul {
 		display: none;
 	}
 }
 
-.fse-template .main-navigation > div > ul {
+.fse-template-part .main-navigation > div > ul {
 	display: flex;
 	flex-wrap: wrap;
 	list-style: none;
@@ -1262,45 +1262,45 @@ b, strong {
 	/* Sub-menus Flyout */
 }
 
-.fse-template .main-navigation > div > ul ul {
+.fse-template-part .main-navigation > div > ul ul {
 	padding-left: 0;
 }
 
-.fse-template .main-navigation > div > ul li {
+.fse-template-part .main-navigation > div > ul li {
 	display: block;
 	position: relative;
 	width: 100%;
 	z-index: 1;
 }
 
-.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
 
-.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li:focus-within {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul li {
+	.fse-template-part .main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
 	}
-	.fse-template .main-navigation > div > ul li:hover > ul,
-	.fse-template .main-navigation > div > ul li[focus-within] > ul,
-	.fse-template .main-navigation > div > ul li ul:hover,
-	.fse-template .main-navigation > div > ul li ul:focus {
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
 	}
-	.fse-template .main-navigation > div > ul li:hover > ul,
-	.fse-template .main-navigation > div > ul li:focus-within > ul,
-	.fse-template .main-navigation > div > ul li ul:hover,
-	.fse-template .main-navigation > div > ul li ul:focus {
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li:focus-within > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
@@ -1308,36 +1308,36 @@ b, strong {
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > li > a {
+	.fse-template-part .main-navigation > div > ul > li > a {
 		line-height: 1;
 	}
-	.fse-template .main-navigation > div > ul > li > a:before, .fse-template .main-navigation > div > ul > li > a:after {
+	.fse-template-part .main-navigation > div > ul > li > a:before, .fse-template-part .main-navigation > div > ul > li > a:after {
 		content: '';
 		display: block;
 		height: 0;
 		width: 0;
 	}
-	.fse-template .main-navigation > div > ul > li > a:before {
+	.fse-template-part .main-navigation > div > ul > li > a:before {
 		margin-bottom: -0.12em;
 	}
-	.fse-template .main-navigation > div > ul > li > a:after {
+	.fse-template-part .main-navigation > div > ul > li > a:after {
 		margin-top: -0.11em;
 	}
-	.fse-template .main-navigation > div > ul > li:first-of-type > a {
+	.fse-template-part .main-navigation > div > ul > li:first-of-type > a {
 		padding-left: 0;
 	}
-	.fse-template .main-navigation > div > ul > li:last-of-type > a {
+	.fse-template-part .main-navigation > div > ul > li:last-of-type > a {
 		padding-right: 0;
 	}
 }
 
-.fse-template .main-navigation > div > ul > li > .sub-menu {
+.fse-template-part .main-navigation > div > ul > li > .sub-menu {
 	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > li > .sub-menu {
+	.fse-template-part .main-navigation > div > ul > li > .sub-menu {
 		background: #FFFFFF;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.1);
 		left: 0;
@@ -1350,11 +1350,11 @@ b, strong {
 	}
 }
 
-.fse-template .main-navigation > div > ul > li > .sub-menu .sub-menu {
+.fse-template-part .main-navigation > div > ul > li > .sub-menu .sub-menu {
 	width: 100%;
 }
 
-.fse-template .main-navigation a {
+.fse-template-part .main-navigation a {
 	color: #181818;
 	display: block;
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -1364,32 +1364,32 @@ b, strong {
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation a {
+	.fse-template-part .main-navigation a {
 		padding: 8px;
 	}
 }
 
-.fse-template .main-navigation a:link, .fse-template .main-navigation a:visited {
+.fse-template-part .main-navigation a:link, .fse-template-part .main-navigation a:visited {
 	color: #181818;
 }
 
-.fse-template .main-navigation a:hover {
+.fse-template-part .main-navigation a:hover {
 	color: #897248;
 }
 
-.fse-template .main-navigation .sub-menu {
+.fse-template-part .main-navigation .sub-menu {
 	list-style: none;
 	margin-left: 0;
 	/* Reset the counter for each UL */
 	counter-reset: nested-list;
 }
 
-.fse-template .main-navigation .sub-menu .menu-item a {
+.fse-template-part .main-navigation .sub-menu .menu-item a {
 	padding-top: 4px;
 	padding-bottom: 4px;
 }
 
-.fse-template .main-navigation .sub-menu .menu-item a::before {
+.fse-template-part .main-navigation .sub-menu .menu-item a::before {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
@@ -1397,7 +1397,7 @@ b, strong {
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > .menu-item-has-children > a::after {
+	.fse-template-part .main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
 		font-size: 0.69444rem;
@@ -1406,7 +1406,7 @@ b, strong {
 	}
 }
 
-.fse-template .main-navigation .hide-visually {
+.fse-template-part .main-navigation .hide-visually {
 	position: absolute !important;
 	clip: rect(1px, 1px, 1px, 1px);
 	padding: 0 !important;
@@ -1416,7 +1416,7 @@ b, strong {
 	overflow: hidden;
 }
 
-.fse-template body:not(.fse-enabled) .main-navigation a {
+.fse-template-part body:not(.fse-enabled) .main-navigation a {
 	font-size: 1rem;
 }
 
@@ -1676,28 +1676,28 @@ body:not(.fse-enabled) .footer-menu a {
 	font-size: inherit;
 }
 
-.fse-template .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+.fse-template-part .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px;
 }
 
@@ -1726,21 +1726,21 @@ body:not(.fse-enabled) .footer-menu a {
 	z-index: 20;
 }
 
-.fse-template .has-normal-font-size {
+.fse-template-part .has-normal-font-size {
 	font-size: 1.2rem;
 }
 
-.fse-template .main-navigation a {
+.fse-template-part .main-navigation a {
 	text-decoration: none;
 }
 
-.fse-template .wp-block-cover .site-title,
-.fse-template .wp-block-cover-image .site-title {
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover-image .site-title {
 	font-weight: 700;
 }
 
-.fse-template .wp-block-cover .has-background,
-.fse-template .wp-block-cover-image .has-background {
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
 	text-shadow: none;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1699,6 +1699,25 @@ body:not(.fse-enabled) .footer-menu a {
 	padding: 16px;
 }
 
+@media only screen and (min-width: 560px) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 14px;
+	}
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 0;
+	}
+}
+
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+		margin-top: -32px;
+	}
+}
+
 .post-content__block {
 	margin-bottom: 160px;
 	margin-top: 36px;

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3890,8 +3890,8 @@ p:not(.site-title) a:hover {
 	.wp-block-cover-image {
 		min-height: 640px;
 	}
-	.wp-block-cover h1,
-	.wp-block-cover-image h1 {
+	.wp-block-cover h1:not(.site-title),
+	.wp-block-cover-image h1:not(.site-title) {
 		font-size: 2.98598rem;
 	}
 	.wp-block-cover h2,
@@ -4034,6 +4034,69 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
 .fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 	padding-bottom: 32px;
 }
@@ -4055,4 +4118,9 @@ p:not(.site-title) a:hover {
 	.fse-template .main-navigation > div {
 		padding: 0 32px;
 	}
+}
+
+.fse-template .wp-block-cover .site-title a,
+.fse-template .wp-block-cover-image .site-title a {
+	text-decoration: none;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4124,3 +4124,8 @@ p:not(.site-title) a:hover {
 .fse-template .wp-block-cover-image .site-title a {
 	text-decoration: none;
 }
+
+.fse-template .wp-block-cover .has-background,
+.fse-template .wp-block-cover-image .has-background {
+	text-shadow: none;
+}

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2704,12 +2704,12 @@ body:not(.fse-enabled) .main-navigation a {
 	color: #685636;
 }
 
-.footer-navigation, .fse-enabled .site-footer .main-navigation {
+.footer-navigation {
 	display: inline;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation, .fse-enabled .site-footer .main-navigation {
+	.footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
 		margin-top: 0;
@@ -2718,37 +2718,37 @@ body:not(.fse-enabled) .main-navigation a {
 	}
 }
 
-.footer-navigation > div, .fse-enabled .site-footer .main-navigation > div {
+.footer-navigation > div {
 	display: inline;
 }
 
-.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+.footer-navigation .footer-menu {
 	color: #686868;
 	margin: 0;
 	padding-right: 0;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+	.footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-end;
 	}
 }
 
-.footer-navigation .footer-menu > li, .fse-enabled .site-footer .main-navigation .footer-menu > li {
+.footer-navigation .footer-menu > li {
 	display: inline;
 }
 
-.footer-navigation .footer-menu > li:first-of-type > a, .fse-enabled .site-footer .main-navigation .footer-menu > li:first-of-type > a {
+.footer-navigation .footer-menu > li:first-of-type > a {
 	padding-right: 0;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	padding-left: 0;
 }
 
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-weight: 700;
@@ -2756,11 +2756,11 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:link, .fse-enabled .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .fse-enabled .site-footer .main-navigation .footer-menu a:visited {
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:hover, .fse-enabled .site-footer .main-navigation .footer-menu a:hover {
+.footer-navigation .footer-menu a:hover {
 	color: #685636;
 }
 
@@ -4022,11 +4022,11 @@ p:not(.site-title) a:hover {
 /**
  * Footer Navigation
  */
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	padding: 0 8px;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	margin-left: -8px;
 }
 
@@ -4034,84 +4034,66 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-enabled .site-footer {
-	display: block;
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
 }
 
-.fse-enabled .site-footer .main-navigation {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .footer-menu {
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-enabled .site-footer .main-navigation > div {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .hide-visually,
-.fse-enabled .site-footer .main-navigation #toggle-menu {
-	display: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation > div {
-		display: block;
-	}
-	.fse-enabled .site-footer .main-navigation li {
-		width: auto;
-	}
-	.fse-enabled .site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.fse-enabled .site-footer .site-info {
-	text-align: center;
-}
-
-.fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.fse-enabled .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-enabled .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-enabled .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-enabled .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
 
-.fse-enabled .site-header.entry-content {
-	margin-bottom: 0;
-	max-width: 100%;
-	padding: 0;
-	width: 100%;
+.fse-header > *:first-child {
+	margin-top: 21.312px;
 }
 
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-header.entry-content .main-navigation > div {
-		padding: 0 32px;
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
 	}
 }
 
@@ -4125,56 +4107,15 @@ p:not(.site-title) a:hover {
 	}
 }
 
-@media only screen and (min-width: 640px) {
-	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
-		margin-bottom: 21.312px;
-		margin-top: 21.312px;
-	}
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
-		padding: 8px;
-	}
-}
-
-.fse-enabled .wp-block-cover .site-title,
-.fse-enabled .wp-block-cover-image .site-title {
-	font-size: 20px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .wp-block-cover .site-title,
-	.fse-enabled .wp-block-cover-image .site-title {
-		font-size: 24px;
-	}
-}
-
-.fse-enabled .wp-block-cover .site-title a,
-.fse-enabled .wp-block-cover-image .site-title a {
+.fse-template .main-navigation a {
 	text-decoration: none;
 }
 
-.fse-enabled .wp-block-cover .site-description,
-.fse-enabled .wp-block-cover-image .site-description {
-	font-size: 13.8px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .wp-block-cover .site-description,
-	.fse-enabled .wp-block-cover-image .site-description {
-		font-size: 16.6px;
+@media only screen and (max-width: 559px) {
+	.fse-template {
+		max-width: calc( 100% - 32px);
 	}
-}
-
-.fse-enabled .wp-block-cover .main-navigation a,
-.fse-enabled .wp-block-cover-image .main-navigation a {
-	text-decoration: none;
-}
-
-.fse-enabled #colophon {
-	margin-right: auto;
-	margin-left: auto;
-	max-width: none;
-	width: 100%;
+	.fse-template .main-navigation > div {
+		padding: 0 32px;
+	}
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4034,38 +4034,38 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-template {
+.fse-template-part {
 	margin-bottom: 0;
 	margin-top: 0;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
@@ -4107,25 +4107,25 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-template .main-navigation a {
+.fse-template-part .main-navigation a {
 	text-decoration: none;
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-template {
+	.fse-template-part {
 		max-width: calc( 100% - 32px);
 	}
-	.fse-template .main-navigation > div {
+	.fse-template-part .main-navigation > div {
 		padding: 0 32px;
 	}
 }
 
-.fse-template .wp-block-cover .site-title a,
-.fse-template .wp-block-cover-image .site-title a {
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
 	text-decoration: none;
 }
 
-.fse-template .wp-block-cover .has-background,
-.fse-template .wp-block-cover-image .has-background {
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
 	text-shadow: none;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4097,12 +4097,12 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
 	padding-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
 		padding-bottom: 48px;
 	}
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4034,69 +4034,6 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-template {
-	margin-bottom: 0;
-	margin-top: 0;
-}
-
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
-	justify-content: flex-start;
-}
-
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
-	justify-content: center;
-}
-
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
-	justify-content: flex-end;
-}
-
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
-	padding: 16px 0;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
-		padding: 16px;
-	}
-}
-
-.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
-	font-size: 0.6em;
-	vertical-align: middle;
-}
-
-.fse-header > *:first-child:not(.alignfull) {
-	margin-top: 21.312px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-header > *:first-child:not(.alignfull) {
-		margin-top: 32px;
-	}
-}
-
-.fse-footer {
-	display: block;
-}
-
-.fse-footer .site-info {
-	margin-top: 21.312px;
-	margin-bottom: 21.312px;
-	text-align: center;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-footer .site-info {
-		margin-top: 32px;
-		margin-bottom: 32px;
-	}
-}
-
 .fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
 	padding-bottom: 32px;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4070,12 +4070,12 @@ p:not(.site-title) a:hover {
 	vertical-align: middle;
 }
 
-.fse-header > *:first-child {
+.fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-header > *:first-child {
+	.fse-header > *:first-child:not(.alignfull) {
 		margin-top: 32px;
 	}
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4126,12 +4126,12 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
 	padding-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled.home.page.hide-homepage-title .site-header.entry-content {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
 		padding-bottom: 48px;
 	}
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3919,8 +3919,8 @@ p:not(.site-title) a:hover {
 	.wp-block-cover-image {
 		min-height: 640px;
 	}
-	.wp-block-cover h1,
-	.wp-block-cover-image h1 {
+	.wp-block-cover h1:not(.site-title),
+	.wp-block-cover-image h1:not(.site-title) {
 		font-size: 2.98598rem;
 	}
 	.wp-block-cover h2,
@@ -4147,4 +4147,14 @@ p:not(.site-title) a:hover {
 	.fse-template .main-navigation > div {
 		padding: 0 32px;
 	}
+}
+
+.fse-template .wp-block-cover .site-title a,
+.fse-template .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template .wp-block-cover .has-background,
+.fse-template .wp-block-cover-image .has-background {
+	text-shadow: none;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2721,12 +2721,12 @@ body:not(.fse-enabled) .main-navigation a {
 	color: #685636;
 }
 
-.footer-navigation, .fse-enabled .site-footer .main-navigation {
+.footer-navigation {
 	display: inline;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation, .fse-enabled .site-footer .main-navigation {
+	.footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
 		margin-top: 0;
@@ -2735,37 +2735,37 @@ body:not(.fse-enabled) .main-navigation a {
 	}
 }
 
-.footer-navigation > div, .fse-enabled .site-footer .main-navigation > div {
+.footer-navigation > div {
 	display: inline;
 }
 
-.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+.footer-navigation .footer-menu {
 	color: #686868;
 	margin: 0;
 	padding-left: 0;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+	.footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-end;
 	}
 }
 
-.footer-navigation .footer-menu > li, .fse-enabled .site-footer .main-navigation .footer-menu > li {
+.footer-navigation .footer-menu > li {
 	display: inline;
 }
 
-.footer-navigation .footer-menu > li:first-of-type > a, .fse-enabled .site-footer .main-navigation .footer-menu > li:first-of-type > a {
+.footer-navigation .footer-menu > li:first-of-type > a {
 	padding-left: 0;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	padding-right: 0;
 }
 
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-weight: 700;
@@ -2773,11 +2773,11 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:link, .fse-enabled .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .fse-enabled .site-footer .main-navigation .footer-menu a:visited {
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:hover, .fse-enabled .site-footer .main-navigation .footer-menu a:hover {
+.footer-navigation .footer-menu a:hover {
 	color: #685636;
 }
 
@@ -4051,11 +4051,11 @@ p:not(.site-title) a:hover {
 /**
  * Footer Navigation
  */
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	padding: 0 8px;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	margin-right: -8px;
 }
 
@@ -4063,84 +4063,66 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-enabled .site-footer {
-	display: block;
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
 }
 
-.fse-enabled .site-footer .main-navigation {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .footer-menu {
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-enabled .site-footer .main-navigation > div {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .hide-visually,
-.fse-enabled .site-footer .main-navigation #toggle-menu {
-	display: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation > div {
-		display: block;
-	}
-	.fse-enabled .site-footer .main-navigation li {
-		width: auto;
-	}
-	.fse-enabled .site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.fse-enabled .site-footer .site-info {
-	text-align: center;
-}
-
-.fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.fse-enabled .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-enabled .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-enabled .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-enabled .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
 
-.fse-enabled .site-header.entry-content {
-	margin-bottom: 0;
-	max-width: 100%;
-	padding: 0;
-	width: 100%;
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
 }
 
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-header.entry-content .main-navigation > div {
-		padding: 0 32px;
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
 	}
 }
 
@@ -4154,56 +4136,15 @@ p:not(.site-title) a:hover {
 	}
 }
 
-@media only screen and (min-width: 640px) {
-	.fse-enabled .site-footer .wp-block-a8c-navigation-menu {
-		margin-bottom: 21.312px;
-		margin-top: 21.312px;
-	}
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .site-footer .wp-block-a8c-navigation-menu .footer-menu a {
-		padding: 8px;
-	}
-}
-
-.fse-enabled .wp-block-cover .site-title,
-.fse-enabled .wp-block-cover-image .site-title {
-	font-size: 20px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .wp-block-cover .site-title,
-	.fse-enabled .wp-block-cover-image .site-title {
-		font-size: 24px;
-	}
-}
-
-.fse-enabled .wp-block-cover .site-title a,
-.fse-enabled .wp-block-cover-image .site-title a {
+.fse-template .main-navigation a {
 	text-decoration: none;
 }
 
-.fse-enabled .wp-block-cover .site-description,
-.fse-enabled .wp-block-cover-image .site-description {
-	font-size: 13.8px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled .wp-block-cover .site-description,
-	.fse-enabled .wp-block-cover-image .site-description {
-		font-size: 16.6px;
+@media only screen and (max-width: 559px) {
+	.fse-template {
+		max-width: calc( 100% - 32px);
 	}
-}
-
-.fse-enabled .wp-block-cover .main-navigation a,
-.fse-enabled .wp-block-cover-image .main-navigation a {
-	text-decoration: none;
-}
-
-.fse-enabled #colophon {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: none;
-	width: 100%;
+	.fse-template .main-navigation > div {
+		padding: 0 32px;
+	}
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4063,38 +4063,38 @@ p:not(.site-title) a:hover {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-template {
+.fse-template-part {
 	margin-bottom: 0;
 	margin-top: 0;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
@@ -4136,25 +4136,25 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.fse-template .main-navigation a {
+.fse-template-part .main-navigation a {
 	text-decoration: none;
 }
 
 @media only screen and (max-width: 559px) {
-	.fse-template {
+	.fse-template-part {
 		max-width: calc( 100% - 32px);
 	}
-	.fse-template .main-navigation > div {
+	.fse-template-part .main-navigation > div {
 		padding: 0 32px;
 	}
 }
 
-.fse-template .wp-block-cover .site-title a,
-.fse-template .wp-block-cover-image .site-title a {
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
 	text-decoration: none;
 }
 
-.fse-template .wp-block-cover .has-background,
-.fse-template .wp-block-cover-image .has-background {
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
 	text-shadow: none;
 }

--- a/varia/footer.php
+++ b/varia/footer.php
@@ -16,7 +16,7 @@
 	</div><!-- #content -->
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
-	<footer class="fse-template fse-footer entry-content">
+	<footer class="fse-template-part fse-footer entry-content">
 	<?php
 		$template = new A8C\FSE\WP_Template();
 		$template->output_template_content( A8C\FSE\WP_Template::FOOTER );

--- a/varia/footer.php
+++ b/varia/footer.php
@@ -15,29 +15,30 @@
 
 	</div><!-- #content -->
 
-	<footer id="colophon" class="site-footer <?php echo class_exists( 'A8C\FSE\WP_Template' ) ? 'entry-content' : 'responsive-max-width'; ?>">
-		<?php
-			if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content.
-				$template = new A8C\FSE\WP_Template();
-				$template->output_template_content( A8C\FSE\WP_Template::FOOTER );
-			else : // Otherwise we'll fallback to the default Varia footer below.
-				get_template_part( 'template-parts/footer/footer', 'widgets' );
+	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
+	<footer class="fse-template fse-footer entry-content">
+	<?php
+		$template = new A8C\FSE\WP_Template();
+		$template->output_template_content( A8C\FSE\WP_Template::FOOTER );
+	else : // Otherwise we'll fallback to the default Varia footer below. ?>
+	<footer id="colophon" class="site-footer responsive-max-width">
+	<?php
+		get_template_part( 'template-parts/footer/footer', 'widgets' );
 
-				if ( has_nav_menu( 'menu-2' ) ) : ?>
-					<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'varia' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'menu-2',
-								'menu_class'     => 'footer-menu',
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav><!-- .footer-navigation -->
-				<?php endif;
-			endif;
-		?>
+		if ( has_nav_menu( 'menu-2' ) ) : ?>
+			<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'varia' ); ?>">
+				<?php
+				wp_nav_menu(
+					array(
+						'theme_location' => 'menu-2',
+						'menu_class'     => 'footer-menu',
+						'depth'          => 1,
+					)
+				);
+				?>
+			</nav><!-- .footer-navigation -->
+		<?php endif;
+	endif; ?>
 
 		<div class="site-info">
 			<?php $blog_info = get_bloginfo( 'name' ); ?>

--- a/varia/header.php
+++ b/varia/header.php
@@ -25,7 +25,7 @@
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
-		<header id="masthead" class="site-header site-branding entry-content">
+		<header id="masthead" class="fse-template fse-header entry-content">
 			<?php
 				$template = new A8C\FSE\WP_Template();
 				$template->output_template_content( A8C\FSE\WP_Template::HEADER );

--- a/varia/header.php
+++ b/varia/header.php
@@ -25,7 +25,7 @@
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
-		<header id="masthead" class="fse-template fse-header entry-content">
+		<header id="masthead" class="fse-template-part fse-header entry-content">
 			<?php
 				$template = new A8C\FSE\WP_Template();
 				$template->output_template_content( A8C\FSE\WP_Template::HEADER );

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -14,6 +14,10 @@
 		@include media(mobile) {
 			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 		}
+
+		figure.fse-site-logo {
+			width: auto;
+		}
 	}
 }
 

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -46,7 +46,24 @@
 			padding: #{map-deep-get($config-global, "spacing", "unit")};
 		}
 	}
+}
 
+// Remove top margin/padding from the header if the first block is .alignfull
+@include media(mobile) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block {
+		&.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+			margin-top: 14px;
+		}
+		&:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+			margin-top: 0;
+		}
+	}
+}
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+	@include media(mobile) {
+		margin-top: -32px;
+	}
 }
 
 .post-content__block {

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -38,8 +38,12 @@
 	@import '../components/header/site-main-navigation';
 
 	.main-navigation {
-		@import "../blocks/button/style";
 		text-align: center;
+
+		@import "../base/extends";
+		.button {
+			@extend %button-style
+		}
 
 		.main-menu.footer-menu li {
 			a {

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -38,6 +38,9 @@
 	@import '../components/header/site-main-navigation';
 
 	.main-navigation {
+		@import "../blocks/button/style";
+		text-align: center;
+
 		.main-menu.footer-menu li {
 			a {
 				font-size: inherit;

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -1,3 +1,12 @@
+.a8c-template-editor {
+	@media (min-width: 600px) {
+		.block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+}
+
 .template-block {
 	.fse-template {
 		padding: #{map-deep-get($config-global, "spacing", "unit")};

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -8,7 +8,7 @@
 }
 
 .template-block {
-	.fse-template {
+	.fse-template-part {
 		padding: #{map-deep-get($config-global, "spacing", "unit")};
 
 		@include media(mobile) {
@@ -17,7 +17,7 @@
 	}
 }
 
-.fse-template {
+.fse-template-part {
 	.wp-block-cover,
 	.wp-block-cover-image {
 		.site-title,

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -27,6 +27,10 @@
 		}
 	}
 
+	.block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+		width: auto;
+	}
+
 	@import '../components/header/site-main-navigation';
 
 	.main-navigation {

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -1,17 +1,14 @@
-@import "../base/extends";
-@import "../components/header/header";
-@import "../components/footer/footer";
-
 .template-block {
-	.site-header,
-	.site-footer {
+	.fse-template {
 		padding: #{map-deep-get($config-global, "spacing", "unit")};
 
 		@include media(mobile) {
 			padding: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 		}
 	}
+}
 
+.fse-template {
 	.wp-block-cover,
 	.wp-block-cover-image {
 		.site-title,
@@ -20,91 +17,8 @@
 			color: inherit;
 		}
 	}
-}
 
-.a8c-template-editor {
-	.wp-block-cover,
-	.wp-block-cover-image {
-		.site-title,
-		.site-description {
-			background: transparent;
-			color: inherit;
-		}
-	}
-}
-
-.site-header {
-	.site-title {
-		font-size: 21.6px;
-		font-weight: 700;
-		text-decoration: underline;
-	}
-
-	.site-description {
-		font-size: 15px;
-	}
-
-	.main-navigation {
-		@import "../blocks/button/style";
-	}
-}
-
-.post-content__block {
-	margin-bottom: 160px;
-	margin-top: 36px;
-
-	// Minimum z-index to appear above the Template block overlay.
-	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/packages/block-editor/src/components/block-list/style.scss#L495-L496
-	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/assets/stylesheets/_z-index.scss#L8
-	z-index: 20;
-}
-
-.site-footer {
-	@include media(tablet) {
-		display: block;
-	}
-
-	.main-navigation {
-		@extend .footer-navigation;
-
-		.footer-menu {
-			color: inherit;
-		}
-
-		display: block;
-		& > div {
-			display: block;
-		}
-
-		.hide-visually,
-		#toggle-menu {
-			display: none;
-		}
-
-		@include media(mobile-only) {
-			> div {
-				display: block;
-			}
-			li {
-				width: auto;
-
-				.sub-menu {
-					display: none;
-				}
-			}
-		}
-	}
-}
-
-.site-header,
-.site-footer {
-	.site-title,
-	.site-description {
-		&.has-background {
-			border-radius: 0;
-			padding: #{map-deep-get($config-global, "spacing", "unit")};
-		}
-	}
+	@import '../components/header/site-main-navigation';
 
 	.main-navigation {
 		.main-menu.footer-menu li {
@@ -132,4 +46,15 @@
 			padding: #{map-deep-get($config-global, "spacing", "unit")};
 		}
 	}
+
+}
+
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+
+	// Minimum z-index to appear above the Template block overlay.
+	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/packages/block-editor/src/components/block-list/style.scss#L495-L496
+	// @see https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/assets/stylesheets/_z-index.scss#L8
+	z-index: 20;
 }

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -1,42 +1,6 @@
-.fse-enabled {
-	.site-footer {
-		display: block;
-
-		.main-navigation {
-			@extend .footer-navigation;
-
-			.footer-menu {
-				color: inherit;
-			}
-
-			display: block;
-			& > div {
-				display: block;
-			}
-
-			.hide-visually,
-			#toggle-menu {
-				display: none;
-			}
-
-			@include media(mobile-only) {
-				> div {
-					display: block;
-				}
-				li {
-					width: auto;
-
-					.sub-menu {
-						display: none;
-					}
-				}
-			}
-		}
-
-		.site-info {
-			text-align: center;
-		}
-	}
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
 
 	.main-navigation {
 		.has-text-color > .main-menu.footer-menu > li > a {
@@ -60,6 +24,29 @@
 		& > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 			font-size: 0.6em;
 			vertical-align: middle;
+		}
+	}
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+
+	@include media(mobile) {
+		margin-top: map-deep-get($config-global, "spacing", "vertical");
+	}
+}
+
+.fse-footer {
+	display: block;
+	
+	.site-info {
+		margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+		margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+		text-align: center;
+
+		@include media(mobile) {
+			margin-top: map-deep-get($config-global, "spacing", "vertical");
+			margin-bottom: map-deep-get($config-global, "spacing", "vertical");
 		}
 	}
 }

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -1,4 +1,4 @@
-.fse-template {
+.fse-template-part {
 	margin-bottom: 0;
 	margin-top: 0;
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1158,6 +1158,10 @@ table th,
 	}
 }
 
+.template-block .fse-template-part figure.fse-site-logo {
+	width: auto;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1384,6 +1388,100 @@ table th,
 
 .fse-template-part body:not(.fse-enabled) .main-navigation a {
 	font-size: 1.2rem;
+}
+
+.fse-template-part .main-navigation {
+	/**
+ * Placeholder button style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Block Options
+ */
+	text-align: center;
+}
+
+.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation .button,
+.fse-template-part .main-navigation input[type="submit"],
+.fse-template-part .main-navigation .wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: sans-serif;
+	font-family: var(--font-headings, sans-serif);
+	font-size: 1.2rem;
+	background-color: blue;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation .button:before,
+.fse-template-part .main-navigation input[type="submit"]:before,
+.fse-template-part .main-navigation .wp-block-button__link:before,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .button:after,
+.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation .button:before,
+.fse-template-part .main-navigation input[type="submit"]:before,
+.fse-template-part .main-navigation .wp-block-button__link:before,
+.fse-template-part .main-navigation .wp-block-file__button:before {
+	margin-bottom: -0.12em;
+}
+
+.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .button:after,
+.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:after {
+	margin-top: -0.11em;
+}
+
+.fse-template-part .main-navigation button:hover,
+.fse-template-part .main-navigation .button:hover,
+.fse-template-part .main-navigation input:hover[type="submit"],
+.fse-template-part .main-navigation .wp-block-button__link:hover,
+.fse-template-part .main-navigation .wp-block-file__button:hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .button:focus,
+.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .has-focus.button,
+.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .has-focus.wp-block-file__button {
+	color: white;
+	background-color: indigo;
+}
+
+.fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link {
+	color: blue;
+	background: transparent;
+	border: 2px solid currentcolor;
+	padding: 14px 16px;
+}
+
+.fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:hover, .fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:focus, .fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	color: indigo;
+}
+
+.fse-template-part .main-navigation .wp-block-button.is-style-squared .wp-block-button__link {
+	border-radius: 0;
 }
 
 .fse-template-part .main-navigation .main-menu.footer-menu li a {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1148,10 +1148,8 @@ table th,
 	color: indigo;
 }
 
-.site-description {
-	color: currentColor;
-	font-family: serif;
-	font-family: var(--font-base, serif);
+.template-block .fse-template {
+	padding: 16px;
 }
 
 @media only screen and (min-width: 560px) {
@@ -1166,6 +1164,10 @@ table th,
 .fse-template .wp-block-cover-image .site-description {
 	background: transparent;
 	color: inherit;
+}
+
+.fse-template .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	width: auto;
 }
 
 .fse-template .main-navigation {
@@ -1380,208 +1382,7 @@ table th,
 	overflow: hidden;
 }
 
-body:not(.fse-enabled) .main-navigation a {
-	font-size: 1.2rem;
-}
-
-.social-navigation > div > ul {
-	align-content: center;
-	display: flex;
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-}
-
-.social-navigation > div > ul > li:first-of-type > a {
-	padding-left: 0;
-}
-
-.social-navigation > div > ul > li:last-of-type > a {
-	padding-right: 0;
-}
-
-.social-navigation a {
-	color: blue;
-	display: inline-block;
-	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
-}
-
-.social-navigation a:hover {
-	color: indigo;
-}
-
-.social-navigation svg {
-	fill: currentColor;
-	vertical-align: middle;
-}
-
-.site-footer {
-	overflow: hidden;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-footer {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-	}
-}
-
-.site-info {
-	color: #767676;
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	font-size: 0.83333rem;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-info {
-		order: 1;
-		flex: 1 0 50%;
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-}
-
-.site-info .site-name {
-	font-weight: bold;
-}
-
-.site-info a {
-	color: currentColor;
-}
-
-.site-info a:link, .site-info a:visited {
-	color: currentColor;
-}
-
-.site-info a:hover {
-	color: indigo;
-}
-
-.footer-navigation, .site-footer .main-navigation {
-	display: inline;
-}
-
-@media only screen and (min-width: 640px) {
-	.footer-navigation, .site-footer .main-navigation {
-		flex: 1 0 50%;
-		order: 2;
-		margin-top: 0;
-		margin-bottom: 0;
-		text-align: right;
-	}
-}
-
-.footer-navigation > div, .site-footer .main-navigation > div {
-	display: inline;
-}
-
-.footer-navigation .footer-menu, .site-footer .main-navigation .footer-menu {
-	color: #767676;
-	margin: 0;
-	padding-left: 0;
-}
-
-@media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .site-footer .main-navigation .footer-menu {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
-}
-
-.footer-navigation .footer-menu > li, .site-footer .main-navigation .footer-menu > li {
-	display: inline;
-}
-
-.footer-navigation .footer-menu > li:first-of-type > a, .site-footer .main-navigation .footer-menu > li:first-of-type > a {
-	padding-left: 0;
-}
-
-.footer-navigation .footer-menu > li:last-of-type, .site-footer .main-navigation .footer-menu > li:last-of-type {
-	padding-right: 0;
-}
-
-.footer-navigation .footer-menu a, .site-footer .main-navigation .footer-menu a {
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	font-weight: bold;
-	padding: 16px;
-	color: currentColor;
-}
-
-.footer-navigation .footer-menu a:link, .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .site-footer .main-navigation .footer-menu a:visited {
-	color: currentColor;
-}
-
-.footer-navigation .footer-menu a:hover, .site-footer .main-navigation .footer-menu a:hover {
-	color: indigo;
-}
-
-body:not(.fse-enabled) .footer-menu a {
-	font-size: 0.83333rem;
-}
-
-.template-block .site-header,
-.template-block .site-footer {
-	padding: 16px;
-}
-
-@media only screen and (min-width: 560px) {
-	.template-block .site-header,
-	.template-block .site-footer {
-		padding: 32px 0;
-	}
-}
-
-.template-block .wp-block-cover .site-title,
-.template-block .wp-block-cover .site-description,
-.template-block .wp-block-cover-image .site-title,
-.template-block .wp-block-cover-image .site-description {
-	background: transparent;
-	color: inherit;
-}
-
-.a8c-template-editor .wp-block-cover .site-title,
-.a8c-template-editor .wp-block-cover .site-description,
-.a8c-template-editor .wp-block-cover-image .site-title,
-.a8c-template-editor .wp-block-cover-image .site-description {
-	background: transparent;
-	color: inherit;
-}
-
-.site-header .site-title {
-	font-size: 21.6px;
-	font-weight: 700;
-	text-decoration: underline;
-}
-
-.site-header .site-description {
-	font-size: 15px;
-}
-
-.site-header .main-navigation {
-	/**
- * Button
- */
-	/**
- * Block Options
- */
-}
-
-.site-header .main-navigation button,
-.site-header .main-navigation .button,
-.site-header .main-navigation input[type="submit"],
-.site-header .main-navigation .wp-block-button__link,
-.site-header .main-navigation .wp-block-file__button {
-	line-height: 1;
-	color: white;
-	cursor: pointer;
-	font-weight: bold;
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
+.fse-template body:not(.fse-enabled) .main-navigation a {
 	font-size: 1.2rem;
 }
 
@@ -1612,6 +1413,25 @@ body:not(.fse-enabled) .footer-menu a {
 
 .fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 14px;
+	}
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 0;
+	}
+}
+
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+		margin-top: -32px;
+	}
 }
 
 .post-content__block {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1154,62 +1154,68 @@ table th,
 	font-family: var(--font-base, serif);
 }
 
-body:not(.fse-enabled) .site-title {
-	font-size: 1.2rem;
+@media only screen and (min-width: 560px) {
+	.template-block .fse-template {
+		padding: 32px 0;
+	}
 }
 
-body:not(.fse-enabled) .site-description {
-	font-size: 0.83333rem;
+.fse-template .wp-block-cover .site-title,
+.fse-template .wp-block-cover .site-description,
+.fse-template .wp-block-cover-image .site-title,
+.fse-template .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
 }
 
-.main-navigation {
+.fse-template .main-navigation {
 	color: #444444;
 }
 
-.main-navigation > div {
+.fse-template .main-navigation > div {
 	display: none;
 }
 
-.main-navigation #toggle-menu {
+.fse-template .main-navigation #toggle-menu {
 	display: inline-block;
 	margin: 0;
 }
 
-.main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+.fse-template .main-navigation #toggle:checked ~ div {
 	display: block;
 }
 
-.main-navigation #toggle:focus + #toggle-menu {
+.fse-template .main-navigation #toggle:focus + #toggle-menu {
 	background-color: indigo;
 	outline: inherit;
 	text-decoration: underline;
 }
 
-.main-navigation .dropdown-icon.close {
+.fse-template .main-navigation .dropdown-icon.close {
 	display: none;
 }
 
-.main-navigation #toggle:checked + #toggle-menu .open {
+.fse-template .main-navigation #toggle:checked + #toggle-menu .open {
 	display: none;
 }
 
-.main-navigation #toggle:checked + #toggle-menu .close {
+.fse-template .main-navigation #toggle:checked + #toggle-menu .close {
 	display: inline;
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div {
-		display: inline-block;
+	.fse-template .main-navigation > div {
+		display: block;
 	}
-	.main-navigation #toggle-menu {
+	.fse-template .main-navigation #toggle-menu {
 		display: none;
 	}
-	.main-navigation > div > ul > li > ul {
+	.fse-template .main-navigation > div > ul > li > ul {
 		display: none;
 	}
 }
 
-.main-navigation > div > ul {
+.fse-template .main-navigation > div > ul {
 	display: flex;
 	flex-wrap: wrap;
 	list-style: none;
@@ -1220,45 +1226,45 @@ body:not(.fse-enabled) .site-description {
 	/* Sub-menus Flyout */
 }
 
-.main-navigation > div > ul ul {
+.fse-template .main-navigation > div > ul ul {
 	padding-left: 0;
 }
 
-.main-navigation > div > ul li {
+.fse-template .main-navigation > div > ul li {
 	display: block;
 	position: relative;
 	width: 100%;
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
+.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul li {
+	.fse-template .main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
 	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
+	.fse-template .main-navigation > div > ul li:hover > ul,
+	.fse-template .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template .main-navigation > div > ul li ul:hover,
+	.fse-template .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
 	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li:focus-within > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
+	.fse-template .main-navigation > div > ul li:hover > ul,
+	.fse-template .main-navigation > div > ul li:focus-within > ul,
+	.fse-template .main-navigation > div > ul li ul:hover,
+	.fse-template .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
@@ -1266,36 +1272,36 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > li > a {
+	.fse-template .main-navigation > div > ul > li > a {
 		line-height: 1;
 	}
-	.main-navigation > div > ul > li > a:before, .main-navigation > div > ul > li > a:after {
+	.fse-template .main-navigation > div > ul > li > a:before, .fse-template .main-navigation > div > ul > li > a:after {
 		content: '';
 		display: block;
 		height: 0;
 		width: 0;
 	}
-	.main-navigation > div > ul > li > a:before {
+	.fse-template .main-navigation > div > ul > li > a:before {
 		margin-bottom: -0.12em;
 	}
-	.main-navigation > div > ul > li > a:after {
+	.fse-template .main-navigation > div > ul > li > a:after {
 		margin-top: -0.11em;
 	}
-	.main-navigation > div > ul > li:first-of-type > a {
+	.fse-template .main-navigation > div > ul > li:first-of-type > a {
 		padding-left: 0;
 	}
-	.main-navigation > div > ul > li:last-of-type > a {
+	.fse-template .main-navigation > div > ul > li:last-of-type > a {
 		padding-right: 0;
 	}
 }
 
-.main-navigation > div > ul > li > .sub-menu {
+.fse-template .main-navigation > div > ul > li > .sub-menu {
 	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > li > .sub-menu {
+	.fse-template .main-navigation > div > ul > li > .sub-menu {
 		background: white;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
 		left: 0;
@@ -1308,11 +1314,11 @@ body:not(.fse-enabled) .site-description {
 	}
 }
 
-.main-navigation > div > ul > li > .sub-menu .sub-menu {
+.fse-template .main-navigation > div > ul > li > .sub-menu .sub-menu {
 	width: 100%;
 }
 
-.main-navigation a {
+.fse-template .main-navigation a {
 	color: blue;
 	display: block;
 	font-family: sans-serif;
@@ -1322,32 +1328,32 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation a {
+	.fse-template .main-navigation a {
 		padding: 16px;
 	}
 }
 
-.main-navigation a:link, .main-navigation a:visited {
+.fse-template .main-navigation a:link, .fse-template .main-navigation a:visited {
 	color: blue;
 }
 
-.main-navigation a:hover {
+.fse-template .main-navigation a:hover {
 	color: indigo;
 }
 
-.main-navigation .sub-menu {
+.fse-template .main-navigation .sub-menu {
 	list-style: none;
 	margin-left: 0;
 	/* Reset the counter for each UL */
 	counter-reset: nested-list;
 }
 
-.main-navigation .sub-menu .menu-item a {
+.fse-template .main-navigation .sub-menu .menu-item a {
 	padding-top: 8px;
 	padding-bottom: 8px;
 }
 
-.main-navigation .sub-menu .menu-item a::before {
+.fse-template .main-navigation .sub-menu .menu-item a::before {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
@@ -1355,7 +1361,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 @media only screen and (min-width: 560px) {
-	.main-navigation > div > ul > .menu-item-has-children > a::after {
+	.fse-template .main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
 		font-size: 0.69444rem;
@@ -1364,7 +1370,7 @@ body:not(.fse-enabled) .site-description {
 	}
 }
 
-.main-navigation .hide-visually {
+.fse-template .main-navigation .hide-visually {
 	position: absolute !important;
 	clip: rect(1px, 1px, 1px, 1px);
 	padding: 0 !important;
@@ -1565,102 +1571,51 @@ body:not(.fse-enabled) .footer-menu a {
  */
 }
 
-.site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link {
-	color: blue;
-	background: transparent;
-	border: 2px solid currentcolor;
-	padding: 14px 16px;
+.site-header .main-navigation button,
+.site-header .main-navigation .button,
+.site-header .main-navigation input[type="submit"],
+.site-header .main-navigation .wp-block-button__link,
+.site-header .main-navigation .wp-block-file__button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: sans-serif;
+	font-family: var(--font-headings, sans-serif);
+	font-size: 1.2rem;
 }
 
-.site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:hover, .site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:focus, .site-header .main-navigation .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
-	color: indigo;
+.fse-template .main-navigation .main-menu.footer-menu li a {
+	font-size: inherit;
 }
 
-.site-header .main-navigation .wp-block-button.is-style-squared .wp-block-button__link {
-	border-radius: 0;
+.fse-template .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px;
 }
 
 .post-content__block {
 	margin-bottom: 160px;
 	margin-top: 36px;
 	z-index: 20;
-}
-
-@media only screen and (min-width: 640px) {
-	.site-footer {
-		display: block;
-	}
-}
-
-.site-footer .main-navigation {
-	display: block;
-}
-
-.site-footer .main-navigation .footer-menu {
-	color: inherit;
-}
-
-.site-footer .main-navigation > div {
-	display: block;
-}
-
-.site-footer .main-navigation .hide-visually,
-.site-footer .main-navigation #toggle-menu {
-	display: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.site-footer .main-navigation > div {
-		display: block;
-	}
-	.site-footer .main-navigation li {
-		width: auto;
-	}
-	.site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.site-header .site-title.has-background,
-.site-header .site-description.has-background,
-.site-footer .site-title.has-background,
-.site-footer .site-description.has-background {
-	border-radius: 0;
-	padding: 16px;
-}
-
-.site-header .main-navigation .main-menu.footer-menu li a,
-.site-footer .main-navigation .main-menu.footer-menu li a {
-	font-size: inherit;
-}
-
-.site-header .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after,
-.site-footer .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
-	font-size: 0.6em;
-	vertical-align: middle;
-}
-
-.site-header .main-navigation .has-text-color > .main-menu.footer-menu > li > a,
-.site-footer .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.site-header .main-navigation .has-text-align-left > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-left > .main-menu.footer-menu {
-	justify-content: flex-start;
-}
-
-.site-header .main-navigation .has-text-align-center > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-center > .main-menu.footer-menu {
-	justify-content: center;
-}
-
-.site-header .main-navigation .has-text-align-right > .main-menu.footer-menu,
-.site-footer .main-navigation .has-text-align-right > .main-menu.footer-menu {
-	justify-content: flex-end;
-}
-
-.site-header .main-navigation .has-background > .main-menu.footer-menu,
-.site-footer .main-navigation .has-background > .main-menu.footer-menu {
-	padding: 16px;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1013,107 +1013,11 @@ table th,
  * Full Site Editing
  * - Full Site Editing overrides
  */
-/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-.site-header .main-navigation button,
-.site-header .main-navigation .button,
-.site-header .main-navigation input[type="submit"],
-.site-header .main-navigation .wp-block-button__link,
-.site-header .main-navigation .wp-block-file__button {
-	line-height: 1;
-	color: white;
-	cursor: pointer;
-	font-weight: bold;
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	font-size: 1.2rem;
-	background-color: blue;
-	border-radius: 9px;
-	border-width: 0;
-	padding: 16px 16px;
-}
-
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before, .site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
-	content: '';
-	display: block;
-	height: 0;
-	width: 0;
-}
-
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before {
-	margin-bottom: -0.12em;
-}
-
-.site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
-	margin-top: -0.11em;
-}
-
-.site-header .main-navigation button:hover,
-.site-header .main-navigation .button:hover,
-.site-header .main-navigation input:hover[type="submit"],
-.site-header .main-navigation .wp-block-button__link:hover,
-.site-header .main-navigation .wp-block-file__button:hover, .site-header .main-navigation button:focus,
-.site-header .main-navigation .button:focus,
-.site-header .main-navigation input:focus[type="submit"],
-.site-header .main-navigation .wp-block-button__link:focus,
-.site-header .main-navigation .wp-block-file__button:focus, .site-header .main-navigation button.has-focus,
-.site-header .main-navigation .has-focus.button,
-.site-header .main-navigation input.has-focus[type="submit"],
-.site-header .main-navigation .has-focus.wp-block-button__link,
-.site-header .main-navigation .has-focus.wp-block-file__button {
-	color: white;
-	background-color: indigo;
-}
-
-/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-.site-branding {
-	color: #444444;
-}
-
-.site-title {
-	color: blue;
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	letter-spacing: normal;
-	line-height: 1;
-}
-
-.site-title a {
-	color: currentColor;
-	font-weight: bold;
-}
-
-.site-title a:link, .site-title a:visited {
-	color: currentColor;
-}
-
-.site-title a:hover {
-	color: indigo;
+@media (min-width: 600px) {
+	.a8c-template-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .template-block .fse-template-part {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -125,11 +125,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.site-header .main-navigation button,
-.site-header .main-navigation .button,
-.site-header .main-navigation input[type="submit"],
-.site-header .main-navigation .wp-block-button__link,
-.site-header .main-navigation .wp-block-file__button {
+.fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -143,50 +139,22 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 	padding: 16px 16px;
 }
 
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before, .site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.site-header .main-navigation button:before,
-.site-header .main-navigation .button:before,
-.site-header .main-navigation input[type="submit"]:before,
-.site-header .main-navigation .wp-block-button__link:before,
-.site-header .main-navigation .wp-block-file__button:before {
+.fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.site-header .main-navigation button:after,
-.site-header .main-navigation .button:after,
-.site-header .main-navigation input[type="submit"]:after,
-.site-header .main-navigation .wp-block-button__link:after,
-.site-header .main-navigation .wp-block-file__button:after {
+.fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.site-header .main-navigation button:hover,
-.site-header .main-navigation .button:hover,
-.site-header .main-navigation input:hover[type="submit"],
-.site-header .main-navigation .wp-block-button__link:hover,
-.site-header .main-navigation .wp-block-file__button:hover, .site-header .main-navigation button:focus,
-.site-header .main-navigation .button:focus,
-.site-header .main-navigation input:focus[type="submit"],
-.site-header .main-navigation .wp-block-button__link:focus,
-.site-header .main-navigation .wp-block-file__button:focus, .site-header .main-navigation button.has-focus,
-.site-header .main-navigation .has-focus.button,
-.site-header .main-navigation input.has-focus[type="submit"],
-.site-header .main-navigation .has-focus.wp-block-button__link,
-.site-header .main-navigation .has-focus.wp-block-file__button {
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }
@@ -1187,7 +1155,7 @@ table th,
 	margin: 0;
 }
 
-.fse-template-part .main-navigation #toggle:checked ~ div {
+.fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
 	display: block;
 }
 
@@ -1211,7 +1179,7 @@ table th,
 
 @media only screen and (min-width: 560px) {
 	.fse-template-part .main-navigation > div {
-		display: block;
+		display: inline-block;
 	}
 	.fse-template-part .main-navigation #toggle-menu {
 		display: none;
@@ -1391,23 +1359,22 @@ table th,
 }
 
 .fse-template-part .main-navigation {
+	text-align: center;
 	/**
- * Placeholder button style
+ * Button Placeholder style
  * - Since buttons appear in various blocks,
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
 	/**
- * Block Options
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
  */
-	text-align: center;
 }
 
-.fse-template-part .main-navigation button,
-.fse-template-part .main-navigation .button,
-.fse-template-part .main-navigation input[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link,
-.fse-template-part .main-navigation .wp-block-file__button {
+.fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -1421,67 +1388,24 @@ table th,
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:before,
-.fse-template-part .main-navigation .button:before,
-.fse-template-part .main-navigation input[type="submit"]:before,
-.fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation button:after,
-.fse-template-part .main-navigation .button:after,
-.fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
-.fse-template-part .main-navigation .wp-block-file__button:after {
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
-.fse-template-part .main-navigation .button:before,
-.fse-template-part .main-navigation input[type="submit"]:before,
-.fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before {
+.fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
-.fse-template-part .main-navigation .button:after,
-.fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
-.fse-template-part .main-navigation .wp-block-file__button:after {
+.fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:hover,
-.fse-template-part .main-navigation .button:hover,
-.fse-template-part .main-navigation input:hover[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:hover,
-.fse-template-part .main-navigation .wp-block-file__button:hover, .fse-template-part .main-navigation button:focus,
-.fse-template-part .main-navigation .button:focus,
-.fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation button.has-focus,
-.fse-template-part .main-navigation .has-focus.button,
-.fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
-.fse-template-part .main-navigation .has-focus.wp-block-file__button {
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
-}
-
-.fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link {
-	color: blue;
-	background: transparent;
-	border: 2px solid currentcolor;
-	padding: 14px 16px;
-}
-
-.fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:hover, .fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link:focus, .fse-template-part .main-navigation .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
-	color: indigo;
-}
-
-.fse-template-part .main-navigation .wp-block-button.is-style-squared .wp-block-button__link {
-	border-radius: 0;
 }
 
 .fse-template-part .main-navigation .main-menu.footer-menu li a {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1148,76 +1148,76 @@ table th,
 	color: indigo;
 }
 
-.template-block .fse-template {
+.template-block .fse-template-part {
 	padding: 16px;
 }
 
 @media only screen and (min-width: 560px) {
-	.template-block .fse-template {
+	.template-block .fse-template-part {
 		padding: 32px 0;
 	}
 }
 
-.fse-template .wp-block-cover .site-title,
-.fse-template .wp-block-cover .site-description,
-.fse-template .wp-block-cover-image .site-title,
-.fse-template .wp-block-cover-image .site-description {
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover .site-description,
+.fse-template-part .wp-block-cover-image .site-title,
+.fse-template-part .wp-block-cover-image .site-description {
 	background: transparent;
 	color: inherit;
 }
 
-.fse-template .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 
-.fse-template .main-navigation {
+.fse-template-part .main-navigation {
 	color: #444444;
 }
 
-.fse-template .main-navigation > div {
+.fse-template-part .main-navigation > div {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle-menu {
+.fse-template-part .main-navigation #toggle-menu {
 	display: inline-block;
 	margin: 0;
 }
 
-.fse-template .main-navigation #toggle:checked ~ div {
+.fse-template-part .main-navigation #toggle:checked ~ div {
 	display: block;
 }
 
-.fse-template .main-navigation #toggle:focus + #toggle-menu {
+.fse-template-part .main-navigation #toggle:focus + #toggle-menu {
 	background-color: indigo;
 	outline: inherit;
 	text-decoration: underline;
 }
 
-.fse-template .main-navigation .dropdown-icon.close {
+.fse-template-part .main-navigation .dropdown-icon.close {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle:checked + #toggle-menu .open {
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .open {
 	display: none;
 }
 
-.fse-template .main-navigation #toggle:checked + #toggle-menu .close {
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .close {
 	display: inline;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div {
+	.fse-template-part .main-navigation > div {
 		display: block;
 	}
-	.fse-template .main-navigation #toggle-menu {
+	.fse-template-part .main-navigation #toggle-menu {
 		display: none;
 	}
-	.fse-template .main-navigation > div > ul > li > ul {
+	.fse-template-part .main-navigation > div > ul > li > ul {
 		display: none;
 	}
 }
 
-.fse-template .main-navigation > div > ul {
+.fse-template-part .main-navigation > div > ul {
 	display: flex;
 	flex-wrap: wrap;
 	list-style: none;
@@ -1228,45 +1228,45 @@ table th,
 	/* Sub-menus Flyout */
 }
 
-.fse-template .main-navigation > div > ul ul {
+.fse-template-part .main-navigation > div > ul ul {
 	padding-left: 0;
 }
 
-.fse-template .main-navigation > div > ul li {
+.fse-template-part .main-navigation > div > ul li {
 	display: block;
 	position: relative;
 	width: 100%;
 	z-index: 1;
 }
 
-.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
 
-.fse-template .main-navigation > div > ul li:hover, .fse-template .main-navigation > div > ul li:focus-within {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul li {
+	.fse-template-part .main-navigation > div > ul li {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
 	}
-	.fse-template .main-navigation > div > ul li:hover > ul,
-	.fse-template .main-navigation > div > ul li[focus-within] > ul,
-	.fse-template .main-navigation > div > ul li ul:hover,
-	.fse-template .main-navigation > div > ul li ul:focus {
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
 	}
-	.fse-template .main-navigation > div > ul li:hover > ul,
-	.fse-template .main-navigation > div > ul li:focus-within > ul,
-	.fse-template .main-navigation > div > ul li ul:hover,
-	.fse-template .main-navigation > div > ul li ul:focus {
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li:focus-within > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
 		opacity: 1;
 		display: block;
@@ -1274,36 +1274,36 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > li > a {
+	.fse-template-part .main-navigation > div > ul > li > a {
 		line-height: 1;
 	}
-	.fse-template .main-navigation > div > ul > li > a:before, .fse-template .main-navigation > div > ul > li > a:after {
+	.fse-template-part .main-navigation > div > ul > li > a:before, .fse-template-part .main-navigation > div > ul > li > a:after {
 		content: '';
 		display: block;
 		height: 0;
 		width: 0;
 	}
-	.fse-template .main-navigation > div > ul > li > a:before {
+	.fse-template-part .main-navigation > div > ul > li > a:before {
 		margin-bottom: -0.12em;
 	}
-	.fse-template .main-navigation > div > ul > li > a:after {
+	.fse-template-part .main-navigation > div > ul > li > a:after {
 		margin-top: -0.11em;
 	}
-	.fse-template .main-navigation > div > ul > li:first-of-type > a {
+	.fse-template-part .main-navigation > div > ul > li:first-of-type > a {
 		padding-left: 0;
 	}
-	.fse-template .main-navigation > div > ul > li:last-of-type > a {
+	.fse-template-part .main-navigation > div > ul > li:last-of-type > a {
 		padding-right: 0;
 	}
 }
 
-.fse-template .main-navigation > div > ul > li > .sub-menu {
+.fse-template-part .main-navigation > div > ul > li > .sub-menu {
 	margin: 0;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > li > .sub-menu {
+	.fse-template-part .main-navigation > div > ul > li > .sub-menu {
 		background: white;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
 		left: 0;
@@ -1316,11 +1316,11 @@ table th,
 	}
 }
 
-.fse-template .main-navigation > div > ul > li > .sub-menu .sub-menu {
+.fse-template-part .main-navigation > div > ul > li > .sub-menu .sub-menu {
 	width: 100%;
 }
 
-.fse-template .main-navigation a {
+.fse-template-part .main-navigation a {
 	color: blue;
 	display: block;
 	font-family: sans-serif;
@@ -1330,32 +1330,32 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation a {
+	.fse-template-part .main-navigation a {
 		padding: 16px;
 	}
 }
 
-.fse-template .main-navigation a:link, .fse-template .main-navigation a:visited {
+.fse-template-part .main-navigation a:link, .fse-template-part .main-navigation a:visited {
 	color: blue;
 }
 
-.fse-template .main-navigation a:hover {
+.fse-template-part .main-navigation a:hover {
 	color: indigo;
 }
 
-.fse-template .main-navigation .sub-menu {
+.fse-template-part .main-navigation .sub-menu {
 	list-style: none;
 	margin-left: 0;
 	/* Reset the counter for each UL */
 	counter-reset: nested-list;
 }
 
-.fse-template .main-navigation .sub-menu .menu-item a {
+.fse-template-part .main-navigation .sub-menu .menu-item a {
 	padding-top: 8px;
 	padding-bottom: 8px;
 }
 
-.fse-template .main-navigation .sub-menu .menu-item a::before {
+.fse-template-part .main-navigation .sub-menu .menu-item a::before {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
@@ -1363,7 +1363,7 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation > div > ul > .menu-item-has-children > a::after {
+	.fse-template-part .main-navigation > div > ul > .menu-item-has-children > a::after {
 		content: "\00a0\25BC";
 		display: inline-block;
 		font-size: 0.69444rem;
@@ -1372,7 +1372,7 @@ table th,
 	}
 }
 
-.fse-template .main-navigation .hide-visually {
+.fse-template-part .main-navigation .hide-visually {
 	position: absolute !important;
 	clip: rect(1px, 1px, 1px, 1px);
 	padding: 0 !important;
@@ -1382,36 +1382,36 @@ table th,
 	overflow: hidden;
 }
 
-.fse-template body:not(.fse-enabled) .main-navigation a {
+.fse-template-part body:not(.fse-enabled) .main-navigation a {
 	font-size: 1.2rem;
 }
 
-.fse-template .main-navigation .main-menu.footer-menu li a {
+.fse-template-part .main-navigation .main-menu.footer-menu li a {
 	font-size: inherit;
 }
 
-.fse-template .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+.fse-template-part .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2744,12 +2744,12 @@ body:not(.fse-enabled) .main-navigation a {
 	color: indigo;
 }
 
-.footer-navigation, .fse-enabled .site-footer .main-navigation {
+.footer-navigation {
 	display: inline;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation, .fse-enabled .site-footer .main-navigation {
+	.footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
 		margin-top: 0;
@@ -2758,37 +2758,37 @@ body:not(.fse-enabled) .main-navigation a {
 	}
 }
 
-.footer-navigation > div, .fse-enabled .site-footer .main-navigation > div {
+.footer-navigation > div {
 	display: inline;
 }
 
-.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+.footer-navigation .footer-menu {
 	color: #767676;
 	margin: 0;
 	padding-right: 0;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+	.footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-end;
 	}
 }
 
-.footer-navigation .footer-menu > li, .fse-enabled .site-footer .main-navigation .footer-menu > li {
+.footer-navigation .footer-menu > li {
 	display: inline;
 }
 
-.footer-navigation .footer-menu > li:first-of-type > a, .fse-enabled .site-footer .main-navigation .footer-menu > li:first-of-type > a {
+.footer-navigation .footer-menu > li:first-of-type > a {
 	padding-right: 0;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	padding-left: 0;
 }
 
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
 	font-weight: bold;
@@ -2796,11 +2796,11 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:link, .fse-enabled .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .fse-enabled .site-footer .main-navigation .footer-menu a:visited {
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:hover, .fse-enabled .site-footer .main-navigation .footer-menu a:hover {
+.footer-navigation .footer-menu a:hover {
 	color: indigo;
 }
 
@@ -3698,70 +3698,65 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-enabled .site-footer {
-	display: block;
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
 }
 
-.fse-enabled .site-footer .main-navigation {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .footer-menu {
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-enabled .site-footer .main-navigation > div {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .hide-visually,
-.fse-enabled .site-footer .main-navigation #toggle-menu {
-	display: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation > div {
-		display: block;
-	}
-	.fse-enabled .site-footer .main-navigation li {
-		width: auto;
-	}
-	.fse-enabled .site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.fse-enabled .site-footer .site-info {
-	text-align: center;
-}
-
-.fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.fse-enabled .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-enabled .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-enabled .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-enabled .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3698,38 +3698,38 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-template {
+.fse-template-part {
 	margin-bottom: 0;
 	margin-top: 0;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -2761,12 +2761,12 @@ body:not(.fse-enabled) .main-navigation a {
 	color: indigo;
 }
 
-.footer-navigation, .fse-enabled .site-footer .main-navigation {
+.footer-navigation {
 	display: inline;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation, .fse-enabled .site-footer .main-navigation {
+	.footer-navigation {
 		flex: 1 0 50%;
 		order: 2;
 		margin-top: 0;
@@ -2775,37 +2775,37 @@ body:not(.fse-enabled) .main-navigation a {
 	}
 }
 
-.footer-navigation > div, .fse-enabled .site-footer .main-navigation > div {
+.footer-navigation > div {
 	display: inline;
 }
 
-.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+.footer-navigation .footer-menu {
 	color: #767676;
 	margin: 0;
 	padding-left: 0;
 }
 
 @media only screen and (min-width: 640px) {
-	.footer-navigation .footer-menu, .fse-enabled .site-footer .main-navigation .footer-menu {
+	.footer-navigation .footer-menu {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-end;
 	}
 }
 
-.footer-navigation .footer-menu > li, .fse-enabled .site-footer .main-navigation .footer-menu > li {
+.footer-navigation .footer-menu > li {
 	display: inline;
 }
 
-.footer-navigation .footer-menu > li:first-of-type > a, .fse-enabled .site-footer .main-navigation .footer-menu > li:first-of-type > a {
+.footer-navigation .footer-menu > li:first-of-type > a {
 	padding-left: 0;
 }
 
-.footer-navigation .footer-menu > li:last-of-type, .fse-enabled .site-footer .main-navigation .footer-menu > li:last-of-type {
+.footer-navigation .footer-menu > li:last-of-type {
 	padding-right: 0;
 }
 
-.footer-navigation .footer-menu a, .fse-enabled .site-footer .main-navigation .footer-menu a {
+.footer-navigation .footer-menu a {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
 	font-weight: bold;
@@ -2813,11 +2813,11 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:link, .fse-enabled .site-footer .main-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited, .fse-enabled .site-footer .main-navigation .footer-menu a:visited {
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:hover, .fse-enabled .site-footer .main-navigation .footer-menu a:hover {
+.footer-navigation .footer-menu a:hover {
 	color: indigo;
 }
 
@@ -3727,70 +3727,65 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-enabled .site-footer {
-	display: block;
+.fse-template {
+	margin-bottom: 0;
+	margin-top: 0;
 }
 
-.fse-enabled .site-footer .main-navigation {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .footer-menu {
+.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-enabled .site-footer .main-navigation > div {
-	display: block;
-}
-
-.fse-enabled .site-footer .main-navigation .hide-visually,
-.fse-enabled .site-footer .main-navigation #toggle-menu {
-	display: none;
-}
-
-@media only screen and (max-width: 559px) {
-	.fse-enabled .site-footer .main-navigation > div {
-		display: block;
-	}
-	.fse-enabled .site-footer .main-navigation li {
-		width: auto;
-	}
-	.fse-enabled .site-footer .main-navigation li .sub-menu {
-		display: none;
-	}
-}
-
-.fse-enabled .site-footer .site-info {
-	text-align: center;
-}
-
-.fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
-	color: inherit;
-}
-
-.fse-enabled .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-enabled .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-enabled .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-enabled .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-enabled .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -3727,38 +3727,38 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Full Site Editing
  * - Full Site Editing overrides
  */
-.fse-template {
+.fse-template-part {
 	margin-bottom: 0;
 	margin-top: 0;
 }
 
-.fse-template .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template .main-navigation .has-text-align-left > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template .main-navigation .has-text-align-center > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template .main-navigation .has-text-align-right > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
-.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 	padding: 16px 0;
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template .main-navigation .has-background > .main-menu.footer-menu {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-template .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }


### PR DESCRIPTION
After adding the style attributes to all FSE blocks, I've realized that we are giving the user enough freedom that reusing the default theme classes makes things unnecessarily harder.

Once removing the theme classes, we can also remove a lot of now superfluous overrides.

## Details

I have tested this as thoroughly as possible, but in the end I think these are some relatively simple specs to test against.

### Template Parts Test Content

This is what I've used in my tests. Feel free to reuse it, mix and match it, or try something else.

**Default header**

```html
<!-- wp:image {"align":"center","id":25,"width":188,"height":134,"sizeSlug":"large","className":"size-large fse-site-logo"} -->

<div class="wp-block-image size-large fse-site-logo"><figure class="aligncenter size-large is-resized"><img src="https://fsemaywooddemo.files.wordpress.com/2019/09/maywood-logo-e1569858169507.png" alt="maywood-logo" class="wp-image-25" width="188" height="134" /></figure></div>

<!-- /wp:image -->

<!-- wp:a8c/site-title /-->

<!-- wp:a8c/site-description /-->

<!-- wp:a8c/navigation-menu /-->
```

**Fully customized header**

- Cover with a grey background.
- Site Title full width, right aligned, with a red text color, and a huge font size.
- Site Description full width, right aligned, with a red background, a white text color, and a huge font size.
- Navigation Menu full width, right aligned, with a golden background, a white text color, and a huge font size.

```html
<!-- wp:cover {"overlayColor":"foreground-light","align":"full"} -->
<div class="wp-block-cover alignfull has-foreground-light-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:image {"align":"center","id":25,"width":188,"height":134,"sizeSlug":"large","className":"size-large fse-site-logo"} -->
<div class="wp-block-image size-large fse-site-logo"><figure class="aligncenter size-large is-resized"><img src="https://fsemaywooddemo.files.wordpress.com/2019/09/maywood-logo-e1569858169507.png" alt="maywood-logo" class="wp-image-25" width="188" height="134"/></figure></div>
<!-- /wp:image -->

<!-- wp:a8c/site-title {"align":"full","textAlign":"right","textColor":"secondary","fontSize":"huge"} /-->

<!-- wp:a8c/site-description {"align":"full","textAlign":"right","textColor":"background","backgroundColor":"secondary","fontSize":"huge"} /-->

<!-- wp:a8c/navigation-menu {"align":"full","textAlign":"right","textColor":"background","backgroundColor":"primary","fontSize":"huge"} /--></div></div>
<!-- /wp:cover -->
```

**Default footer**

```html
<!-- wp:separator {"className":"is-style-default"} -->
<hr class="wp-block-separator is-style-default"/>
<!-- /wp:separator -->

<!-- wp:a8c/navigation-menu /-->
```

**Fully customized footer**

```html
<!-- wp:cover {"overlayColor":"foreground-light","align":"full"} -->
<div class="wp-block-cover alignfull has-foreground-light-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:separator {"className":"is-style-default"} -->
<hr class="wp-block-separator is-style-default"/>
<!-- /wp:separator -->

<!-- wp:a8c/site-title {"align":"full","textAlign":"right","textColor":"secondary","fontSize":"huge"} /-->

<!-- wp:a8c/site-description {"align":"full","textAlign":"right","textColor":"background","backgroundColor":"secondary","fontSize":"huge"} /-->

<!-- wp:a8c/navigation-menu {"align":"full","textAlign":"right","textColor":"background","backgroundColor":"primary","fontSize":"huge"} /--></div></div>
<!-- /wp:cover -->
```

### Screenshots

For convenience, I've screenshotted three browser windows side by side, always in the same order (`template editor | page editor | front end`), and roughly vertical aligned, hoping to make the comparison as easy as possible.

## Tests

### Default header

| Prev | Next |
| - | - |
| <img width="2523" alt="header default PREV" src="https://user-images.githubusercontent.com/2070010/67099737-64438800-f1b6-11e9-88db-568e97cbbaf1.png"> | <img width="2525" alt="header default NEXT" src="https://user-images.githubusercontent.com/2070010/67099756-6a396900-f1b6-11e9-88a4-1829387ac314.png"> |

The Navigation Menu block now has a consistent font size.

**Note**: The spacing difference in the page editor is caused by the plugin being too zealous when [hiding the insertion point from the template block](https://github.com/Automattic/wp-calypso/blob/83f1428f1fa10ac716cf17471e59527ba6fdf079/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss#L33-L40).
This is not related to this change, and can be tackled separately. It happened before as well, but it's now more obvious because we don't apply as many overrides and fixes anymore.

### Header with cover and default blocks

| Prev | Next |
| - | - |
| <img width="2521" alt="header cover default PREV" src="https://user-images.githubusercontent.com/2070010/67099927-ad93d780-f1b6-11e9-9783-1f4d49937bee.png"> | <img width="2518" alt="header cover default NEXT" src="https://user-images.githubusercontent.com/2070010/67099929-aff63180-f1b6-11e9-98eb-ceb0de9d28be.png"> |

Both the Site Title and Navigation Menu blocks now has consistent font sizes.

### Header with all style attributes enabled

| Prev | Next |
| - | - |
| <img width="2524" alt="header all attributes PREV 2" src="https://user-images.githubusercontent.com/2070010/67101853-58f25b80-f1ba-11e9-834d-99d6db065395.png"> | <img width="2529" alt="header all attributes NEXT 2" src="https://user-images.githubusercontent.com/2070010/67101941-86d7a000-f1ba-11e9-8a5b-71bc7cb4fbd4.png"> |

**Note**: fully aligned blocks lose their vertical margins on the front end. It's unrelated to the front end, and to be honest I'd consider it a feature.

### Header with cover and all style attributes enabled

| Prev | Next |
| - | - |
| <img width="2528" alt="header cover all attributes PREV 2" src="https://user-images.githubusercontent.com/2070010/67101957-91923500-f1ba-11e9-8a2d-8a92a070b927.png"> | <img width="2531" alt="header cover all attributes NEXT 2" src="https://user-images.githubusercontent.com/2070010/67101878-6576b400-f1ba-11e9-9d28-c12fc5995e54.png"> |

Both the Site Title and Site Description blocks now has consistent font sizes.
The Site Description, when it has a background color, now doesn't have a text shadow anymore.
Fully aligned blocks inside Cover aren't cut off in the template editor anymore.

**Note**: in the page editor NEXT screenshot, the Cover seems to lack vertical paddings.
It's unrelated to this PR, but FYI it happens because the Cover has a defined min-height, and at that particular breakpoint, with the Navigation Menu on 3 lines, it accidentally fills the entire min-height.

### Default footer

| Prev | Next |
| - | - |
| <img width="2521" alt="footer default PREV" src="https://user-images.githubusercontent.com/2070010/67102558-8c81b580-f1bb-11e9-824f-13a1fdd3c622.png"> | <img width="2523" alt="footer default NEXT" src="https://user-images.githubusercontent.com/2070010/67102580-92779680-f1bb-11e9-850a-f628652e5a75.png"> |

The Navigation Menu block now has a consistent font size.

### Footer with cover and default blocks

| Prev | Next |
| - | - |
| <img width="2518" alt="footer cover default PREV" src="https://user-images.githubusercontent.com/2070010/67102684-cb177000-f1bb-11e9-968e-e753defc28db.png"> | <img width="2520" alt="footer cover default NEXT" src="https://user-images.githubusercontent.com/2070010/67102692-ceaaf700-f1bb-11e9-9c7f-16abf72e0aaa.png"> |

The Navigation Menu block now has a consistent font size.
The Cover block now has an appropriate bottom margin.

### Footer with all style attributes enabled

| Prev | Next |
| - | - |
| <img width="2529" alt="footer all attributes PREV 2" src="https://user-images.githubusercontent.com/2070010/67102765-f13d1000-f1bb-11e9-9cac-f81b0d115c7c.png"> | <img width="2526" alt="footer all attributes NEXT 2" src="https://user-images.githubusercontent.com/2070010/67102782-f7cb8780-f1bb-11e9-954d-aedb06741fcb.png"> |

Fully aligned blocks now lose their vertical margins on the front end. It looks like a bug, but in fact it works as intended, and if anything, the previous behaviour was the bug! 😄


### Footer with cover and all style attributes enabled

| Prev | Next |
| - | - |
| <img width="2529" alt="footer cover all attributes PREV 2" src="https://user-images.githubusercontent.com/2070010/67103184-95bf5200-f1bc-11e9-841c-91d63db9f3d3.png"> | <img width="2529" alt="footer cover all attributes NEXT 2" src="https://user-images.githubusercontent.com/2070010/67103196-99eb6f80-f1bc-11e9-8411-7a5cb06ddbb3.png"> |

Both the Site Title and Site Description blocks now has consistent font sizes.
The Site Description, when it has a background color, now doesn't have a text shadow anymore.
Fully aligned blocks inside Cover aren't cut off in the template editor anymore.

### Testing instructions

Follow the instructions provided in Automattic/wp-calypso#36776