### PR TITLE
Pique: Add `orderby` and `menu_order` for Jetpack testimonials archive pages

### DIFF
--- a/pique/functions.php
+++ b/pique/functions.php
@@ -382,3 +382,24 @@ if ( class_exists( 'WooCommerce' ) ) {
 	require get_template_directory() . '/inc/woocommerce.php';
 }
 
+/**
+ * Modifies Jetpack Testimonial Post Loop to include
+ * post ordering by menu_order
+ *
+ * New Order - Date - DESC, Menu Order - ASC
+ *
+ * @param array $query
+ * @return array $query
+ */
+function modify_jetpack_testimonial_archive_query( $query ) {
+	if ( $query->is_main_query() && is_post_type_archive( 'jetpack-testimonial' ) && ! is_admin() ) {
+		$query -> set(
+			'orderby',
+			array(
+				'menu_order' => 'ASC',
+			)
+		);
+	}
+	return $query;
+}
+add_action( 'pre_get_posts', 'modify_jetpack_testimonial_archive_query' );

--- a/pique/functions.php
+++ b/pique/functions.php
@@ -381,25 +381,3 @@ require get_template_directory() . '/inc/jetpack.php';
 if ( class_exists( 'WooCommerce' ) ) {
 	require get_template_directory() . '/inc/woocommerce.php';
 }
-
-/**
- * Modifies Jetpack Testimonial Post Loop to include
- * post ordering by menu_order
- *
- * New Order - Date - DESC, Menu Order - ASC
- *
- * @param array $query
- * @return array $query
- */
-function modify_jetpack_testimonial_archive_query( $query ) {
-	if ( $query->is_main_query() && is_post_type_archive( 'jetpack-testimonial' ) && ! is_admin() ) {
-		$query -> set(
-			'orderby',
-			array(
-				'menu_order' => 'ASC',
-			)
-		);
-	}
-	return $query;
-}
-add_action( 'pre_get_posts', 'modify_jetpack_testimonial_archive_query' );

--- a/pique/inc/jetpack.php
+++ b/pique/inc/jetpack.php
@@ -111,3 +111,25 @@ function pique_get_attachment_image_src( $post_id, $post_thumbnail_id, $size ) {
 	}
 }
 
+/**
+ * Modifies Jetpack Testimonial Post Loop to include
+ * post ordering by menu_order
+ *
+ * New Order - Date - DESC, Menu Order - ASC
+ *
+ * @param array $query
+ * @return array $query
+ */
+function modify_jetpack_testimonial_archive_query( $query ) {
+	if ( $query->is_main_query() && is_post_type_archive( 'jetpack-testimonial' ) && ! is_admin() ) {
+		$query -> set(
+			'orderby',
+			array(
+				'menu_order' => 'ASC',
+				'date'       => 'DESC',
+			)
+		);
+	}
+	return $query;
+}
+add_action( 'pre_get_posts', 'modify_jetpack_testimonial_archive_query' );


### PR DESCRIPTION
Proposed fix for #1818 

Added `orderby` `menu_order`(ASC) to allow ordering of Jetpack Testimonials