### PR TITLE
Template-First Themes: Blog Posts block style updates

### DIFF
--- a/alves/functions.php
+++ b/alves/functions.php
@@ -132,7 +132,7 @@ add_action( 'widgets_init', 'alves_widgets_init', 12 );
  * Filter the content_width in pixels, based on the child-theme's design and stylesheet.
  */
 function alves_content_width() {
-	return 700;
+	return 750;
 }
 add_filter( 'varia_content_width', 'alves_content_width' );
 

--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -2998,7 +2998,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3019,12 +3020,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3039,17 +3042,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3166,7 +3172,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3178,6 +3185,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3192,6 +3200,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3199,12 +3208,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3223,6 +3234,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3303,7 +3315,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3315,6 +3328,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3400,7 +3414,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3436,6 +3451,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3455,6 +3471,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3498,12 +3515,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/alves/sass/_extra-child-theme.scss
+++ b/alves/sass/_extra-child-theme.scss
@@ -521,3 +521,52 @@ body:not(.fse-enabled) {
 .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	text-decoration: none;
 }
+
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				color: #fff;
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}

--- a/alves/sass/style-child-theme-editor.scss
+++ b/alves/sass/style-child-theme-editor.scss
@@ -93,6 +93,58 @@ $font_size_widget_title: #{map-deep-get($config-heading, "font", "size", "h4")};
 	}
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1.25em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #3E7D98;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #2f5f74;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #2f5f74;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #2f5f74;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #4d6974;
-	font-size: 1.04167rem;
+	font-size: 1.04167em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #2f5f74;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Karla", Arial, sans-serif;
+	font-family: var(--font-base, "Karla", Arial, sans-serif);
+	font-size: 1.04167rem;
+	background-color: #3E7D98;
+	border-radius: 160px;
+	border-width: 0;
+	padding: 16px 48px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: #ffffff;
+	background-color: #2f5f74;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.5em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1262,6 +1266,50 @@ p:not(.site-title) a:hover {
 
 .has-background a {
 	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1.04167em;
 }
 
 /**

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: #ffffff;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 48px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
 	background-color: #2f5f74;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.5em;

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #2f5f74;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 1.04167rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -4363,6 +4363,41 @@ body:not(.fse-enabled) #masthead {
 	text-decoration: none;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: #fff;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1.25rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #3E7D98;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #2f5f74;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #3E7D98;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #2f5f74;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #4d6974;
 	font-size: 1.04167rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #2f5f74;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Karla", Arial, sans-serif;
+	font-family: var(--font-base, "Karla", Arial, sans-serif);
+	font-size: 1.04167rem;
+	background-color: #3E7D98;
+	border-radius: 160px;
+	border-width: 0;
+	padding: 16px 48px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #ffffff;
+	background-color: #2f5f74;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -4392,6 +4392,41 @@ body:not(.fse-enabled) #masthead {
 	text-decoration: none;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: #fff;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/alves/style.css
+++ b/alves/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1.25rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #3E7D98;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #2f5f74;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #3E7D98;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #2f5f74;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #4d6974;
 	font-size: 1.04167rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #2f5f74;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Karla", Arial, sans-serif;
+	font-family: var(--font-base, "Karla", Arial, sans-serif);
+	font-size: 1.04167rem;
+	background-color: #3E7D98;
+	border-radius: 160px;
+	border-width: 0;
+	padding: 16px 48px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #ffffff;
+	background-color: #2f5f74;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/balasana/sass/_extra-child-theme.scss
+++ b/balasana/sass/_extra-child-theme.scss
@@ -24,9 +24,9 @@ $font_size_h1: map-deep-get($config-heading, "font", "size", "h1");
  * Reset
  */
 a,
-button,
-.button,
-input[type="submit"] {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.entry-content .more-link {
 	text-decoration: none;
 
 	&:active,

--- a/balasana/sass/style-child-theme-editor.scss
+++ b/balasana/sass/style-child-theme-editor.scss
@@ -39,3 +39,21 @@
 	text-align: center;
 	font-size: (strip-unit( map-deep-get($config-heading, "font", "size", "h1") ) + 0em);
 }
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+	}
+
+	.cat-links a,
+	.more-link,
+	.byline a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/balasana/sass/style-child-theme-editor.scss
+++ b/balasana/sass/style-child-theme-editor.scss
@@ -57,3 +57,6 @@
 		}
 	}
 }
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1233,3 +1233,23 @@ table th,
 	text-align: center;
 	font-size: 2.98598em;
 }
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .byline a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .byline a:active,
+.wp-block-a8c-blog-posts .byline a:focus,
+.wp-block-a8c-blog-posts .byline a:hover {
+	text-decoration: underline;
+}

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1257,3 +1257,7 @@ table th,
 .wp-block-a8c-blog-posts .byline a:hover {
 	text-decoration: underline;
 }
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
+}

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #19744C;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #145f3e;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #145f3e;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #145f3e;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #505050;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #145f3e;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #19744C;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #145f3e;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #145f3e;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #145f3e;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3769,6 +3794,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #19744C;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #145f3e;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #19744C;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #145f3e;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #505050;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #145f3e;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #19744C;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #145f3e;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3952,22 +3952,22 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Reset
  */
 a,
-button,
-.button,
-input[type="submit"] {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.entry-content .more-link {
 	text-decoration: none;
 }
 
 a:active, a:focus, a:hover,
-button:active,
-button:focus,
-button:hover,
-.button:active,
-.button:focus,
-.button:hover,
-input[type="submit"]:active,
-input[type="submit"]:focus,
-input[type="submit"]:hover {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:focus,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.entry-content .more-link:active,
+.entry-content .more-link:focus,
+.entry-content .more-link:hover {
 	text-decoration: underline;
 }
 

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #19744C;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #145f3e;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #19744C;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #145f3e;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #505050;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #145f3e;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #19744C;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #145f3e;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3829,6 +3823,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3981,22 +3981,22 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Reset
  */
 a,
-button,
-.button,
-input[type="submit"] {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.entry-content .more-link {
 	text-decoration: none;
 }
 
 a:active, a:focus, a:hover,
-button:active,
-button:focus,
-button:hover,
-.button:active,
-.button:focus,
-.button:hover,
-input[type="submit"]:active,
-input[type="submit"]:focus,
-input[type="submit"]:hover {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:focus,
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.entry-content .more-link:active,
+.entry-content .more-link:focus,
+.entry-content .more-link:hover {
 	text-decoration: underline;
 }
 

--- a/barnsbury/sass/style-child-theme-editor.scss
+++ b/barnsbury/sass/style-child-theme-editor.scss
@@ -76,8 +76,4 @@
 			color: map-deep-get($config-global, "color", "primary", "default");
 		}
 	}
-
-	&.image-alignbehind .post-has-image a:hover {
-		color: #fff;
-	}
 }

--- a/barnsbury/sass/style-child-theme-editor.scss
+++ b/barnsbury/sass/style-child-theme-editor.scss
@@ -77,3 +77,7 @@
 		}
 	}
 }
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}

--- a/barnsbury/sass/style-child-theme-editor.scss
+++ b/barnsbury/sass/style-child-theme-editor.scss
@@ -65,3 +65,19 @@
 		margin-top: map-deep-get($config-global, "spacing", "unit");
 	}
 }
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: map-deep-get($config-global, "color", "primary", "default");
+		}
+	}
+
+	&.image-alignbehind .post-has-image a:hover {
+		color: #fff;
+	}
+}

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #20603C;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #133a24;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #133a24;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #133a24;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #844d4d;
-	font-size: 0.84746rem;
+	font-size: 0.84746em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #133a24;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: #FFFDF6;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
+	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
+	font-size: 1rem;
+	background-color: #20603C;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 18px 18px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
+	background-color: #133a24;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.18em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1251,3 +1251,15 @@ table th,
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content {
 	margin-top: 16px;
 }
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:active {
+	color: #20603C;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: #fff;
+}

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1258,8 +1262,4 @@ table th,
 
 .wp-block-a8c-blog-posts .entry-title a:hover, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:active {
 	color: #20603C;
-}
-
-.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: #fff;
 }

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: #FFFDF6;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 18px 18px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
 	background-color: #133a24;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.18em;

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1263,3 +1263,7 @@ table th,
 .wp-block-a8c-blog-posts .entry-title a:hover, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:active {
 	color: #20603C;
 }
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
+}

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #20603C;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #133a24;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #20603C;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #133a24;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #844d4d;
 	font-size: 0.84746rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #133a24;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #FFFDF6;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
+	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
+	font-size: 1rem;
+	background-color: #20603C;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 18px 18px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
+	background-color: #133a24;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #133a24;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.84746rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #20603C;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #133a24;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #20603C;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #133a24;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #844d4d;
 	font-size: 0.84746rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #133a24;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #FFFDF6;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
+	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
+	font-size: 1rem;
+	background-color: #20603C;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 18px 18px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
+	background-color: #133a24;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -252,10 +252,22 @@
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__title {
 	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 
+	a {
+		color: inherit;
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title {
 	a {
 		color: inherit;
 		text-decoration: none;

--- a/brompton/sass/style-child-theme-editor.scss
+++ b/brompton/sass/style-child-theme-editor.scss
@@ -39,3 +39,11 @@
 .editor-post-title__input {
 	text-align: center;
 }
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+
+	&:hover {
+		color: #{map-deep-get($config-global, "color", "primary", "default")};
+	}
+}

--- a/brompton/sass/style-child-theme-editor.scss
+++ b/brompton/sass/style-child-theme-editor.scss
@@ -47,3 +47,7 @@
 		color: #{map-deep-get($config-global, "color", "primary", "default")};
 	}
 }
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: #E8E4DD;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #E8E4DD;
 	background-color: #C04239;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1244,3 +1244,7 @@ table th,
 .wp-block-a8c-blog-posts .entry-title a:hover {
 	color: #C04239;
 }
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
+}

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1231,4 +1235,12 @@ table th,
  */
 .editor-post-title__input {
 	text-align: center;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #C04239;
 }

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #C04239;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #252E36;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #252E36;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #252E36;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #252E36;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: #E8E4DD;
+	cursor: pointer;
+	font-weight: 900;
+	font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #252E36;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: #E8E4DD;
+	background-color: #C04239;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #252E36;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -4160,15 +4160,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__title {
 	margin-top: 32px;
 }
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.a8c-posts-list .a8c-posts-list-item__title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -4179,10 +4177,16 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover {
+	color: #C04239;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #C04239;
 }
 

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #C04239;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #252E36;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #C04239;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #252E36;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #252E36;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #E8E4DD;
+	cursor: pointer;
+	font-weight: 900;
+	font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #252E36;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #E8E4DD;
+	background-color: #C04239;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #C04239;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #252E36;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #C04239;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #252E36;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #252E36;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #E8E4DD;
+	cursor: pointer;
+	font-weight: 900;
+	font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #252E36;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #E8E4DD;
+	background-color: #C04239;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -4189,15 +4189,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 article .entry-header .entry-title,
 .page-title,
-.a8c-posts-list .a8c-posts-list-item__title,
-.wp-block-newspack-blocks-homepage-articles article .entry-title {
+.a8c-posts-list .a8c-posts-list-item__title {
 	margin-top: 32px;
 }
 
 article .entry-header .entry-title a,
 .page-title a,
-.a8c-posts-list .a8c-posts-list-item__title a,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.a8c-posts-list .a8c-posts-list-item__title a {
 	color: inherit;
 	text-decoration: none;
 }
@@ -4208,10 +4206,16 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 .page-title a:hover,
 .a8c-posts-list .a8c-posts-list-item__title a:active,
 .a8c-posts-list .a8c-posts-list-item__title a:focus,
-.a8c-posts-list .a8c-posts-list-item__title a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+.a8c-posts-list .a8c-posts-list-item__title a:hover {
+	color: #C04239;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: #C04239;
 }
 

--- a/coutoire/sass/style-child-theme-editor.scss
+++ b/coutoire/sass/style-child-theme-editor.scss
@@ -61,5 +61,6 @@ body {
 
 .wp-block-a8c-blog-posts + .button {
 	border-radius: 0;
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
 	text-transform: uppercase;
 }

--- a/coutoire/sass/style-child-theme-editor.scss
+++ b/coutoire/sass/style-child-theme-editor.scss
@@ -40,3 +40,26 @@ body {
 	font-weight: 300;
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title a:hover {
+		text-decoration: none;
+	}
+
+	.more-link {
+		text-decoration-color: map-deep-get($config-global, "color", "primary", "hover");
+		&:hover {
+			color: inherit;
+		}
+	}
+
+	.entry-meta {
+		text-transform: uppercase;
+		font-weight: 500;
+		letter-spacing: .1em;
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	border-radius: 0;
+	text-transform: uppercase;
+}

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -482,26 +473,32 @@ object {
 	padding: 11.6px 11.6px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #FF7A5C;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1256,5 +1256,6 @@ body {
 
 .wp-block-a8c-blog-posts + .button {
 	border-radius: 0;
+	font-size: 0.83333em;
 	text-transform: uppercase;
 }

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #FF7A5C;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #FF7A5C;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #FF7A5C;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,95 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #FF7A5C;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-width: 0;
+	padding: 11.6px 11.6px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #FF7A5C;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1230,4 +1234,27 @@ table th,
 html,
 body {
 	font-weight: 300;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	text-decoration-color: #FF7A5C;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-meta {
+	text-transform: uppercase;
+	font-weight: 500;
+	letter-spacing: .1em;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	border-radius: 0;
+	text-transform: uppercase;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1148,11 +1148,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1160,26 +1203,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #FF7A5C;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1196,12 +1224,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #FF7A5C;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1210,11 +1260,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1223,55 +1268,129 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #FF7A5C;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-width: 0;
+	padding: 11.6px 11.6px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #FF7A5C;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1176,6 +1176,12 @@ object {
 	color: #FF7A5C;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1201,29 +1207,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1253,10 +1269,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3762,6 +3787,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1148,11 +1148,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1160,26 +1203,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #FF7A5C;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1196,12 +1224,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #FF7A5C;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1210,11 +1260,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1223,55 +1268,129 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #FF7A5C;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-width: 0;
+	padding: 11.6px 11.6px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #FF7A5C;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1223,29 +1223,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3822,6 +3816,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/dalston/sass/_extra-child-theme.scss
+++ b/dalston/sass/_extra-child-theme.scss
@@ -248,9 +248,6 @@ a {
 	font-weight: 600;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
 
 /**
  * Blocks
@@ -271,6 +268,42 @@ a {
 
 	&:hover {
 		text-decoration: none;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.cat-links a,
+		.entry-title a:hover,
+		.entry-meta a {
+			text-decoration: none;
+		}
+	}
+
+	&.image-alignbehind article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.more-link:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a,
+		.more-link {
+			text-decoration: none;
+		}
+
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
 	}
 }
 

--- a/dalston/sass/style-child-theme-editor.scss
+++ b/dalston/sass/style-child-theme-editor.scss
@@ -47,3 +47,38 @@
 		border-color: #{map-deep-get($config-global, "color", "background", "default")};
 	}
 }
+
+.wp-block-a8c-blog-posts {
+	.cat-links a,
+	.entry-title a:hover,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+	}
+
+	&.image-alignbehind {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.more-link:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.more-link:hover,
+		.emtry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #0073AA;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #005177;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #005177;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #005177;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.86957rem;
+	font-size: 0.86957em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #005177;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: #FFFFFF;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
+	font-size: 1rem;
+	background-color: #0073AA;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: #FFFFFF;
+	background-color: #005177;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.15em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: #FFFFFF;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #FFFFFF;
 	background-color: #005177;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.15em;

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1240,4 +1244,37 @@ table th,
 
 .wp-block-media-text.is-style-inset-borders:before {
 	border-color: #FFFFFF;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .entry-title a:hover,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .cat-links a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-title a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .more-link:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .emtry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .emtry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .emtry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #0073AA;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #005177;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0073AA;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #005177;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #005177;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #FFFFFF;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
+	font-size: 1rem;
+	background-color: #0073AA;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #FFFFFF;
+	background-color: #005177;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #005177;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.86957rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -4157,10 +4157,6 @@ a {
 	font-weight: 600;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
 /**
  * Blocks
  */
@@ -4179,6 +4175,40 @@ a {
 
 .entry-content [class*="__inner-container"] a:hover {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link {
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -4186,10 +4186,6 @@ a {
 	font-weight: 600;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
 /**
  * Blocks
  */
@@ -4208,6 +4204,40 @@ a {
 
 .entry-content [class*="__inner-container"] a:hover {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link {
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #0073AA;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #005177;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0073AA;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #005177;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #005177;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: #FFFFFF;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
+	font-size: 1rem;
+	background-color: #0073AA;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #FFFFFF;
+	background-color: #005177;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -2998,7 +2998,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3019,12 +3020,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3039,17 +3042,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3166,7 +3172,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3178,6 +3185,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3192,6 +3200,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3199,12 +3208,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3223,6 +3234,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3303,7 +3315,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3315,6 +3328,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3400,7 +3414,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3436,6 +3451,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3455,6 +3471,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3498,12 +3515,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/exford/sass/_extra-child-theme.scss
+++ b/exford/sass/_extra-child-theme.scss
@@ -230,6 +230,38 @@ a {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.cat-links a,
+		.entry-title a:hover,
+		.entry-meta a {
+			text-decoration: none;
+		}
+	}
+
+	&.image-alignbehind article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+
+
 /**
  * Widgets
  */

--- a/exford/sass/style-child-theme-editor.scss
+++ b/exford/sass/style-child-theme-editor.scss
@@ -82,6 +82,42 @@ $font_size_md: map-deep-get($config-global, "font", "size", "md");
 	}
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+	}
+
+	.cat-links a,
+	.entry-title a:hover,
+	.entry-meta a {
+		text-decoration: none;
+	}
+
+	&.image-alignbehind {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1275,6 +1279,38 @@ table th,
 	.wp-block-cover-image {
 		min-height: 80vh;
 	}
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .entry-title a:hover,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .cat-links a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-title a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
 }
 
 /**

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #23883D;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #195f2b;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #195f2b;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #195f2b;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #6E6E6E;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #195f2b;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #23883D;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #195f2b;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #195f2b;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #23883D;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #195f2b;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #23883D;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #195f2b;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #6E6E6E;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #195f2b;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #23883D;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #195f2b;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -4173,6 +4173,30 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #195f2b;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/exford/style.css
+++ b/exford/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #23883D;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #195f2b;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #23883D;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #195f2b;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #6E6E6E;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #195f2b;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #23883D;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #195f2b;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -4202,6 +4202,30 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/exford/style.css
+++ b/exford/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -2998,7 +2998,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3019,12 +3020,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3039,17 +3042,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3166,7 +3172,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3178,6 +3185,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3192,6 +3200,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3199,12 +3208,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3223,6 +3234,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3303,7 +3315,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3315,6 +3328,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3400,7 +3414,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3436,6 +3451,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3455,6 +3471,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3498,12 +3515,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/hever/sass/_extra-child-theme.scss
+++ b/hever/sass/_extra-child-theme.scss
@@ -241,6 +241,36 @@ table,
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.cat-links a,
+		.entry-title a:hover,
+		.entry-meta a {
+			text-decoration: none;
+		}
+	}
+
+	&.image-alignbehind article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
 /**
  * Hentry
  */

--- a/hever/sass/style-child-theme-editor.scss
+++ b/hever/sass/style-child-theme-editor.scss
@@ -39,6 +39,48 @@
 	text-align: center;
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+
+	.cat-links a,
+	.entry-title a:hover,
+	.entry-meta a {
+		text-decoration: none;
+	}
+
+	&.image-alignbehind {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1231,6 +1235,42 @@ table th,
  */
 .editor-post-title__input {
 	text-align: center;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #1279BE;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .entry-title a:hover,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .cat-links a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-title a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
 }
 
 /**

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #303030;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.15em;

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #1279BE;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #303030;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #303030;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
-	font-size: 0.86957rem;
+	font-size: 0.86957em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #303030;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #1279BE;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #303030;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.15em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -4173,6 +4173,30 @@ table th,
 	border-color: #C5C5C5;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Hentry
  */

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #1279BE;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #303030;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #1279BE;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #303030;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #1279BE;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #303030;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.86957rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3773,6 +3798,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/hever/style.css
+++ b/hever/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #1279BE;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #303030;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #1279BE;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #303030;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #1279BE;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #303030;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -4202,6 +4202,30 @@ table th,
 	border-color: #C5C5C5;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Hentry
  */

--- a/hever/style.css
+++ b/hever/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3833,6 +3827,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/leven/sass/_extra-child-theme.scss
+++ b/leven/sass/_extra-child-theme.scss
@@ -114,6 +114,33 @@ a {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.cat-links a,
+		.entry-title a,
+		.entry-title a:hover,
+		.entry-meta a {
+			text-decoration: none;
+		}
+	}
+
+	&.image-alignbehind article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
 }

--- a/leven/sass/style-child-theme-editor.scss
+++ b/leven/sass/style-child-theme-editor.scss
@@ -40,3 +40,39 @@
 .has-small-font-size {
 	@include font-family( map-deep-get($config-global, "font", "family", "primary") );
 }
+
+.wp-block-a8c-blog-posts {
+	.cat-links a,
+	.entry-title a:hover,
+	.entry-meta a {
+		text-decoration: none;
+	}
+
+	&.image-alignbehind {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+
+	.more-link:hover {
+		color: inherit;
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.cat-links a:hover,
+		.entry-title a:hover,
+		.entry-meta a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "md")) + 0em);
+}

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #ff302c;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #1285ce;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #1285ce;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #1285ce;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.82474rem;
+	font-size: 0.82474em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #1285ce;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1.2125rem;
+	background-color: #ff302c;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #1285ce;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2125em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1232,4 +1236,36 @@ table th,
 .has-small-font-size {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .entry-title a:hover,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .cat-links a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-title a:hover,
+.wp-block-a8c-blog-posts.image-alignbehind .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1.2125em;
 }

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #1285ce;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2125em;

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -4041,6 +4041,27 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #ff302c;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #1285ce;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #ff302c;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #1285ce;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.82474rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #1285ce;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1.2125rem;
+	background-color: #ff302c;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #1285ce;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #1285ce;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.82474rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/leven/style.css
+++ b/leven/style.css
@@ -4070,6 +4070,27 @@ p:not(.site-title) a:hover {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #ff302c;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #1285ce;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #ff302c;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #1285ce;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.82474rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #1285ce;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1.2125rem;
+	background-color: #ff302c;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #1285ce;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/mayland/sass/_extra-child-theme.scss
+++ b/mayland/sass/_extra-child-theme.scss
@@ -199,6 +199,21 @@ a {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.cat-links a,
+		.entry-title a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
 /**
  * Widgets
  */

--- a/mayland/sass/style-child-theme-editor.scss
+++ b/mayland/sass/style-child-theme-editor.scss
@@ -31,3 +31,27 @@
  *   spacing with CSS-variables overrides
  */
 @import "../../varia/sass/blocks/editor";
+
+/**
+ * Extras
+ */
+.wp-block-a8c-blog-posts {
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	.entry-title a:hover,
+	.more-link:hover {
+		color: inherit;
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1223,4 +1227,28 @@ table th,
 .padding-left-default {
 	/*rtl:ignore*/
 	padding-left: 32px !important;
+}
+
+/**
+ * Extras
+ */
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover,
+.wp-block-a8c-blog-posts .more-link:hover {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
 }

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #666666;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #666666;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #666666;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #666666;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #666666;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #666666;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #666666;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3762,6 +3787,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #666666;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #666666;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #666666;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #666666;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -4124,6 +4124,20 @@ strong {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3822,6 +3816,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -4153,6 +4153,20 @@ strong {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: black;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #666666;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: black;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #666666;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #666666;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: black;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #666666;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -2874,7 +2874,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2895,12 +2896,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2915,17 +2918,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3042,7 +3048,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3054,6 +3061,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3068,6 +3076,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3075,12 +3084,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3099,6 +3110,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3179,7 +3191,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3191,6 +3204,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3276,7 +3290,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3312,6 +3327,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3331,6 +3347,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3374,12 +3391,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -259,6 +259,47 @@ a {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a:hover {
+			text-decoration: none;
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		.more-link:hover {
+			color: map-deep-get($config-global, "color", "primary", "hover");
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+
+		.more-link:hover {
+			color: inherit;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
 /**
  * Widgets
  */

--- a/maywood/sass/style-child-theme-editor.scss
+++ b/maywood/sass/style-child-theme-editor.scss
@@ -102,6 +102,50 @@ b, strong {
 	}
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title {
+		font-weight: 300;
+
+		a {
+			color: inherit;
+
+			&:hover {
+				text-decoration: none;
+			}
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #897248;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #685636;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #685636;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #685636;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #686868;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #685636;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #897248;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #685636;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #685636;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1295,6 +1299,44 @@ b, strong {
 	.wp-block-cover-image h6 {
 		font-size: 1.2em;
 	}
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-weight: 300;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
 }
 
 /**

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #685636;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4199,6 +4199,40 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #897248;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #685636;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #897248;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #685636;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #686868;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #685636;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #897248;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #685636;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4228,6 +4228,40 @@ p:not(.site-title) a:hover {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #685636;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #897248;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #685636;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #897248;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #685636;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #686868;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #685636;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #897248;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #685636;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1472,7 +1472,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1493,12 +1494,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1513,17 +1516,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1640,7 +1646,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1652,6 +1659,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1666,6 +1674,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1673,12 +1682,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1697,6 +1708,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1777,7 +1789,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1789,6 +1802,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1874,7 +1888,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1910,6 +1925,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1929,6 +1945,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1972,12 +1989,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/morden/sass/_extra-child-theme.scss
+++ b/morden/sass/_extra-child-theme.scss
@@ -278,6 +278,40 @@ table,
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a:hover {
+			text-decoration: none;
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
 /**
  * Hentry
  */

--- a/morden/sass/style-child-theme-editor.scss
+++ b/morden/sass/style-child-theme-editor.scss
@@ -39,6 +39,55 @@
 	text-align: center;
 }
 
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}
+
 /**
  * Full Site Editing
  * - Full Site Editing overrides

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #303030;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.15em;

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #CD2220;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #303030;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #303030;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
-	font-size: 0.86957rem;
+	font-size: 0.86957em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #303030;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CD2220;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #303030;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.15em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1231,6 +1235,45 @@ table th,
  */
 .editor-post-title__input {
 	text-align: center;
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+	color: #CD2220;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
 }
 
 /**

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CD2220;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #303030;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CD2220;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #303030;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CD2220;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #303030;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -4202,6 +4202,32 @@ table th,
 	border-color: #C5C5C5;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Hentry
  */

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #303030;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.86957rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/morden/style.css
+++ b/morden/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CD2220;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #303030;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CD2220;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #303030;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.86957rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #303030;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CD2220;
+	border-radius: 5px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #303030;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/morden/style.css
+++ b/morden/style.css
@@ -4231,6 +4231,32 @@ table th,
 	border-color: #C5C5C5;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Hentry
  */

--- a/redhill/sass/_extra-child-theme.scss
+++ b/redhill/sass/_extra-child-theme.scss
@@ -259,6 +259,55 @@ table,
 	text-align: left;
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.cat-links,
+		.entry-meta {
+			@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
 // Hentry
 .entry-header {
 	.entry-meta {

--- a/redhill/sass/style-child-theme-editor.scss
+++ b/redhill/sass/style-child-theme-editor.scss
@@ -43,3 +43,64 @@ html {
  *   spacing with CSS-variables overrides
  */
 @import "../../varia/sass/blocks/editor";
+
+.wp-block-a8c-blog-posts {
+	.entry-title {
+		@include font-family( map-deep-get($config-global, "font", "family", "primary") );
+	}
+
+	.entry-title a {
+		color: inherit;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+
+	.cat-links,
+	.entry-meta {
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -307,21 +307,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -481,7 +466,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -495,26 +486,32 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #222222;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -352,6 +352,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -323,6 +323,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1236,4 +1240,58 @@ table th,
 .padding-left-default {
 	/*rtl:ignore*/
 	padding-left: 32px !important;
+}
+
+.wp-block-a8c-blog-posts .entry-title {
+	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
+	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+	color: #CA2017;
+}
+
+.wp-block-a8c-blog-posts .cat-links,
+.wp-block-a8c-blog-posts .entry-meta {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -306,21 +307,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #CA2017;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #222222;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -329,21 +387,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #222222;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -352,24 +440,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #222222;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CA2017;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #222222;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -4186,6 +4186,42 @@ table th,
 	text-align: right;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 .entry-header .entry-meta {
 	display: none;
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CA2017;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #222222;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CA2017;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #222222;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CA2017;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #222222;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #222222;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CA2017;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #222222;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CA2017;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #222222;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #666666;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #222222;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CA2017;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #222222;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -4215,6 +4215,42 @@ table th,
 	text-align: left;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 .entry-header .entry-meta {
 	display: none;
 }

--- a/rivington/functions.php
+++ b/rivington/functions.php
@@ -128,27 +128,15 @@ function rivington_fonts_url() {
 	$fonts_url = '';
 
 	/* Translators: If there are characters in your language that are not
-	* supported by Playfair Display, translate this to 'off'. Do not translate
+	* supported by Poppins, translate this to 'off'. Do not translate
 	* into your own language.
 	*/
-	$playfair = esc_html_x( 'on', 'Playfair Display font: on or off', 'rivington' );
+	$poppins = esc_html_x( 'on', 'Poppins font: on or off', 'rivington' );
 
-	/* Translators: If there are characters in your language that are not
-	* supported by Roboto Sans, translate this to 'off'. Do not translate
-	* into your own language.
-	*/
-	$roboto = esc_html_x( 'on', 'Roboto Sans font: on or off', 'rivington' );
-
-	if ( 'off' !== $playfair || 'off' !== $roboto ) {
+	if ( 'off' !== $poppins ) {
 		$font_families = array();
 
-		if ( 'off' !== $playfair ) {
-			$font_families[] = 'Playfair+Display:400,400i';
-		}
-
-		if ( 'off' !== $roboto ) {
-			$font_families[] = 'Roboto:300,300i,700';
-		}
+		$font_families[] = 'Poppins:400,400i,600,600i';
 
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),

--- a/rivington/sass/_extra-child-theme.scss
+++ b/rivington/sass/_extra-child-theme.scss
@@ -288,6 +288,63 @@ a {
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.more-link {
+
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: $color_primary_hover;
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
 /**
  * Widgets
  */

--- a/rivington/sass/style-child-theme-editor.scss
+++ b/rivington/sass/style-child-theme-editor.scss
@@ -77,3 +77,56 @@ $font_size_md: map-deep-get($config-global, "font", "size", "md");
 		}
 	}
 }
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		color: inherit;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+			color: #{map-deep-get($config-global, "color", "primary", "default")};
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+}

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #CAAB57;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #b59439;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #b59439;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #b59439;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: white;
-	font-size: 0.8rem;
+	font-size: 0.8em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #b59439;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1.15;
+	color: #060f29;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CAAB57;
+	border-radius: 3px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.195em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.185em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: #060f29;
+	background-color: #b59439;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.25em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1268,4 +1272,47 @@ table th,
 	.wp-block-cover-image h6 {
 		font-size: 1.25em;
 	}
+}
+
+.wp-block-a8c-blog-posts .entry-title a {
+	color: inherit;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+	color: #CAAB57;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 1em;
 }

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1.15;
 	color: #060f29;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.195em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.185em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #060f29;
 	background-color: #b59439;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.25em;

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #b59439;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.8rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -4213,6 +4213,41 @@ p:not(.site-title) a:hover {
 	padding-right: 0;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	color: #b59439;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CAAB57;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #b59439;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CAAB57;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #b59439;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: white;
 	font-size: 0.8rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #b59439;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1.15;
+	color: #060f29;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CAAB57;
+	border-radius: 3px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.195em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.185em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #060f29;
+	background-color: #b59439;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #CAAB57;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #b59439;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #CAAB57;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #b59439;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: white;
 	font-size: 0.8rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #b59439;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1.15;
+	color: #060f29;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 1rem;
+	background-color: #CAAB57;
+	border-radius: 3px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.195em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.185em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: #060f29;
+	background-color: #b59439;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4242,6 +4242,41 @@ p:not(.site-title) a:hover {
 	padding-left: 0;
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	color: #b59439;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
 /**
  * Widgets
  */

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -407,26 +407,50 @@ table,
 /**
  * Blog Posts (Newspack)
  */
-.wp-block-newspack-blocks-homepage-articles article {
-	margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
-	margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
 
-	@include media(mobile) {
-		margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
-		margin-top: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
-.wp-block-newspack-blocks-homepage-articles article p {
-	&:not(:last-child) {
-		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
-
-		@include media(mobile) {
-			margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 }

--- a/rockfield/sass/style-child-theme-editor.scss
+++ b/rockfield/sass/style-child-theme-editor.scss
@@ -38,7 +38,7 @@
  .editor-post-title__input {
  	text-align: center;
  }
- 
+
 .wp-block-pullquote {
 	border-bottom-width: 1px;
 }
@@ -63,4 +63,56 @@
 	&:before {
 		border-radius: 100px;
 	}
+}
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+	outline: 2px solid;
+	outline-offset: -5px;
 }

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #222222;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #444444;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #444444;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #444444;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #757575;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #444444;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #222222;
+	border-radius: 0;
+	border-width: 0;
+	padding: 16px 20px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #444444;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 20px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #444444;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1255,4 +1259,44 @@ table th,
 
 .is-style-circular .wp-block-button__link:before {
 	border-radius: 100px;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
+	outline: 2px solid;
+	outline-offset: -5px;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #222222;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #444444;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #222222;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #444444;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #444444;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #222222;
+	border-radius: 0;
+	border-width: 0;
+	padding: 16px 20px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #444444;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #444444;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -4335,30 +4335,38 @@ table th,
 /**
  * Blog Posts (Newspack)
  */
-.wp-block-newspack-blocks-homepage-articles article {
-	margin-bottom: 32px;
-	margin-top: 32px;
-}
-
-@media only screen and (min-width: 560px) {
-	.wp-block-newspack-blocks-homepage-articles article {
-		margin-bottom: 64px;
-		margin-top: 64px;
-	}
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
-	margin-bottom: 32px;
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
 }
 
-@media only screen and (min-width: 560px) {
-	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
-		margin-bottom: 64px;
-	}
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -4364,30 +4364,38 @@ table th,
 /**
  * Blog Posts (Newspack)
  */
-.wp-block-newspack-blocks-homepage-articles article {
-	margin-bottom: 32px;
-	margin-top: 32px;
-}
-
-@media only screen and (min-width: 560px) {
-	.wp-block-newspack-blocks-homepage-articles article {
-		margin-bottom: 64px;
-		margin-top: 64px;
-	}
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
-	margin-bottom: 32px;
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
 }
 
-@media only screen and (min-width: 560px) {
-	.wp-block-newspack-blocks-homepage-articles article p:not(:last-child) {
-		margin-bottom: 64px;
-	}
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #222222;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #444444;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #222222;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #444444;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #757575;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #444444;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, Raleway, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #222222;
+	border-radius: 0;
+	border-width: 0;
+	padding: 16px 20px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #444444;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1472,7 +1472,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1493,12 +1494,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1513,17 +1516,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1640,7 +1646,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1652,6 +1659,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1666,6 +1674,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1673,12 +1682,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1697,6 +1708,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1777,7 +1789,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1789,6 +1802,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1874,7 +1888,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1910,6 +1925,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1929,6 +1945,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1972,12 +1989,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -152,19 +152,6 @@ hr.wp-block-separator.is-style-wide,
 		text-align: center;
 	}
 
-	.wp-block-newspack-blocks-homepage-articles article .entry-title {
-		a {
-			color: inherit;
-			text-decoration: none;
-
-			&:active,
-			&:focus,
-			&:hover {
-				color: map-deep-get($config-global, "color", "primary", "default");
-			}
-		}
-	}
-
 	.a8c-posts-list-item__excerpt {
 		text-align: left;
 	}
@@ -292,6 +279,58 @@ table,
 	td,
 	th {
 		border-color: #{map-deep-get($config-global, "color", "border", "default")};
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a {
+			color: inherit;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: map-deep-get($config-global, "color", "primary", "default");
+				text-decoration: none;
+			}
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
 	}
 }
 

--- a/shawburn/sass/style-child-theme-editor.scss
+++ b/shawburn/sass/style-child-theme-editor.scss
@@ -32,6 +32,56 @@
  */
 @import "../../varia/sass/blocks/editor";
 
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+}
+
 /**
  * Extras
  */

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #085a72;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #0C80A1;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #085a72;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #085a72;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #085a72;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #085a72;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "PT Sans", Arial, sans-serif;
+	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
+	font-size: 0.83333rem;
+	background-color: #0C80A1;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #085a72;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1224,6 +1228,44 @@ table th,
 .padding-left-default {
 	/*rtl:ignore*/
 	padding-left: 32px !important;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
 }
 
 /**

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #085a72;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3762,6 +3787,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -4086,15 +4086,6 @@ hr.wp-block-separator.is-style-wide,
 	text-align: center;
 }
 
-#page .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: inherit;
-	text-decoration: none;
-}
-
-#page .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #0C80A1;
-}
-
 #page .a8c-posts-list-item__excerpt {
 	text-align: right;
 }
@@ -4205,6 +4196,46 @@ table th,
 .wp-block-table td,
 .wp-block-table th {
 	border-color: #EAEAEA;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #0C80A1;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: inherit;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #0C80A1;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #085a72;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0C80A1;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #085a72;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #085a72;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "PT Sans", Arial, sans-serif;
+	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
+	font-size: 0.83333rem;
+	background-color: #0C80A1;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #085a72;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3822,6 +3816,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #0C80A1;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #085a72;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #0C80A1;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #085a72;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #085a72;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: "PT Sans", Arial, sans-serif;
+	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
+	font-size: 0.83333rem;
+	background-color: #0C80A1;
+	border-radius: 4px;
+	border-width: 0;
+	padding: 16px 24px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #085a72;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4115,15 +4115,6 @@ hr.wp-block-separator.is-style-wide,
 	text-align: center;
 }
 
-#page .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: inherit;
-	text-decoration: none;
-}
-
-#page .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, #page .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #0C80A1;
-}
-
 #page .a8c-posts-list-item__excerpt {
 	text-align: left;
 }
@@ -4234,6 +4225,46 @@ table th,
 .wp-block-table td,
 .wp-block-table th {
 	border-color: #EAEAEA;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: inherit;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #0C80A1;
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: inherit;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
 }
 
 /**

--- a/stow/sass/_extra-child-theme.scss
+++ b/stow/sass/_extra-child-theme.scss
@@ -372,6 +372,75 @@ body:not( .fse-enabled ) {
 /**
  * 6.1. Blog Posts (Newspack) Block
  */
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+				text-decoration: underline;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
+		}
+	}
 }

--- a/stow/sass/style-child-theme-editor.scss
+++ b/stow/sass/style-child-theme-editor.scss
@@ -69,11 +69,11 @@ a {
  * 2.1. Column Block
  */
  .wp-block-coblocks-column {
-	h1, 
-	h2, 
-	h3, 
-	h4, 
-	h5, 
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
 	h6 {
 		margin-bottom: .857em;
 	}
@@ -88,8 +88,8 @@ a {
 /**
  * 2.2. Quote Block
  */
- .wp-block-quote, 
- .wp-block-quote[style*="text-align:center"], 
+ .wp-block-quote,
+ .wp-block-quote[style*="text-align:center"],
  .wp-block-quote[style*="text-align:right"] {
 	 border: 1px solid #f2f2f2;
 	 padding: #{map-deep-get($config-global, "spacing", "horizontal")};;
@@ -119,8 +119,8 @@ a {
 			border-width: #{map-deep-get($config-button, "border-width")};
 			padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 			display: inline-block;
-			&:focus, 
-			&:hover, 
+			&:focus,
+			&:hover,
 			&:visited {
 				color: #{map-deep-get($config-button, "color", "text-hover")};
 				background-color: #{map-deep-get($config-button, "color", "background-hover")};
@@ -168,8 +168,8 @@ a {
 		border-width: #{map-deep-get($config-button, "border-width")};
 		padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 		display: inline-block;
-		&:focus, 
-		&:hover, 
+		&:focus,
+		&:hover,
 		&:visited {
 			color: #{map-deep-get($config-button, "color", "text-hover")};
 			background-color: #{map-deep-get($config-button, "color", "background-hover")};
@@ -178,6 +178,56 @@ a {
 		border: none;
 		box-shadow: none;
 	}
+}
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "xs")) + 0em);
 }
 
 /**

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #4f4f4f;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -341,6 +341,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1365,6 +1369,44 @@ a {
 	color: white;
 	background-color: #4f4f4f;
 	opacity: 1;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.69444em;
 }
 
 /**

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -295,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #404040;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #f25f70;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -318,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #f25f70;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #f25f70;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -341,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #f25f70;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.69444rem;
+	background-color: #f25f70;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: #4f4f4f;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #f25f70;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #404040;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #f25f70;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #404040;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #f25f70;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #f25f70;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.69444rem;
+	background-color: #f25f70;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #4f4f4f;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -4293,8 +4293,57 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 /**
  * 6.1. Blog Posts (Newspack) Block
  */
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:active, .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: inherit;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: inherit;
 }
 
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -4322,8 +4322,57 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 /**
  * 6.1. Blog Posts (Newspack) Block
  */
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:active, .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #f25f70;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: inherit;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: inherit;
 }
 
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #404040;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #f25f70;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #404040;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #f25f70;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #f25f70;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.69444rem;
+	background-color: #f25f70;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #4f4f4f;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/stratford/sass/_extra-child-theme.scss
+++ b/stratford/sass/_extra-child-theme.scss
@@ -344,10 +344,6 @@ a {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
 button,
 .button,
 input[type="submit"],
@@ -388,6 +384,79 @@ button[data-load-more-btn] {
 				&.wp-block-latest-posts__post-date {
 					font-size: $font_size_base;
 				}
+			}
+		}
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles {
+	article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: none;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			}
+		}
+
+		.cat-links a,
+		.more-link,
+		.entry-meta a {
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				color: #fff;
+				text-decoration: underline;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-newspack-blocks-homepage-articles article {
+		.entry-title a{
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		.more-link {
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
 			}
 		}
 	}

--- a/stratford/sass/style-child-theme-editor.scss
+++ b/stratford/sass/style-child-theme-editor.scss
@@ -52,14 +52,14 @@ $font_line_height_body: #{map-deep-get($config-global, "font", "line-height", "b
 $button_line_height: #{map-deep-get($config-button, "font", "line-height")};
 $button_font_weight: #{map-deep-get($config-button, "font", "weight")};
 $button_font_size: #{map-deep-get($config-button, "font", "size")};
-$button_spacing_vertical: #{map-deep-get($config-button, "padding", "vertical")}; 
+$button_spacing_vertical: #{map-deep-get($config-button, "padding", "vertical")};
 $button_spacing_horizontal: #{map-deep-get($config-button, "padding", "horizontal")};
 $button_color: #{map-deep-get($config-button, "color", "text")};
 $button_color_hover: #{map-deep-get($config-button, "color", "text-hover")};
 $button_background: #{map-deep-get($config-button, "color", "background")};
 $button_background_hover: #{map-deep-get($config-button, "color", "background-hover")};
 $font_size_widget_title: #{map-deep-get($config-heading, "font", "size", "h3")};
-  
+
 /**
  * 1. General Styles
  */
@@ -134,8 +134,8 @@ h6 {
 /**
  * 2.2. Quote Block
  */
- .wp-block-quote, 
- .wp-block-quote[style*="text-align:center"], 
+ .wp-block-quote,
+ .wp-block-quote[style*="text-align:center"],
  .wp-block-quote[style*="text-align:right"] {
 	border: 1px solid $color_background_light;
 	padding: $spacing_horizontal;
@@ -237,8 +237,8 @@ h6 {
 		border-width: 0;
 		padding: $button_spacing_vertical $button_spacing_horizontal;
 		display: inline-block;
-		&:focus, 
-		&:hover, 
+		&:focus,
+		&:hover,
 		&:visited {
 			color: $button_color_hover;
 			background-color: $button_background_hover;
@@ -247,4 +247,57 @@ h6 {
 		border: none;
 		box-shadow: none;
 	}
+}
+
+.wp-block-a8c-blog-posts {
+	.entry-title a {
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.cat-links a,
+	.more-link,
+	.entry-meta a {
+		text-decoration: none;
+
+		&:active,
+		&:focus,
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&.image-alignbehind article {
+		.entry-title a {
+			&:active,
+			&:focus,
+			&:hover {
+				color: #fff;
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.has-background:not(.has-background-background-color),
+[class*="background-color"]:not(.has-background-background-color),
+[style*="background-color"] {
+	.wp-block-a8c-blog-posts {
+		.entry-title a{
+			text-decoration: none;
+
+			&:active,
+			&:focus,
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
 }

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -311,6 +311,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }
@@ -1409,4 +1413,49 @@ h6 {
 	color: white;
 	background-color: #2c313f;
 	opacity: 1;
+}
+
+.wp-block-a8c-blog-posts .entry-title a:active, .wp-block-a8c-blog-posts .entry-title a:focus, .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a,
+.wp-block-a8c-blog-posts .more-link,
+.wp-block-a8c-blog-posts .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-a8c-blog-posts .cat-links a:active, .wp-block-a8c-blog-posts .cat-links a:focus, .wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .more-link:active,
+.wp-block-a8c-blog-posts .more-link:focus,
+.wp-block-a8c-blog-posts .more-link:hover,
+.wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .entry-meta a:focus,
+.wp-block-a8c-blog-posts .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:active, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:focus, .wp-block-a8c-blog-posts.image-alignbehind article .entry-title a:hover {
+	color: #fff;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:focus,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	font-size: 0.83333em;
 }

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -294,21 +295,78 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: #2c313f;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: #3e69dc;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -317,21 +375,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: #3e69dc;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: #3e69dc;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -340,24 +428,96 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: #3e69dc;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+	line-height: 1.44;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #3e69dc;
+	border-radius: 10px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+	margin-bottom: -0.34em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+	margin-top: -0.33em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+	color: white;
+	background-color: #2c313f;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -295,21 +295,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -469,7 +454,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button {
 	line-height: 1.44;
 	color: white;
 	cursor: pointer;
@@ -483,26 +474,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts + .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before {
+.wp-block-a8c-blog-posts + .button:before {
 	margin-bottom: -0.34em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after {
+.wp-block-a8c-blog-posts + .button:after {
 	margin-top: -0.33em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #2c313f;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -340,6 +340,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #2c313f;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #3e69dc;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #2c313f;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #3e69dc;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-left: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-left: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-left: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #3e69dc;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1.44;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #3e69dc;
+	border-radius: 10px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.34em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.33em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #2c313f;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -4233,10 +4233,6 @@ p:not(.site-title) a:hover {
 	border: 2px solid;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
 button,
 .button,
 input[type="submit"],
@@ -4304,6 +4300,59 @@ button[data-load-more-btn].has-background:visited {
 .wp-block-columns .wp-block-latest-posts > li > time.wp-block-latest-posts__post-date,
 .wp-block-group .wp-block-latest-posts > li > time.wp-block-latest-posts__post-date {
 	font-size: 1rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:active, .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: #fff;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: inherit;
 }
 
 /**

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1177,6 +1177,12 @@ object {
 	color: #3e69dc;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1202,29 +1208,39 @@ object {
 	font-size: 0.83333rem;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
-	margin-left: 16px;
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
+	margin-left: 16px;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-left: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1254,10 +1270,19 @@ object {
 
 .wp-block-newspack-blocks-homepage-articles.is-grid article {
 	margin-top: 0;
+	margin-bottom: calc(3 * 32px);
 }
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**
@@ -3763,6 +3788,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-right: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1149,11 +1149,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1161,26 +1204,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: #2c313f;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: #3e69dc;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1197,12 +1225,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: #2c313f;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: #3e69dc;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1211,11 +1261,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1224,55 +1269,130 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: #3e69dc;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1.44;
+	color: white;
+	cursor: pointer;
+	font-weight: 700;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-family: var(--font-base, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
+	font-size: 0.83333rem;
+	background-color: #3e69dc;
+	border-radius: 10px;
+	border-width: 0;
+	padding: 16px 16px;
 }
 
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.34em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.33em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: #2c313f;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4262,10 +4262,6 @@ p:not(.site-title) a:hover {
 	border: 2px solid;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	text-decoration: none;
-}
-
 button,
 .button,
 input[type="submit"],
@@ -4333,6 +4329,59 @@ button[data-load-more-btn].has-background:visited {
 .wp-block-columns .wp-block-latest-posts > li > time.wp-block-latest-posts__post-date,
 .wp-block-group .wp-block-latest-posts > li > time.wp-block-latest-posts__post-date {
 	font-size: 1rem;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .more-link:active, .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: #3e69dc;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a,
+.wp-block-newspack-blocks-homepage-articles article .more-link,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a {
+	text-decoration: none;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active, .wp-block-newspack-blocks-homepage-articles article .cat-links a:focus, .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+.wp-block-newspack-blocks-homepage-articles article .more-link:active,
+.wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+.wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:focus,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .entry-title a:hover {
+	color: #fff;
+	text-decoration: underline;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:active, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:focus, .wp-block-newspack-blocks-homepage-articles.image-alignbehind article .more-link:hover {
+	color: inherit;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .more-link:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .more-link:hover {
+	color: inherit;
 }
 
 /**

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1224,29 +1224,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -3823,6 +3817,29 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  */
 .jetpack-business-hours dd {
 	padding-left: 0;
+}
+
+/**
+ * Layout Grid
+ */
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	margin-top: 21.312px;
+	margin-bottom: 21.312px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+		margin-top: 32px;
+		margin-bottom: 32px;
+	}
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
+	margin-bottom: 0;
 }
 
 /**

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -146,24 +146,24 @@
 			}
 		}
 	}
+}
 
-	@import "../../base/extends";
-	& + .button {
+@import "../../base/extends";
+.wp-block-a8c-blog-posts + .button {
 	// Extend button style
 	@extend %button-style;
 	display: inline-block;
 	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "md")) + 0em);
 
-		&:hover {
-			cursor: default;
-		}
+	&:hover {
+		cursor: default;
+	}
 
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
-		[style*="background-color"] & {
-			background-color: transparent;
-			border: 2px solid currentColor;
-			color: currentColor;
-		}
+	.has-background:not(.has-background-background-color) &,
+	[class*="background-color"]:not(.has-background-background-color) &,
+	[style*="background-color"] & {
+		background-color: transparent;
+		border: 2px solid currentColor;
+		color: currentColor;
 	}
 }

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -157,6 +157,7 @@
 	// Extend button style
 	@extend %button-style;
 	display: inline-block;
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "md")) + 0em);
 
 	&:hover {
 		cursor: default;

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -1,19 +1,81 @@
 .wp-block-a8c-blog-posts {
-	article {
-		margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
+	&.image-aligntop {
+		.post-thumbnail {
+			margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+		}
 	}
 
-	.post-thumbnail img {
-		width: auto;
+	&.image-alignleft {
+		.post-thumbnail {
+			margin-right: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	&.image-alignright {
+		.post-thumbnail {
+			margin-left: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	&.image-alignbehind .post-has-image {
+		 .entry-wrapper {
+			padding: #{map-deep-get($config-global, "spacing", "vertical")};;
+		}
+
+		a:hover {
+			color: currentColor;
+		}
+	}
+
+	.article-section-title {
+		font-size: (strip-unit(map-deep-get($config-global, "font", "size", "base")) + 0em);
+		margin-top: 0;
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+	}
+
+	article {
+		margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+
+		@include media(mobile) {
+			margin-bottom: #{3 * map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	.post-thumbnail {
+		img {
+			vertical-align: middle;
+			width: auto;
+		}
+	}
+
+	.entry-wrapper > * {
+		/* Vertical margins logic between post details */
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+		margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.entry-title {
 		a {
 			color: #{map-deep-get($config-global, "color", "primary", "default")};
-			text-decoration: underline;
+
+			.has-background:not(.has-background-background-color) &,
+			[class*="background-color"]:not(.has-background-background-color) &,
+			[style*="background-color"] & {
+				color: currentColor;
+			}
+
 
 			&:hover {
 				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+				text-decoration: underline;
 			}
 
 			.has-background:not(.has-background-background-color) &,
@@ -24,11 +86,34 @@
 		}
 	}
 
+	.more-link {
+		display: block;
+		color: inherit;
+		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+
+		&:after {
+			content: "\02192";
+			display: inline-block;
+			margin-left: 0.5em;
+		}
+
+		&:hover,
+		&:active {
+			color: #{map-deep-get($config-global, "color", "primary", "hover")};
+			text-decoration: none;
+
+			.has-background:not(.has-background-background-color) &,
+			[class*="background-color"]:not(.has-background-background-color) &,
+			[style*="background-color"] & {
+				color: currentColor;
+			}
+		}
+	}
+
 	.entry-meta,
-	.entry-footer,
 	.cat-links {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};
-		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+		font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
 
 		.has-background:not(.has-background-background-color) &,
 		[class*="background-color"]:not(.has-background-background-color) &,
@@ -36,18 +121,48 @@
 			color: currentColor;
 		}
 
-		> * {
-			display: inline-block;
+		.byline:not(:last-child) {
 			margin-right: #{map-deep-get($config-global, "spacing", "unit")};
-			vertical-align: middle;
-
-			&:last-child {
-				margin-right: 0;
-			}
 		}
 
 		.published + .updated {
 			display: none;
+		}
+
+		a {
+			color: currentColor;
+			text-decoration: underline;
+
+			&:hover,
+			&:active {
+				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+				text-decoration: none;
+
+				.has-background:not(.has-background-background-color) &,
+				[class*="background-color"]:not(.has-background-background-color) &,
+				[style*="background-color"] & {
+					color: currentColor;
+				}
+			}
+		}
+	}
+
+	& + .button {
+	// Extend button style
+	@extend %button-style;
+	display: inline-block;
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "md")) + 0em);
+
+		&:hover {
+			cursor: default;
+		}
+
+		.has-background:not(.has-background-background-color) &,
+		[class*="background-color"]:not(.has-background-background-color) &,
+		[style*="background-color"] & {
+			background-color: transparent;
+			border: 2px solid currentColor;
+			color: currentColor;
 		}
 	}
 }

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -147,6 +147,7 @@
 		}
 	}
 
+	@import "../../base/extends";
 	& + .button {
 	// Extend button style
 	@extend %button-style;

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -22,6 +22,10 @@
 			padding: #{map-deep-get($config-global, "spacing", "vertical")};;
 		}
 
+		.cat-links {
+			color: #fff;
+		}
+
 		a:hover {
 			color: currentColor;
 		}

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -35,5 +35,19 @@
 		[style*="background-color"] & {
 			color: currentColor;
 		}
+
+		> * {
+			display: inline-block;
+			margin-right: #{map-deep-get($config-global, "spacing", "unit")};
+			vertical-align: middle;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
+		.published + .updated {
+			display: none;
+		}
 	}
 }

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -157,7 +157,6 @@
 	// Extend button style
 	@extend %button-style;
 	display: inline-block;
-	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "md")) + 0em);
 
 	&:hover {
 		cursor: default;

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -1,105 +1,152 @@
-.wp-block-newspack-blocks-homepage-articles article {
-	display: block;
-
-	/* Vertical margins logic between posts */
-	margin-top: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
-	margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
-
-	&:first-child {
-		margin-top: 0;
-	}
-
-	&:last-child {
-		margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
-	}
-
-	.post-thumbnail img {
-		width: auto;
-	}
-
-	.entry-title {
-		a {
-			color: #{map-deep-get($config-global, "color", "primary", "default")};
-			text-decoration: underline;
-
-			&:hover {
-				color: #{map-deep-get($config-global, "color", "primary", "hover")};
-			}
-
-			.has-background:not(.has-background-background-color) &,
-			[class*="background-color"]:not(.has-background-background-color) &,
-			[style*="background-color"] & {
-				color: currentColor;
-			}
+.wp-block-newspack-blocks-homepage-articles {
+	&.image-aligntop {
+		.post-thumbnail {
+			margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
 		}
 	}
 
-	.entry-wrapper > * {
-		/* Vertical margins logic between post details */
-		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
-		margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
+	&.image-alignleft {
+		.post-thumbnail {
+			margin-right: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	&.image-alignright {
+		.post-thumbnail {
+			margin-left: #{map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	&.image-alignbehind .post-has-image .entry-wrapper {
+		padding: #{map-deep-get($config-global, "spacing", "vertical")};;
+	}
+
+	&.is-grid article {
+		margin-top: 0;
+		margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+
+		@include media(mobile) {
+			margin-bottom: #{3 * map-deep-get($config-global, "spacing", "vertical")};
+		}
+	}
+
+	.article-section-title {
+		font-size: #{map-deep-get($config-global, "font", "size", "base")};
+		margin-bottom: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
+
+		& + article {
+			margin-top: 0;
+		}
+	}
+
+	article {
+		display: block;
+
+		/* Vertical margins logic between posts */
+		margin-top: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+		margin-bottom: #{2 * map-deep-get($config-global, "spacing", "vertical")};
+
+		@include media(mobile) {
+			margin-top: #{3 * map-deep-get($config-global, "spacing", "vertical")};
+			margin-bottom: #{3 * map-deep-get($config-global, "spacing", "vertical")};
+		}
 
 		&:first-child {
 			margin-top: 0;
 		}
 
 		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	.more-link {
-		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
-	}
-
-	.entry-meta,
-	.entry-footer,
-	.cat-links {
-		color: #{map-deep-get($config-global, "color", "foreground", "light")};
-		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
-
-		.has-background:not(.has-background-background-color) &,
-		[class*="background-color"]:not(.has-background-background-color) &,
-		[style*="background-color"] & {
-			color: currentColor;
+			margin-bottom: #{3 * map-deep-get($config-global, "spacing", "vertical")};
 		}
 
-		> * {
-			display: inline-block;
-			margin-right: #{map-deep-get($config-global, "spacing", "unit")};
-			vertical-align: middle;
+		.post-thumbnail img {
+			width: auto;
+		}
+
+		.entry-wrapper > * {
+			/* Vertical margins logic between post details */
+			margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+			margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
+
+			&:first-child {
+				margin-top: 0;
+			}
 
 			&:last-child {
-				margin-right: 0;
+				margin-bottom: 0;
 			}
 		}
 
-		.published + .updated {
-			display: none;
-		}
+		.entry-title {
+			a {
+				color: #{map-deep-get($config-global, "color", "primary", "default")};
 
-		a {
-			color: currentColor;
+				.has-background:not(.has-background-background-color) &,
+				[class*="background-color"]:not(.has-background-background-color) &,
+				[style*="background-color"] & {
+					color: currentColor;
+				}
 
-			&:hover,
-			&:active {
-				color: #{map-deep-get($config-global, "color", "primary", "hover")};
+				&:hover {
+					color: #{map-deep-get($config-global, "color", "primary", "hover")};
+					text-decoration: underline;
+
+					.has-background:not(.has-background-background-color) &,
+					[class*="background-color"]:not(.has-background-background-color) &,
+					[style*="background-color"] & {
+						color: currentColor;
+					}
+				}
 			}
 		}
 
-		.svg-icon {
-			fill: currentColor;
-			position: relative;
-			display: inline-block;
-			vertical-align: middle;
-			margin-right: calc(0.25 * #{map-deep-get($config-global, "spacing", "unit")});
+		.more-link {
+			@include media(mobile) {
+				margin-top: #{map-deep-get($config-global, "spacing", "unit")};
+			}
+		}
+
+		.entry-meta,
+		.cat-links {
+			color: #{map-deep-get($config-global, "color", "foreground", "light")};
+			font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
+			.has-background:not(.has-background-background-color) &,
+			[class*="background-color"]:not(.has-background-background-color) &,
+			[style*="background-color"] & {
+				color: currentColor;
+			}
+
+			> span > * {
+				vertical-align: top;
+			}
+
+			.byline:not(:last-child) {
+				margin-right: #{map-deep-get($config-global, "spacing", "unit")};
+			}
+
+			.published + .updated {
+				display: none;
+			}
+
+			a {
+				color: currentColor;
+				text-decoration: underline;
+
+				&:hover,
+				&:active {
+					color: #{map-deep-get($config-global, "color", "primary", "hover")};
+					text-decoration: none;
+
+					.has-background:not(.has-background-background-color) &,
+					[class*="background-color"]:not(.has-background-background-color) &,
+					[style*="background-color"] & {
+						color: currentColor;
+					}
+				}
+			}
 		}
 	}
-}
-
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * #{map-deep-get($config-global, "spacing", "vertical")});
 }
 
 button[data-load-more-btn] {

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -64,22 +64,18 @@
 			color: currentColor;
 		}
 
-		> span {
+		> * {
 			display: inline-block;
 			margin-right: #{map-deep-get($config-global, "spacing", "unit")};
-
-			& > * {
-				display: inline-block;
-				vertical-align: middle;
-			}
+			vertical-align: middle;
 
 			&:last-child {
 				margin-right: 0;
 			}
+		}
 
-			.published + .updated {
-				display: none; // Hide updated date?
-			}
+		.published + .updated {
+			display: none;
 		}
 
 		a {

--- a/varia/sass/blocks/blog-posts/_style.scss
+++ b/varia/sass/blocks/blog-posts/_style.scss
@@ -149,6 +149,7 @@
 	}
 }
 
+@import "../../base/extends";
 button[data-load-more-btn] {
 	// Extend button style
 	@extend %button-style;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -300,21 +300,6 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
-.wp-block-a8c-blog-posts {
-	/**
- * Button Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-	/**
- * Onsale Placeholder style
- * - Since buttons appear in various blocks,
- *   let’s use a placeholder to keep them all
- *   in-sync
- */
-}
-
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -474,7 +459,13 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -488,26 +479,32 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }
 
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
 	font-size: 1.2em;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -125,7 +125,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.fse-template-part .main-navigation .button {
+.wp-block-a8c-blog-posts + .button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -139,22 +139,22 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .button:after {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
 	height: 0;
 	width: 0;
 }
 
-.fse-template-part .main-navigation .button:before {
+.wp-block-a8c-blog-posts + .button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation .button:after {
+.wp-block-a8c-blog-posts + .button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }
@@ -300,21 +300,63 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .article-section-title {
+	font-size: 1em;
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
 .wp-block-a8c-blog-posts article {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-a8c-blog-posts article {
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-a8c-blog-posts .post-thumbnail img {
+	vertical-align: middle;
 	width: auto;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > * {
+	/* Vertical margins logic between post details */
+	margin-top: 16px;
+	margin-bottom: 16px;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:first-child {
+	margin-top: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-wrapper > *:last-child {
+	margin-bottom: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-title a {
 	color: blue;
-	text-decoration: underline;
-}
-
-.wp-block-a8c-blog-posts .entry-title a:hover {
-	color: indigo;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
@@ -323,21 +365,51 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-title a:hover {
+	color: indigo;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .more-link {
+	display: block;
+	color: inherit;
+	margin-top: 16px;
+}
+
+.wp-block-a8c-blog-posts .more-link:after {
+	content: "\02192";
+	display: inline-block;
+	margin-left: 0.5em;
+}
+
+.wp-block-a8c-blog-posts .more-link:hover, .wp-block-a8c-blog-posts .more-link:active {
+	color: indigo;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
+	color: currentColor;
+}
+
 .wp-block-a8c-blog-posts .entry-meta,
-.wp-block-a8c-blog-posts .entry-footer,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333rem;
+	font-size: 0.83333em;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-a8c-blog-posts .entry-footer,
-[style*="background-color"]
-.wp-block-a8c-blog-posts .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-a8c-blog-posts .cat-links,
@@ -346,24 +418,62 @@ object {
 	color: currentColor;
 }
 
-.wp-block-a8c-blog-posts .entry-meta > *,
-.wp-block-a8c-blog-posts .entry-footer > *,
-.wp-block-a8c-blog-posts .cat-links > * {
-	display: inline-block;
+.wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
+.wp-block-a8c-blog-posts .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
-	vertical-align: middle;
-}
-
-.wp-block-a8c-blog-posts .entry-meta > *:last-child,
-.wp-block-a8c-blog-posts .entry-footer > *:last-child,
-.wp-block-a8c-blog-posts .cat-links > *:last-child {
-	margin-right: 0;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .published + .updated,
-.wp-block-a8c-blog-posts .entry-footer .published + .updated,
 .wp-block-a8c-blog-posts .cat-links .published + .updated {
 	display: none;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a,
+.wp-block-a8c-blog-posts .cat-links a {
+	color: currentColor;
+	text-decoration: underline;
+}
+
+.wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
+.wp-block-a8c-blog-posts .cat-links a:hover,
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: indigo;
+	text-decoration: none;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:hover,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta a:active,
+[style*="background-color"] .wp-block-a8c-blog-posts .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:hover,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-a8c-blog-posts .cat-links a:active,
+[style*="background-color"]
+.wp-block-a8c-blog-posts .cat-links a:active {
+	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts + .button {
+	display: inline-block;
+	font-size: 1.2em;
+}
+
+.wp-block-a8c-blog-posts + .button:hover {
+	cursor: default;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
+[style*="background-color"] .wp-block-a8c-blog-posts + .button {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 .wp-block-button {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -346,6 +346,26 @@ object {
 	color: currentColor;
 }
 
+.wp-block-a8c-blog-posts .entry-meta > *,
+.wp-block-a8c-blog-posts .entry-footer > *,
+.wp-block-a8c-blog-posts .cat-links > * {
+	display: inline-block;
+	margin-right: 16px;
+	vertical-align: middle;
+}
+
+.wp-block-a8c-blog-posts .entry-meta > *:last-child,
+.wp-block-a8c-blog-posts .entry-footer > *:last-child,
+.wp-block-a8c-blog-posts .cat-links > *:last-child {
+	margin-right: 0;
+}
+
+.wp-block-a8c-blog-posts .entry-meta .published + .updated,
+.wp-block-a8c-blog-posts .entry-footer .published + .updated,
+.wp-block-a8c-blog-posts .cat-links .published + .updated {
+	display: none;
+}
+
 .wp-block-button {
 	/* Default Style */
 	/* Outline Style */

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -511,7 +511,6 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -316,6 +316,10 @@ object {
 	padding: 32px;
 }
 
+.wp-block-a8c-blog-posts.image-alignbehind .post-has-image .cat-links {
+	color: #fff;
+}
+
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
 	color: currentColor;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -300,6 +300,21 @@ object {
  * - In the future the Block styles may get compiled to individual .css
  *   files and conditionally loaded
  */
+.wp-block-a8c-blog-posts {
+	/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+	/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+}
+
 .wp-block-a8c-blog-posts.image-aligntop .post-thumbnail {
 	margin-bottom: 16px;
 }
@@ -457,6 +472,40 @@ object {
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
 	color: currentColor;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: sans-serif;
+	font-family: var(--font-headings, sans-serif);
+	font-size: 1.2rem;
+	background-color: blue;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:before, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:before {
+	margin-bottom: -0.12em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:after, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:after, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:after {
+	margin-top: -0.11em;
+}
+
+.wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:hover, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .button:focus, .wp-block-a8c-blog-posts .wp-block-a8c-blog-posts + .has-focus.button, .wp-block-a8c-blog-posts .fse-template-part .main-navigation .has-focus.button, .fse-template-part .main-navigation .wp-block-a8c-blog-posts .has-focus.button {
+	color: white;
+	background-color: indigo;
 }
 
 .wp-block-a8c-blog-posts + .button {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -511,6 +511,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
+	font-size: 1.2em;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1355,6 +1355,84 @@ object {
 	color: currentColor;
 }
 
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: sans-serif;
+	font-family: var(--font-headings, sans-serif);
+	font-size: 1.2rem;
+	background-color: blue;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: indigo;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1217,6 +1217,12 @@ object {
 	color: indigo;
 }
 
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
 	/* Vertical margins logic between post details */
 	margin-top: 16px;
@@ -1240,6 +1246,22 @@ object {
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .entry-footer,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
+	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
@@ -1299,6 +1321,14 @@ object {
 
 button[data-load-more-btn] {
 	display: inline-block;
+}
+
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn] {
+	background-color: transparent;
+	border: 2px solid currentColor;
+	color: currentColor;
 }
 
 /**

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1189,11 +1189,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1201,26 +1244,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: blue;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: indigo;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1237,12 +1265,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: blue;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: indigo;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1251,11 +1301,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1264,59 +1309,50 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
-	display: inline-block;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
 	margin-left: 16px;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
-	vertical-align: middle;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
-	margin-left: 0;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: indigo;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: calc(0.25 * 16px);
-}
-
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
 button[data-load-more-btn] {

--- a/varia/style.css
+++ b/varia/style.css
@@ -1355,6 +1355,84 @@ object {
 	color: currentColor;
 }
 
+/**
+ * Button Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
+button[data-load-more-btn], button,
+.button,
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button, .a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+	line-height: 1;
+	color: white;
+	cursor: pointer;
+	font-weight: bold;
+	font-family: sans-serif;
+	font-family: var(--font-headings, sans-serif);
+	font-size: 1.2rem;
+	background-color: blue;
+	border-radius: 9px;
+	border-width: 0;
+	padding: 16px 16px;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	content: '';
+	display: block;
+	height: 0;
+	width: 0;
+}
+
+button[data-load-more-btn]:before, button:before,
+.button:before,
+input[type="submit"]:before,
+.wp-block-button__link:before,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+	margin-bottom: -0.12em;
+}
+
+button[data-load-more-btn]:after, button:after,
+.button:after,
+input[type="submit"]:after,
+.wp-block-button__link:after,
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+	margin-top: -0.11em;
+}
+
+button:hover,
+.button:hover,
+input:hover[type="submit"],
+.wp-block-button__link:hover,
+.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, button:focus,
+.button:focus,
+input:focus[type="submit"],
+.wp-block-button__link:focus,
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, button.has-focus,
+.has-focus.button,
+input.has-focus[type="submit"],
+.has-focus.wp-block-button__link,
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+	color: white;
+	background-color: indigo;
+}
+
+/**
+ * Onsale Placeholder style
+ * - Since buttons appear in various blocks,
+ *   let’s use a placeholder to keep them all
+ *   in-sync
+ */
 button[data-load-more-btn] {
 	display: inline-block;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -1264,29 +1264,23 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
 	display: inline-block;
 	margin-right: 16px;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
-	display: inline-block;
 	vertical-align: middle;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
 	margin-right: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > span .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > span .published + .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -1189,11 +1189,54 @@ object {
 	min-width: 300px;
 }
 
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-thumbnail {
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignleft .post-thumbnail {
+	margin-right: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignright .post-thumbnail {
+	margin-left: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
+	padding: 32px;
+}
+
+.wp-block-newspack-blocks-homepage-articles.is-grid article {
+	margin-top: 0;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles.is-grid article {
+		margin-bottom: 96px;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+	font-size: 1rem;
+	margin-bottom: 16px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title + article {
+	margin-top: 0;
+}
+
 .wp-block-newspack-blocks-homepage-articles article {
 	display: block;
 	/* Vertical margins logic between posts */
-	margin-top: calc(3 * 32px);
-	margin-bottom: calc(3 * 32px);
+	margin-top: 64px;
+	margin-bottom: 64px;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article {
+		margin-top: 96px;
+		margin-bottom: 96px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article:first-child {
@@ -1201,26 +1244,11 @@ object {
 }
 
 .wp-block-newspack-blocks-homepage-articles article:last-child {
-	margin-bottom: calc(3 * 32px);
+	margin-bottom: 96px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .post-thumbnail img {
 	width: auto;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: blue;
-	text-decoration: underline;
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
-	color: indigo;
-}
-
-.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
-	color: currentColor;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-wrapper > * {
@@ -1237,12 +1265,34 @@ object {
 	margin-bottom: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .more-link {
-	margin-top: 16px;
+.wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: blue;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
+	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: indigo;
+	text-decoration: underline;
+}
+
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+	color: currentColor;
+}
+
+@media only screen and (min-width: 560px) {
+	.wp-block-newspack-blocks-homepage-articles article .more-link {
+		margin-top: 16px;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: #767676;
 	font-size: 0.83333rem;
@@ -1251,11 +1301,6 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 [style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[class*="background-color"]:not(.has-background-background-color)
-.wp-block-newspack-blocks-homepage-articles article .entry-footer,
-[style*="background-color"]
-.wp-block-newspack-blocks-homepage-articles article .entry-footer, .has-background:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
 [class*="background-color"]:not(.has-background-background-color)
 .wp-block-newspack-blocks-homepage-articles article .cat-links,
@@ -1264,53 +1309,50 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > * {
-	display: inline-block;
-	margin-right: 16px;
-	vertical-align: middle;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta > span > *,
+.wp-block-newspack-blocks-homepage-articles article .cat-links > span > * {
+	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer > *:last-child,
-.wp-block-newspack-blocks-homepage-articles article .cat-links > *:last-child {
-	margin-right: 0;
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
+	margin-right: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .published + .updated,
 .wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a {
 	color: currentColor;
+	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: indigo;
+	text-decoration: none;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .entry-footer .svg-icon,
-.wp-block-newspack-blocks-homepage-articles article .cat-links .svg-icon {
-	fill: currentColor;
-	position: relative;
-	display: inline-block;
-	vertical-align: middle;
-	margin-right: calc(0.25 * 16px);
-}
-
-.wp-block-newspack-blocks-homepage-articles.is-grid article {
-	margin-top: 0;
-	margin-bottom: calc(3 * 32px);
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
+	color: currentColor;
 }
 
 button[data-load-more-btn] {


### PR DESCRIPTION
Initial theme styles were added for the new Blog Posts (Newspack) block in #1710. This additionally fixes some layout issues and bugs.

**Included:**
- fixes: https://github.com/Automattic/wp-calypso/issues/38389
- rebuilds child themes from: #1704