### PR TITLE
Dyad 2 - Remove color inhertiance from input/textarea/button fields

### DIFF
--- a/dyad-2/style.css
+++ b/dyad-2/style.css
@@ -698,7 +698,6 @@ button,
 input,
 textarea {
 	border: 1px solid #ddd;
-	color: inherit;
 	font-family: inherit;
 	font-size: 1.6rem;
 	line-height: 1.5;


### PR DESCRIPTION
Removed `color: inherit` from `style.css` since it was conflicting with the default styles of cover block and rendering the input fields text color as white.

Proposed fix for #1833 