### PR TITLE
Varia: Adjust bold formating (Maywood, Coutoire & Stow)

### DIFF
--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.8",
+  "version": "1.3.10",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/_extra-child-theme.scss
+++ b/coutoire/sass/_extra-child-theme.scss
@@ -22,6 +22,10 @@ body {
 	font-weight: 300;
 }
 
+b, strong {
+	font-weight: 700;
+}
+
 a {
 	text-decoration-color: $color_primary_hover;
 

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3999,6 +3999,11 @@ body {
 	font-weight: 300;
 }
 
+b,
+strong {
+	font-weight: 700;
+}
+
 a {
 	text-decoration-color: #FF7A5C;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -4028,6 +4028,11 @@ body {
 	font-weight: 300;
 }
 
+b,
+strong {
+	font-weight: 700;
+}
+
 a {
 	text-decoration-color: #FF7A5C;
 }

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -28,7 +28,7 @@ a {
 }
 
 b, strong {
-	font-weight: 500;
+	font-weight: 700;
 }
 
 .site-branding,

--- a/maywood/sass/style-child-theme-editor.scss
+++ b/maywood/sass/style-child-theme-editor.scss
@@ -54,7 +54,7 @@ body {
 }
 
 b, strong {
-	font-weight: 500;
+	font-weight: 700;
 }
 
 .editor-post-title__block .editor-post-title__input {

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1307,7 +1307,7 @@ body {
 }
 
 b, strong {
-	font-weight: 500;
+	font-weight: 700;
 }
 
 .editor-post-title__block .editor-post-title__input {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4017,7 +4017,7 @@ p:not(.site-title) a:hover {
 
 b,
 strong {
-	font-weight: 500;
+	font-weight: 700;
 }
 
 .site-branding,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4046,7 +4046,7 @@ p:not(.site-title) a:hover {
 
 b,
 strong {
-	font-weight: 500;
+	font-weight: 700;
 }
 
 .site-branding,

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/_extra-child-theme.scss
+++ b/stow/sass/_extra-child-theme.scss
@@ -25,6 +25,10 @@ body {
 	font-weight: 300;
 }
 
+b, strong {
+	font-weight: 700;
+}
+
 .home.page.hide-homepage-title {
 	.site-main {
 		padding: 0;

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -4012,6 +4012,11 @@ body {
 	font-weight: 300;
 }
 
+b,
+strong {
+	font-weight: 700;
+}
+
 .home.page.hide-homepage-title .site-main {
 	padding: 0;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style.css
+++ b/stow/style.css
@@ -4041,6 +4041,11 @@ body {
 	font-weight: 300;
 }
 
+b,
+strong {
+	font-weight: 700;
+}
+
 .home.page.hide-homepage-title .site-main {
 	padding: 0;
 }


### PR DESCRIPTION
Fixes #1812 

## Maywood (Editor & Frontend: https://github.com/Automattic/themes/commit/8d0b9b73ce96b8ebc682a21abf3d7c8e7874b187)

<table>
<tr>
<td>Before / Editor: 500
<br><br>

![#1812-Maywood-editor-before](https://user-images.githubusercontent.com/3323310/74833984-22397700-534d-11ea-868d-39b6b4776076.png)
</td>
<td>After / Editor: 500
<br><br>

![#1812-Maywood-editor-after](https://user-images.githubusercontent.com/3323310/74833979-206fb380-534d-11ea-8c26-e15294551ca7.png)
</td>
</tr>
<tr>
<td>Before / Frontend: 500
<br><br>

![#1812-Maywood-frontend-before](https://user-images.githubusercontent.com/3323310/74833987-22d20d80-534d-11ea-97a8-14d66479bc7a.png)
</td>
<td>After / Frontend: 500
<br><br>

![#1812-Maywood-frontend-after](https://user-images.githubusercontent.com/3323310/74833985-22d20d80-534d-11ea-8261-74a1adbc4954.png)
</td>
</tr>
</table>

## Coutoire (Frontend: https://github.com/Automattic/themes/commit/dbfd29453b54253584ac831373f6317ddd3867a9)

<table>
<tr>
<td>Before / Frontend: 400
<br><br>

![#1812-Coutoire-frontend-before](https://user-images.githubusercontent.com/3323310/74834386-e6eb7800-534d-11ea-8b02-6a1954abcae5.png)
</td>
<td>After / Frontend: 700
<br><br>

![#1812-Coutoire-frontend-after](https://user-images.githubusercontent.com/3323310/74834390-e81ca500-534d-11ea-8f06-696ea7b543e3.png)
</td>
</tr>
</table>

## Stow (Frontend: https://github.com/Automattic/themes/commit/d0e266d7c159b63574dca2df90d909ecff5226f9)

<table>
<tr>
<td>Before / Frontend: 400
<br><br>

![#1812-Stow-frontend-before](https://user-images.githubusercontent.com/3323310/74834435-fd91cf00-534d-11ea-811d-21dbbd2119ed.png)
</td>
<td>After / Frontend: 700
<br><br>

![#1812-Stow-frontend-after](https://user-images.githubusercontent.com/3323310/74834440-fec2fc00-534d-11ea-9345-fd15323a1b04.png)
</td>
</tr>
</table>

---

I've also checked all other child themes of the Varia theme and they all seem okay. These are their font-weights:

|Theme|Editor|Frontend|
|---|---|---|
|Alves|600|700|
|Brompton|600|700|
|Balasana|600|700|
|Barnsbury|600|700|
|Dalston|600|700|
|Exford|600|700|
|Hever|600|700|
|Leven|600|700|
|Mayland|600|600|
|Morden|600|700|
|Redhill|600|700|
|Rivington|600|600|
|Rockfield|600|700|
|Shawburn|600|700|
|Stratford|600|700|