### PR TITLE
Hever: Add FSE support. 

### DIFF
--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -2998,8 +2998,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3020,14 +3019,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3042,20 +3039,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3172,8 +3166,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3185,7 +3178,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3200,7 +3192,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3208,14 +3199,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3234,7 +3223,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3315,8 +3303,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3328,7 +3315,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3414,8 +3400,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3451,7 +3436,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3471,7 +3455,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3515,14 +3498,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/hever/sass/_extra-child-theme.scss
+++ b/hever/sass/_extra-child-theme.scss
@@ -22,16 +22,18 @@ a {
 /**
  * Wide Header & Footer
  */
-#masthead,
-#colophon {
-	padding-left: 16px;
-	padding-right: 16px;
-	position: relative;
-	@extend %responsive-alignwide;
-
-	@include media(mobile) {
-		padding-left: 0;
-		padding-right: 0;
+body:not(.fse-enabled) { 
+	#masthead,
+	#colophon {
+		padding-left: 16px;
+		padding-right: 16px;
+		position: relative;
+		@extend %responsive-alignwide;
+	
+		@include media(mobile) {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 }
 

--- a/hever/sass/_full-site-editing-editor.scss
+++ b/hever/sass/_full-site-editing-editor.scss
@@ -1,0 +1,34 @@
+@import "../../varia/sass/full-site-editing/editor";
+
+.fse-template-part {
+	.has-normal-font-size {
+		font-size: map-deep-get($config-global, "font", "size", "md");
+	}
+
+	.main-navigation a {
+		text-decoration: none;
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title {
+			font-weight: #{map-deep-get($config-heading, "font", "weight")};
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}
+
+.post-content__block {
+	margin-top: -36px;
+}
+
+.fse-header {
+	.wp-block-columns .wp-block-column {
+		& > * {
+			margin: 0;
+		}
+	}
+}

--- a/hever/sass/_full-site-editing-editor.scss
+++ b/hever/sass/_full-site-editing-editor.scss
@@ -24,11 +24,3 @@
 .post-content__block {
 	margin-top: -36px;
 }
-
-.fse-header {
-	.wp-block-columns .wp-block-column {
-		& > * {
-			margin: 0;
-		}
-	}
-}

--- a/hever/sass/_full-site-editing.scss
+++ b/hever/sass/_full-site-editing.scss
@@ -1,0 +1,43 @@
+@import "../../varia/sass/full-site-editing/imports";
+
+$spacing_vertical: map-deep-get($config-global, "spacing", "vertical");
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: $spacing_vertical;
+	@include media(mobile) {
+		padding-bottom: #{1.5 * $spacing_vertical};
+	}
+}
+
+.fse-template-part {
+	.main-navigation a {
+		text-decoration: none;
+	}
+
+	@include media(mobile-only) {
+		max-width: calc( 100% - #{ $spacing_vertical } );
+
+		.main-navigation > div {
+			padding: 0 32px;
+		}
+	}
+
+	.wp-block-cover,
+	.wp-block-cover-image {
+		.site-title a {
+			text-decoration: none;
+		}
+
+		.has-background {
+			text-shadow: none;
+		}
+	}
+}
+
+.fse-header {
+	.wp-block-columns .wp-block-column {
+		& > * {
+			margin: 0;
+		}
+	}
+}

--- a/hever/sass/_full-site-editing.scss
+++ b/hever/sass/_full-site-editing.scss
@@ -33,11 +33,3 @@ $spacing_vertical: map-deep-get($config-global, "spacing", "vertical");
 		}
 	}
 }
-
-.fse-header {
-	.wp-block-columns .wp-block-column {
-		& > * {
-			margin: 0;
-		}
-	}
-}

--- a/hever/sass/style-child-theme-editor.scss
+++ b/hever/sass/style-child-theme-editor.scss
@@ -38,3 +38,9 @@
 .editor-post-title__input {
 	text-align: center;
 }
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing-editor";

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -10,7 +10,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: hever
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -88,3 +88,9 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
  * Child Theme Extra Styles
  */
 @import "extra-child-theme";
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+ @import "full-site-editing";

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1064,8 +1064,8 @@ table th,
 	width: 100%;
 }
 
-.fse-template-part .wp-block-column > * {
-	margin: 0;
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
 }
 
 .fse-template-part .main-navigation {
@@ -1412,8 +1412,4 @@ table th,
 
 .post-content__block {
 	margin-top: -36px;
-}
-
-.fse-header .wp-block-columns .wp-block-column > * {
-	margin: 0;
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -1008,4 +1009,411 @@ table th,
  */
 .editor-post-title__input {
 	text-align: center;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+@media (min-width: 600px) {
+	.a8c-template-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+.a8c-template-editor .block-editor-block-list__block-edit [data-block] {
+	margin: 12px 0 0 0;
+}
+
+.template-block .fse-template-part {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-template-part {
+		padding: 32px 0;
+	}
+}
+
+.template-block .fse-template-part figure.fse-site-logo {
+	width: auto;
+}
+
+.template-block .fse-template-part .block-list-appender {
+	display: none;
+}
+
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
+	margin-top: 0;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover .site-description,
+.fse-template-part .wp-block-cover-image .site-title,
+.fse-template-part .wp-block-cover-image .site-description {
+	background: transparent;
+	color: inherit;
+}
+
+.fse-template-part .block-editor-block-list__layout .block-editor-block-list__block[data-align='full'] > .block-editor-block-list__block-edit figure.fse-site-logo {
+	width: auto;
+}
+
+.fse-template-part .wp-block-column {
+	width: 100%;
+}
+
+.fse-template-part .wp-block-column > * {
+	margin: 0;
+}
+
+.fse-template-part .main-navigation {
+	color: #303030;
+}
+
+.fse-template-part .main-navigation > div {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle-menu {
+	display: inline-block;
+	margin: 0;
+}
+
+.fse-template-part .main-navigation #toggle:checked ~ div:not(.woocommerce-menu-container) {
+	display: block;
+}
+
+.fse-template-part .main-navigation #toggle:focus + #toggle-menu {
+	background-color: #1279BE;
+	outline: inherit;
+	text-decoration: underline;
+}
+
+.fse-template-part .main-navigation .dropdown-icon.close {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .open {
+	display: none;
+}
+
+.fse-template-part .main-navigation #toggle:checked + #toggle-menu .close {
+	display: inline;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div {
+		display: inline-block;
+	}
+	.fse-template-part .main-navigation #toggle-menu {
+		display: none;
+	}
+	.fse-template-part .main-navigation > div > ul > li > ul {
+		display: none;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul {
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	max-width: none;
+	padding-left: 0;
+	position: relative;
+	/* Sub-menus Flyout */
+}
+
+.fse-template-part .main-navigation > div > ul ul {
+	padding-left: 0;
+}
+
+.fse-template-part .main-navigation > div > ul li {
+	display: block;
+	position: relative;
+	width: 100%;
+	z-index: 1;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li:focus-within {
+	cursor: pointer;
+	z-index: 99999;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul li {
+		display: inherit;
+		width: inherit;
+		/* Submenu display */
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+	.fse-template-part .main-navigation > div > ul li:hover > ul,
+	.fse-template-part .main-navigation > div > ul li:focus-within > ul,
+	.fse-template-part .main-navigation > div > ul li ul:hover,
+	.fse-template-part .main-navigation > div > ul li ul:focus {
+		visibility: visible;
+		opacity: 1;
+		display: block;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > a {
+		line-height: 1;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before, .fse-template-part .main-navigation > div > ul > li > a:after {
+		content: '';
+		display: block;
+		height: 0;
+		width: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:before {
+		margin-bottom: -0.12em;
+	}
+	.fse-template-part .main-navigation > div > ul > li > a:after {
+		margin-top: -0.11em;
+	}
+	.fse-template-part .main-navigation > div > ul > li:first-of-type > a {
+		padding-left: 0;
+	}
+	.fse-template-part .main-navigation > div > ul > li:last-of-type > a {
+		padding-right: 0;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+	margin: 0;
+	position: relative;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > li > .sub-menu {
+		background: white;
+		box-shadow: 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
+		left: 0;
+		top: 100%;
+		min-width: max-content;
+		opacity: 0;
+		position: absolute;
+		transition: all 0.5s ease;
+		visibility: hidden;
+	}
+}
+
+.fse-template-part .main-navigation > div > ul > li > .sub-menu .sub-menu {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation a {
+	color: #303030;
+	display: block;
+	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-weight: bold;
+	padding: 4px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation a {
+		padding: 8px;
+	}
+}
+
+.fse-template-part .main-navigation a:link, .fse-template-part .main-navigation a:visited {
+	color: #303030;
+}
+
+.fse-template-part .main-navigation a:hover {
+	color: #1279BE;
+}
+
+.fse-template-part .main-navigation .sub-menu {
+	list-style: none;
+	margin-left: 0;
+	/* Reset the counter for each UL */
+	counter-reset: nested-list;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a {
+	padding-top: 4px;
+	padding-bottom: 4px;
+}
+
+.fse-template-part .main-navigation .sub-menu .menu-item a::before {
+	/* Increment the dashes */
+	counter-increment: nested-list;
+	/* Insert dashes with spaces in between */
+	content: "– " counters(nested-list, "– ", none);
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation > div > ul > .menu-item-has-children > a::after {
+		content: "\00a0\25BC";
+		display: inline-block;
+		font-size: 0.75614rem;
+		height: inherit;
+		width: inherit;
+	}
+}
+
+.fse-template-part .main-navigation .hide-visually {
+	position: absolute !important;
+	clip: rect(1px, 1px, 1px, 1px);
+	padding: 0 !important;
+	border: 0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+}
+
+.fse-template-part body:not(.fse-enabled) .main-navigation a {
+	font-size: 1rem;
+}
+
+.fse-template-part .main-navigation {
+	text-align: center;
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #1279BE;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.fse-template-part .main-navigation .button:before {
+	margin-bottom: -0.12em;
+}
+
+.fse-template-part .main-navigation .button:after {
+	margin-top: -0.11em;
+}
+
+.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+	color: white;
+	background-color: #303030;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li a {
+	font-size: inherit;
+}
+
+.fse-template-part .main-navigation .main-menu.footer-menu li.menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block.is-selected:first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 14px;
+	}
+	.a8c-template-editor.fse-header .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected):first-child[data-align='full'] > .block-editor-block-list__block-edit > [data-block] {
+		margin-top: 0;
+	}
+}
+
+.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+	margin-top: -16px;
+}
+
+@media only screen and (min-width: 560px) {
+	.template-block .fse-header .block-editor-block-list__layout > .block-editor-block-list__block:first-child[data-align='full'] {
+		margin-top: -32px;
+	}
+}
+
+.post-content__block {
+	margin-bottom: 160px;
+	margin-top: 36px;
+	z-index: 20;
+}
+
+.fse-template-part .has-normal-font-size {
+	font-size: 1.15rem;
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .site-title,
+.fse-template-part .wp-block-cover-image .site-title {
+	font-weight: bold;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.post-content__block {
+	margin-top: -36px;
+}
+
+.fse-header .wp-block-columns .wp-block-column > * {
+	margin: 0;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3350,8 +3350,8 @@ img#wpstats {
 	}
 }
 
-.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-#colophon {
+.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+body:not(.fse-enabled) #colophon {
 	margin-right: auto;
 	margin-left: auto;
 	max-width: 100%;
@@ -3359,37 +3359,37 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 782px - 32px);
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
@@ -3694,16 +3694,16 @@ p:not(.site-title) a:hover {
 /**
  * Wide Header & Footer
  */
-#masthead,
-#colophon {
+body:not(.fse-enabled) #masthead,
+body:not(.fse-enabled) #colophon {
 	padding-right: 16px;
 	padding-left: 16px;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	#masthead,
-	#colophon {
+	body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		padding-right: 0;
 		padding-left: 0;
 	}

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -11,7 +11,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: hever
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4105,4 +4105,112 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	display: block;
 	margin-bottom: 8px;
 	width: 100%;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: 48px;
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.fse-header .wp-block-columns .wp-block-column > * {
+	margin: 0;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -4151,6 +4151,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }
@@ -4209,8 +4213,4 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .fse-template-part .wp-block-cover .has-background,
 .fse-template-part .wp-block-cover-image .has-background {
 	text-shadow: none;
-}
-
-.fse-header .wp-block-columns .wp-block-column > * {
-	margin: 0;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -11,7 +11,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: hever
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
@@ -4134,4 +4134,112 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	display: block;
 	margin-bottom: 8px;
 	width: 100%;
+}
+
+/**
+ * Full Site Editing
+ * - Full Site Editing overrides
+ */
+.fse-template-part {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
+	width: 100%;
+}
+
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
+	color: inherit;
+}
+
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
+	justify-content: flex-start;
+}
+
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
+	justify-content: center;
+}
+
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
+	justify-content: flex-end;
+}
+
+.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+	padding: 16px 0;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
+		padding: 16px;
+	}
+}
+
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
+	font-size: 0.6em;
+	vertical-align: middle;
+}
+
+.fse-header > *:first-child:not(.alignfull) {
+	margin-top: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-header > *:first-child:not(.alignfull) {
+		margin-top: 32px;
+	}
+}
+
+.fse-footer {
+	display: block;
+}
+
+.fse-footer .site-info {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+	text-align: center;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-footer .site-info {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+	padding-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.fse-enabled.home.page.hide-homepage-title .fse-header.entry-content {
+		padding-bottom: 48px;
+	}
+}
+
+.fse-template-part .main-navigation a {
+	text-decoration: none;
+}
+
+@media only screen and (max-width: 559px) {
+	.fse-template-part {
+		max-width: calc( 100% - 32px);
+	}
+	.fse-template-part .main-navigation > div {
+		padding: 0 32px;
+	}
+}
+
+.fse-template-part .wp-block-cover .site-title a,
+.fse-template-part .wp-block-cover-image .site-title a {
+	text-decoration: none;
+}
+
+.fse-template-part .wp-block-cover .has-background,
+.fse-template-part .wp-block-cover-image .has-background {
+	text-shadow: none;
+}
+
+.fse-header .wp-block-columns .wp-block-column > * {
+	margin: 0;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -4180,6 +4180,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }
@@ -4238,8 +4242,4 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .fse-template-part .wp-block-cover .has-background,
 .fse-template-part .wp-block-cover-image .has-background {
 	text-shadow: none;
-}
-
-.fse-header .wp-block-columns .wp-block-column > * {
-	margin: 0;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -3367,8 +3367,8 @@ img#wpstats {
 	}
 }
 
-.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-#colophon {
+.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+body:not(.fse-enabled) #colophon {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: 100%;
@@ -3376,37 +3376,37 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		max-width: calc( 782px - 32px);
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, #masthead,
-	#colophon {
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery, body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
@@ -3723,16 +3723,16 @@ p:not(.site-title) a:hover {
 /**
  * Wide Header & Footer
  */
-#masthead,
-#colophon {
+body:not(.fse-enabled) #masthead,
+body:not(.fse-enabled) #colophon {
 	padding-left: 16px;
 	padding-right: 16px;
 	position: relative;
 }
 
 @media only screen and (min-width: 560px) {
-	#masthead,
-	#colophon {
+	body:not(.fse-enabled) #masthead,
+	body:not(.fse-enabled) #colophon {
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.0
+Version: 1.4.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -55,6 +55,10 @@
 	// Make sure each column in a Columns block is max width, so that nested FSE blocks can behave as expected.
 	.wp-block-column {
 		width: 100%;
+
+		& > * {
+			margin: 0;
+		}
 	}
 
 	// Remove large margins on column children when used in a template part.

--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -55,10 +55,6 @@
 	// Make sure each column in a Columns block is max width, so that nested FSE blocks can behave as expected.
 	.wp-block-column {
 		width: 100%;
-
-		& > * {
-			margin: 0;
-		}
 	}
 
 	// Remove large margins on column children when used in a template part.

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3738,6 +3738,10 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }


### PR DESCRIPTION
Add CSS column and block margin changes to Varia so that columns can be used to layout header and footer template parts more accurately.

<img width="1022" alt="Screen Shot 2019-12-03 at 9 52 04 AM" src="https://user-images.githubusercontent.com/1464705/70075921-9700de80-15b2-11ea-9aba-4284e8713ddf.png">

To test:

1. Run a copy of WordPress locally with the Full Site Editing plugin installed, and Gutenberg plugin installed.

2. Install the hever and varia theme from this PR

3. Activate hever, and the two plugins

4. Create a new page and use the Hever homepage template, confirm that you see the header template as it appears in the visual above. Confirm this works correctly on the front end.

