### PR TITLE
Mayland: Fix key prop warning in Editor.

### DIFF
--- a/mayland/functions.php
+++ b/mayland/functions.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'mayland_setup' ) ) :
 				array(
 					'name'  => __( 'Black', 'mayland' ),
 					'slug'  => 'foreground',
-					'color' => '#000000',
+					'color' => '#010101',
 				),
 				array(
 					'name'  => __( 'Light Gray', 'mayland' ),

--- a/mayland/sass/_config-child-theme-deep.scss
+++ b/mayland/sass/_config-child-theme-deep.scss
@@ -70,7 +70,7 @@ $config-global: (
 	/* Colors */
 	"color": (
 		"primary": (
-			"default": black,
+			"default": #000000,
 			"hover": #666666,
 		),
 		"secondary": (
@@ -78,12 +78,12 @@ $config-global: (
 			"hover": #666666,
 		),
 		"foreground": (
-			"default": black,
+			"default": #010101,
 			"light": #666666, // must be accessible against background
 			"dark": #333333, // must be accessible against background
 		),
 		"background": (
-			"default": white,
+			"default": #ffffff,
 			"light": #f2f2f2, // must be accessible against foreground-default
 			"dark": #d9d9d9, // must be accessible against foreground-default
 		),

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -165,8 +165,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  * - Reset the browser
  */
 body {
-	color: black;
-	background-color: white;
+	color: #010101;
+	background-color: #ffffff;
 	font-family: Poppins, serif;
 	font-family: var(--font-base, Poppins, serif);
 	font-size: 20px;
@@ -186,7 +186,7 @@ p {
 }
 
 a {
-	color: black;
+	color: #000000;
 }
 
 a:hover {
@@ -355,7 +355,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
-	color: black;
+	color: #000000;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -472,7 +472,7 @@ object {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -534,7 +534,7 @@ object {
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333em;
 	line-height: 1;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	padding: 16px 16px;
 }
@@ -545,7 +545,7 @@ object {
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: black;
+	color: #000000;
 	background: transparent;
 	border: 2px solid currentcolor;
 }
@@ -811,7 +811,7 @@ p.has-background:not(.has-background-background-color) a {
 	border-top-width: 4px;
 	border-bottom-color: #e6e6e6;
 	border-bottom-width: 4px;
-	color: black;
+	color: #010101;
 	/**
 	 * Block Options
 	 */
@@ -846,8 +846,8 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-pullquote.is-style-solid-color {
-	background-color: black;
-	color: white;
+	background-color: #000000;
+	color: #ffffff;
 }
 
 .wp-block-pullquote.is-style-solid-color.alignleft blockquote,
@@ -876,7 +876,7 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote {
-	border-left-color: black;
+	border-left-color: #000000;
 	margin: 32px 0;
 	padding-left: 16px;
 }
@@ -992,7 +992,7 @@ table th,
  * - Needs a special styles
  */
 .editor-post-title__block .editor-post-title__input {
-	color: black;
+	color: #010101;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	font-weight: 600;
@@ -1002,7 +1002,7 @@ table th,
 }
 
 .has-primary-color[class] {
-	color: black !important;
+	color: #000000 !important;
 }
 
 .has-secondary-color[class] {
@@ -1010,7 +1010,7 @@ table th,
 }
 
 .has-foreground-color[class] {
-	color: black !important;
+	color: #010101 !important;
 }
 
 .has-foreground-light-color[class] {
@@ -1030,7 +1030,7 @@ table th,
 }
 
 .has-background-color[class] {
-	color: white !important;
+	color: #ffffff !important;
 }
 
 .has-background:not(.has-background-background-color) a,
@@ -1039,48 +1039,48 @@ table th,
 }
 
 .has-primary-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #000000 !important;
+	color: #ffffff;
 }
 
 .has-primary-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #000000 !important;
+	color: #ffffff;
 }
 
 .has-secondary-background-color[class] {
 	background-color: #1a1a1a !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #010101 !important;
+	color: #ffffff;
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: #666666 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: #333333 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-background-light-background-color[class] {
 	background-color: #f2f2f2 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-dark-background-color[class] {
 	background-color: #d9d9d9 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-background-color[class] {
-	background-color: white !important;
-	color: black;
+	background-color: #ffffff !important;
+	color: #010101;
 }
 
 .is-small-text,

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -206,7 +206,7 @@ input[type="submit"],
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -677,16 +677,16 @@ html {
 body {
 	font-size: 1rem;
 	font-weight: normal;
-	color: black;
+	color: #010101;
 	text-align: right;
-	background-color: white;
+	background-color: #ffffff;
 }
 
 /**
  * Links styles
  */
 a {
-	color: black;
+	color: #000000;
 }
 
 a:hover {
@@ -714,12 +714,12 @@ a {
 }
 
 .screen-reader-text:focus {
-	background-color: white;
+	background-color: #ffffff;
 	border-radius: 3px;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	clip-path: none;
-	color: black;
+	color: #010101;
 	display: block;
 	font-size: 1.2rem;
 	font-weight: bold;
@@ -1056,7 +1056,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
-	color: black;
+	color: #010101;
 	border: 1px solid #e6e6e6;
 	border-radius: 3px;
 	padding: 16px;
@@ -1078,7 +1078,7 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-	color: black;
+	color: #010101;
 	border-color: #666666;
 }
 
@@ -1226,7 +1226,7 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
+	color: #000000;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
@@ -1333,7 +1333,7 @@ input[type="submit"],
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -1412,7 +1412,7 @@ button[data-load-more-btn] {
  * Block Options
  */
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: black;
+	color: #000000;
 	background: transparent;
 	border: 2px solid currentcolor;
 	padding: 14px 16px;
@@ -1427,14 +1427,14 @@ button[data-load-more-btn] {
 }
 
 .wp-block-code {
-	color: black;
+	color: #010101;
 	font-size: 0.83333rem;
 	padding: 16px;
 	border-color: #e6e6e6;
 }
 
 .wp-block-code pre {
-	color: black;
+	color: #010101;
 }
 
 .wp-block-columns {
@@ -1615,7 +1615,7 @@ button[data-load-more-btn] {
 }
 
 .wp-block-file .wp-block-file__button {
-	background-color: black;
+	background-color: #000000;
 	color: white;
 	font-size: 0.83333rem;
 	margin-right: 16px;
@@ -2006,8 +2006,8 @@ p.has-background {
 }
 
 .a8c-posts-list-item__featured span {
-	color: white;
-	background-color: black;
+	color: #ffffff;
+	background-color: #000000;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	font-weight: bold;
@@ -2075,7 +2075,7 @@ p.has-background {
 	border-top-width: 4px;
 	border-bottom-color: #e6e6e6;
 	border-bottom-width: 4px;
-	color: black;
+	color: #010101;
 	/**
 	 * Block Options
 	 */
@@ -2115,8 +2115,8 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color {
-	background-color: black;
-	color: white;
+	background-color: #000000;
+	color: #ffffff;
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
@@ -2140,7 +2140,7 @@ p.has-background {
 }
 
 .wp-block-quote {
-	border-right-color: black;
+	border-right-color: #000000;
 	margin: 32px 0;
 	padding-right: 16px;
 	/**
@@ -2199,7 +2199,7 @@ p.has-background {
 }
 
 .wp-block-quote[style*="text-align:right"], .wp-block-quote[style*="text-align: right"] {
-	border-left-color: black;
+	border-left-color: #000000;
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
@@ -2399,7 +2399,7 @@ table th,
 }
 
 .has-primary-color[class] {
-	color: black !important;
+	color: #000000 !important;
 }
 
 .has-secondary-color[class] {
@@ -2407,7 +2407,7 @@ table th,
 }
 
 .has-foreground-color[class] {
-	color: black !important;
+	color: #010101 !important;
 }
 
 .has-foreground-light-color[class] {
@@ -2427,7 +2427,7 @@ table th,
 }
 
 .has-background-color[class] {
-	color: white !important;
+	color: #ffffff !important;
 }
 
 .has-background:not(.has-background-background-color) a,
@@ -2436,43 +2436,43 @@ table th,
 }
 
 .has-primary-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #000000 !important;
+	color: #ffffff;
 }
 
 .has-secondary-background-color[class] {
 	background-color: #1a1a1a !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #010101 !important;
+	color: #ffffff;
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: #666666 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: #333333 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-background-light-background-color[class] {
 	background-color: #f2f2f2 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-dark-background-color[class] {
 	background-color: #d9d9d9 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-background-color[class] {
-	background-color: white !important;
-	color: black;
+	background-color: #ffffff !important;
+	color: #010101;
 }
 
 .is-small-text,
@@ -2647,7 +2647,7 @@ table th,
 }
 
 .site-title {
-	color: black;
+	color: #010101;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	letter-spacing: normal;
@@ -2682,7 +2682,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation {
-	color: black;
+	color: #010101;
 }
 
 .main-navigation > div {
@@ -2815,7 +2815,7 @@ body:not(.fse-enabled) .site-description {
 
 @media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > li > .sub-menu {
-		background: white;
+		background: #ffffff;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.1);
 		right: 0;
 		top: 100%;
@@ -2832,7 +2832,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation a {
-	color: black;
+	color: #000000;
 	display: block;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
@@ -2847,7 +2847,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation a:link, .main-navigation a:visited {
-	color: black;
+	color: #000000;
 }
 
 .main-navigation a:hover {
@@ -2914,7 +2914,7 @@ body:not(.fse-enabled) .main-navigation a {
 }
 
 .social-navigation a {
-	color: black;
+	color: #010101;
 	display: inline-block;
 	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
 }
@@ -3332,7 +3332,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .comment-meta .comment-metadata {
-	color: black;
+	color: #010101;
 	padding-left: 40px;
 }
 
@@ -3537,8 +3537,8 @@ img#wpstats {
  * - Page specific styles
  */
 .sticky-post {
-	color: white;
-	background-color: black;
+	color: #ffffff;
+	background-color: #000000;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	font-weight: bold;
@@ -3833,9 +3833,9 @@ body .widget_eu_cookie_law_widget.widget.top {
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law {
-	background: white;
+	background: #ffffff;
 	border: 1px solid #e6e6e6;
-	color: black;
+	color: #010101;
 	font-size: 0.83333rem;
 	line-height: inherit;
 	padding: 16px;
@@ -3848,14 +3848,14 @@ body .widget_eu_cookie_law_widget #eu-cookie-law {
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative {
-	background: black;
+	background: #010101;
 	border-color: #333333;
-	color: white;
+	color: #ffffff;
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept {
-	background: white;
-	color: black;
+	background: #ffffff;
+	color: #010101;
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept.has-focus {
@@ -4086,7 +4086,7 @@ strong {
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: black;
+	color: #000000;
 }
 
 .sticky-post,

--- a/mayland/style-woocommerce-rtl.css
+++ b/mayland/style-woocommerce-rtl.css
@@ -224,7 +224,7 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -395,7 +395,7 @@ body[class*="woocommerce"] #page .woocommerce-warning {
 	margin-bottom: 32px;
 	background-color: #f2f2f2;
 	color: #333333;
-	border-top-color: black;
+	border-top-color: #000000;
 }
 
 body[class*="woocommerce"] #page .woocommerce-notice--message,
@@ -498,7 +498,7 @@ body[class*="woocommerce"] #page a.remove {
 }
 
 body[class*="woocommerce"] #page a.remove:hover {
-	color: white !important;
+	color: #ffffff !important;
 	background: red;
 }
 
@@ -639,7 +639,7 @@ body[class*="woocommerce"] #page .woocommerce button.button:disabled[disabled]:h
 body[class*="woocommerce"] #page .woocommerce input.button.disabled:hover,
 body[class*="woocommerce"] #page .woocommerce input.button:disabled:hover,
 body[class*="woocommerce"] #page .woocommerce input.button:disabled[disabled]:hover {
-	background-color: black;
+	background-color: #000000;
 }
 
 /**
@@ -819,8 +819,8 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
-		background-color: white;
-		color: black;
+		background-color: #ffffff;
+		color: #010101;
 		padding: 0;
 		width: 100%;
 	}
@@ -851,7 +851,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link > *:not
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-subtotal {
-	color: black;
+	color: #010101;
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-count {
@@ -873,8 +873,8 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
-	background-color: white;
-	color: black;
+	background-color: #ffffff;
+	color: #010101;
 	max-width: 100%;
 	padding: 8px 0;
 }
@@ -915,7 +915,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget .wooc
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget .woocommerce-mini-cart__buttons a {
 	clear: left;
 	color: white;
-	background-color: black;
+	background-color: #000000;
 	margin: 0;
 	float: left;
 }
@@ -1017,7 +1017,7 @@ body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li span.c
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li a:hover,
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li a:focus {
 	background: transparent;
-	color: black;
+	color: #010101;
 }
 
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers .svg-icon {
@@ -1166,9 +1166,9 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li a:hover {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active {
-	background-color: white;
+	background-color: #ffffff;
 	border-color: #e6e6e6;
-	border-bottom-color: white;
+	border-bottom-color: #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active a {
@@ -1177,11 +1177,11 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active a {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active::before {
-	box-shadow: -2px 2px 0 white;
+	box-shadow: -2px 2px 0 #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active::after {
-	box-shadow: 2px 2px 0 white;
+	box-shadow: 2px 2px 0 #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before, body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::after {
@@ -1299,8 +1299,8 @@ body[class*="woocommerce"] #page #reviews #comments .commentlist > li::before {
  */
 body[class*="woocommerce"] .woocommerce-store-notice,
 body[class*="woocommerce"] p.demo_store {
-	background-color: black;
-	color: white;
+	background-color: #000000;
+	color: #ffffff;
 	position: fixed;
 	top: auto;
 	bottom: 0;
@@ -1910,7 +1910,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__wrapper .zoomImg {
-	background-color: white;
+	background-color: #ffffff;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__image--placeholder {
@@ -1919,7 +1919,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger {
 	font-size: 1.2rem;
-	background: white;
+	background: #ffffff;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::before {
@@ -1966,7 +1966,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary .stock {
-	color: black;
+	color: #000000;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary .out-of-stock {
@@ -2121,7 +2121,7 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a#wo
  */
 body[class*="woocommerce"] #page .widget_price_filter .ui-slider .ui-slider-range,
 body[class*="woocommerce"] #page .widget_price_filter .ui-slider .ui-slider-handle {
-	background-color: black;
+	background-color: #000000;
 }
 
 body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-widget-content {

--- a/mayland/style-woocommerce.css
+++ b/mayland/style-woocommerce.css
@@ -224,7 +224,7 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -395,7 +395,7 @@ body[class*="woocommerce"] #page .woocommerce-warning {
 	margin-bottom: 32px;
 	background-color: #f2f2f2;
 	color: #333333;
-	border-top-color: black;
+	border-top-color: #000000;
 }
 
 body[class*="woocommerce"] #page .woocommerce-notice--message,
@@ -498,7 +498,7 @@ body[class*="woocommerce"] #page a.remove {
 }
 
 body[class*="woocommerce"] #page a.remove:hover {
-	color: white !important;
+	color: #ffffff !important;
 	background: red;
 }
 
@@ -639,7 +639,7 @@ body[class*="woocommerce"] #page .woocommerce button.button:disabled[disabled]:h
 body[class*="woocommerce"] #page .woocommerce input.button.disabled:hover,
 body[class*="woocommerce"] #page .woocommerce input.button:disabled:hover,
 body[class*="woocommerce"] #page .woocommerce input.button:disabled[disabled]:hover {
-	background-color: black;
+	background-color: #000000;
 }
 
 /**
@@ -819,8 +819,8 @@ body[class*="woocommerce"] #page .main-navigation #woocommerce-toggle:checked + 
 
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page .main-navigation .woocommerce-menu-container {
-		background-color: white;
-		color: black;
+		background-color: #ffffff;
+		color: #010101;
 		padding: 0;
 		width: 100%;
 	}
@@ -851,7 +851,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link > *:not
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-subtotal {
-	color: black;
+	color: #010101;
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .woocommerce-cart-count {
@@ -873,8 +873,8 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-link .svg-ic
 }
 
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget {
-	background-color: white;
-	color: black;
+	background-color: #ffffff;
+	color: #010101;
 	max-width: 100%;
 	padding: 8px 0;
 }
@@ -915,7 +915,7 @@ body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget .wooc
 body[class*="woocommerce"] #page .main-navigation .woocommerce-cart-widget .woocommerce-mini-cart__buttons a {
 	clear: right;
 	color: white;
-	background-color: black;
+	background-color: #000000;
 	margin: 0;
 	float: right;
 }
@@ -1017,7 +1017,7 @@ body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li span.c
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li a:hover,
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers li a:focus {
 	background: transparent;
-	color: black;
+	color: #010101;
 }
 
 body[class*="woocommerce"] #page .woocommerce-pagination .page-numbers .svg-icon {
@@ -1166,9 +1166,9 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li a:hover {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active {
-	background-color: white;
+	background-color: #ffffff;
 	border-color: #e6e6e6;
-	border-bottom-color: white;
+	border-bottom-color: #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active a {
@@ -1177,11 +1177,11 @@ body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active a {
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active::before {
-	box-shadow: 2px 2px 0 white;
+	box-shadow: 2px 2px 0 #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li.active::after {
-	box-shadow: -2px 2px 0 white;
+	box-shadow: -2px 2px 0 #ffffff;
 }
 
 body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::before, body[class*="woocommerce"] #page .woocommerce-tabs ul.tabs li::after {
@@ -1299,8 +1299,8 @@ body[class*="woocommerce"] #page #reviews #comments .commentlist > li::before {
  */
 body[class*="woocommerce"] .woocommerce-store-notice,
 body[class*="woocommerce"] p.demo_store {
-	background-color: black;
-	color: white;
+	background-color: #000000;
+	color: #ffffff;
 	position: fixed;
 	top: auto;
 	bottom: 0;
@@ -1910,7 +1910,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__wrapper .zoomImg {
-	background-color: white;
+	background-color: #ffffff;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__image--placeholder {
@@ -1919,7 +1919,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger {
 	font-size: 1.2rem;
-	background: white;
+	background: #ffffff;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.images .woocommerce-product-gallery__trigger::before {
@@ -1966,7 +1966,7 @@ body[class*="woocommerce"] #page .woocommerce-ordering select {
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary .stock {
-	color: black;
+	color: #000000;
 }
 
 .single-product #page #woocommerce-wrapper div.product div.summary .out-of-stock {
@@ -2121,7 +2121,7 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a#wo
  */
 body[class*="woocommerce"] #page .widget_price_filter .ui-slider .ui-slider-range,
 body[class*="woocommerce"] #page .widget_price_filter .ui-slider .ui-slider-handle {
-	background-color: black;
+	background-color: #000000;
 }
 
 body[class*="woocommerce"] #page .widget_price_filter .price_slider_wrapper .ui-widget-content {

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -206,7 +206,7 @@ input[type="submit"],
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -677,16 +677,16 @@ html {
 body {
 	font-size: 1rem;
 	font-weight: normal;
-	color: black;
+	color: #010101;
 	text-align: left;
-	background-color: white;
+	background-color: #ffffff;
 }
 
 /**
  * Links styles
  */
 a {
-	color: black;
+	color: #000000;
 }
 
 a:hover {
@@ -714,12 +714,12 @@ a {
 }
 
 .screen-reader-text:focus {
-	background-color: white;
+	background-color: #ffffff;
 	border-radius: 3px;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	clip-path: none;
-	color: black;
+	color: #010101;
 	display: block;
 	font-size: 1.2rem;
 	font-weight: bold;
@@ -1056,7 +1056,7 @@ input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
 textarea {
-	color: black;
+	color: #010101;
 	border: 1px solid #e6e6e6;
 	border-radius: 3px;
 	padding: 16px;
@@ -1078,7 +1078,7 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-	color: black;
+	color: #010101;
 	border-color: #666666;
 }
 
@@ -1226,7 +1226,7 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
+	color: #000000;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
@@ -1333,7 +1333,7 @@ input[type="submit"],
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
 	font-size: 0.83333rem;
-	background-color: black;
+	background-color: #000000;
 	border-radius: 5px;
 	border-width: 0;
 	padding: 16px 16px;
@@ -1412,7 +1412,7 @@ button[data-load-more-btn] {
  * Block Options
  */
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: black;
+	color: #000000;
 	background: transparent;
 	border: 2px solid currentcolor;
 	padding: 14px 16px;
@@ -1427,14 +1427,14 @@ button[data-load-more-btn] {
 }
 
 .wp-block-code {
-	color: black;
+	color: #010101;
 	font-size: 0.83333rem;
 	padding: 16px;
 	border-color: #e6e6e6;
 }
 
 .wp-block-code pre {
-	color: black;
+	color: #010101;
 }
 
 .wp-block-columns {
@@ -1615,7 +1615,7 @@ button[data-load-more-btn] {
 }
 
 .wp-block-file .wp-block-file__button {
-	background-color: black;
+	background-color: #000000;
 	color: white;
 	font-size: 0.83333rem;
 	margin-left: 16px;
@@ -2006,8 +2006,8 @@ p.has-background {
 }
 
 .a8c-posts-list-item__featured span {
-	color: white;
-	background-color: black;
+	color: #ffffff;
+	background-color: #000000;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	font-weight: bold;
@@ -2075,7 +2075,7 @@ p.has-background {
 	border-top-width: 4px;
 	border-bottom-color: #e6e6e6;
 	border-bottom-width: 4px;
-	color: black;
+	color: #010101;
 	/**
 	 * Block Options
 	 */
@@ -2115,8 +2115,8 @@ p.has-background {
 }
 
 .wp-block-pullquote.is-style-solid-color {
-	background-color: black;
-	color: white;
+	background-color: #000000;
+	color: #ffffff;
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {
@@ -2140,7 +2140,7 @@ p.has-background {
 }
 
 .wp-block-quote {
-	border-left-color: black;
+	border-left-color: #000000;
 	margin: 32px 0;
 	padding-left: 16px;
 	/**
@@ -2199,7 +2199,7 @@ p.has-background {
 }
 
 .wp-block-quote[style*="text-align:right"], .wp-block-quote[style*="text-align: right"] {
-	border-right-color: black;
+	border-right-color: #000000;
 }
 
 .wp-block-quote.is-style-large, .wp-block-quote.is-large {
@@ -2404,7 +2404,7 @@ table th,
 }
 
 .has-primary-color[class] {
-	color: black !important;
+	color: #000000 !important;
 }
 
 .has-secondary-color[class] {
@@ -2412,7 +2412,7 @@ table th,
 }
 
 .has-foreground-color[class] {
-	color: black !important;
+	color: #010101 !important;
 }
 
 .has-foreground-light-color[class] {
@@ -2432,7 +2432,7 @@ table th,
 }
 
 .has-background-color[class] {
-	color: white !important;
+	color: #ffffff !important;
 }
 
 .has-background:not(.has-background-background-color) a,
@@ -2441,43 +2441,43 @@ table th,
 }
 
 .has-primary-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #000000 !important;
+	color: #ffffff;
 }
 
 .has-secondary-background-color[class] {
 	background-color: #1a1a1a !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-background-color[class] {
-	background-color: black !important;
-	color: white;
+	background-color: #010101 !important;
+	color: #ffffff;
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: #666666 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: #333333 !important;
-	color: white;
+	color: #ffffff;
 }
 
 .has-background-light-background-color[class] {
 	background-color: #f2f2f2 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-dark-background-color[class] {
 	background-color: #d9d9d9 !important;
-	color: black;
+	color: #010101;
 }
 
 .has-background-background-color[class] {
-	background-color: white !important;
-	color: black;
+	background-color: #ffffff !important;
+	color: #010101;
 }
 
 .is-small-text,
@@ -2664,7 +2664,7 @@ table th,
 }
 
 .site-title {
-	color: black;
+	color: #010101;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	letter-spacing: normal;
@@ -2699,7 +2699,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation {
-	color: black;
+	color: #010101;
 }
 
 .main-navigation > div {
@@ -2832,7 +2832,7 @@ body:not(.fse-enabled) .site-description {
 
 @media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > li > .sub-menu {
-		background: white;
+		background: #ffffff;
 		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.1);
 		left: 0;
 		top: 100%;
@@ -2849,7 +2849,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation a {
-	color: black;
+	color: #000000;
 	display: block;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
@@ -2864,7 +2864,7 @@ body:not(.fse-enabled) .site-description {
 }
 
 .main-navigation a:link, .main-navigation a:visited {
-	color: black;
+	color: #000000;
 }
 
 .main-navigation a:hover {
@@ -2931,7 +2931,7 @@ body:not(.fse-enabled) .main-navigation a {
 }
 
 .social-navigation a {
-	color: black;
+	color: #010101;
 	display: inline-block;
 	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
 }
@@ -3349,7 +3349,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .comment-meta .comment-metadata {
-	color: black;
+	color: #010101;
 	padding-right: 40px;
 }
 
@@ -3554,8 +3554,8 @@ img#wpstats {
  * - Page specific styles
  */
 .sticky-post {
-	color: white;
-	background-color: black;
+	color: #ffffff;
+	background-color: #000000;
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
 	font-weight: bold;
@@ -3862,9 +3862,9 @@ body .widget_eu_cookie_law_widget.widget.top {
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law {
-	background: white;
+	background: #ffffff;
 	border: 1px solid #e6e6e6;
-	color: black;
+	color: #010101;
 	font-size: 0.83333rem;
 	line-height: inherit;
 	padding: 16px;
@@ -3877,14 +3877,14 @@ body .widget_eu_cookie_law_widget #eu-cookie-law {
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative {
-	background: black;
+	background: #010101;
 	border-color: #333333;
-	color: white;
+	color: #ffffff;
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept {
-	background: white;
-	color: black;
+	background: #ffffff;
+	color: #010101;
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept.has-focus {
@@ -4115,7 +4115,7 @@ strong {
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
 .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: black;
+	color: #000000;
 }
 
 .sticky-post,


### PR DESCRIPTION
Simply removing the duplicate colors might cause disruptions for customers who have selected one of the two `#000000` colors in their editor content. As an alternative solution, I changed the Black color to `#010101` which isn’t perfect black but it’s close enough to _not_ cause an obvious disruption.

The difference is virtually indistinguishable as you can see here: 
![image](https://user-images.githubusercontent.com/709581/68718807-5811d700-0578-11ea-8e64-f4bf757e7401.png)


#### Changes proposed in this Pull Request:

- Change duplicate `#000000` theme color to `#010101` to fix key prop console errors.
- Replaces some instances of `black` and `white` keyword colors with their hex color equivalents to help distinguish between theme-specific colors, and similarly named general colors that come from Varia.
- Recompiles all stylesheets with the color change.

#### Related issue(s):

Fixes: #1659 