### PR TITLE
(DON'T MERGE) Only display default credit info if FSE is not active.

### DIFF
--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2832,6 +2832,13 @@ body:not(.fse-enabled) .footer-menu a {
 .entry-content .more-link {
 	display: block;
 	color: inherit;
+	margin-top: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.entry-content .more-link {
+		margin-top: 32px;
+	}
 }
 
 .entry-content .more-link:after {
@@ -3650,6 +3657,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Business Hours
+ */
+.jetpack-business-hours dd {
+	padding-left: 0;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**
@@ -4060,10 +4074,6 @@ p:not(.site-title) a:hover {
 	.fse-enabled .site-footer .main-navigation li .sub-menu {
 		display: none;
 	}
-}
-
-.fse-enabled .site-footer .site-info {
-	text-align: center;
 }
 
 .fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {

--- a/varia/footer.php
+++ b/varia/footer.php
@@ -35,24 +35,23 @@
 						);
 						?>
 					</nav><!-- .footer-navigation -->
+					<div class="site-info">
+						<?php $blog_info = get_bloginfo( 'name' ); ?>
+						<?php if ( ! empty( $blog_info ) ) : ?>
+							<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a><span class="comma">,</span>
+						<?php endif; ?>
+						<?php /* translators: 1: WordPress link, 2: WordPress. */
+						printf( '<a href="%1$s" class="imprint">proudly powered by %2$s</a>.',
+							esc_url( __( 'https://wordpress.org/', 'varia' ) ),
+							'WordPress'
+						); ?>
+						<?php if ( function_exists( 'the_privacy_policy_link' ) ) {
+							the_privacy_policy_link();
+						} ?>
+					</div><!-- .site-info -->
 				<?php endif;
 			endif;
 		?>
-
-		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a><span class="comma">,</span>
-			<?php endif; ?>
-			<?php /* translators: 1: WordPress link, 2: WordPress. */
-			printf( '<a href="%1$s" class="imprint">proudly powered by %2$s</a>.',
-				esc_url( __( 'https://wordpress.org/', 'varia' ) ),
-				'WordPress'
-			); ?>
-			<?php if ( function_exists( 'the_privacy_policy_link' ) ) {
-				the_privacy_policy_link();
-			} ?>
-		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 
 </div><!-- #page -->

--- a/varia/footer.php
+++ b/varia/footer.php
@@ -35,22 +35,23 @@
 						);
 						?>
 					</nav><!-- .footer-navigation -->
-					<div class="site-info">
-						<?php $blog_info = get_bloginfo( 'name' ); ?>
-						<?php if ( ! empty( $blog_info ) ) : ?>
-							<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a><span class="comma">,</span>
-						<?php endif; ?>
-						<?php /* translators: 1: WordPress link, 2: WordPress. */
-						printf( '<a href="%1$s" class="imprint">proudly powered by %2$s</a>.',
-							esc_url( __( 'https://wordpress.org/', 'varia' ) ),
-							'WordPress'
-						); ?>
-						<?php if ( function_exists( 'the_privacy_policy_link' ) ) {
-							the_privacy_policy_link();
-						} ?>
-					</div><!-- .site-info -->
-				<?php endif;
-			endif;
+				<?php endif; ?>
+
+				<div class="site-info">
+					<?php $blog_info = get_bloginfo( 'name' ); ?>
+					<?php if ( ! empty( $blog_info ) ) : ?>
+						<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a><span class="comma">,</span>
+					<?php endif; ?>
+					<?php /* translators: 1: WordPress link, 2: WordPress. */
+					printf( '<a href="%1$s" class="imprint">proudly powered by %2$s</a>.',
+						esc_url( __( 'https://wordpress.org/', 'varia' ) ),
+						'WordPress'
+					); ?>
+					<?php if ( function_exists( 'the_privacy_policy_link' ) ) {
+						the_privacy_policy_link();
+					} ?>
+				</div><!-- .site-info -->
+			<?php endif;
 		?>
 	</footer><!-- #colophon -->
 

--- a/varia/package-lock.json
+++ b/varia/package-lock.json
@@ -1478,8 +1478,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1500,14 +1499,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1522,20 +1519,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1652,8 +1646,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1665,7 +1658,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1680,7 +1672,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1688,14 +1679,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1714,7 +1703,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1795,8 +1783,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1808,7 +1795,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1894,8 +1880,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1931,7 +1916,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1951,7 +1935,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1995,14 +1978,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -32,10 +32,6 @@
 				}
 			}
 		}
-
-		.site-info {
-			text-align: center;
-		}
 	}
 
 	.main-navigation {

--- a/varia/style.css
+++ b/varia/style.css
@@ -3659,10 +3659,6 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	}
 }
 
-.fse-enabled .site-footer .site-info {
-	text-align: center;
-}
-
 .fse-enabled .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }


### PR DESCRIPTION
We'll be using the FSE footer credit block instead.

**Note: This should NOT be deployed until the footer credit is included on WordPress.com.**

### Changes:
- Move footer credit structure inside if statement which runs if FSE is not active. 
- (EDIT): Removed manual text align setting for credit if FSE is active. We want the user to set that with blocks (tm)

### Testing:
1. Pull these changes to your local FSE setup.
2. The footer credit will no longer show up if FSE is active.
3. The footer credit will show up if FSE is inactive.
4. You can use the footer credit block from the below PR. If you put it in the footer, it should look identical to the implementation we are moving in this PR.

#### Related issue(s): https://github.com/Automattic/wp-calypso/pull/37012
