### PR TITLE
Alves: Add Full Site Editing support

### DIFF
--- a/alves/footer.php
+++ b/alves/footer.php
@@ -15,6 +15,12 @@
 
 	</div><!-- #content -->
 
+	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
+	<footer class="fse-template-part fse-footer entry-content">
+	<?php
+		$template = new A8C\FSE\WP_Template();
+		$template->output_template_content( A8C\FSE\WP_Template::FOOTER );
+	else : // Otherwise we'll fallback to the default Varia footer below. ?>
 	<footer id="colophon" class="site-footer">
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 
@@ -37,7 +43,8 @@
 				);
 				?>
 			</nav><!-- .footer-navigation -->
-		<?php endif; ?>
+			<?php endif;
+	endif; ?>
 
 		<div class="site-info">
 				<?php $blog_info = get_bloginfo( 'name' ); ?>

--- a/alves/languages/alves.pot
+++ b/alves/languages/alves.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Alves 1.1.0\n"
+"Project-Id-Version: Alves 1.4.0\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/alves\n"
 "POT-Creation-Date: 2019-08-27 13:10:39+00:00\n"
 "MIME-Version: 1.0\n"

--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/_extra-child-theme.scss
+++ b/alves/sass/_extra-child-theme.scss
@@ -146,16 +146,18 @@ blockquote p {
 /**
  * Wide Header & Footer
  */
-#masthead {
-	padding-left: 16px;
-	padding-right: 16px;
-	padding-bottom: $spacing_vertical;
-	position: relative;
-	@extend %responsive-alignwide-nested;
+body:not(.fse-enabled) {
+	#masthead {
+		padding-left: 16px;
+		padding-right: 16px;
+		padding-bottom: $spacing_vertical;
+		position: relative;
+		@extend %responsive-alignwide-nested;
 
-	@include media(desktop) {
-		padding-left: 0;
-		padding-right: 0;
+		@include media(desktop) {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 }
 

--- a/alves/sass/_full-site-editing-editor.scss
+++ b/alves/sass/_full-site-editing-editor.scss
@@ -1,0 +1,26 @@
+@import "../../varia/sass/full-site-editing/editor";
+
+.fse-template-part {
+	.has-normal-font-size {
+		font-size: map-deep-get($config-global, "font", "size", "md");
+	}
+
+	.main-navigation a {
+		text-decoration: none;
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title {
+			font-weight: #{map-deep-get($config-heading, "font", "weight")};
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}
+
+.post-content__block {
+	margin-top: -36px;
+}

--- a/alves/sass/_full-site-editing-editor.scss
+++ b/alves/sass/_full-site-editing-editor.scss
@@ -5,16 +5,16 @@
 		font-size: map-deep-get($config-global, "font", "size", "md");
 	}
 
+	.site-title {
+		font-weight: bold;
+	}
+
 	.main-navigation a {
 		text-decoration: none;
 	}
 
 	.wp-block-cover,
 	.wp-block-cover-image {
-		.site-title {
-			font-weight: #{map-deep-get($config-heading, "font", "weight")};
-		}
-
 		.has-background {
 			text-shadow: none;
 		}

--- a/alves/sass/_full-site-editing.scss
+++ b/alves/sass/_full-site-editing.scss
@@ -1,0 +1,33 @@
+@import "../../varia/sass/full-site-editing/imports";
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: $spacing_vertical;
+	@include media(mobile) {
+		padding-bottom: calc( 1.5 * #{ $spacing_vertical } );
+	}
+}
+
+.fse-template-part {
+	.main-navigation a {
+		text-decoration: none;
+	}
+	
+	@include media(mobile-only) {
+		max-width: calc( 100% - #{ $spacing_vertical } );
+
+		.main-navigation > div {
+			padding: 0 32px;
+		}
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title a {
+			text-decoration: none;
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}

--- a/alves/sass/style-child-theme-editor.scss
+++ b/alves/sass/style-child-theme-editor.scss
@@ -92,3 +92,9 @@ $font_size_widget_title: #{map-deep-get($config-heading, "font", "size", "h4")};
 		color: currentColor;
 	}
 }
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing-editor";

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,12 +5,12 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: alves
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -88,3 +88,9 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * Child Theme Extra Styles
  */
 @import "extra-child-theme";
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing";

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1083,7 +1083,7 @@ p:not(.site-title) a:hover {
 	color: inherit;
 }
 
-.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -1039,4 +1040,387 @@ p:not(.site-title) a:hover {
 
 .has-background a {
 	color: currentColor;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+@media (min-width: 600px) {
+	.a8c-template-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+.template-block .fse-template-part {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-template-part {
+		padding: 32px 0;
+	}
+}
+
+.template-block .fse-template-part figure.fse-site-logo {
+	width: auto;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover .site-description,
+.fse-template-part .wp-block-cover-image .site-title,
+.fse-template-part .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	width: auto;
+}
+
+.fse-template-part .main-navigation {
+	color: #394d55;
+}
+
+.fse-template-part .main-navigation > div {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle-menu {
+	display: inline-block;
+	margin: 0;
+}
+
+.fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	display: block;
+}
+
+.fse-template-part .main-navigation #toggle:focus + #toggle-menu {
+	background-color: #2f5f74;
+	outline: inherit;
+	text-decoration: underline;
+}
+
+.fse-template-part .main-navigation .dropdown-icon.close {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .open {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .close {
+	display: inline;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div {
+		display: inline-block;
+	}
+	.fse-template-part .main-navigation #toggle-menu {
+		display: none;
+	}
+	.fse-template-part .main-navigation > div > ul > li > ul {
+		display: none;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul {
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	max-width: none;
+	padding-left: 0;
+	position: relative;
+	/* Sub-menus Flyout */
+}
+
+.fse-template-part .main-navigation > div > ul ul {
+	padding-left: 0;
+}
+
+.fse-template-part .main-navigation > div > ul li {
+	display: block;
+	position: relative;
+	width: 100%;
+	z-index: 1;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li:focus-within {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul li {
+		display: inherit;
+		width: inherit;
+		/* Submenu display */
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li:focus-within > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > a {
+		line-height: 1;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before, .fse-template-part .main-navigation > div > ul > li > a:after {
+		content: '';
+		display: block;
+		height: 0;
+		width: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before {
+		margin-bottom: -0.12em;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:after {
+		margin-top: -0.11em;
+	}
+	.fse-template-part .main-navigation > div > ul > li:first-of-type > a {
+		padding-left: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li:last-of-type > a {
+		padding-right: 0;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+	margin: 0;
+	position: relative;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+		background: #ffffff;
+		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
+		left: 0;
+		top: 100%;
+		min-width: max-content;
+		opacity: 0;
+		position: absolute;
+		transition: all 0.5s ease;
+		visibility: hidden;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu .sub-menu {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation a {
+	color: #394d55;
+	display: block;
+	font-family: "Karla", Arial, sans-serif;
+	font-family: var(--font-base, "Karla", Arial, sans-serif);
+	font-weight: bold;
+	padding: 8px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation a {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation a:link, .fse-template-part .main-navigation a:visited {
+	color: #394d55;
+}
+
+.fse-template-part .main-navigation a:hover {
+	color: #2f5f74;
+}
+
+.fse-template-part .main-navigation .sub-menu {
+	list-style: none;
+	margin-left: 0;
+	/* Reset the counter for each UL */
+	counter-reset: nested-list;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a {
+	padding-top: 8px;
+	padding-bottom: 8px;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a::before {
+	/* Increment the dashes */
+	counter-increment: nested-list;
+	/* Insert dashes with spaces in between */
+	content: "– " counters(nested-list, "– ", none);
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > .menu-item-has-children > a::after {
+		content: "\00a0\25BC";
+		display: inline-block;
+		font-size: 0.86806rem;
+		height: inherit;
+		width: inherit;
+	}
+}
+
+.fse-template-part .main-navigation .hide-visually {
+	position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0 !important;
+	border: 0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+}
+
+.fse-template-part body:not(.fse-enabled) .main-navigation a {
+	font-size: 1.04167rem;
+}
+
+.fse-template-part .main-navigation {
+	text-align: center;
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .button {
+	line-height: 1;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Karla", Arial, sans-serif;
+	font-family: var(--font-base, "Karla", Arial, sans-serif);
+	font-size: 1.04167rem;
+	background-color: #3E7D98;
+	border-radius: 160px;
+	border-width: 0;
+	padding: 16px 48px;
+}
+
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.fse-template-part .main-navigation .button:before {
+	margin-bottom: -0.12em;
+}
+
+.fse-template-part .main-navigation .button:after {
+	margin-top: -0.11em;
+}
+
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+	color: #ffffff;
+	background-color: #2f5f74;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li a {
+	font-size: inherit;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 14px;
+	}
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 0;
+	}
+}
+
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+		margin-top: -32px;
+	}
+}
+
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
+}
+
+.fse-template-part .has-normal-font-size {
+	font-size: 1.5rem;
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover-image .site-title {
+	font-weight: normal;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.post-content__block {
+	margin-top: -36px;
 }

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1067,6 +1067,14 @@ p:not(.site-title) a:hover {
 	width: auto;
 }
 
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1077,6 +1085,10 @@ p:not(.site-title) a:hover {
 
 .fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
 }
 
 .fse-template-part .main-navigation {
@@ -1407,13 +1419,12 @@ p:not(.site-title) a:hover {
 	font-size: 1.5rem;
 }
 
-.fse-template-part .main-navigation a {
-	text-decoration: none;
+.fse-template-part .site-title {
+	font-weight: bold;
 }
 
-.fse-template-part .wp-block-cover .site-title,
-.fse-template-part .wp-block-cover-image .site-title {
-	font-weight: normal;
+.fse-template-part .main-navigation a {
+	text-decoration: none;
 }
 
 .fse-template-part .wp-block-cover .has-background,

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3389,7 +3389,7 @@ img#wpstats {
 	}
 }
 
-.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 	width: calc(100% + 256px);
 	max-width: 100%;
 	margin-right: auto;
@@ -3397,35 +3397,35 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 560px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 640px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
@@ -3772,7 +3772,7 @@ blockquote p {
 /**
  * Wide Header & Footer
  */
-#masthead {
+body:not(.fse-enabled) #masthead {
 	padding-right: 16px;
 	padding-left: 16px;
 	padding-bottom: 32px;
@@ -3780,7 +3780,7 @@ blockquote p {
 }
 
 @media only screen and (min-width: 1024px) {
-	#masthead {
+	body:not(.fse-enabled) #masthead {
 		padding-right: 0;
 		padding-left: 0;
 	}

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -11,7 +11,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: alves
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4078,4 +4078,108 @@ blockquote p {
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	margin-top: 32px;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: calc( 1.5 * 32px);
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -3406,7 +3406,7 @@ img#wpstats {
 	}
 }
 
-.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 	width: calc(100% + 256px);
 	max-width: 100%;
 	margin-left: auto;
@@ -3414,35 +3414,35 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 560px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 640px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide, body:not(.fse-enabled) #masthead, .site-footer #footer-widgets, .site-footer #footer-info-wrapper {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
@@ -3801,7 +3801,7 @@ blockquote p {
 /**
  * Wide Header & Footer
  */
-#masthead {
+body:not(.fse-enabled) #masthead {
 	padding-left: 16px;
 	padding-right: 16px;
 	padding-bottom: 32px;
@@ -3809,7 +3809,7 @@ blockquote p {
 }
 
 @media only screen and (min-width: 1024px) {
-	#masthead {
+	body:not(.fse-enabled) #masthead {
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,12 +6,12 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: alves
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4107,4 +4107,108 @@ blockquote p {
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	margin-top: 32px;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: calc( 1.5 * 32px);
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
 }

--- a/exford/languages/exford.pot
+++ b/exford/languages/exford.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Exford 1.4.0\n"
+"Project-Id-Version: Exford 1.4.1\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/exford\n"
 "POT-Creation-Date: 2019-08-22 06:43:49+00:00\n"
 "MIME-Version: 1.0\n"

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2651,7 +2651,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.1.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -2666,7 +2666,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.1.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.0
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1096,7 +1096,7 @@ table th,
 	color: inherit;
 }
 
-.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1080,6 +1080,14 @@ table th,
 	width: auto;
 }
 
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1090,6 +1098,10 @@ table th,
 
 .fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
 }
 
 .fse-template-part .main-navigation {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.0
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.0
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/languages/maywood.pot
+++ b/maywood/languages/maywood.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Maywood 1.4.1\n"
+"Project-Id-Version: Maywood 1.4.2\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/maywood\n"
 "POT-Creation-Date: 2019-08-28 16:20:11+00:00\n"
 "MIME-Version: 1.0\n"

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1100,6 +1100,14 @@ b, strong {
 	width: auto;
 }
 
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1110,6 +1118,10 @@ b, strong {
 
 .fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
 }
 
 .fse-template-part .main-navigation {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1116,7 +1116,7 @@ b, strong {
 	color: inherit;
 }
 
-.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/languages/shawburn.pot
+++ b/shawburn/languages/shawburn.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Shawburn 1.3.0\n"
+"Project-Id-Version: Shawburn 1.3.1\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/shawburn\n"
 "POT-Creation-Date: 2019-08-28 17:10:55+00:00\n"
 "MIME-Version: 1.0\n"

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -900,7 +900,7 @@
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
@@ -1330,7 +1330,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.1.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -3239,7 +3239,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.1.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1036,6 +1036,14 @@ table th,
 	width: auto;
 }
 
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1046,6 +1054,10 @@ table th,
 
 .fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
 }
 
 .fse-template-part .main-navigation {

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1052,7 +1052,7 @@ table th,
 	color: inherit;
 }
 
-.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/varia/package-lock.json
+++ b/varia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/varia/package.json
+++ b/varia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A variable-based design system for WordPress sites built with Gutenberg.",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues?q=is%3Aopen+is%3Aissue+label%3Avaria"

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -24,7 +24,7 @@
 			display: none;
 		}
 
-		// Remove the top margin if the Site Title block is the first 
+		// Remove the top margin if the Site Title block is the first in a column block
 		.wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
 			margin-top: 0;
 		}
@@ -41,7 +41,7 @@
 		}
 	}
 
-	.block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	.block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 		width: auto;
 	}
 

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -18,6 +18,16 @@
 		figure.fse-site-logo {
 			width: auto;
 		}
+
+		// Hide the (+) icons when rendering the Template Part block inside the Page editor.
+		.block-list-appender {
+			display: none;
+		}
+
+		// Remove the top margin if the Site Title block is the first 
+		.wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+			margin-top: 0;
+		}
 	}
 }
 
@@ -33,6 +43,11 @@
 
 	.block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 		width: auto;
+	}
+
+	// Make sure each column in a Columns block is max width, so that nested FSE blocks can behave as expected.
+	.wp-block-column {
+		width: 100%;
 	}
 
 	@import '../components/header/site-main-navigation';

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1034,6 +1034,14 @@ table th,
 	width: auto;
 }
 
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover .site-description,
 .fse-template-part .wp-block-cover-image .site-title,
@@ -1044,6 +1052,10 @@ table th,
 
 .fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
 }
 
 .fse-template-part .main-navigation {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1038,7 +1038,7 @@ table th,
 	display: none;
 }
 
-.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title:not([data-align='full']) {
 	margin-top: 0;
 }
 
@@ -1050,7 +1050,7 @@ table th,
 	color: inherit;
 }
 
-.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align=full] > .block-editor-block-list__block-edit figure.fse-site-logo {
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
 	width: auto;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia

--- a/varia/style.css
+++ b/varia/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia


### PR DESCRIPTION
* Added FSE support to Alves.
  * Note: the theme `#masthead` style were preventing the FSE header to be full width as intended. Instead of needlessly overriding the whole `header.php`, I've opted to add a simpler `body:not( .fse-enabled ) #masthead`.
* Update Varia (and the other FSE themes) with FSE improvements:
  * Hide the (+) icons when rendering the Template Part block inside the Page editor (especially useful for the Columns block).
  * Remove the top margin if the Site Title block is the first child of an editor layout.
  * Make sure each column in a Columns block is max width, so that nested FSE blocks can behave as expected.

| Template | Page | Front End |
| - | - | - |
| <img width="1371" alt="Screenshot 2019-11-26 at 14 53 51" src="https://user-images.githubusercontent.com/2070010/69645782-9fab5f00-105e-11ea-98d6-9262bbad0e47.png"> | <img width="1379" alt="Screenshot 2019-11-26 at 14 53 35" src="https://user-images.githubusercontent.com/2070010/69645792-a33ee600-105e-11ea-8d7d-81033cd2818e.png"> | <img width="1126" alt="Screenshot 2019-11-26 at 14 54 01" src="https://user-images.githubusercontent.com/2070010/69645798-a8039a00-105e-11ea-981b-6cb6d8724faf.png"> |

#### Testing instructions

Smoke test Alves on an FSE environment!