### PR TITLE
Varia + various child-themes: Add missing config variables

### DIFF
--- a/alves/sass/_config-child-theme-deep.scss
+++ b/alves/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/balasana/sass/_config-child-theme-deep.scss
+++ b/balasana/sass/_config-child-theme-deep.scss
@@ -275,6 +275,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/barnsbury/sass/_config-child-theme-deep.scss
+++ b/barnsbury/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.33 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/dalston/sass/_config-child-theme-deep.scss
+++ b/dalston/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/exford/sass/_config-child-theme-deep.scss
+++ b/exford/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/mayland/sass/_config-child-theme-deep.scss
+++ b/mayland/sass/_config-child-theme-deep.scss
@@ -279,6 +279,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/maywood/sass/_config-child-theme-deep.scss
+++ b/maywood/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/redhill/sass/_config-child-theme-deep.scss
+++ b/redhill/sass/_config-child-theme-deep.scss
@@ -355,5 +355,6 @@ $config-footer: (
 	"font": (
 		"family": map-deep-get($config-global, "font", "family", "secondary"),
 		"size": map-deep-get($config-global, "font", "size", "sm"),
+		"line-height": map-deep-get($config-global, "font", "line-height", "sm"),
 	),
 );

--- a/rivington/sass/_config-child-theme-deep.scss
+++ b/rivington/sass/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**

--- a/varia/sass/child-theme/_config-child-theme-deep.scss
+++ b/varia/sass/child-theme/_config-child-theme-deep.scss
@@ -280,6 +280,7 @@ $config-quote: (
 
 $config-separator: (
 	"height": #{0.25 * $baseline-unit},
+	"width": #{6 * map-deep-get($config-global, "spacing", "horizontal")},
 );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds `config-separator.width` variable to the base Varia child-theme variables array so it gets copied into new child-themes properly.
- Adds a width variable to the `config-separator` array for various child-themes to prevent potential compiling errors.
- Add `config-footer.font.line-height` default variable to Redhill.

#### Related issue(s):

Fixes: #1519 