### PR TITLE
Button-2: Center image caption on frontend

### DIFF
--- a/button-2/blocks.css
+++ b/button-2/blocks.css
@@ -20,7 +20,10 @@ Description: Used to style Gutenberg blocks
 
 /* Captions */
 
-[class^="wp-block-"] figcaption {}
+[class^="wp-block-"] figcaption {
+	font-size: 14px;
+	text-align: center;
+}
 
 
 /*--------------------------------------------------------------

--- a/button-2/blocks.css
+++ b/button-2/blocks.css
@@ -21,8 +21,12 @@ Description: Used to style Gutenberg blocks
 /* Captions */
 
 [class^="wp-block-"] figcaption {
-	font-size: 14px;
+	color: #555d66;
+	font-family: Lora, Garamond, serif;
+	font-size: 13px;
+	font-style: italic;
 	text-align: center;
+	line-height: 1.6;
 }
 
 

--- a/button-2/editor-blocks.css
+++ b/button-2/editor-blocks.css
@@ -155,8 +155,10 @@ Description: Gutenberg Block Editor Styles
 
 [class^="wp-block-"] figcaption {
 	color: #555d66;
-	font-family: Lato, Helvetica, sans-serif;
+	font-family: Lora, Garamond, serif;
 	font-size: 13px;
+	font-style: italic;
+	text-align: center;
 	line-height: 1.6;
 }
 

--- a/button-2/style.css
+++ b/button-2/style.css
@@ -1914,9 +1914,12 @@ figure {
 }
 
 .wp-caption-text {
+	color: #555d66;
 	font-family: Lora, Garamond, serif;
+	font-size: 13px;
 	font-style: italic;
 	text-align: center;
+	line-height: 1.6;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Fixes #1725 

<table>
<tr>
<td>Before:
<br><br>

![#1725-before](https://user-images.githubusercontent.com/3323310/71499871-753b0480-289d-11ea-8d3c-e59ceb9f6008.png)

</td>
<td>After:
<br><br>

![#1725-after](https://user-images.githubusercontent.com/3323310/71499878-7cfaa900-289d-11ea-9c88-a944645959ae.png)
</td>
</tr>
</table>