### PR TITLE
Button-2: Fix gallery block styles

### DIFF
--- a/button-2/editor-blocks.css
+++ b/button-2/editor-blocks.css
@@ -140,8 +140,8 @@ Description: Gutenberg Block Editor Styles
 
 /* List styles */
 
-.edit-post-visual-editor figure:not(.wp-block-gallery) ul li,
-.editor-block-list__block figure:not(.wp-block-gallery) ul li,
+.edit-post-visual-editor ul li:not(.blocks-gallery-item),
+.editor-block-list__block ul li:not(.blocks-gallery-item),
 .edit-post-visual-editor ol li,
 .editor-block-list__block ol li,
 .block-library-list li,

--- a/button-2/editor-blocks.css
+++ b/button-2/editor-blocks.css
@@ -140,8 +140,8 @@ Description: Gutenberg Block Editor Styles
 
 /* List styles */
 
-.edit-post-visual-editor ul:not(.wp-block-gallery) li,
-.editor-block-list__block ul:not(.wp-block-gallery) li,
+.edit-post-visual-editor figure:not(.wp-block-gallery) ul li,
+.editor-block-list__block figure:not(.wp-block-gallery) ul li,
 .edit-post-visual-editor ol li,
 .editor-block-list__block ol li,
 .block-library-list li,


### PR DESCRIPTION
Fixes #1728 

<table>
<tr>
<td>Before:
<br><br>

![#1728-before](https://user-images.githubusercontent.com/3323310/71540419-3ed8b480-2985-11ea-8fbd-8ea5e8b5c259.png)

</td>
<td>After:
<br><br>

![#1728-after](https://user-images.githubusercontent.com/3323310/71540421-4435ff00-2985-11ea-8d8d-88694c8aa261.png)

</td>
</tr>
</table>