### PR TITLE
Balasana: Revert menu display on mobile.

### DIFF
--- a/balasana/sass/_extra-child-theme.scss
+++ b/balasana/sass/_extra-child-theme.scss
@@ -76,11 +76,9 @@ dt {
 // Site Header
 .site-header {
 
-	@include media(mobile) {
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-	}
+ 	align-items: center;
+ 	display: flex;
+ 	justify-content: space-between;
 
 	& > * {
 		margin-top: 0;

--- a/balasana/sass/style-child-theme-woocommerce.scss
+++ b/balasana/sass/style-child-theme-woocommerce.scss
@@ -48,6 +48,7 @@ body[class*="woocommerce"] #page {
 
 		#masthead {
 			position: relative;
+			display: inherit; // Remove flexbox to allot space for the mini-cart toggle
 
 			.site-branding {
 				margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3724,12 +3724,10 @@ dt {
 /**
  * Header
  */
-@media only screen and (min-width: 560px) {
-	.site-header {
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-	}
+.site-header {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
 }
 
 .site-header > * {

--- a/balasana/style-woocommerce-rtl.css
+++ b/balasana/style-woocommerce-rtl.css
@@ -2188,6 +2188,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page #masthead {
 		position: relative;
+		display: inherit;
 	}
 	body[class*="woocommerce"] #page #masthead .site-branding {
 		margin-bottom: 16px;

--- a/balasana/style-woocommerce.css
+++ b/balasana/style-woocommerce.css
@@ -2188,6 +2188,7 @@ body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page #masthead {
 		position: relative;
+		display: inherit;
 	}
 	body[class*="woocommerce"] #page #masthead .site-branding {
 		margin-bottom: 16px;

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3753,12 +3753,10 @@ dt {
 /**
  * Header
  */
-@media only screen and (min-width: 560px) {
-	.site-header {
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-	}
+.site-header {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
 }
 
 .site-header > * {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Reverts the menu-toggle display to its original appearance when WooCommerce is _not_ activated.
- When WooCommerce _is_ activated, there isn’t enough horizontal space to display the site-title, the menu-toggle and the mini-cart-toggle on a single line at all times. When the viewport gets too narrow, the two toggle buttons have to move to their own line. Again, this only happens when WC is active. 

## Before:
![image](https://user-images.githubusercontent.com/709581/68128758-5300b800-fee6-11e9-8a13-05657d567382.png)

## After:
![image](https://user-images.githubusercontent.com/709581/68128812-70ce1d00-fee6-11e9-9e2f-da8692285577.png)

## After with WooCommerce activated:
![2019-11-04 09 48 55](https://user-images.githubusercontent.com/709581/68129895-657bf100-fee8-11e9-817e-19c59a2bbf0a.gif)

#### Related issue(s):

Fixes: #1637 