### PR TITLE
Varia: Add `Continue reading ->` link filter for excerpts and read more blocks.

### DIFF
--- a/varia/inc/template-functions.php
+++ b/varia/inc/template-functions.php
@@ -165,6 +165,28 @@ function varia_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
 }
 add_filter( 'nav_menu_link_attributes', 'varia_nav_menu_link_attributes', 10, 4 );
 
+/*
+ * Create the continue reading link
+ */
+function varia_continue_reading_link() {
+
+	if ( ! is_admin() ) {
+		$continue_reading = sprintf(
+			/* translators: %s: Name of current post. */
+			wp_kses( __( 'Continue reading %s', 'varia' ), array( 'span' => array( 'class' => array() ) ) ),
+			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+		);
+
+		return '<a class="more-link" href="' . esc_url( get_permalink() ) . '">' . $continue_reading . '</a>';
+	}
+}
+
+// Filter the excerpt more link
+add_filter( 'excerpt_more', 'varia_continue_reading_link' );
+
+// Filter the content more link
+add_filter( 'the_content_more_link', 'varia_continue_reading_link' );
+
 /**
  * Add a dropdown icon to top-level menu items.
  *

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -16,6 +16,11 @@
 	.more-link {
 		display: block;
 		color: inherit;
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+
+		@include media(mobile) {
+			margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
 
 		&:after {
 			content: "\02192";

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2774,6 +2774,7 @@ body:not(.fse-enabled) .footer-menu a {
 .entry-content .more-link {
 	display: block;
 	color: inherit;
+	margin-top: 32px;
 }
 
 .entry-content .more-link:after {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2774,7 +2774,13 @@ body:not(.fse-enabled) .footer-menu a {
 .entry-content .more-link {
 	display: block;
 	color: inherit;
-	margin-top: 32px;
+	margin-top: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.entry-content .more-link {
+		margin-top: 32px;
+	}
 }
 
 .entry-content .more-link:after {

--- a/varia/style.css
+++ b/varia/style.css
@@ -2791,6 +2791,13 @@ body:not(.fse-enabled) .footer-menu a {
 .entry-content .more-link {
 	display: block;
 	color: inherit;
+	margin-top: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.entry-content .more-link {
+		margin-top: 32px;
+	}
 }
 
 .entry-content .more-link:after {

--- a/varia/template-parts/content/content.php
+++ b/varia/template-parts/content/content.php
@@ -29,20 +29,7 @@
 
 	<div class="entry-content">
 		<?php
-		the_content(
-			sprintf(
-				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'varia' ),
-					array(
-						'span' => array(
-							'class' => array(),
-						),
-					)
-				),
-				get_the_title()
-			)
-		);
+		the_content();
 
 		wp_link_pages(
 			array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds a filter to add a “Continue reading ->” link to excerpts and full-post content when using the read-more block or the read-more classic comment.

**Note:** 
This change should be _non-destructive_, so all Varia child-themes can be re-compiled on this PR or on master branch after this is approved and committed. 

#### Related issue(s):

Fixes: #1576 