### PR TITLE
Varia: Adjust menu logic

### DIFF
--- a/varia/header.php
+++ b/varia/header.php
@@ -45,7 +45,7 @@
 
 			<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+			<?php if ( has_nav_menu( 'menu-1' ) && wp_get_nav_menu_items( 'menu-1' ) ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varia' ); ?>">
 					<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
 					<label for="toggle" id="toggle-menu" class="button">


### PR DESCRIPTION
Fixes #1808
Fixes #1813 (added later)

---

By changing `has_nav_menu( 'menu-1' )` to `has_nav_menu( 'menu-1' ) && wp_get_nav_menu_items( 'menu-1' )` the underlying `<nav>` part only gets loaded if the menu it not empty. Otherwise, the `<nav>` part itself does not even get loaded, which leads to less HTML code and should therefore load the site a bit faster.

<table>
<tr>
<td>Before:
<br><br>

![#1808-before](https://user-images.githubusercontent.com/3323310/74622316-f1054f00-5172-11ea-8f82-81c83f24e237.png)
</td>
<td>After:
<br><br>

![#1808-after](https://user-images.githubusercontent.com/3323310/74622318-f367a900-5172-11ea-9a5b-614e688db7b3.png)
</td>
</tr>
</table>