### PR TITLE
Multiple Varia Child Themes: Fix custom-logo support to prevent scaling up too small images.

### DIFF
--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -111,7 +111,7 @@ if ( ! function_exists( 'dalston_setup' ) ) :
 				'height'      => 96,
 				'width'       => 100,
 				'flex-width'  => true,
-				'flex-height' => false,
+				'flex-height' => true,
 				'header-text' => array( 'site-title' ),
 			)
 		);

--- a/redhill/functions.php
+++ b/redhill/functions.php
@@ -115,7 +115,7 @@
 				'height'      => 120,
 				'width'       => 100,
 				'flex-width'  => true,
-				'flex-height' => false,
+				'flex-height' => true,
 				'header-text' => array( 'site-title', 'site-description' ),
 			)
 		);


### PR DESCRIPTION
This PR applies the fix from #1565 to Dalston & Redhill, which provide their own logo size settings that was overriding the fix in Varia.

#### Changes proposed in this Pull Request:

- Removes the sizing constrains from custom logo to prevent too small images from getting scaled up.
- Fixes **Dalston** 
- Fixes **Redhill** 

**Before** | **After**
------------|------------
Forced cropping and low-quality scaled image.|Optional cropping & full-size high-quality image.
![image](https://user-images.githubusercontent.com/709581/70574201-8ed80e80-1b71-11ea-8619-604fa5878680.png)|![image](https://user-images.githubusercontent.com/709581/70574149-70721300-1b71-11ea-9218-7da667025fd5.png)
![image](https://user-images.githubusercontent.com/709581/70574315-d78fc780-1b71-11ea-98d6-1e38d393947e.png)|![image](https://user-images.githubusercontent.com/709581/70574379-f42bff80-1b71-11ea-8c2e-6e8777e06ca3.png)

#### Related issue(s):

- Fixes: https://github.com/Automattic/themes/issues/1287
- #1565 
- #1363 (was fixed in #1565)