### PR TITLE
Varia: Skip skip-link-focus-fix in AMP

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -273,6 +273,12 @@ add_action( 'wp_enqueue_scripts', 'varia_scripts' );
  * @link https://git.io/vWdr2
  */
 function varia_skip_link_focus_fix() {
+	// Prevent outputting skip-link-focus-fix in AMP since the AMP framework has it built-in,
+	// per <https://github.com/ampproject/amphtml/issues/18671>.
+	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		return;
+	}
+
 	// The following is minified via `terser --compress --mangle -- js/skip-link-focus-fix.js`.
 	?>
 	<script>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The skip-link-focus-fix involves custom JavaScript which is not allowed in AMP (in this way). In any case, the AMP framework has internalized this IE11 a11y fix per https://github.com/ampproject/amphtml/issues/18671 so there is no reason to add it on AMP pages.