### PR TITLE
Template-First Themes: add styling for Blog Posts (Newspack) block.

### DIFF
--- a/alves/sass/_extra-child-theme.scss
+++ b/alves/sass/_extra-child-theme.scss
@@ -182,9 +182,9 @@ body:not(.fse-enabled) {
 		grid-template-rows: auto;
 		grid-column-gap: #{map-deep-get($config-global, "spacing", "unit")};
 		grid-template-areas:
-			"site-logo site-logo"
-			"site-title main-navigation"
-			"site-description social-navigation";
+				"site-logo site-logo"
+				"site-title main-navigation"
+				"site-description social-navigation";
 
 		&:before,
 		&:after {
@@ -255,7 +255,7 @@ body:not(.fse-enabled) {
 				}
 
 				& > .menu-item-has-children > a::after {
-						font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 				}
 			}
 
@@ -335,7 +335,7 @@ body:not(.fse-enabled) {
  * 3. Main Wrapper and Content
  */
 
- .home.page.hide-homepage-title {
+.home.page.hide-homepage-title {
 	.site-content {
 		.site-main {
 			padding-top: 0;
@@ -516,4 +516,8 @@ body:not(.fse-enabled) {
 	.wp-block-latest-posts__post-full-content {
 		margin-top: $spacing_vertical;
 	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -303,12 +303,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.592rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #3E7D98;
 	text-decoration: underline;

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -295,6 +295,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.592rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #3E7D98;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #2f5f74;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #4d6974;
+	font-size: 1.04167rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #2f5f74;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #4d6974;
 	font-size: 1.04167rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.592rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #3E7D98;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 48px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.592rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #3E7D98;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #2f5f74;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #4d6974;
+	font-size: 1.04167rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #2f5f74;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -4078,6 +4191,10 @@ body:not(.fse-enabled) #masthead {
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	margin-top: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/alves/style.css
+++ b/alves/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.592rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #3E7D98;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/alves/style.css
+++ b/alves/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #2f5f74;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #4d6974;
 	font-size: 1.04167rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/alves/style.css
+++ b/alves/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 48px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.592rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #3E7D98;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #2f5f74;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #4d6974;
+	font-size: 1.04167rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #2f5f74;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -4107,6 +4220,10 @@ body:not(.fse-enabled) #masthead {
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt,
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	margin-top: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/balasana/sass/_extra-child-theme.scss
+++ b/balasana/sass/_extra-child-theme.scss
@@ -468,24 +468,12 @@ table,
 }
 
 // Posts List
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-//Newspack 'load more' is outside the wrapper.
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 // Font Sizes

--- a/balasana/sass/_extra-child-theme.scss
+++ b/balasana/sass/_extra-child-theme.scss
@@ -76,9 +76,9 @@ dt {
 // Site Header
 .site-header {
 
- 	align-items: center;
- 	display: flex;
- 	justify-content: space-between;
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
 
 	& > * {
 		margin-top: 0;
@@ -164,13 +164,13 @@ dt {
 			}
 
 			& > .menu-item-has-children > a::after {
-					border-left: #{0.25 * $spacing_unit} solid transparent;
-					border-right: #{0.25 * $spacing_unit} solid transparent;
-					border-top: #{0.25 * $spacing_unit} solid $color_primary;
-					content: "";
-					margin: 0;
-					margin-left: #{0.25 * $spacing_unit};
-					vertical-align: middle;
+				border-left: #{0.25 * $spacing_unit} solid transparent;
+				border-right: #{0.25 * $spacing_unit} solid transparent;
+				border-top: #{0.25 * $spacing_unit} solid $color_primary;
+				content: "";
+				margin: 0;
+				margin-left: #{0.25 * $spacing_unit};
+				vertical-align: middle;
 			}
 		}
 
@@ -307,9 +307,11 @@ dt {
 // Entry Title
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
+		text-decoration: none;
 
 		&:active,
 		&:focus,
@@ -460,18 +462,30 @@ dt {
 table,
 .wp-block-table {
 	td,
- 	th {
- 		border-color: $color_border;
- 	}
+	th {
+		border-color: $color_border;
+	}
 }
 
 // Posts List
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+//Newspack 'load more' is outside the wrapper.
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 // Font Sizes

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #19744C;
 	text-decoration: underline;

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #145f3e;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #505050;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #19744C;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #145f3e;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #505050;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #19744C;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #145f3e;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #505050;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #145f3e;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3945,8 +4058,10 @@ dt {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
+	text-decoration: none;
 }
 
 .entry-title a:active, .entry-title a:focus, .entry-title a:hover,
@@ -3955,7 +4070,10 @@ dt {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #19744C;
 }
 
@@ -4083,12 +4201,23 @@ table th,
 	border-color: #D0D0D0;
 }
 
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: right;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .is-larger-text,

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #19744C;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -4201,23 +4199,12 @@ table th,
 	border-color: #D0D0D0;
 }
 
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: right;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .is-larger-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #19744C;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -4230,23 +4228,12 @@ table th,
 	border-color: #D0D0D0;
 }
 
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .is-larger-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #19744C;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #145f3e;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #505050;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #145f3e;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3974,8 +4087,10 @@ dt {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
+	text-decoration: none;
 }
 
 .entry-title a:active, .entry-title a:focus, .entry-title a:hover,
@@ -3984,7 +4099,10 @@ dt {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #19744C;
 }
 
@@ -4112,12 +4230,23 @@ table th,
 	border-color: #D0D0D0;
 }
 
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .is-larger-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #145f3e;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #505050;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/barnsbury/sass/_extra-child-theme.scss
+++ b/barnsbury/sass/_extra-child-theme.scss
@@ -58,9 +58,9 @@ a {
 		grid-template-rows: auto;
 		grid-column-gap: $spacing_unit;
 		grid-template-areas:
-			"site-logo site-logo"
-			"site-title social-navigation"
-			"site-description main-navigation";
+				"site-logo site-logo"
+				"site-title social-navigation"
+				"site-description main-navigation";
 
 		&:before,
 		&:after {
@@ -112,7 +112,7 @@ a {
 			}
 
 			& > .menu-item-has-children > a::after {
-					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+				font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 			}
 		}
 
@@ -172,9 +172,9 @@ a {
 .site-main > .page-header,
 .site-main > .not-found > .page-header {
 	margin-top: #{0.666 * $spacing_vertical};
-		@include media(mobile) {
-			margin-top: #{2 * $spacing_vertical};
-		}
+	@include media(mobile) {
+		margin-top: #{2 * $spacing_vertical};
+	}
 }
 
 .site-main > {
@@ -199,7 +199,8 @@ a {
 
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #133a24;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #844d4d;
 	font-size: 0.84746rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.28776rem;
+	letter-spacing: normal;
+	line-height: 1.15;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #20603C;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #133a24;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #844d4d;
+	font-size: 0.84746rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.28776rem;
-	letter-spacing: normal;
-	line-height: 1.15;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #20603C;
 	text-decoration: underline;

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 18px 18px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.28776rem;
+	letter-spacing: normal;
+	line-height: 1.15;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #20603C;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #133a24;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #844d4d;
+	font-size: 0.84746rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #133a24;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3841,7 +3954,8 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3852,7 +3966,10 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #20603C;
 }
 

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.28776rem;
-	letter-spacing: normal;
-	line-height: 1.15;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #20603C;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #133a24;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #844d4d;
 	font-size: 0.84746rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 18px 18px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.28776rem;
+	letter-spacing: normal;
+	line-height: 1.15;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #20603C;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #133a24;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #844d4d;
+	font-size: 0.84746rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #133a24;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3870,7 +3983,8 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3881,7 +3995,10 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #20603C;
 }
 

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.28776rem;
-	letter-spacing: normal;
-	line-height: 1.15;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #20603C;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -89,7 +89,7 @@
 		z-index: 2;
 	}
 
-  @include media(mobile) {
+	@include media(mobile) {
 		padding: #{map-deep-get($config-global, "spacing", "vertical")} #{2* map-deep-get($config-global, "spacing", "horizontal")};
 
 		.main-navigation {
@@ -239,32 +239,33 @@
 	}
 
 	a {
-    color: inherit;
+		color: inherit;
 		text-decoration: none;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: #{map-deep-get($config-global, "color", "primary", "default")};
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
 }
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 
-  a {
-    color: inherit;
+	a {
+		color: inherit;
 		text-decoration: none;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: #{map-deep-get($config-global, "color", "primary", "default")};
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
 }
 
 // Cover & Hero block
@@ -291,9 +292,9 @@ article .entry-header .entry-title,
 
 // Quote block
 .wp-block-quote {
-  p {
-    @include font-family( map-deep-get($config-global, "font", "family", "secondary") );
-  }
+	p {
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+	}
 }
 
 // Table block
@@ -347,30 +348,30 @@ table,
 
 // Pagination
 .pagination {
-  text-align: center;
+	text-align: center;
 
-  .nav-links {
+	.nav-links {
 		& > * {
-	    color: #{map-deep-get($config-global, "color", "foreground", "default")};
+			color: #{map-deep-get($config-global, "color", "foreground", "default")};
 			font-size: #{map-deep-get($config-global, "font", "size", "base")};
 			font-weight: 900;
-	    text-transform: uppercase;
+			text-transform: uppercase;
 
-	    &.current,
-	    &:active,
-	    &:focus,
-	    &:hover {
-	      color: #{map-deep-get($config-global, "color", "primary", "default")};
-	    }
-	  }
+			&.current,
+			&:active,
+			&:focus,
+			&:hover {
+				color: #{map-deep-get($config-global, "color", "primary", "default")};
+			}
+		}
 
 		a {
 			text-decoration: none;
 		}
 
-	  .svg-icon {
-	    display: none;
-	  }
+		.svg-icon {
+			display: none;
+		}
 	}
 }
 
@@ -559,12 +560,12 @@ table,
 
 // Comments Navigation
 .comment-navigation {
-    a {
-    font-size: #{map-deep-get($config-global, "font", "size", "base")};
+	a {
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
 		font-weight: 900;
 		text-decoration: none;
-    text-transform: uppercase;
-  }
+		text-transform: uppercase;
+	}
 }
 
 // Widgets
@@ -573,42 +574,42 @@ table,
 	padding-top: #{map-deep-get($config-global, "spacing", "vertical")};
 	width: 100%;
 
-  .widget-title,
-  .widgettitle {
-  	font-size: #{map-deep-get($config-global, "font", "size", "base")};
-    margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
-    text-transform: uppercase;
+	.widget-title,
+	.widgettitle {
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+		text-transform: uppercase;
 
-    &:empty {
-      display: none;
-    }
-  }
+		&:empty {
+			display: none;
+		}
+	}
 
-  @include media(laptop) {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+	@include media(laptop) {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 
-    & > *:nth-child(2) {
-      margin-top: 0;
-    }
+		& > *:nth-child(2) {
+			margin-top: 0;
+		}
 
-    .widget {
-      width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
-    }
-  }
+		.widget {
+			width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
+		}
+	}
 }
 
 .widget_calendar,
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -626,45 +627,45 @@ table,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "light");
-    list-style: none;
-    margin-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "light");
+		list-style: none;
+		margin-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "light");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "light");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }
 
 .widget_search {
-  input[type="search"] {
-    display: block;
-    margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-    width: 100%;
-  }
+	input[type="search"] {
+		display: block;
+		margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+		width: 100%;
+	}
 }
 
 // Homepage, if first block is full-width

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #252E36;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -294,6 +294,30 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #C04239;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #252E36;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #C04239;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #252E36;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #252E36;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3881,13 +3992,15 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	margin-top: 32px;
 }
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3898,7 +4011,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #C04239;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #C04239;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #252E36;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #252E36;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3910,13 +4021,15 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	margin-top: 32px;
 }
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3927,7 +4040,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #C04239;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #252E36;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/coutoire/sass/_extra-child-theme.scss
+++ b/coutoire/sass/_extra-child-theme.scss
@@ -187,6 +187,19 @@ a.wp-block-file__button {
 	text-transform: uppercase;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	text-transform: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration-color: $color_primary_hover;
+
+	&:hover,
+	&:focus {
+		text-decoration: none;
+	}
+}
+
 @include media(mobile-only) {
 	.site-header {
 		position: relative;

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: black;
 	text-decoration: underline;

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #FF7A5C;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #FF7A5C;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1167,12 +1167,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: black;
 	text-decoration: underline;
@@ -1255,6 +1249,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -211,11 +211,11 @@ input[type="submit"],
 	padding: 11.6px 11.6px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -226,7 +226,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -234,7 +234,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1146,6 +1146,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3839,6 +3952,18 @@ a.wp-block-file__button {
 
 .wp-block-latest-posts > li > a {
 	text-transform: uppercase;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	text-transform: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration-color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
+	text-decoration: none;
 }
 
 @media only screen and (max-width: 559px) {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -211,11 +211,11 @@ input[type="submit"],
 	padding: 11.6px 11.6px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -226,7 +226,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -234,7 +234,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1146,6 +1146,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3868,6 +3981,18 @@ a.wp-block-file__button {
 
 .wp-block-latest-posts > li > a {
 	text-transform: uppercase;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	text-transform: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration-color: #FF7A5C;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
+	text-decoration: none;
 }
 
 @media only screen and (max-width: 559px) {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1176,6 +1176,12 @@ object {
 	color: #FF7A5C;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1199,6 +1205,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1253,10 +1275,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1167,12 +1167,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: black;
 	text-decoration: underline;
@@ -1255,6 +1249,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/dalston/sass/_extra-child-theme.scss
+++ b/dalston/sass/_extra-child-theme.scss
@@ -52,9 +52,9 @@ a {
 		grid-auto-flow: row;
 		grid-column-gap: $spacing_unit;
 		grid-template-areas:
-			"site-branding site-branding"
-			"site-description site-description"
-			"main-navigation social-navigation";
+				"site-branding site-branding"
+				"site-description site-description"
+				"main-navigation social-navigation";
 
 		&:before,
 		&:after {
@@ -107,7 +107,7 @@ a {
 				}
 
 				& > .menu-item-has-children > a::after {
-						font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 				}
 			}
 
@@ -179,8 +179,8 @@ a {
 		grid-auto-flow: row;
 		grid-column-gap: #{2 * $spacing_unit};
 		grid-template-areas:
-			". main-navigation social-navigation"
-			"site-branding site-description social-navigation";
+				". main-navigation social-navigation"
+				"site-branding site-description social-navigation";
 
 	}
 }
@@ -246,6 +246,10 @@ a {
 .entry-title {
 	font-size: map-deep-get($config-global, "font", "size", "xxxxl");
 	font-weight: 600;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #005177;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.2;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #0073AA;
 	text-decoration: underline;

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.2;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #0073AA;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #005177;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.86957rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.2;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0073AA;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #005177;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #005177;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3876,6 +3989,10 @@ a {
 .entry-title {
 	font-size: 2.31306rem;
 	font-weight: 600;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.2;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #0073AA;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.2;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0073AA;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #005177;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #005177;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3905,6 +4018,10 @@ a {
 .entry-title {
 	font-size: 2.31306rem;
 	font-weight: 600;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.2;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #0073AA;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #005177;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/exford/sass/_extra-child-theme.scss
+++ b/exford/sass/_extra-child-theme.scss
@@ -111,15 +111,16 @@ a {
 
 .site-main > article > .entry-header {
 	margin-top: #{0.666 * $spacing_vertical};
-		@include media(mobile) {
-			margin-top: $spacing_vertical;
-		}
+	@include media(mobile) {
+		margin-top: $spacing_vertical;
+	}
 }
 
 // Entry Title Link
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;
@@ -185,12 +186,24 @@ a {
  * Blocks
  */
 // Posts List
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+//Newspack 'load more' is outside the wrapper.
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 // Cover

--- a/exford/sass/_extra-child-theme.scss
+++ b/exford/sass/_extra-child-theme.scss
@@ -186,24 +186,12 @@ a {
  * Blocks
  */
 // Posts List
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-//Newspack 'load more' is outside the wrapper.
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 // Cover

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -303,12 +303,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #23883D;
 	text-decoration: underline;

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #195f2b;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #6E6E6E;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -295,6 +295,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #23883D;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #195f2b;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #6E6E6E;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #23883D;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #195f2b;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #6E6E6E;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #195f2b;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3777,7 +3890,8 @@ p:not(.site-title) a:hover {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3788,7 +3902,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #23883D;
 }
 
@@ -3838,12 +3955,23 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: right;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .wp-block-cover h1,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #23883D;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -3955,23 +3953,12 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: right;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .wp-block-cover h1,

--- a/exford/style.css
+++ b/exford/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #23883D;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #195f2b;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #6E6E6E;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #195f2b;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3806,7 +3919,8 @@ p:not(.site-title) a:hover {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3817,7 +3931,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #23883D;
 }
 
@@ -3867,12 +3984,23 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .wp-block-cover h1,

--- a/exford/style.css
+++ b/exford/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #195f2b;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #6E6E6E;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/exford/style.css
+++ b/exford/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #23883D;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -3984,23 +3982,12 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .wp-block-cover h1,

--- a/hever/sass/_extra-child-theme.scss
+++ b/hever/sass/_extra-child-theme.scss
@@ -22,14 +22,14 @@ a {
 /**
  * Wide Header & Footer
  */
-body:not(.fse-enabled) { 
+body:not(.fse-enabled) {
 	#masthead,
 	#colophon {
 		padding-left: 16px;
 		padding-right: 16px;
 		position: relative;
 		@extend %responsive-alignwide;
-	
+
 		@include media(mobile) {
 			padding-left: 0;
 			padding-right: 0;
@@ -67,9 +67,9 @@ body:not(.fse-enabled) {
 		grid-template-rows: auto;
 		grid-column-gap: #{map-deep-get($config-global, "spacing", "unit")};
 		grid-template-areas:
-			"site-logo site-logo"
-			"site-title main-navigation"
-			"site-description social-navigation";
+				"site-logo site-logo"
+				"site-title main-navigation"
+				"site-description social-navigation";
 
 		&:before,
 		&:after {
@@ -120,7 +120,7 @@ body:not(.fse-enabled) {
 				}
 
 				& > .menu-item-has-children > a::after {
-						font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 				}
 			}
 
@@ -245,7 +245,7 @@ table,
  * Hentry
  */
 // Entry Title
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	text-align: center;
 
@@ -283,17 +283,18 @@ table,
 // Entry Title Link
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
-  a {
-    color: inherit;
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	a {
+		color: inherit;
 		text-decoration: none;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: #{map-deep-get($config-global, "color", "primary", "default")};
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
 }
 
 // Remove margin if alignfull is first element
@@ -354,15 +355,15 @@ article .entry-header .entry-title,
 
 	.widget-title,
 	.widgettitle {
-  	font-size: #{map-deep-get($config-global, "font", "size", "md")};
-    margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+		font-size: #{map-deep-get($config-global, "font", "size", "md")};
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
 
-    &:empty {
-      display: none;
-    }
-  }
+		&:empty {
+			display: none;
+		}
+	}
 
-  @include media(laptop) {
+	@include media(laptop) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -372,9 +373,9 @@ article .entry-header .entry-title,
 		}
 
 		& > *:nth-child(2) {
-      margin-top: 0;
-    }
-  }
+			margin-top: 0;
+		}
+	}
 
 	@include media(desktop) {
 		.widget {
@@ -382,21 +383,21 @@ article .entry-header .entry-title,
 		}
 
 		& > *:nth-child(3) {
-      margin-top: 0;
-    }
-  }
+			margin-top: 0;
+		}
+	}
 }
 
 .widget_calendar,
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -414,43 +415,43 @@ article .entry-header .entry-title,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
-    list-style: none;
-    padding-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
+		list-style: none;
+		padding-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }
 
 .widget_search {
-  input[type="search"] {
-    display: block;
-    margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-    width: 100%;
-  }
+	input[type="search"] {
+		display: block;
+		margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+		width: 100%;
+	}
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -295,6 +295,30 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #1279BE;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #1279BE;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3437,7 +3548,7 @@ body:not(.fse-enabled) #colophon {
 	}
 }
 
-.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 .page-title:before,
 .page-title:after {
 	margin-right: -16px;
@@ -3448,7 +3559,7 @@ body:not(.fse-enabled) #colophon {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+	.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 	.page-title:before,
 	.page-title:after {
 		margin-right: inherit;
@@ -3897,12 +4008,12 @@ table th,
 /**
  * Hentry
  */
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	text-align: center;
 }
 
-.singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+.singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 .page-title:before,
 .page-title:after {
 	background: #F8F8F8;
@@ -3913,20 +4024,20 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+	.singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 	.page-title:before,
 	.page-title:after {
 		margin-bottom: 64px;
 	}
 }
 
-.singular .hentry .entry-title:after,
+.singular .hentry .entry-header .entry-title:after,
 .page-title:after {
 	margin-top: 16px;
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title:after,
+	.singular .hentry .entry-header .entry-title:after,
 	.page-title:after {
 		margin-top: 64px;
 	}
@@ -3938,7 +4049,8 @@ table th,
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3949,7 +4061,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #1279BE;
 }
 

--- a/hever/style.css
+++ b/hever/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #1279BE;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3454,7 +3565,7 @@ body:not(.fse-enabled) #colophon {
 	}
 }
 
-.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 .page-title:before,
 .page-title:after {
 	margin-left: -16px;
@@ -3465,7 +3576,7 @@ body:not(.fse-enabled) #colophon {
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+	.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery, .singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 	.page-title:before,
 	.page-title:after {
 		margin-left: inherit;
@@ -3926,12 +4037,12 @@ table th,
 /**
  * Hentry
  */
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	text-align: center;
 }
 
-.singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+.singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 .page-title:before,
 .page-title:after {
 	background: #F8F8F8;
@@ -3942,20 +4053,20 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title:before, .singular .hentry .entry-title:after,
+	.singular .hentry .entry-header .entry-title:before, .singular .hentry .entry-header .entry-title:after,
 	.page-title:before,
 	.page-title:after {
 		margin-bottom: 64px;
 	}
 }
 
-.singular .hentry .entry-title:after,
+.singular .hentry .entry-header .entry-title:after,
 .page-title:after {
 	margin-top: 16px;
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title:after,
+	.singular .hentry .entry-header .entry-title:after,
 	.page-title:after {
 		margin-top: 64px;
 	}
@@ -3967,7 +4078,8 @@ table th,
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3978,7 +4090,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #1279BE;
 }
 

--- a/hever/style.css
+++ b/hever/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/leven/sass/_extra-child-theme.scss
+++ b/leven/sass/_extra-child-theme.scss
@@ -67,9 +67,9 @@ a {
 		grid-template-rows: auto;
 		grid-column-gap: #{map-deep-get($config-global, "spacing", "unit")};
 		grid-template-areas:
-			"site-logo site-logo"
-			"site-branding main-navigation"
-			"site-branding social-navigation";
+				"site-logo site-logo"
+				"site-branding main-navigation"
+				"site-branding social-navigation";
 
 		&:before,
 		&:after {
@@ -112,4 +112,8 @@ a {
 			}
 		}
 	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #1285ce;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.82474rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -294,6 +294,30 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #ff302c;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #1285ce;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.82474rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #ff302c;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #1285ce;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.82474rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #1285ce;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3760,4 +3871,8 @@ p:not(.site-title) a:hover {
 	.site-header .social-navigation > div > ul {
 		justify-content: flex-end;
 	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #ff302c;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #1285ce;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.82474rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #1285ce;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3789,4 +3900,8 @@ p:not(.site-title) a:hover {
 	.site-header .social-navigation > div > ul {
 		justify-content: flex-end;
 	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #1285ce;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.82474rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/mayland/sass/_extra-child-theme.scss
+++ b/mayland/sass/_extra-child-theme.scss
@@ -108,9 +108,9 @@ a {
 .site-main > .page-header,
 .site-main > .not-found > .page-header {
 	margin-top: #{0.666 * $spacing_vertical};
-		@include media(mobile) {
-			margin-top: #{2 * $spacing_vertical};
-		}
+	@include media(mobile) {
+		margin-top: #{2 * $spacing_vertical};
+	}
 }
 
 .site-main > {
@@ -132,7 +132,8 @@ a {
 // Entry Title Link
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: -0.015em;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #666666;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: -0.015em;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: black;
 	text-decoration: underline;

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #666666;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: -0.015em;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: black;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: -0.015em;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #666666;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #666666;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3777,7 +3890,8 @@ strong {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3788,7 +3902,10 @@ strong {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: black;
 }
 

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #666666;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: -0.015em;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #666666;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #666666;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3806,7 +3919,8 @@ strong {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3817,7 +3931,10 @@ strong {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: black;
 }
 

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: -0.015em;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: black;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -203,30 +203,17 @@ a {
  * Blocks
  */
 // Posts List
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list-item__title {
 	font-weight: 300;
 	font-size: map-deep-get($config-global, "font", "size", "xxl");
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-//Newspack 'load more' is outside the wrapper.
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 // Cover

--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -116,9 +116,9 @@ a {
 
 .site-main > article > .entry-header {
 	margin-top: #{0.666 * $spacing_vertical};
-		@include media(mobile) {
-			margin-top: $spacing_vertical;
-		}
+	@include media(mobile) {
+		margin-top: $spacing_vertical;
+	}
 }
 
 // Entry Title
@@ -137,7 +137,8 @@ a {
 // Entry Title Link
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;
@@ -202,17 +203,30 @@ a {
  * Blocks
  */
 // Posts List
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title {
+.a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	font-weight: 300;
 	font-size: map-deep-get($config-global, "font", "size", "xxl");
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+//Newspack 'load more' is outside the wrapper.
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 // Cover

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #685636;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #686868;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -295,6 +295,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #897248;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #685636;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #686868;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -303,12 +303,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #897248;
 	text-decoration: underline;

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #897248;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #686868;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3795,7 +3908,8 @@ p:not(.site-title) a:hover {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3806,7 +3920,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #897248;
 }
 
@@ -3856,17 +3973,29 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title {
+.a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	font-weight: 300;
 	font-size: 2.0736rem;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: right;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .wp-block-cover p,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #897248;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -3973,29 +3971,17 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list-item__title {
 	font-weight: 300;
 	font-size: 2.0736rem;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: right;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .wp-block-cover p,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #685636;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #686868;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #897248;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #686868;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3824,7 +3937,8 @@ p:not(.site-title) a:hover {
 
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3835,7 +3949,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #897248;
 }
 
@@ -3885,17 +4002,29 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title {
+.a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	font-weight: 300;
 	font-size: 2.0736rem;
 }
 
-.a8c-posts-list-item__excerpt {
+.a8c-posts-list-item__excerpt,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 .wp-block-cover p,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #897248;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -4002,29 +4000,17 @@ p:not(.site-title) a:hover {
 /**
  * Blocks
  */
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list-item__title {
 	font-weight: 300;
 	font-size: 2.0736rem;
 }
 
-.a8c-posts-list-item__excerpt,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 .wp-block-cover p,

--- a/morden/sass/_extra-child-theme.scss
+++ b/morden/sass/_extra-child-theme.scss
@@ -101,9 +101,9 @@ body {
 		grid-template-rows: auto;
 		grid-column-gap: #{map-deep-get($config-global, "spacing", "unit")};
 		grid-template-areas:
-			"site-logo site-logo"
-			"site-title main-navigation"
-			"site-description social-navigation";
+				"site-logo site-logo"
+				"site-title main-navigation"
+				"site-description social-navigation";
 
 		&:before,
 		&:after {
@@ -144,7 +144,7 @@ body {
 				justify-content: flex-end;
 
 				& > .menu-item-has-children > a::after {
-						font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 				}
 			}
 
@@ -282,7 +282,7 @@ table,
  * Hentry
  */
 // Entry Title
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	background: #{map-deep-get($config-global, "color", "background", "light")};
 	margin-top: -#{0.5 * map-deep-get($config-global, "spacing", "vertical")};
@@ -317,17 +317,18 @@ table,
 // Entry Title Link
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
-  a {
-    color: inherit;
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	a {
+		color: inherit;
 		text-decoration: none;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: #{map-deep-get($config-global, "color", "primary", "default")};
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
 }
 
 // Remove margin if alignfull is first element
@@ -388,15 +389,15 @@ article .entry-header .entry-title,
 
 	.widget-title,
 	.widgettitle {
-  	font-size: #{map-deep-get($config-global, "font", "size", "md")};
-    margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+		font-size: #{map-deep-get($config-global, "font", "size", "md")};
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
 
-    &:empty {
-      display: none;
-    }
-  }
+		&:empty {
+			display: none;
+		}
+	}
 
-  @include media(laptop) {
+	@include media(laptop) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -406,9 +407,9 @@ article .entry-header .entry-title,
 		}
 
 		& > *:nth-child(2) {
-      margin-top: 0;
-    }
-  }
+			margin-top: 0;
+		}
+	}
 
 	@include media(desktop) {
 		.widget {
@@ -416,21 +417,21 @@ article .entry-header .entry-title,
 		}
 
 		& > *:nth-child(3) {
-      margin-top: 0;
-    }
-  }
+			margin-top: 0;
+		}
+	}
 }
 
 .widget_calendar,
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -448,43 +449,43 @@ article .entry-header .entry-title,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
-    list-style: none;
-    padding-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
+		list-style: none;
+		padding-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }
 
 .widget_search {
-  input[type="search"] {
-    display: block;
-    margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-    width: 100%;
-  }
+	input[type="search"] {
+		display: block;
+		margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+		width: 100%;
+	}
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -303,12 +303,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #CD2220;
 	text-decoration: underline;

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -295,6 +295,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #CD2220;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CD2220;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3926,7 +4039,7 @@ table th,
 /**
  * Hentry
  */
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	background: #F8F8F8;
 	margin-top: -16px;
@@ -3936,7 +4049,7 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title,
+	.singular .hentry .entry-header .entry-title,
 	.page-title {
 		margin-bottom: 64px;
 		margin-top: -64px;
@@ -3959,7 +4072,8 @@ table th,
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3970,7 +4084,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CD2220;
 }
 

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #CD2220;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/morden/style.css
+++ b/morden/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.01136rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CD2220;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.86957rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #303030;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3955,7 +4068,7 @@ table th,
 /**
  * Hentry
  */
-.singular .hentry .entry-title,
+.singular .hentry .entry-header .entry-title,
 .page-title {
 	background: #F8F8F8;
 	margin-top: -16px;
@@ -3965,7 +4078,7 @@ table th,
 }
 
 @media only screen and (min-width: 560px) {
-	.singular .hentry .entry-title,
+	.singular .hentry .entry-header .entry-title,
 	.page-title {
 		margin-bottom: 64px;
 		margin-top: -64px;
@@ -3988,7 +4101,8 @@ table th,
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3999,7 +4113,10 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CD2220;
 }
 

--- a/morden/style.css
+++ b/morden/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.01136rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #CD2220;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/morden/style.css
+++ b/morden/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/redhill/sass/_extra-child-theme.scss
+++ b/redhill/sass/_extra-child-theme.scss
@@ -31,17 +31,17 @@ a {
 
 	&:before {
 		border-top: 1px solid rgba(#fff, 0.5);
-    content: "";
-    left: 0;
-    position: absolute;
-    top: -5px;
-    width: 100%;
+		content: "";
+		left: 0;
+		position: absolute;
+		top: -5px;
+		width: 100%;
 	}
 }
 
 // Header
 #masthead {
-  padding-top: map-deep-get($config-global, "spacing", "vertical");
+	padding-top: map-deep-get($config-global, "spacing", "vertical");
 
 	.custom-logo-link {
 		display: inline-block;
@@ -175,7 +175,7 @@ a {
 		}
 
 		& > div > ul > .menu-item-has-children > a::after {
-				opacity: 0.67;
+			opacity: 0.67;
 		}
 	}
 }
@@ -240,9 +240,9 @@ a {
 
 // Quote block
 .wp-block-quote {
-  p {
-    @include font-family( map-deep-get($config-global, "font", "family", "primary") );
-  }
+	p {
+		@include font-family( map-deep-get($config-global, "font", "family", "primary") );
+	}
 }
 
 // Table block
@@ -275,20 +275,36 @@ table,
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list-item__title {
+.a8c-posts-list-item__title  {
 	@include font-family( map-deep-get($config-global, "font", "family", "primary") );
 	font-size: #{map-deep-get($config-global, "font", "size", "xxxl")};
 	margin-bottom: #{1.5 * map-deep-get($config-global, "spacing", "vertical")};
 
-  a {
-    color: inherit;
+	a {
+		color: inherit;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: #{map-deep-get($config-global, "color", "primary", "default")};
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	@include font-family( map-deep-get($config-global, "font", "family", "primary") );
+	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+
+	a {
+		color: inherit;
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
 }
 
 .entry-content {
@@ -297,27 +313,27 @@ article .entry-header .entry-title,
 
 // Pagination
 .pagination {
-  text-align: center;
+	text-align: center;
 
-  .nav-links > * {
-    color: map-deep-get($config-global, "color", "foreground", "light");
-    @include font-family( map-deep-get($config-global, "font", "family", "secondary") );
-    font-size: #{map-deep-get($config-global, "font", "size", "base")};
-    text-transform: uppercase;
+	.nav-links > * {
+		color: map-deep-get($config-global, "color", "foreground", "light");
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
+		text-transform: uppercase;
 
-    &.current,
-    &:active,
-    &:focus,
-    &:hover {
-      color: map-deep-get($config-global, "color", "primary", "default");
-    }
-  }
+		&.current,
+		&:active,
+		&:focus,
+		&:hover {
+			color: map-deep-get($config-global, "color", "primary", "default");
+		}
+	}
 
-  svg {
-    fill: currentColor;
-  }
+	svg {
+		fill: currentColor;
+	}
 
-  &:before {
+	&:before {
 		background: map-deep-get($config-global, "color", "border", "default");;
 		height: 1px;
 		content: "";
@@ -409,87 +425,87 @@ article .entry-header .entry-title,
 }
 
 .comment-meta {
-  .comment-metadata {
-    color: map-deep-get($config-global, "color", "foreground", "light");
-    @include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+	.comment-metadata {
+		color: map-deep-get($config-global, "color", "foreground", "light");
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
 
-    a {
-      color: inherit;
-    }
+		a {
+			color: inherit;
+		}
 
-    a:active,
-    a:focus,
-    a:hover {
-      color: map-deep-get($config-global, "color", "primary", "default");
-    }
-  }
+		a:active,
+		a:focus,
+		a:hover {
+			color: map-deep-get($config-global, "color", "primary", "default");
+		}
+	}
 }
 
 // Comments Navigation
 .comment-navigation {
-    a {
-    color: map-deep-get($config-global, "color", "foreground", "light");
-    @include font-family( map-deep-get($config-global, "font", "family", "secondary") );
-    font-size: #{map-deep-get($config-global, "font", "size", "sm")};
-    text-transform: uppercase;
+	a {
+		color: map-deep-get($config-global, "color", "foreground", "light");
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+		text-transform: uppercase;
 
-    &:active,
-    &:focus,
-    &:hover {
-      color: map-deep-get($config-global, "color", "primary", "default");
-    }
-  }
+		&:active,
+		&:focus,
+		&:hover {
+			color: map-deep-get($config-global, "color", "primary", "default");
+		}
+	}
 
-  .comments-title + & {
-    display: none;
-  }
+	.comments-title + & {
+		display: none;
+	}
 }
 
 // Widgets
 .widget-area {
-  font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+	font-size: #{map-deep-get($config-global, "font", "size", "sm")};
 
-  .widget-title,
-  .widgettitle {
-    @include font-family( map-deep-get($config-global, "font", "family", "secondary") );
-    font-size: #{map-deep-get($config-global, "font", "size", "base")};
-    margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
-    text-transform: uppercase;
+	.widget-title,
+	.widgettitle {
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+		text-transform: uppercase;
 
-    &:empty {
-      display: none;
-    }
-  }
+		&:empty {
+			display: none;
+		}
+	}
 
-  @include media(mobile) {
-    padding-top: map-deep-get($config-global, "spacing", "vertical");
-  }
+	@include media(mobile) {
+		padding-top: map-deep-get($config-global, "spacing", "vertical");
+	}
 
-  @include media(laptop) {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+	@include media(laptop) {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 
-    & > *:nth-child(2) {
-      margin-top: 0;
-    }
+		& > *:nth-child(2) {
+			margin-top: 0;
+		}
 
-    .widget {
-      width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
-    }
-  }
+		.widget {
+			width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
+		}
+	}
 }
 
 .widget_calendar,
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -507,43 +523,43 @@ article .entry-header .entry-title,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "light");
-    list-style: none;
-    padding-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "light");
+		list-style: none;
+		padding-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "light");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "light");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }
 
 .widget_search {
-  input[type="search"] {
-    display: block;
-    margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-    width: 100%;
-  }
+	input[type="search"] {
+		display: block;
+		margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+		width: 100%;
+	}
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -306,6 +306,30 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #CA2017;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #222222;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -307,7 +307,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -323,11 +323,33 @@ object {
 	color: #222222;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CA2017;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #222222;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #222222;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3941,6 +4052,21 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .a8c-posts-list-item__title a:active,
 .a8c-posts-list-item__title a:focus,
 .a8c-posts-list-item__title a:hover {
+	color: #CA2017;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
+	margin-top: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CA2017;
 }
 

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #222222;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CA2017;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #222222;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #666666;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #222222;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3970,6 +4081,21 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .a8c-posts-list-item__title a:active,
 .a8c-posts-list-item__title a:focus,
 .a8c-posts-list-item__title a:hover {
+	color: #CA2017;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
+	margin-top: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CA2017;
 }
 

--- a/rivington/sass/_extra-child-theme.scss
+++ b/rivington/sass/_extra-child-theme.scss
@@ -60,7 +60,7 @@ a {
 		grid-template-rows: auto;
 		grid-column-gap: #{map-deep-get($config-global, "spacing", "unit")};
 		grid-template-areas:
-			"site-branding main-navigation";
+				"site-branding main-navigation";
 
 		&:before,
 		&:after {
@@ -166,9 +166,9 @@ a {
 .site-main > .page-header,
 .site-main > .not-found > .page-header {
 	margin-top: #{0.666 * $spacing_vertical};
-		@include media(mobile) {
-			margin-top: #{2 * $spacing_vertical};
-		}
+	@include media(mobile) {
+		margin-top: #{2 * $spacing_vertical};
+	}
 }
 
 /**
@@ -178,7 +178,8 @@ a {
 // Entry Title Link
 .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title {
+.a8c-posts-list .a8c-posts-list-item__title,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #b59439;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: white;
 	font-size: 0.8rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 1.95312rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #CAAB57;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #b59439;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: white;
+	font-size: 0.8rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 1.95312rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #CAAB57;
 	text-decoration: underline;

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.195em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.95312rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CAAB57;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #b59439;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: white;
+	font-size: 0.8rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #b59439;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -3935,7 +3935,8 @@ p:not(.site-title) a:hover {
  */
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3946,7 +3947,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CAAB57;
 }
 

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.95312rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #CAAB57;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.195em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.95312rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CAAB57;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #b59439;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: white;
+	font-size: 0.8rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #b59439;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3851,7 +3964,8 @@ p:not(.site-title) a:hover {
  */
 .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a {
+.a8c-posts-list .a8c-posts-list-item__title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -3862,7 +3976,10 @@ p:not(.site-title) a:hover {
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #CAAB57;
 }
 

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #b59439;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: white;
 	font-size: 0.8rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.95312rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #CAAB57;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -272,8 +272,7 @@ a {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__featured {
 	text-align: center;
 }
 
@@ -375,13 +374,11 @@ table,
 }
 
 // Blog Posts Listing
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list__item,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list__item {
 	margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
 	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 
@@ -395,16 +392,7 @@ table,
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-.a8c-posts-list__listing,
-.wp-block-newspack-blocks-homepage-articles article p {
+.a8c-posts-list__listing {
 	text-align: left;
 
 	&:not(:last-child) {
@@ -416,10 +404,31 @@ table,
 	}
 }
 
-//Newspack 'load more' is outside the wrapper.
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
+/**
+ * Blog Posts (Newspack)
+ */
+.wp-block-newspack-blocks-homepage-articles article {
+	margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+
+	@include media(mobile) {
+		margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+		margin-top: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article p {
+	&:not(:last-child) {
+		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+
+		@include media(mobile) {
+			margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
 }
 
 /**

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -108,7 +108,7 @@ a {
 	margin: 0;
 	text-align: right;
 
- 	> div {
+	> div {
 		background: #{map-deep-get($config-global, "color", "foreground", "dark")};
 		border-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} solid #{map-deep-get($config-global, "color", "foreground", "dark")};
 		box-shadow: inset 0 1px 0 0 #{map-deep-get($config-global, "color", "primary", "default")};
@@ -132,7 +132,7 @@ a {
 			justify-content: flex-end;
 
 			& > .menu-item-has-children > a::after {
-					font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
+				font-size: #{0.5 * map-deep-get($config-global, "font", "size", "base")};
 			}
 
 			.sub-menu .menu-item a {
@@ -272,7 +272,8 @@ a {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured {
+.a8c-posts-list .a8c-posts-list-item__featured,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	text-align: center;
 }
 
@@ -374,11 +375,13 @@ table,
 }
 
 // Blog Posts Listing
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list__item {
+.a8c-posts-list__item,
+.wp-block-newspack-blocks-homepage-articles article {
 	margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
 	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 
@@ -392,7 +395,16 @@ table,
 	}
 }
 
-.a8c-posts-list__listing {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+.a8c-posts-list__listing,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
 
 	&:not(:last-child) {
@@ -402,6 +414,12 @@ table,
 			margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
 		}
 	}
+}
+
+//Newspack 'load more' is outside the wrapper.
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 /**
@@ -419,9 +437,9 @@ table,
 
 .comment-body {
 	content: "";
-  display: table;
-  table-layout: fixed;
-  width: 100%;
+	display: table;
+	table-layout: fixed;
+	width: 100%;
 }
 
 .comment-meta .comment-metadata {
@@ -465,7 +483,7 @@ table,
 
 			.avatar,
 			.fn {
-		    display: block;
+				display: block;
 				margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
 			}
 		}
@@ -504,43 +522,43 @@ table,
 		@extend %responsive-alignfull;
 	}
 
-  .widget-title,
-  .widgettitle {
-    font-size: #{map-deep-get($config-global, "font", "size", "base")};
-    @include font-family( map-deep-get($config-global, "font", "family", "ui") );
-    margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+	.widget-title,
+	.widgettitle {
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
+		@include font-family( map-deep-get($config-global, "font", "family", "ui") );
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
 
-    &:empty {
-      display: none;
-    }
-  }
+		&:empty {
+			display: none;
+		}
+	}
 
-  @include media(laptop) {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+	@include media(laptop) {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
 
-    & > *:nth-child(2) {
-      margin-top: 0;
-    }
+		& > *:nth-child(2) {
+			margin-top: 0;
+		}
 
-    .widget {
-      width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
-    }
-  }
+		.widget {
+			width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
+		}
+	}
 }
 
 // Widgets
 .widget_calendar,
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -558,45 +576,45 @@ table,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
-    list-style: none;
-    padding-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
+		list-style: none;
+		padding-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }
 
 .widget_search {
-  input[type="search"] {
-    display: block;
-    margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-    width: 100%;
-  }
+	input[type="search"] {
+		display: block;
+		margin-bottom: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+		width: 100%;
+	}
 }
 
 /**

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #444444;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #757575;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #222222;
 	text-decoration: underline;

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #444444;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #222222;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -4044,8 +4042,7 @@ p:not(.site-title) a:hover {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__featured {
 	text-align: center;
 }
 
@@ -4133,58 +4130,67 @@ table th,
 	border-color: #E0E0E0;
 }
 
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list__item,
+.a8c-posts-list__item {
+	margin-bottom: 32px;
+	margin-top: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-posts-list__item {
+		margin-bottom: 64px;
+		margin-top: 64px;
+	}
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta {
+	text-align: center;
+}
+
+.a8c-posts-list__listing {
+	text-align: right;
+}
+
+.a8c-posts-list__listing:not(:last-child) {
+	margin-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-posts-list__listing:not(:last-child) {
+		margin-bottom: 64px;
+	}
+}
+
+/**
+ * Blog Posts (Newspack)
+ */
 .wp-block-newspack-blocks-homepage-articles article {
 	margin-bottom: 32px;
 	margin-top: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__item,
 	.wp-block-newspack-blocks-homepage-articles article {
 		margin-bottom: 64px;
 		margin-top: 64px;
 	}
 }
 
-.a8c-posts-list__item .a8c-posts-list-item__meta,
-.wp-block-newspack-blocks-homepage-articles article .a8c-posts-list-item__meta {
-	text-align: center;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-.a8c-posts-list__listing,
-.wp-block-newspack-blocks-homepage-articles article p {
-	text-align: right;
-}
-
-.a8c-posts-list__listing:not(:last-child),
 .wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__listing:not(:last-child),
 	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 		margin-bottom: 64px;
 	}
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 /**

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 20px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #444444;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #444444;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3931,7 +4044,8 @@ p:not(.site-title) a:hover {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured {
+.a8c-posts-list .a8c-posts-list-item__featured,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	text-align: center;
 }
 
@@ -4019,38 +4133,58 @@ table th,
 	border-color: #E0E0E0;
 }
 
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list__item {
+.a8c-posts-list__item,
+.wp-block-newspack-blocks-homepage-articles article {
 	margin-bottom: 32px;
 	margin-top: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__item {
+	.a8c-posts-list__item,
+	.wp-block-newspack-blocks-homepage-articles article {
 		margin-bottom: 64px;
 		margin-top: 64px;
 	}
 }
 
-.a8c-posts-list__item .a8c-posts-list-item__meta {
+.a8c-posts-list__item .a8c-posts-list-item__meta,
+.wp-block-newspack-blocks-homepage-articles article .a8c-posts-list-item__meta {
 	text-align: center;
 }
 
-.a8c-posts-list__listing {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+.a8c-posts-list__listing,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: right;
 }
 
-.a8c-posts-list__listing:not(:last-child) {
+.a8c-posts-list__listing:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__listing:not(:last-child) {
+	.a8c-posts-list__listing:not(:last-child),
+	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 		margin-bottom: 64px;
 	}
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #222222;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -4073,8 +4071,7 @@ p:not(.site-title) a:hover {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__featured {
 	text-align: center;
 }
 
@@ -4162,58 +4159,67 @@ table th,
 	border-color: #E0E0E0;
 }
 
-.a8c-posts-list,
-.wp-block-newspack-blocks-homepage-articles article {
+.a8c-posts-list {
 	text-align: center;
 }
 
-.a8c-posts-list__item,
+.a8c-posts-list__item {
+	margin-bottom: 32px;
+	margin-top: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-posts-list__item {
+		margin-bottom: 64px;
+		margin-top: 64px;
+	}
+}
+
+.a8c-posts-list__item .a8c-posts-list-item__meta {
+	text-align: center;
+}
+
+.a8c-posts-list__listing {
+	text-align: left;
+}
+
+.a8c-posts-list__listing:not(:last-child) {
+	margin-bottom: 32px;
+}
+
+@media only screen and (min-width: 560px) {
+	.a8c-posts-list__listing:not(:last-child) {
+		margin-bottom: 64px;
+	}
+}
+
+/**
+ * Blog Posts (Newspack)
+ */
 .wp-block-newspack-blocks-homepage-articles article {
 	margin-bottom: 32px;
 	margin-top: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__item,
 	.wp-block-newspack-blocks-homepage-articles article {
 		margin-bottom: 64px;
 		margin-top: 64px;
 	}
 }
 
-.a8c-posts-list__item .a8c-posts-list-item__meta,
-.wp-block-newspack-blocks-homepage-articles article .a8c-posts-list-item__meta {
-	text-align: center;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-.a8c-posts-list__listing,
-.wp-block-newspack-blocks-homepage-articles article p {
-	text-align: left;
-}
-
-.a8c-posts-list__listing:not(:last-child),
 .wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__listing:not(:last-child),
 	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 		margin-bottom: 64px;
 	}
-}
-
-button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #444444;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 20px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #444444;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #757575;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #444444;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3960,7 +4073,8 @@ p:not(.site-title) a:hover {
 .entry-header,
 .page-title,
 .a8c-posts-list-item__title,
-.a8c-posts-list .a8c-posts-list-item__featured {
+.a8c-posts-list .a8c-posts-list-item__featured,
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	text-align: center;
 }
 
@@ -4048,38 +4162,58 @@ table th,
 	border-color: #E0E0E0;
 }
 
-.a8c-posts-list {
+.a8c-posts-list,
+.wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-.a8c-posts-list__item {
+.a8c-posts-list__item,
+.wp-block-newspack-blocks-homepage-articles article {
 	margin-bottom: 32px;
 	margin-top: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__item {
+	.a8c-posts-list__item,
+	.wp-block-newspack-blocks-homepage-articles article {
 		margin-bottom: 64px;
 		margin-top: 64px;
 	}
 }
 
-.a8c-posts-list__item .a8c-posts-list-item__meta {
+.a8c-posts-list__item .a8c-posts-list-item__meta,
+.wp-block-newspack-blocks-homepage-articles article .a8c-posts-list-item__meta {
 	text-align: center;
 }
 
-.a8c-posts-list__listing {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+.a8c-posts-list__listing,
+.wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
 }
 
-.a8c-posts-list__listing:not(:last-child) {
+.a8c-posts-list__listing:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 	margin-bottom: 32px;
 }
 
 @media only screen and (min-width: 560px) {
-	.a8c-posts-list__listing:not(:last-child) {
+	.a8c-posts-list__listing:not(:last-child),
+	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
 		margin-bottom: 64px;
 	}
+}
+
+button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 /**

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -148,8 +148,7 @@ hr.wp-block-separator.is-style-wide,
 	.entry-header,
 	.page-header,
 	.entry-footer,
-	.a8c-posts-list,
-	.wp-block-newspack-blocks-homepage-articles article {
+	.a8c-posts-list {
 		text-align: center;
 	}
 
@@ -166,19 +165,8 @@ hr.wp-block-separator.is-style-wide,
 		}
 	}
 
-	.a8c-posts-list-item__excerpt,
-	.wp-block-newspack-blocks-homepage-articles article p {
+	.a8c-posts-list-item__excerpt {
 		text-align: left;
-	}
-
-	.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-		display: block;
-	}
-
-	//Newspack 'load more' is outside the wrapper.
-	button[data-load-more-btn] {
-		display: flex;
-		margin: 0 auto;
 	}
 }
 

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -148,12 +148,37 @@ hr.wp-block-separator.is-style-wide,
 	.entry-header,
 	.page-header,
 	.entry-footer,
-	.a8c-posts-list {
+	.a8c-posts-list,
+	.wp-block-newspack-blocks-homepage-articles article {
 		text-align: center;
 	}
 
-	.a8c-posts-list-item__excerpt {
+	.wp-block-newspack-blocks-homepage-articles article .entry-title {
+		a {
+			color: inherit;
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: map-deep-get($config-global, "color", "primary", "default");
+			}
+		}
+	}
+
+	.a8c-posts-list-item__excerpt,
+	.wp-block-newspack-blocks-homepage-articles article p {
 		text-align: left;
+	}
+
+	.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+		display: block;
+	}
+
+	//Newspack 'load more' is outside the wrapper.
+	button[data-load-more-btn] {
+		display: flex;
+		margin: 0 auto;
 	}
 }
 
@@ -286,14 +311,14 @@ table,
  * Widgets
  */
 .widget_calendar {
-  caption {
-    font-weight: bold;
-  }
+	caption {
+		font-weight: bold;
+	}
 
-  td,
-  th {
-	   text-align: center;
-  }
+	td,
+	th {
+		text-align: center;
+	}
 }
 
 .widget_archive,
@@ -311,35 +336,35 @@ table,
 .widget_jp_blogs_i_follow,
 .widget_top-click,
 .widget_upcoming_events_widget {
-  ul {
-    border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
-    list-style: none;
-    padding-left: 0;
-  }
+	ul {
+		border-bottom: 1px solid map-deep-get($config-global, "color", "border", "default");
+		list-style: none;
+		padding-left: 0;
+	}
 
-  li {
-    border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
-    padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
-  }
+	li {
+		border-top: 1px solid map-deep-get($config-global, "color", "border", "default");
+		padding: #{0.25 * map-deep-get($config-global, "spacing", "vertical")} 0;
+	}
 }
 
 .widget_categories .children,
 .widget_nav_menu .sub-menu,
 .widget_pages .children {
-  border-bottom: 0;
-  margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
-  padding-left: map-deep-get($config-global, "spacing", "horizontal");
+	border-bottom: 0;
+	margin-bottom: #{-0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	margin-top: #{0.25 * map-deep-get($config-global, "spacing", "vertical")};
+	padding-left: map-deep-get($config-global, "spacing", "horizontal");
 }
 
 .widget_recent_entries .post-date {
-  display: block;
+	display: block;
 }
 
 .widget_rss {
-  cite,
-  .rssSummary,
-  .rss-date {
-    display: block;
-  }
+	cite,
+	.rssSummary,
+	.rss-date {
+		display: block;
+	}
 }

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -295,6 +295,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #0C80A1;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #085a72;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -303,12 +303,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #0C80A1;
 	text-decoration: underline;

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #085a72;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0C80A1;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #085a72;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #085a72;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3803,12 +3916,32 @@ hr.wp-block-separator.is-style-wide,
 #page .entry-header,
 #page .page-header,
 #page .entry-footer,
-#page .a8c-posts-list {
+#page .a8c-posts-list,
+#page .wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-#page .a8c-posts-list-item__excerpt {
+#page .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+#page .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #0C80A1;
+}
+
+#page .a8c-posts-list-item__excerpt,
+#page .wp-block-newspack-blocks-homepage-articles article p {
 	text-align: right;
+}
+
+#page .wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+#page button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 /**

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #0C80A1;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -3916,8 +3914,7 @@ hr.wp-block-separator.is-style-wide,
 #page .entry-header,
 #page .page-header,
 #page .entry-footer,
-#page .a8c-posts-list,
-#page .wp-block-newspack-blocks-homepage-articles article {
+#page .a8c-posts-list {
 	text-align: center;
 }
 
@@ -3930,18 +3927,8 @@ hr.wp-block-separator.is-style-wide,
 	color: #0C80A1;
 }
 
-#page .a8c-posts-list-item__excerpt,
-#page .wp-block-newspack-blocks-homepage-articles article p {
+#page .a8c-posts-list-item__excerpt {
 	text-align: right;
-}
-
-#page .wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-#page button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #085a72;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 1.728rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0C80A1;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #085a72;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #085a72;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3832,12 +3945,32 @@ hr.wp-block-separator.is-style-wide,
 #page .entry-header,
 #page .page-header,
 #page .entry-footer,
-#page .a8c-posts-list {
+#page .a8c-posts-list,
+#page .wp-block-newspack-blocks-homepage-articles article {
 	text-align: center;
 }
 
-#page .a8c-posts-list-item__excerpt {
+#page .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+#page .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #0C80A1;
+}
+
+#page .a8c-posts-list-item__excerpt,
+#page .wp-block-newspack-blocks-homepage-articles article p {
 	text-align: left;
+}
+
+#page .wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	display: block;
+}
+
+#page button[data-load-more-btn] {
+	display: flex;
+	margin: 0 auto;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 1.728rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #0C80A1;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {
@@ -3945,8 +3943,7 @@ hr.wp-block-separator.is-style-wide,
 #page .entry-header,
 #page .page-header,
 #page .entry-footer,
-#page .a8c-posts-list,
-#page .wp-block-newspack-blocks-homepage-articles article {
+#page .a8c-posts-list {
 	text-align: center;
 }
 
@@ -3959,18 +3956,8 @@ hr.wp-block-separator.is-style-wide,
 	color: #0C80A1;
 }
 
-#page .a8c-posts-list-item__excerpt,
-#page .wp-block-newspack-blocks-homepage-articles article p {
+#page .a8c-posts-list-item__excerpt {
 	text-align: left;
-}
-
-#page .wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	display: block;
-}
-
-#page button[data-load-more-btn] {
-	display: flex;
-	margin: 0 auto;
 }
 
 /**

--- a/stow/sass/_extra-child-theme.scss
+++ b/stow/sass/_extra-child-theme.scss
@@ -132,18 +132,18 @@ body:not( .fse-enabled ) {
 		margin-left: 0;
 		margin-right: 0;
 		text-align: center;
-	
+
 		& > div {
 			text-align: left;
 		}
-	
+
 		&.main-navigation {
-	
+
 			& > div {
 				padding-left: #{map-deep-get($config-global, "spacing", "unit")};
 				padding-right: #{map-deep-get($config-global, "spacing", "unit")};
 			}
-	
+
 			ul {
 				li {
 					&.current-menu-item {
@@ -367,4 +367,11 @@ body:not( .fse-enabled ) {
 			margin-bottom: .857em;
 		}
 	}
+}
+
+/**
+ * 6.1. Blog Posts (Newspack) Block
+ */
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -296,7 +296,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -312,11 +312,33 @@ object {
 	color: #f25f70;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -295,6 +295,30 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #404040;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #f25f70;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #404040;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -4009,6 +4120,13 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
  */
 .site-footer .widget-area .widget-title {
 	margin-bottom: .857em;
+}
+
+/**
+ * 6.1. Blog Posts (Newspack) Block
+ */
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,117 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #404040;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -4038,6 +4149,13 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
  */
 .site-footer .widget-area .widget-title {
 	margin-bottom: .857em;
+}
+
+/**
+ * 6.1. Blog Posts (Newspack) Block
+ */
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
 }
 
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #f25f70;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/stratford/sass/_extra-child-theme.scss
+++ b/stratford/sass/_extra-child-theme.scss
@@ -217,7 +217,7 @@ a {
 	}
 }
 
- @include media(mobile-only) {
+@include media(mobile-only) {
 	.site-title,
 	.site-description {
 		font-size: $font_size_xl;
@@ -344,12 +344,17 @@ a {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
 button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button,
-.a8c-posts-list__view-all {
+.a8c-posts-list__view-all,
+button[data-load-more-btn] {
 	border: 0;
 	border-radius: 5em;
 	text-transform: uppercase;
@@ -381,7 +386,7 @@ input[type="submit"],
 			}
 			> time {
 				&.wp-block-latest-posts__post-date {
-				 font-size: $font_size_base;
+					font-size: $font_size_base;
 				}
 			}
 		}

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -302,12 +302,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #2c313f;
 	text-decoration: underline;

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -295,7 +295,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
@@ -311,11 +311,33 @@ object {
 	color: #3e69dc;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -294,6 +294,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: #2c313f;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #3e69dc;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.34em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #2c313f;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3954,12 +4067,17 @@ p:not(.site-title) a:hover {
 	border: 2px solid;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
 button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button,
-.a8c-posts-list__view-all {
+.a8c-posts-list__view-all,
+button[data-load-more-btn] {
 	border: 0;
 	border-radius: 5em;
 	text-transform: uppercase;
@@ -3980,7 +4098,10 @@ input[type="submit"].has-background:visited,
 .wp-block-file__button.has-background:visited,
 .a8c-posts-list__view-all.has-background:focus,
 .a8c-posts-list__view-all.has-background:hover,
-.a8c-posts-list__view-all.has-background:visited {
+.a8c-posts-list__view-all.has-background:visited,
+button[data-load-more-btn].has-background:focus,
+button[data-load-more-btn].has-background:hover,
+button[data-load-more-btn].has-background:visited {
 	opacity: .8;
 }
 

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #2c313f;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -194,7 +194,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -212,11 +212,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -227,7 +227,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -235,7 +235,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.34em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1147,6 +1147,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #2c313f;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**
@@ -3983,12 +4096,17 @@ p:not(.site-title) a:hover {
 	border: 2px solid;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	text-decoration: none;
+}
+
 button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button,
-.a8c-posts-list__view-all {
+.a8c-posts-list__view-all,
+button[data-load-more-btn] {
 	border: 0;
 	border-radius: 5em;
 	text-transform: uppercase;
@@ -4009,7 +4127,10 @@ input[type="submit"].has-background:visited,
 .wp-block-file__button.has-background:visited,
 .a8c-posts-list__view-all.has-background:focus,
 .a8c-posts-list__view-all.has-background:hover,
-.a8c-posts-list__view-all.has-background:visited {
+.a8c-posts-list__view-all.has-background:visited,
+button[data-load-more-btn].has-background:focus,
+button[data-load-more-btn].has-background:hover,
+button[data-load-more-btn].has-background:visited {
 	opacity: .8;
 }
 

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1177,6 +1177,12 @@ object {
 	color: #3e69dc;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1200,6 +1206,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1254,10 +1276,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1168,12 +1168,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: #2c313f;
 	text-decoration: underline;
@@ -1256,6 +1250,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -7,6 +7,7 @@
  *   files and conditionally loaded
  */
 
+@import "blog-posts/editor";
 @import "button/editor";
 @import "code/editor";
 @import "cover/editor";

--- a/varia/sass/blocks/_imports.scss
+++ b/varia/sass/blocks/_imports.scss
@@ -7,6 +7,7 @@
  */
 
 @import "audio/style";
+@import "blog-posts/style";
 @import "button/style";
 @import "code/style";
 @import "columns/style";

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -1,6 +1,6 @@
 .wp-block-a8c-blog-posts {
 	article {
-		margin-bottom: 96px;
+		margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
 	}
 
 	.post-thumbnail img {

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -8,10 +8,6 @@
 	}
 
 	.entry-title {
-		font-size: #{map-deep-get($config-heading, "font", "size", "h2")};
-		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h2")};
-		line-height: #{map-deep-get($config-heading, "font", "line-height", "h2")};
-
 		a {
 			color: #{map-deep-get($config-global, "color", "primary", "default")};
 			text-decoration: underline;

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -15,6 +15,12 @@
 			&:hover {
 				color: #{map-deep-get($config-global, "color", "primary", "hover")};
 			}
+
+			.has-background:not(.has-background-background-color) &,
+			[class*="background-color"]:not(.has-background-background-color) &,
+			[style*="background-color"] & {
+				color: currentColor;
+			}
 		}
 	}
 
@@ -23,5 +29,11 @@
 	.cat-links {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};
 		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
+		.has-background:not(.has-background-background-color) &,
+		[class*="background-color"]:not(.has-background-background-color) &,
+		[style*="background-color"] & {
+			color: currentColor;
+		}
 	}
 }

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -1,0 +1,31 @@
+.wp-block-a8c-blog-posts {
+	article {
+		margin-bottom: 96px;
+	}
+
+	.post-thumbnail img {
+		width: auto;
+	}
+
+	.entry-title {
+		font-size: #{map-deep-get($config-heading, "font", "size", "h2")};
+		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h2")};
+		line-height: #{map-deep-get($config-heading, "font", "line-height", "h2")};
+
+		a {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+			text-decoration: underline;
+
+			&:hover {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
+	}
+
+	.entry-meta,
+	.entry-footer,
+	.cat-links {
+		color: #{map-deep-get($config-global, "color", "foreground", "light")};
+		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+	}
+}

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -25,6 +25,12 @@
 			&:hover {
 				color: #{map-deep-get($config-global, "color", "primary", "hover")};
 			}
+
+			.has-background:not(.has-background-background-color) &,
+			[class*="background-color"]:not(.has-background-background-color) &,
+			[style*="background-color"] & {
+				color: currentColor;
+			}
 		}
 	}
 
@@ -51,6 +57,12 @@
 	.cat-links {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};
 		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
+		.has-background:not(.has-background-background-color) &,
+		[class*="background-color"]:not(.has-background-background-color) &,
+		[style*="background-color"] & {
+			color: currentColor;
+		}
 
 		> span {
 			display: inline-block;
@@ -98,4 +110,12 @@ button[data-load-more-btn] {
 	// Extend button style
 	@extend %button-style;
 	display: inline-block;
+
+	.has-background:not(.has-background-background-color) &,
+	[class*="background-color"]:not(.has-background-background-color) &,
+	[style*="background-color"] & {
+		background-color: transparent;
+		border: 2px solid currentColor;
+		color: currentColor;
+	}
 }

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -1,0 +1,100 @@
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+	margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+
+	&:first-child {
+		margin-top: 0;
+	}
+
+	&:last-child {
+		margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+	}
+
+	.post-thumbnail img {
+		width: auto;
+	}
+
+	.entry-title {
+		font-size: #{map-deep-get($config-heading, "font", "size", "h2")};
+		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h2")};
+		line-height: #{map-deep-get($config-heading, "font", "line-height", "h2")};
+
+		a {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+			text-decoration: underline;
+
+			&:hover {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
+	}
+
+	.entry-wrapper > * {
+		/* Vertical margins logic between post details */
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+		margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.more-link {
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+	}
+
+	.entry-meta,
+	.entry-footer,
+	.cat-links {
+		color: #{map-deep-get($config-global, "color", "foreground", "light")};
+		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
+		> span {
+			display: inline-block;
+			margin-right: #{map-deep-get($config-global, "spacing", "unit")};
+
+			& > * {
+				display: inline-block;
+				vertical-align: middle;
+			}
+
+			&:last-child {
+				margin-right: 0;
+			}
+
+			.published + .updated {
+				display: none; // Hide updated date?
+			}
+		}
+
+		a {
+			color: currentColor;
+
+			&:hover,
+			&:active {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
+
+		.svg-icon {
+			fill: currentColor;
+			position: relative;
+			display: inline-block;
+			vertical-align: middle;
+			margin-right: calc(0.25 * #{map-deep-get($config-global, "spacing", "unit")});
+		}
+	}
+}
+
+button[data-load-more-btn] {
+	// Extend button style
+	@extend %button-style;
+	display: inline-block;
+}

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -91,6 +91,7 @@
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
 }
 
 button[data-load-more-btn] {

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -18,10 +18,6 @@
 	}
 
 	.entry-title {
-		font-size: #{map-deep-get($config-heading, "font", "size", "h2")};
-		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h2")};
-		line-height: #{map-deep-get($config-heading, "font", "line-height", "h2")};
-
 		a {
 			color: #{map-deep-get($config-global, "color", "primary", "default")};
 			text-decoration: underline;
@@ -91,6 +87,10 @@
 			margin-right: calc(0.25 * #{map-deep-get($config-global, "spacing", "unit")});
 		}
 	}
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -301,7 +301,7 @@ object {
  *   files and conditionally loaded
  */
 .wp-block-a8c-blog-posts article {
-	margin-bottom: 96px;
+	margin-bottom: calc(3 * 32px);
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -308,12 +308,6 @@ object {
 	width: auto;
 }
 
-.wp-block-a8c-blog-posts .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-a8c-blog-posts .entry-title a {
 	color: blue;
 	text-decoration: underline;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -317,11 +317,33 @@ object {
 	color: indigo;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .entry-footer,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links {
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -300,6 +300,36 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts article {
+	margin-bottom: 96px;
+}
+
+.wp-block-a8c-blog-posts .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: blue;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: indigo;
+}
+
+.wp-block-a8c-blog-posts .entry-meta,
+.wp-block-a8c-blog-posts .entry-footer,
+.wp-block-a8c-blog-posts .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */
@@ -1042,7 +1072,7 @@ table th,
 	display: none;
 }
 
-.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title:not([data-align='full']) {
+.template-block .fse-template-part .wp-block-column .block-editor-block-list__layout [data-type='a8c/site-title']:first-child .site-title {
 	margin-top: 0;
 }
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1208,12 +1208,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: blue;
 	text-decoration: underline;
@@ -1296,6 +1290,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-left: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -148,7 +148,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -166,11 +166,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -181,7 +181,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -189,7 +189,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -234,7 +234,7 @@ input.has-focus[type="submit"],
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -252,11 +252,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -267,7 +267,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -275,7 +275,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1187,6 +1187,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: blue;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: indigo;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-left: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-left: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: indigo;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1294,6 +1294,7 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1217,6 +1217,12 @@ object {
 	color: indigo;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1240,6 +1246,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1299,6 +1321,14 @@ object {
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/varia/style.css
+++ b/varia/style.css
@@ -1208,12 +1208,6 @@ object {
 	width: auto;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
-	font-size: 2.48832rem;
-	letter-spacing: normal;
-	line-height: 1.125;
-}
-
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: blue;
 	text-decoration: underline;
@@ -1296,6 +1290,10 @@ object {
 	display: inline-block;
 	vertical-align: middle;
 	margin-right: calc(0.25 * 16px);
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
 }
 
 button[data-load-more-btn] {

--- a/varia/style.css
+++ b/varia/style.css
@@ -148,7 +148,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -166,11 +166,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -181,7 +181,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -189,7 +189,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -234,7 +234,7 @@ input.has-focus[type="submit"],
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-button,
+button[data-load-more-btn], button,
 .button,
 input[type="submit"],
 .wp-block-button__link,
@@ -252,11 +252,11 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -267,7 +267,7 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-button:before,
+button[data-load-more-btn]:before, button:before,
 .button:before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
@@ -275,7 +275,7 @@ input[type="submit"]:before,
 	margin-bottom: -0.12em;
 }
 
-button:after,
+button[data-load-more-btn]:after, button:after,
 .button:after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
@@ -1187,6 +1187,119 @@ object {
 
 .wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article {
+	display: block;
+	/* Vertical margins logic between posts */
+	margin-top: calc(3 * 32px);
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article:last-child {
+	margin-bottom: calc(3 * 32px);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
+	width: auto;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
+	font-size: 2.48832rem;
+	letter-spacing: normal;
+	line-height: 1.125;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: blue;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: indigo;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link {
+	margin-top: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: #767676;
+	font-size: 0.83333rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+	display: inline-block;
+	margin-right: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+	margin-right: 0;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+	display: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: indigo;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
+	fill: currentColor;
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: calc(0.25 * 16px);
+}
+
+button[data-load-more-btn] {
+	display: inline-block;
 }
 
 /**

--- a/varia/style.css
+++ b/varia/style.css
@@ -1294,6 +1294,7 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {


### PR DESCRIPTION
The Newspack Blog Posts block has been ported to WordPress.com, and is now the recommended upgrade from the previous a8c-posts-list block. The block comes with a number of default styles, which need to be overwritten to allow the template-first theme blog styling to work.

Theme | Old Block | New Block (before) | New Block (after
------------ | ------------ | ------------- | -------------
Varia | ![old-block](https://user-images.githubusercontent.com/942359/70941461-845ac080-201a-11ea-954b-8793517fad89.png) | ![new-block-before](https://user-images.githubusercontent.com/942359/70941490-98062700-201a-11ea-855e-ae5e2dd0d191.png) | ![new-block-after](https://user-images.githubusercontent.com/942359/70941529-ab18f700-201a-11ea-9b46-273520004501.png)
Barnsbury | ![barnsbury-old-block](https://user-images.githubusercontent.com/942359/70941689-f7fccd80-201a-11ea-9916-c303939bb059.png) | ![barnsbury-new-block-before](https://user-images.githubusercontent.com/942359/70941722-0a770700-201b-11ea-8d15-a8d2697bcb2a.png) | ![barnsbury-new-block-after](https://user-images.githubusercontent.com/942359/70941745-2084c780-201b-11ea-8ab3-2e6b84400224.png)

ref: p7DVsv-7Rw-p2
additionally fixes https://github.com/Automattic/wp-calypso/issues/38389
