### PR TITLE
Varia: Adds support for left, center and right aligned lists.

### DIFF
--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -6,11 +6,13 @@ ol {
 	// Utility classes
 	&.aligncenter {
 		list-style-position: inside;
+		padding: 0;
 	}
 
 	&.alignright {
 		list-style-position: inside;
 		text-align: right;
+		padding: 0;
 	}
 }
 

--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -1,14 +1,21 @@
-.block-library-list {
-	ul,
-	ol {
-		margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
-		padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
+ul,
+ol {
+	margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
+	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
+
+	&.aligncenter {
+		list-style-position: inside;
 	}
 
-	li {
-		> ul,
-		> ol {
-			margin: 0;
-		}
+	&.alignright {
+		list-style-position: inside;
+		text-align: right;
+	}
+}
+
+li {
+	> ul,
+	> ol {
+		margin: 0;
 	}
 }

--- a/varia/sass/blocks/list/_editor.scss
+++ b/varia/sass/blocks/list/_editor.scss
@@ -3,6 +3,7 @@ ol {
 	margin: #{map-deep-get($config-global, "spacing", "vertical")} 0;
 	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
 
+	// Utility classes
 	&.aligncenter {
 		list-style-position: inside;
 	}

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -3,6 +3,15 @@ ol {
 	@include font-family( map-deep-get($config-list, "font", "family") );
 	margin: 0;
 	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
+
+	&.aligncenter {
+		list-style-position: inside;
+	}
+
+	&.alignright {
+		list-style-position: inside;
+		text-align: right;
+	}
 }
 
 ul {

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -7,11 +7,13 @@ ol {
 	// Utility classes
 	&.aligncenter {
 		list-style-position: inside;
+		padding: 0;
 	}
 
 	&.alignright {
 		list-style-position: inside;
 		text-align: right;
+		padding: 0;
 	}
 }
 

--- a/varia/sass/blocks/list/_style.scss
+++ b/varia/sass/blocks/list/_style.scss
@@ -4,6 +4,7 @@ ol {
 	margin: 0;
 	padding-left: #{2 * map-deep-get($config-global, "spacing", "horizontal")};
 
+	// Utility classes
 	&.aligncenter {
 		list-style-position: inside;
 	}
@@ -20,11 +21,6 @@ ul {
 
 ol {
 	list-style-type: decimal;
-}
-
-li > ul,
-li > ol {
-
 }
 
 dt {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -754,14 +754,27 @@ object {
 	margin: 0;
 }
 
-.block-library-list ul,
-.block-library-list ol {
+ul,
+ol {
 	margin: 32px 0;
 	padding-left: 32px;
 }
 
-.block-library-list li > ul,
-.block-library-list li > ol {
+ul.aligncenter,
+ol.aligncenter {
+	list-style-position: inside;
+	padding: 0;
+}
+
+ul.alignright,
+ol.alignright {
+	list-style-position: inside;
+	text-align: right;
+	padding: 0;
+}
+
+li > ul,
+li > ol {
 	margin: 0;
 }
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -754,14 +754,25 @@ object {
 	margin: 0;
 }
 
-.block-library-list ul,
-.block-library-list ol {
+ul,
+ol {
 	margin: 32px 0;
 	padding-left: 32px;
 }
 
-.block-library-list li > ul,
-.block-library-list li > ol {
+ul.aligncenter,
+ol.aligncenter {
+	list-style-position: inside;
+}
+
+ul.alignright,
+ol.alignright {
+	list-style-position: inside;
+	text-align: right;
+}
+
+li > ul,
+li > ol {
 	margin: 0;
 }
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -754,27 +754,14 @@ object {
 	margin: 0;
 }
 
-ul,
-ol {
+.block-library-list ul,
+.block-library-list ol {
 	margin: 32px 0;
 	padding-left: 32px;
 }
 
-ul.aligncenter,
-ol.aligncenter {
-	list-style-position: inside;
-	padding: 0;
-}
-
-ul.alignright,
-ol.alignright {
-	list-style-position: inside;
-	text-align: right;
-	padding: 0;
-}
-
-li > ul,
-li > ol {
+.block-library-list li > ul,
+.block-library-list li > ol {
 	margin: 0;
 }
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -763,12 +763,14 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
+	padding: 0;
 }
 
 ul.alignright,
 ol.alignright {
 	list-style-position: inside;
 	text-align: right;
+	padding: 0;
 }
 
 li > ul,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1251,6 +1251,21 @@ object {
 	width: auto;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: blue;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: indigo;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1301,12 +1316,24 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [style*="background-color"]
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1952,17 +1952,19 @@ ol {
 	padding-right: 32px;
 }
 
-ul {
-	list-style-type: disc;
-}
-
-ul.aligncenter {
+ul.aligncenter,
+ol.aligncenter {
 	list-style-position: inside;
 }
 
-ul.alignright {
+ul.alignright,
+ol.alignright {
 	list-style-position: inside;
 	text-align: left;
+}
+
+ul {
+	list-style-type: disc;
 }
 
 ol {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1956,6 +1956,15 @@ ul {
 	list-style-type: disc;
 }
 
+ul.aligncenter {
+	list-style-position: inside;
+}
+
+ul.alignright {
+	list-style-position: inside;
+	text-align: left;
+}
+
 ol {
 	list-style-type: decimal;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1251,21 +1251,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: blue;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: indigo;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1316,24 +1301,12 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [style*="background-color"]
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: currentColor;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
@@ -1977,17 +1950,6 @@ ol {
 	font-family: var(--font-base, serif);
 	margin: 0;
 	padding-right: 32px;
-}
-
-ul.aligncenter,
-ol.aligncenter {
-	list-style-position: inside;
-}
-
-ul.alignright,
-ol.alignright {
-	list-style-position: inside;
-	text-align: left;
 }
 
 ul {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1955,12 +1955,14 @@ ol {
 ul.aligncenter,
 ol.aligncenter {
 	list-style-position: inside;
+	padding: 0;
 }
 
 ul.alignright,
 ol.alignright {
 	list-style-position: inside;
 	text-align: right;
+	padding: 0;
 }
 
 ul {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1952,6 +1952,17 @@ ol {
 	padding-left: 32px;
 }
 
+ul.aligncenter,
+ol.aligncenter {
+	list-style-position: inside;
+}
+
+ul.alignright,
+ol.alignright {
+	list-style-position: inside;
+	text-align: right;
+}
+
 ul {
 	list-style-type: disc;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -1952,6 +1952,19 @@ ol {
 	padding-left: 32px;
 }
 
+ul.aligncenter,
+ol.aligncenter {
+	list-style-position: inside;
+	padding: 0;
+}
+
+ul.alignright,
+ol.alignright {
+	list-style-position: inside;
+	text-align: right;
+	padding: 0;
+}
+
 ul {
 	list-style-type: disc;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -1952,19 +1952,6 @@ ol {
 	padding-left: 32px;
 }
 
-ul.aligncenter,
-ol.aligncenter {
-	list-style-position: inside;
-	padding: 0;
-}
-
-ul.alignright,
-ol.alignright {
-	list-style-position: inside;
-	text-align: right;
-	padding: 0;
-}
-
 ul {
 	list-style-type: disc;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Allow list-item `li` text and bullets to respect text-alignment rules in the editor and frontend when it makes sense.
- Applies to both unordered `ul` and ordered `ol` lists whenever a text-align utility class is added to them.
- Also applies to core widget blocks like archives, categories and other lists that support text alignment options. 

**Before:**
![image](https://user-images.githubusercontent.com/709581/68716368-0cf4c580-0572-11ea-8511-a1dc746367ec.png)

**After:**
![image](https://user-images.githubusercontent.com/709581/68716248-cb641a80-0571-11ea-9ee8-b624ef45545c.png)

**Editor After:**
![image](https://user-images.githubusercontent.com/709581/68717053-b25c6900-0573-11ea-89f3-e2905c43c4bf.png)

#### Related issue(s):

Fixes: #1597 