### PR TITLE
Varia: Add vertical margins to blocks inside Jetpack’s Layout Grid block.

### DIFF
--- a/varia/sass/vendors/_jetpack.scss
+++ b/varia/sass/vendors/_jetpack.scss
@@ -141,9 +141,35 @@ body {
 /**
  * Business Hours
  */
-
 .jetpack-business-hours {
 	dd {
 		padding-left: 0;
+	}
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid {
+
+	.wp-block-jetpack-layout-grid-column {
+
+		& > * {
+			margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+			margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
+
+			@include media(mobile) {
+				margin-top: map-deep-get($config-global, "spacing", "vertical");
+				margin-bottom: map-deep-get($config-global, "spacing", "vertical");
+			}
+
+			&:first-child {
+				margin-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1042,7 +1042,7 @@ table th,
 	display: none;
 }
 
-.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title:not([data-align='full']) {
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
 	margin-top: 0;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3695,6 +3695,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
+}
+
+/**
  * Full Site Editing
  * - Full Site Editing overrides
  */

--- a/varia/style.css
+++ b/varia/style.css
@@ -3724,6 +3724,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
+}
+
+/**
  * Full Site Editing
  * - Full Site Editing overrides
  */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adds the same vertical margin logic used in `.entry-content` to content within the Layout Grid. 

**Before**|**After**
------------|------------
![image](https://user-images.githubusercontent.com/709581/70578979-41619e80-1b7d-11ea-932f-6dcf70bcaaaf.png)|![image](https://user-images.githubusercontent.com/709581/70579127-b6cd6f00-1b7d-11ea-80a0-73a39338c32a.png)

#### Related issue(s):

- Fixes #1672 

#### ToDo:

- [ ] Recompile all child themes