### PR TITLE
Varia: Restore the “Skip cropping” option to custom-logo setup.

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -88,7 +88,7 @@ if ( ! function_exists( 'varia_setup' ) ) :
 				'height'      => 96,
 				'width'       => 100,
 				'flex-width'  => true,
-				'flex-height' => false,
+				'flex-height' => true,
 				'header-text' => array( 'site-title', 'site-description' ),
 			)
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Sets the _custom-logo_ `flex-height` and `flex-width` parameters to true so that customers are not forced to crop their logo and/or manually remove the crop area. 
- Customers can still crop their logos if they choose to.
- This change may require some logos to be resized manually before uploading to the customizer.

**Note**
- This change should be tested against a site that already has a logo setup with the previous logo size settings to make sure there’s no disruption when/if this change gets deployed.

#### Related issue(s):

Fixes: #1488 