### PR TITLE
Varia: Make sure centre aligned image in classic block is centred

### DIFF
--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -23,6 +23,7 @@
  */
 .aligncenter {
 	clear: both;
+	display: block;
 	float: none;
 	margin-right: auto;
 	margin-left: auto;

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -24,6 +24,8 @@
 .aligncenter {
 	clear: both;
 	float: none;
+	margin-right: auto;
+	margin-left: auto;
 	text-align: center;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2018,6 +2018,8 @@ table th,
 .aligncenter {
 	clear: both;
 	float: none;
+	margin-left: auto;
+	margin-right: auto;
 	text-align: center;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2017,6 +2017,7 @@ table th,
  */
 .aligncenter {
 	clear: both;
+	display: block;
 	float: none;
 	margin-left: auto;
 	margin-right: auto;

--- a/varia/style.css
+++ b/varia/style.css
@@ -2021,6 +2021,8 @@ table th,
 .aligncenter {
 	clear: both;
 	float: none;
+	margin-right: auto;
+	margin-left: auto;
 	text-align: center;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -2020,6 +2020,7 @@ table th,
  */
 .aligncenter {
 	clear: both;
+	display: block;
 	float: none;
 	margin-right: auto;
 	margin-left: auto;


### PR DESCRIPTION
Fixes #1511

**Before**
<img width="839" alt="Screenshot 2019-10-22 at 20 01 36" src="https://user-images.githubusercontent.com/908665/67322036-52404d00-f508-11e9-9e54-3650e5254982.png">

**After**
<img width="806" alt="Screenshot 2019-10-22 at 20 10 49" src="https://user-images.githubusercontent.com/908665/67322068-5c624b80-f508-11e9-969d-09bbff30fe48.png">
