### PR TITLE
Varia, Maywood: Fix FSE Navigation Menu width when alignwide or alignfull

### DIFF
--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1344,6 +1344,10 @@ b, strong {
  */
 }
 
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
 .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4068,6 +4068,10 @@ p:not(.site-title) a:hover {
 	margin-top: 0;
 }
 
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
 .fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -40,6 +40,10 @@
 	.main-navigation {
 		text-align: center;
 
+		.alignwide, .alignfull {
+			width: 100%;
+		}
+
 		@import "../base/extends";
 		.button {
 			@extend %button-style

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -3,6 +3,10 @@
 	margin-top: 0;
 
 	.main-navigation {
+		.alignwide, .alignfull {
+			width: 100%;
+		}
+
 		.has-text-color > .main-menu.footer-menu > li > a {
 			color: inherit;
 		}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1278,6 +1278,10 @@ table th,
  */
 }
 
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
 .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;

--- a/varia/style.css
+++ b/varia/style.css
@@ -3732,6 +3732,10 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-top: 0;
 }
 
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
 .fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }


### PR DESCRIPTION
Fix a regression on Maywood, that caused `alignwide` and `alignfull` Navigation Menu blocks not having the expected width.

| Before (`alignwide`) | After (`alignwide`) |
| - | - |
| <img width="1132" alt="Screenshot 2019-11-11 at 20 24 42" src="https://user-images.githubusercontent.com/2070010/68618538-7a94e900-04c1-11ea-97b6-eb14ebee623e.png"> | <img width="1131" alt="Screenshot 2019-11-11 at 20 24 28" src="https://user-images.githubusercontent.com/2070010/68618550-81236080-04c1-11ea-83cf-a02692049954.png"> |