### PR TITLE
Add ‘wp_body_open’ hook.

### DIFF
--- a/varia/header.php
+++ b/varia/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 


### PR DESCRIPTION
Starting from WordPress 5.2 a new function is added – `wp_body_open()` – that is used to trigger a `wp_body_open` action. The function should be placed inside of the <body> tag immediately after it is opened.
