### PR TITLE
Varia: Limit the margins on child blocks inside columns in template parts

### DIFF
--- a/varia/sass/full-site-editing/_editor.scss
+++ b/varia/sass/full-site-editing/_editor.scss
@@ -57,6 +57,13 @@
 		width: 100%;
 	}
 
+	// Remove large margins on column children when used in a template part.
+	.wp-block-columns .wp-block-column {
+		& > * {
+			margin: 0 0 5px 0;
+		}
+	}
+
 	@import '../components/header/site-main-navigation';
 
 	.main-navigation {

--- a/varia/sass/full-site-editing/_imports.scss
+++ b/varia/sass/full-site-editing/_imports.scss
@@ -30,6 +30,13 @@
 			vertical-align: middle;
 		}
 	}
+
+	// Remove large margins on column children when used in a template part.
+	.wp-block-columns .wp-block-column {
+		& > * {
+			margin: 0 0 5px 0;
+		}
+	}
 }
 
 .fse-header > *:first-child:not(.alignfull) {
@@ -42,7 +49,7 @@
 
 .fse-footer {
 	display: block;
-	
+
 	.site-info {
 		margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
 		margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1062,6 +1062,10 @@ table th,
 	width: 100%;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-template-part .main-navigation {
 	color: #444444;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -3767,6 +3767,10 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	vertical-align: middle;
 }
 
+.fse-template-part .wp-block-columns .wp-block-column > * {
+	margin: 0 0 5px 0;
+}
+
 .fse-header > *:first-child:not(.alignfull) {
 	margin-top: 21.312px;
 }


### PR DESCRIPTION
Varia by default adds large margins to child blocks inside of columns. This makes spacing in header and footers that use columns problematic. This removes these large margins and just adds a small bottom margin that lines up with the amount of margin we see in most template-first themes.

To test, check out this branch and rebuild the css in maywood. Check that the header and footer still render correctly.