### PR TITLE
Exford: Make sure sub-menu item is one line in Safari

### DIFF
--- a/exford/sass/_extra-child-theme.scss
+++ b/exford/sass/_extra-child-theme.scss
@@ -88,8 +88,9 @@ a {
 
 			> div > ul > li > .sub-menu {
 				border: 1px solid map-deep-get($config-global, "color", "border", "default");
-				box-shadow: none;
 				border-radius: map-deep-get($config-global, "border-radius", "sm");
+				box-shadow: none;
+				box-sizing: content-box; // for Safari
 			}
 		}
 	}

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -684,9 +684,7 @@ a {
 .site-header:after,
 .site-content:after,
 .site-footer:after {
-	content: "";
-	display: table;
-	table-layout: fixed;
+	clear: both;
 }
 
 /**
@@ -1965,6 +1963,10 @@ hr.wp-block-separator {
 	/**
 		 * Block Options
 		 */
+}
+
+hr.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: 96px;
 }
 
 hr.wp-block-separator.is-style-dots:before {
@@ -3681,8 +3683,9 @@ p:not(.site-title) a:hover {
 	}
 	.site-header > *.main-navigation > div > ul > li > .sub-menu {
 		border: 1px solid #CCCCCC;
-		box-shadow: none;
 		border-radius: 5px;
+		box-shadow: none;
+		box-sizing: content-box;
 	}
 }
 

--- a/exford/style.css
+++ b/exford/style.css
@@ -684,9 +684,7 @@ a {
 .site-header:after,
 .site-content:after,
 .site-footer:after {
-	content: "";
-	display: table;
-	table-layout: fixed;
+	clear: both;
 }
 
 /**
@@ -1965,6 +1963,10 @@ hr.wp-block-separator {
 	/**
 		 * Block Options
 		 */
+}
+
+hr.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: 96px;
 }
 
 hr.wp-block-separator.is-style-dots:before {
@@ -3710,8 +3712,9 @@ p:not(.site-title) a:hover {
 	}
 	.site-header > *.main-navigation > div > ul > li > .sub-menu {
 		border: 1px solid #CCCCCC;
-		box-shadow: none;
 		border-radius: 5px;
+		box-shadow: none;
+		box-sizing: content-box;
 	}
 }
 


### PR DESCRIPTION
Fixes #1416 

**Before:**
<img width="364" alt="Screenshot 2019-10-22 at 21 57 24" src="https://user-images.githubusercontent.com/908665/67332518-0648d480-f517-11e9-9d96-d3c8c908280c.png">

**After:**
<img width="427" alt="Screenshot 2019-10-22 at 21 56 45" src="https://user-images.githubusercontent.com/908665/67332537-119c0000-f517-11e9-842c-f678e246f6c6.png">
