### PR TITLE
Morden: Add Full Site Editing support

### DIFF
--- a/morden/header.php
+++ b/morden/header.php
@@ -23,6 +23,17 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 
+	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
+
+		<header class="fse-template-part fse-header entry-content">
+			<?php
+				$template = new A8C\FSE\WP_Template();
+				$template->output_template_content( A8C\FSE\WP_Template::HEADER );
+			?>
+		</header>
+
+	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>
+
 		<header id="masthead" class="site-header">
 
 			<div class="site-header-wrap">
@@ -70,5 +81,7 @@
 			</div>
 
 		</header><!-- #masthead -->
+
+	<?php endif; ?>
 
 	<div id="content" class="site-content">

--- a/morden/languages/morden.pot
+++ b/morden/languages/morden.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Morden 1.0\n"
+"Project-Id-Version: Morden 1.5.0\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/theme/morden\n"
 "POT-Creation-Date: 2019-08-08 09:07:01+00:00\n"
 "MIME-Version: 1.0\n"

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1472,8 +1472,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1494,14 +1493,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1516,20 +1513,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1646,8 +1640,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1659,7 +1652,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1674,7 +1666,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1682,14 +1673,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1708,7 +1697,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1789,8 +1777,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1802,7 +1789,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1888,8 +1874,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1925,7 +1910,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1945,7 +1929,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1989,14 +1972,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/_full-site-editing-editor.scss
+++ b/morden/sass/_full-site-editing-editor.scss
@@ -1,0 +1,26 @@
+@import "../../varia/sass/full-site-editing/editor";
+
+.fse-template-part {
+	.has-normal-font-size {
+		font-size: map-deep-get($config-global, "font", "size", "md");
+	}
+
+	.main-navigation a {
+		text-decoration: none;
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title {
+			font-weight: #{map-deep-get($config-heading, "font", "weight")};
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}
+
+.post-content__block {
+	margin-top: -36px;
+}

--- a/morden/sass/_full-site-editing-editor.scss
+++ b/morden/sass/_full-site-editing-editor.scss
@@ -9,6 +9,11 @@
 		text-decoration: none;
 	}
 
+	#toggle-menu.has-background-color {
+		background: map-deep-get($config-global, "color", "background", "default");
+		color: map-deep-get($config-global, "color", "foreground", "default") !important;
+	}
+
 	.wp-block-cover,
 	.wp-block-cover-image {
 		.site-title {

--- a/morden/sass/_full-site-editing.scss
+++ b/morden/sass/_full-site-editing.scss
@@ -14,6 +14,9 @@ $spacing_vertical: map-deep-get($config-global, "spacing", "vertical");
 	@include media(mobile-only) {
 		max-width: calc( 100% - #{ $spacing_vertical } );
 
+		#toggle-menu.has-background-color {
+			color: map-deep-get($config-global, "color", "foreground", "default") !important;
+		}
 		.main-navigation > div {
 			padding: 0 32px;
 		}

--- a/morden/sass/_full-site-editing.scss
+++ b/morden/sass/_full-site-editing.scss
@@ -3,10 +3,7 @@
 $spacing_vertical: map-deep-get($config-global, "spacing", "vertical");
 
 .fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
-	padding-bottom: $spacing_vertical;
-	@include media(mobile) {
-		padding-bottom: #{1.5 * $spacing_vertical};
-	}
+	padding-bottom: 0;
 }
 
 .fse-template-part {

--- a/morden/sass/_full-site-editing.scss
+++ b/morden/sass/_full-site-editing.scss
@@ -1,0 +1,47 @@
+@import "../../varia/sass/full-site-editing/imports";
+
+$spacing_vertical: map-deep-get($config-global, "spacing", "vertical");
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: $spacing_vertical;
+	@include media(mobile) {
+		padding-bottom: #{1.5 * $spacing_vertical};
+	}
+}
+
+.fse-template-part {
+	.main-navigation a {
+		text-decoration: none;
+	}
+	
+	@include media(mobile-only) {
+		max-width: calc( 100% - #{ $spacing_vertical } );
+
+		.main-navigation > div {
+			padding: 0 32px;
+		}
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title a {
+			text-decoration: none;
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container {
+	margin-top: 0;
+	margin-bottom: 0;
+
+	.wp-block-spacer:first-child {
+		display: none;
+	}
+	.wp-block-columns.alignfull:nth-child(2) {
+		margin-top: 0;
+	}
+}

--- a/morden/sass/style-child-theme-editor.scss
+++ b/morden/sass/style-child-theme-editor.scss
@@ -38,3 +38,9 @@
 .editor-post-title__input {
 	text-align: center;
 }
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing-editor";

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,12 +5,12 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.5.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: morden
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -88,3 +88,9 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * Child Theme Extra Styles
  */
 @import "extra-child-theme";
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing";

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1392,6 +1392,11 @@ table th,
 	text-decoration: none;
 }
 
+.fse-template-part #toggle-menu.has-background-color {
+	background: white;
+	color: #303030 !important;
+}
+
 .fse-template-part .wp-block-cover .site-title,
 .fse-template-part .wp-block-cover-image .site-title {
 	font-weight: bold;

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -1008,4 +1009,399 @@ table th,
  */
 .editor-post-title__input {
 	text-align: center;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+@media (min-width: 600px) {
+	.a8c-template-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+.template-block .fse-template-part {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-template-part {
+		padding: 32px 0;
+	}
+}
+
+.template-block .fse-template-part figure.fse-site-logo {
+	width: auto;
+}
+
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover .site-description,
+.fse-template-part .wp-block-cover-image .site-title,
+.fse-template-part .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation {
+	color: white;
+}
+
+.fse-template-part .main-navigation > div {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle-menu {
+	display: inline-block;
+	margin: 0;
+}
+
+.fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	display: block;
+}
+
+.fse-template-part .main-navigation #toggle:focus + #toggle-menu {
+	background-color: rgba(255, 255, 255, 0.8);
+	outline: inherit;
+	text-decoration: underline;
+}
+
+.fse-template-part .main-navigation .dropdown-icon.close {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .open {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .close {
+	display: inline;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div {
+		display: inline-block;
+	}
+	.fse-template-part .main-navigation #toggle-menu {
+		display: none;
+	}
+	.fse-template-part .main-navigation > div > ul > li > ul {
+		display: none;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul {
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	max-width: none;
+	padding-left: 0;
+	position: relative;
+	/* Sub-menus Flyout */
+}
+
+.fse-template-part .main-navigation > div > ul ul {
+	padding-left: 0;
+}
+
+.fse-template-part .main-navigation > div > ul li {
+	display: block;
+	position: relative;
+	width: 100%;
+	z-index: 1;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li:focus-within {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul li {
+		display: inherit;
+		width: inherit;
+		/* Submenu display */
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li:focus-within > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > a {
+		line-height: 1;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before, .fse-template-part .main-navigation > div > ul > li > a:after {
+		content: '';
+		display: block;
+		height: 0;
+		width: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before {
+		margin-bottom: -0.12em;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:after {
+		margin-top: -0.11em;
+	}
+	.fse-template-part .main-navigation > div > ul > li:first-of-type > a {
+		padding-left: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li:last-of-type > a {
+		padding-right: 0;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+	margin: 0;
+	position: relative;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+		background: white;
+		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
+		left: 0;
+		top: 100%;
+		min-width: max-content;
+		opacity: 0;
+		position: absolute;
+		transition: all 0.5s ease;
+		visibility: hidden;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu .sub-menu {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation a {
+	color: white;
+	display: block;
+	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-weight: bold;
+	padding: 4px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation a {
+		padding: 8px;
+	}
+}
+
+.fse-template-part .main-navigation a:link, .fse-template-part .main-navigation a:visited {
+	color: white;
+}
+
+.fse-template-part .main-navigation a:hover {
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.fse-template-part .main-navigation .sub-menu {
+	list-style: none;
+	margin-left: 0;
+	/* Reset the counter for each UL */
+	counter-reset: nested-list;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a {
+	padding-top: 4px;
+	padding-bottom: 4px;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a::before {
+	/* Increment the dashes */
+	counter-increment: nested-list;
+	/* Insert dashes with spaces in between */
+	content: "– " counters(nested-list, "– ", none);
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > .menu-item-has-children > a::after {
+		content: "\00a0\25BC";
+		display: inline-block;
+		font-size: 0.75614rem;
+		height: inherit;
+		width: inherit;
+	}
+}
+
+.fse-template-part .main-navigation .hide-visually {
+	position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0 !important;
+	border: 0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+}
+
+.fse-template-part body:not(.fse-enabled) .main-navigation a {
+	font-size: 1rem;
+}
+
+.fse-template-part .main-navigation {
+	text-align: center;
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CD2220;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.fse-template-part .main-navigation .button:before {
+	margin-bottom: -0.12em;
+}
+
+.fse-template-part .main-navigation .button:after {
+	margin-top: -0.11em;
+}
+
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+	color: white;
+	background-color: #303030;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li a {
+	font-size: inherit;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 14px;
+	}
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 0;
+	}
+}
+
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+		margin-top: -32px;
+	}
+}
+
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
+}
+
+.fse-template-part .has-normal-font-size {
+	font-size: 1.15rem;
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover-image .site-title {
+	font-weight: bold;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.post-content__block {
+	margin-top: -36px;
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1022,6 +1022,10 @@ table th,
 	}
 }
 
+.a8c-template-editor .block-editor-block-list__block-edit [data-block] {
+	margin: 12px 0 0 0;
+}
+
 .template-block .fse-template-part {
 	padding: 16px;
 }
@@ -1058,6 +1062,10 @@ table th,
 
 .fse-template-part .wp-block-column {
 	width: 100%;
+}
+
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
 }
 
 .fse-template-part .main-navigation {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -4200,13 +4200,7 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 }
 
 .fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
-	padding-bottom: 32px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
-		padding-bottom: 48px;
-	}
+	padding-bottom: 0;
 }
 
 .fse-template-part .main-navigation a {
@@ -4216,6 +4210,9 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 @media only screen and (max-width: 559px) {
 	.fse-template-part {
 		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part #toggle-menu {
+		color: #303030 !important;
 	}
 	.fse-template-part .main-navigation > div {
 		padding: 0 32px;

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,12 +6,12 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.5.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: morden
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4126,4 +4126,121 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	display: block;
 	margin-bottom: 8px;
 	width: 100%;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: 48px;
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container .wp-block-spacer:first-child {
+	display: none;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container .wp-block-columns.alignfull:nth-child(2) {
+	margin-top: 0;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -4172,6 +4172,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }
@@ -4211,7 +4215,7 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	.fse-template-part {
 		max-width: calc( 100% - 32px);
 	}
-	.fse-template-part #toggle-menu {
+	.fse-template-part #toggle-menu.has-background-color {
 		color: #303030 !important;
 	}
 	.fse-template-part .main-navigation > div {

--- a/morden/style.css
+++ b/morden/style.css
@@ -4240,6 +4240,9 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	.fse-template-part {
 		max-width: calc( 100% - 32px);
 	}
+	.fse-template-part #toggle-menu.has-background-color {
+		color: #303030 !important;
+	}
 	.fse-template-part .main-navigation > div {
 		padding: 0 32px;
 	}

--- a/morden/style.css
+++ b/morden/style.css
@@ -4201,6 +4201,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -4229,13 +4229,7 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 }
 
 .fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
-	padding-bottom: 32px;
-}
-
-@media only screen and (min-width: 560px) {
-	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
-		padding-bottom: 48px;
-	}
+	padding-bottom: 0;
 }
 
 .fse-template-part .main-navigation a {

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,12 +6,12 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.5.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: morden
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4155,4 +4155,121 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	display: block;
 	margin-bottom: 8px;
 	width: 100%;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: 48px;
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container .wp-block-spacer:first-child {
+	display: none;
+}
+
+.fse-header .wp-block-cover:first-child .wp-block-cover__inner-container .wp-block-columns.alignfull:nth-child(2) {
+	margin-top: 0;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1042,7 +1042,7 @@ table th,
 	display: none;
 }
 
-.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title:not([data-align='full']) {
 	margin-top: 0;
 }
 


### PR DESCRIPTION
* Added FSE support to Morden.

Note: since Morden has a multi-column header like Alves, I've checked out this branch off `add/alves-fse-support` to obtain the new Varia columns fixes.
They help a bit, but definitely not enough. Unfortunately working with the Columns block is just very wonky.

| Template | Page | Front End |
| - | - | - |
| <img width="1191" alt="Screenshot 2019-11-28 at 16 38 51" src="https://user-images.githubusercontent.com/2070010/69822277-dd92b980-11fd-11ea-9a9f-6f1861c81e41.png"> | <img width="1167" alt="Screenshot 2019-11-28 at 16 39 07" src="https://user-images.githubusercontent.com/2070010/69822280-e1bed700-11fd-11ea-8d05-9070d824a160.png"> | <img width="1177" alt="Screenshot 2019-11-28 at 16 39 18" src="https://user-images.githubusercontent.com/2070010/69822285-e4213100-11fd-11ea-835c-62eb6e53bc2b.png"> |

#### Testing instructions

Smoke test Morden on an FSE environment!