### PR TITLE
Shoreditch: Make default color AA/AAA compliant

### DIFF
--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -527,7 +527,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .has-medium-gray-color:focus,
 .has-medium-gray-color:active,
 .has-medium-gray-color:visited {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .has-medium-gray-background-color,
@@ -535,7 +535,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .has-medium-gray-background-color:focus,
 .has-medium-gray-background-color:active,
 .has-medium-gray-background-color:visited {
-	background-color: #7a7c84;
+	background-color: #767676;
 }
 
 .has-light-gray-color,

--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -527,7 +527,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .has-medium-gray-color:focus,
 .has-medium-gray-color:active,
 .has-medium-gray-color:visited {
-	color: #767676;
+	color: #73757D;
 }
 
 .has-medium-gray-background-color,
@@ -535,7 +535,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .has-medium-gray-background-color:focus,
 .has-medium-gray-background-color:active,
 .has-medium-gray-background-color:visited {
-	background-color: #767676;
+	background-color: #73757D;
 }
 
 .has-light-gray-color,

--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -44,7 +44,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 /* Color */
 
 .edit-post-visual-editor .editor-block-list__block {
-	color: #767676;
+	color: #73757D;
 }
 
 /* Post title */
@@ -266,7 +266,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 .wp-block-freeform.block-library-rich-text__tinymce pre {
 	border: 1px solid #f3f3f3;
-	color: #767676;
+	color: #73757D;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 	padding: 1.5em;
@@ -449,7 +449,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Verse */
 
 .wp-block-verse pre {
-	color: #767676;
+	color: #73757D;
 	font-style: italic;
 }
 
@@ -464,7 +464,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-code .editor-plain-text {
 	background: transparent;
-	color: #767676;
+	color: #73757D;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 }
@@ -486,7 +486,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-preformatted pre {
 	background: transparent;
-	color: #767676;
+	color: #73757D;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 }
@@ -506,7 +506,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-pullquote blockquote {
-	color: #767676;
+	color: #73757D;
 	font-style: italic;
 }
 

--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -44,7 +44,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 /* Color */
 
 .edit-post-visual-editor .editor-block-list__block {
-	color: #7a7c84;
+	color: #767676;
 }
 
 /* Post title */
@@ -266,7 +266,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 .wp-block-freeform.block-library-rich-text__tinymce pre {
 	border: 1px solid #f3f3f3;
-	color: #7a7c84;
+	color: #767676;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 	padding: 1.5em;
@@ -449,7 +449,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Verse */
 
 .wp-block-verse pre {
-	color: #7a7c84;
+	color: #767676;
 	font-style: italic;
 }
 
@@ -464,7 +464,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-code .editor-plain-text {
 	background: transparent;
-	color: #7a7c84;
+	color: #767676;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 }
@@ -486,7 +486,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-preformatted pre {
 	background: transparent;
-	color: #7a7c84;
+	color: #767676;
 	font-family: Inconsolata, monospace;
 	font-size: 16px;
 }
@@ -506,7 +506,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-pullquote blockquote {
-	color: #7a7c84;
+	color: #767676;
 	font-style: italic;
 }
 

--- a/shoreditch/functions.php
+++ b/shoreditch/functions.php
@@ -100,7 +100,7 @@ function shoreditch_setup() {
 		array(
 			'name'  => esc_html__( 'Medium Gray', 'shoreditch' ),
 			'slug'  => 'medium-gray',
-			'color' => '#7a7c84',
+			'color' => '#767676',
 		),
 		array(
 			'name'  => esc_html__( 'Light Gray', 'shoreditch' ),

--- a/shoreditch/functions.php
+++ b/shoreditch/functions.php
@@ -100,7 +100,7 @@ function shoreditch_setup() {
 		array(
 			'name'  => esc_html__( 'Medium Gray', 'shoreditch' ),
 			'slug'  => 'medium-gray',
-			'color' => '#767676',
+			'color' => '#73757D',
 		),
 		array(
 			'name'  => esc_html__( 'Light Gray', 'shoreditch' ),

--- a/shoreditch/inc/style-wpcom.css
+++ b/shoreditch/inc/style-wpcom.css
@@ -82,7 +82,7 @@
 #comments #respond #comment-form-comment textarea,
 #comments #comment-form-share-text-padder textarea,
 #comments #respond .comment-form-fields div.comment-form-input input {
-	color: #767676;
+	color: #73757D;
 	text-shadow: none;
 }
 
@@ -95,7 +95,7 @@
 #comments #respond #comment-form-comment textarea,
 #comments #comment-form-share-text-padder textarea,
 #comments #respond p.comment-subscription-form label {
-	color: #767676;
+	color: #73757D;
 	font-family: inherit;
 }
 

--- a/shoreditch/inc/style-wpcom.css
+++ b/shoreditch/inc/style-wpcom.css
@@ -82,7 +82,7 @@
 #comments #respond #comment-form-comment textarea,
 #comments #comment-form-share-text-padder textarea,
 #comments #respond .comment-form-fields div.comment-form-input input {
-	color: #7a7c84;
+	color: #767676;
 	text-shadow: none;
 }
 
@@ -95,7 +95,7 @@
 #comments #respond #comment-form-comment textarea,
 #comments #comment-form-share-text-padder textarea,
 #comments #respond p.comment-subscription-form label {
-	color: #7a7c84;
+	color: #767676;
 	font-family: inherit;
 }
 

--- a/shoreditch/inc/wpcom-colors.php
+++ b/shoreditch/inc/wpcom-colors.php
@@ -193,7 +193,7 @@ add_color_rule( 'bg', '#ffffff', array(
 
 ), __( 'Background' ) );
 
-add_color_rule( 'txt', '#767676', array(
+add_color_rule( 'txt', '#73757D', array(
 
 	array(
 		'.author-title,
@@ -650,7 +650,7 @@ add_color_rule( 'fg2', '#3e69dc', array(
 /* Additional color palettes */
 add_color_palette( array(
     '#ffffff',
-    '#767676',
+    '#73757D',
     '#2c313f',
     '#d82620',
     '#d82620',
@@ -658,7 +658,7 @@ add_color_palette( array(
 
 add_color_palette( array(
     '#ffffff',
-    '#767676',
+    '#73757D',
     '#2c313f',
     '#0e853b',
     '#0e853b',
@@ -666,7 +666,7 @@ add_color_palette( array(
 
 add_color_palette( array(
     '#ffffff',
-    '#767676',
+    '#73757D',
     '#2c313f',
     '#fdb000',
     '#2c313f',

--- a/shoreditch/inc/wpcom-colors.php
+++ b/shoreditch/inc/wpcom-colors.php
@@ -193,7 +193,7 @@ add_color_rule( 'bg', '#ffffff', array(
 
 ), __( 'Background' ) );
 
-add_color_rule( 'txt', '#7a7c84', array(
+add_color_rule( 'txt', '#767676', array(
 
 	array(
 		'.author-title,
@@ -650,7 +650,7 @@ add_color_rule( 'fg2', '#3e69dc', array(
 /* Additional color palettes */
 add_color_palette( array(
     '#ffffff',
-    '#7a7c84',
+    '#767676',
     '#2c313f',
     '#d82620',
     '#d82620',
@@ -658,7 +658,7 @@ add_color_palette( array(
 
 add_color_palette( array(
     '#ffffff',
-    '#7a7c84',
+    '#767676',
     '#2c313f',
     '#0e853b',
     '#0e853b',
@@ -666,7 +666,7 @@ add_color_palette( array(
 
 add_color_palette( array(
     '#ffffff',
-    '#7a7c84',
+    '#767676',
     '#2c313f',
     '#fdb000',
     '#2c313f',

--- a/shoreditch/inc/wpcom.php
+++ b/shoreditch/inc/wpcom.php
@@ -20,7 +20,7 @@ function shoreditch_wpcom_setup() {
 		$themecolors = array(
 			'bg'     => 'ffffff',
 			'border' => 'f3f3f3',
-			'text'   => '767676',
+			'text'   => '73757D',
 			'link'   => '3e69dc',
 			'url'    => '3e69dc',
 		);

--- a/shoreditch/inc/wpcom.php
+++ b/shoreditch/inc/wpcom.php
@@ -20,7 +20,7 @@ function shoreditch_wpcom_setup() {
 		$themecolors = array(
 			'bg'     => 'ffffff',
 			'border' => 'f3f3f3',
-			'text'   => '7a7c84',
+			'text'   => '767676',
 			'link'   => '3e69dc',
 			'url'    => '3e69dc',
 		);

--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -298,7 +298,7 @@ button,
 input,
 select,
 textarea {
-	color: #767676;
+	color: #73757D;
 	font-family: Lato, sans-serif;
 	font-size: 16px;
 	font-size: 1rem;
@@ -771,7 +771,7 @@ label {
 
 /* Placeholder */
 ::input-placeholder {
-	color: #767676;
+	color: #73757D;
 }
 
 .widget-footer-top-area ::input-placeholder {
@@ -779,7 +779,7 @@ label {
 }
 
 ::-webkit-input-placeholder {
-	color: #767676;
+	color: #73757D;
 }
 
 .widget-footer-top-area ::-webkit-input-placeholder {
@@ -787,7 +787,7 @@ label {
 }
 
 :-moz-placeholder {
-	color: #767676;
+	color: #73757D;
 	opacity: 1;
 }
 
@@ -796,7 +796,7 @@ label {
 }
 
 ::-moz-placeholder {
-	color: #767676;
+	color: #73757D;
 	opacity: 1;
 }
 
@@ -805,7 +805,7 @@ label {
 }
 
 :-ms-input-placeholder {
-	color: #767676;
+	color: #73757D;
 }
 
 .widget-footer-top-area :-ms-input-placeholder {
@@ -996,7 +996,7 @@ label {
 }
 
 .site-info a {
-	color: #767676;
+	color: #73757D;
 }
 
 .site-info a:focus,
@@ -1329,7 +1329,7 @@ a:hover {
 }
 
 .post-navigation .meta-nav {
-	color: #767676;
+	color: #73757D;
 	display: block;
 	font-size: 13px;
     font-size: 0.8125rem;
@@ -1687,7 +1687,7 @@ a:hover {
 }
 
 .page-title span {
-	color: #767676;
+	color: #73757D;
 }
 
 .entry-header {
@@ -1805,7 +1805,7 @@ a:hover {
 }
 
 .author-title {
-	color: #767676;
+	color: #73757D;
 	font-family: Lato, sans-serif;
 	font-size: 13px;
     font-size: 0.8125rem;
@@ -2387,7 +2387,7 @@ p video {
 
 .site .tiled-gallery-caption {
 	background: #fff;
-	color: #767676;
+	color: #73757D;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	font-style: italic;
@@ -2900,7 +2900,7 @@ div#jp-relatedposts a:focus {
 .site .jetpack-social-navigation a {
 	border: 1px solid #f3f3f3;
 	border-radius: 50%;
-	color: #767676;
+	color: #73757D;
 	display: block;
 	font-size: 16px;
 	font-size: 1rem;

--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -298,7 +298,7 @@ button,
 input,
 select,
 textarea {
-	color: #7a7c84;
+	color: #767676;
 	font-family: Lato, sans-serif;
 	font-size: 16px;
 	font-size: 1rem;
@@ -771,7 +771,7 @@ label {
 
 /* Placeholder */
 ::input-placeholder {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .widget-footer-top-area ::input-placeholder {
@@ -779,7 +779,7 @@ label {
 }
 
 ::-webkit-input-placeholder {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .widget-footer-top-area ::-webkit-input-placeholder {
@@ -787,7 +787,7 @@ label {
 }
 
 :-moz-placeholder {
-	color: #7a7c84;
+	color: #767676;
 	opacity: 1;
 }
 
@@ -796,7 +796,7 @@ label {
 }
 
 ::-moz-placeholder {
-	color: #7a7c84;
+	color: #767676;
 	opacity: 1;
 }
 
@@ -805,7 +805,7 @@ label {
 }
 
 :-ms-input-placeholder {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .widget-footer-top-area :-ms-input-placeholder {
@@ -996,7 +996,7 @@ label {
 }
 
 .site-info a {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .site-info a:focus,
@@ -1329,7 +1329,7 @@ a:hover {
 }
 
 .post-navigation .meta-nav {
-	color: #7a7c84;
+	color: #767676;
 	display: block;
 	font-size: 13px;
     font-size: 0.8125rem;
@@ -1687,7 +1687,7 @@ a:hover {
 }
 
 .page-title span {
-	color: #7a7c84;
+	color: #767676;
 }
 
 .entry-header {
@@ -1805,7 +1805,7 @@ a:hover {
 }
 
 .author-title {
-	color: #7a7c84;
+	color: #767676;
 	font-family: Lato, sans-serif;
 	font-size: 13px;
     font-size: 0.8125rem;
@@ -2387,7 +2387,7 @@ p video {
 
 .site .tiled-gallery-caption {
 	background: #fff;
-	color: #7a7c84;
+	color: #767676;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	font-style: italic;
@@ -2900,7 +2900,7 @@ div#jp-relatedposts a:focus {
 .site .jetpack-social-navigation a {
 	border: 1px solid #f3f3f3;
 	border-radius: 50%;
-	color: #7a7c84;
+	color: #767676;
 	display: block;
 	font-size: 16px;
 	font-size: 1rem;

--- a/shoreditch/woocommerce-rtl.css
+++ b/shoreditch/woocommerce-rtl.css
@@ -767,7 +767,7 @@ ul#shipping_method {
       margin-right: .25rem;
       font-size: .85rem;
       font-weight: normal;
-      color: #7a7c84; }
+      color: #767676; }
     .site-header-cart .cart-contents:before {
       content: "\f447";
       display: inline-block;
@@ -1214,7 +1214,7 @@ p.price {
         margin-right: .25rem;
         font-size: .85rem;
         font-weight: normal;
-        color: #7a7c84; }
+        color: #767676; }
       .site-header-cart .cart-contents:before {
         content: "\f447";
         display: inline-block;

--- a/shoreditch/woocommerce-rtl.css
+++ b/shoreditch/woocommerce-rtl.css
@@ -767,7 +767,7 @@ ul#shipping_method {
       margin-right: .25rem;
       font-size: .85rem;
       font-weight: normal;
-      color: #767676; }
+      color: #73757D; }
     .site-header-cart .cart-contents:before {
       content: "\f447";
       display: inline-block;
@@ -1214,7 +1214,7 @@ p.price {
         margin-right: .25rem;
         font-size: .85rem;
         font-weight: normal;
-        color: #767676; }
+        color: #73757D; }
       .site-header-cart .cart-contents:before {
         content: "\f447";
         display: inline-block;

--- a/shoreditch/woocommerce.css
+++ b/shoreditch/woocommerce.css
@@ -767,7 +767,7 @@ ul#shipping_method {
       margin-left: .25rem;
       font-size: .85rem;
       font-weight: normal;
-      color: #767676; }
+      color: #73757D; }
     .site-header-cart .cart-contents:before {
       content: "\f447";
       display: inline-block;
@@ -1214,7 +1214,7 @@ p.price {
         margin-left: .25rem;
         font-size: .85rem;
         font-weight: normal;
-        color: #767676; }
+        color: #73757D; }
       .site-header-cart .cart-contents:before {
         content: "\f447";
         display: inline-block;

--- a/shoreditch/woocommerce.css
+++ b/shoreditch/woocommerce.css
@@ -767,7 +767,7 @@ ul#shipping_method {
       margin-left: .25rem;
       font-size: .85rem;
       font-weight: normal;
-      color: #7a7c84; }
+      color: #767676; }
     .site-header-cart .cart-contents:before {
       content: "\f447";
       display: inline-block;
@@ -1214,7 +1214,7 @@ p.price {
         margin-left: .25rem;
         font-size: .85rem;
         font-weight: normal;
-        color: #7a7c84; }
+        color: #767676; }
       .site-header-cart .cart-contents:before {
         content: "\f447";
         display: inline-block;


### PR DESCRIPTION
Fixes #1768

<table>
<tr>
<td>Before:
<br><br>

![#1768-contrast-ratio-before](https://user-images.githubusercontent.com/3323310/73265640-f0c70300-4207-11ea-8aab-9b385a4abfca.png)
</td>
<td>After:
<br><br>

![#1768-contrast-ratio-after](https://user-images.githubusercontent.com/3323310/73265638-f0c70300-4207-11ea-9fda-7b275cc9578c.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Before:
<br><br>

![#1768-editor-before](https://user-images.githubusercontent.com/3323310/73265643-f15f9980-4207-11ea-9a91-67abdc0f00f3.png)
</td>
<td>After:
<br><br>

![#1768-editor-after](https://user-images.githubusercontent.com/3323310/73265641-f0c70300-4207-11ea-8e5d-52d86893cf60.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Before:
<br><br>

![#1768-frontend-before](https://user-images.githubusercontent.com/3323310/73265646-f15f9980-4207-11ea-908d-46fba2267574.png)
</td>
<td>After:
<br><br>

![#1768-frontend-after](https://user-images.githubusercontent.com/3323310/73265644-f15f9980-4207-11ea-9ce4-3530d51bc29c.png)
</td>
</tr>
</table>