### PR TITLE
Varia: Remove "Post Type" from Projects Archive title

### DIFF
--- a/varia/inc/template-functions.php
+++ b/varia/inc/template-functions.php
@@ -95,11 +95,17 @@ function varia_get_the_archive_title() {
 	} elseif ( is_day() ) {
 		$title = __( 'Daily Archives: ', 'varia' ) . '<span class="page-description">' . get_the_date() . '</span>';
 	} elseif ( is_post_type_archive() ) {
-		$title = __( 'Post Type Archives: ', 'varia' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
+		$cpt = get_post_type_object( get_queried_object()->name );
+		/* translators: %s: Post type singular name */
+		$title = sprintf( esc_html__( '%s Archives', 'varia' ),
+			$cpt->labels->singular_name
+		);
 	} elseif ( is_tax() ) {
 		$tax = get_taxonomy( get_queried_object()->taxonomy );
 		/* translators: %s: Taxonomy singular name */
-		$title = sprintf( esc_html__( '%s Archives:', 'varia' ), $tax->labels->singular_name );
+		$title = sprintf( esc_html__( '%s Archives', 'varia' ),
+			$tax->labels->singular_name
+		);
 	} else {
 		$title = __( 'Archives:', 'varia' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Remove "Post Type" from Projects Archive title 
- Add post-type singular name.
- Custom post type archives are _one-dimensional_ so there’s no need to point to a description with a  `:`.

Custom post type archive titles before: 
**Archives: Projects**, **Archives: Testimonials**, or **Archives: _Post type singular-name_**

Custom post type archive titles after: 
**Project Archives**, **Testimonial Archives**, or **_Post type singular-name_ Archives**

#### Related issue(s):

#1655 