### PR TITLE
Varia: Update margins to match in template editor view and main page view

### DIFF
--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -5,6 +5,13 @@
 			margin-right: 0;
 		}
 	}
+
+	// Match margins for template parts rendered in the page and template part editor view.
+	.block-editor-block-list__block-edit {
+		[data-block] {
+			margin: 12px 0 0 0;
+		}
+	}
 }
 
 .template-block {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1020,6 +1020,10 @@ table th,
 	}
 }
 
+.a8c-template-editor .block-editor-block-list__block-edit [data-block] {
+	margin: 12px 0 0 0;
+}
+
 .template-block .fse-template-part {
 	padding: 16px;
 }
@@ -1038,7 +1042,7 @@ table th,
 	display: none;
 }
 
-.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title:not([data-align='full']) {
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
 	margin-top: 0;
 }
 


### PR DESCRIPTION
This change updates block margins to that header and footer template parts render close or identical to how they render when viewed when editing a page.

This will improve consistency when using full site editing, and also allow us to compress excess margins on blocks like the social icons block.

The main thing to test is Maywood, since this is the only live FSE theme. Apply this change to Varia, and then test Maywood to make sure that the header renders correctly when editing a page, and also renders correctly when editing the header template part.