### PR TITLE
Add a No Text Shadow style to cover block.

### DIFF
--- a/maywood/block-extends/extend-cover-block.css
+++ b/maywood/block-extends/extend-cover-block.css
@@ -1,0 +1,45 @@
+/**
+ * Editor
+ */
+ .editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow p, 
+ .editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow p {
+ 	text-shadow: none;
+ }
+
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h1, 
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h2, 
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h3, 
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h4, 
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h5, 
+.editor-styles-wrapper .wp-block-cover.is-style-no-text-shadow h6, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h1, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h2, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h3, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h4, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h5, 
+.editor-styles-wrapper .wp-block-cover-image.is-style-no-text-shadow h6 {
+	text-shadow: none;
+}
+
+/**
+ * Front End
+ */
+ .wp-block-cover.is-style-no-text-shadow p, 
+ .wp-block-cover-image.is-style-no-text-shadow p {
+ 	text-shadow: none;
+ }
+
+.wp-block-cover.is-style-no-text-shadow h1, 
+.wp-block-cover.is-style-no-text-shadow h2, 
+.wp-block-cover.is-style-no-text-shadow h3, 
+.wp-block-cover.is-style-no-text-shadow h4, 
+.wp-block-cover.is-style-no-text-shadow h5, 
+.wp-block-cover.is-style-no-text-shadow h6, 
+.wp-block-cover-image.is-style-no-text-shadow h1, 
+.wp-block-cover-image.is-style-no-text-shadow h2, 
+.wp-block-cover-image.is-style-no-text-shadow h3, 
+.wp-block-cover-image.is-style-no-text-shadow h4, 
+.wp-block-cover-image.is-style-no-text-shadow h5, 
+.wp-block-cover-image.is-style-no-text-shadow h6 {
+	text-shadow: none;
+}

--- a/maywood/block-extends/extend-cover-block.js
+++ b/maywood/block-extends/extend-cover-block.js
@@ -1,0 +1,6 @@
+( function( blocks ) {
+	blocks.registerBlockStyle( 'core/cover', {
+		name: 'no-text-shadow',
+		label: 'No Text Shadow'
+	} );
+}( window.wp.blocks ) );

--- a/maywood/functions.php
+++ b/maywood/functions.php
@@ -175,3 +175,20 @@ function maywood_editor_styles() {
 	wp_enqueue_style( 'maywood-editor-fonts', maywood_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'maywood_editor_styles' );
+
+/**
+ * Enqueue Custom Cover Block Styles and Scripts
+ */
+function maywood_block_extends() {
+
+	// Cover Block Tweaks
+	wp_enqueue_script( 'maywood-extend-cover-block',
+		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.js',
+		array( 'wp-blocks' )
+	);
+
+	wp_enqueue_style( 'maywood-extend-cover-block-style',
+		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'
+	);
+}
+add_action( 'enqueue_block_assets', 'maywood_block_extends' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
By default text in cover block gets a dark shadow. 

![image](https://user-images.githubusercontent.com/4550351/75936836-6db85d00-5ed7-11ea-9e9d-e3024a5a8436.png)

This PR adds a No Text Shadow style to cover block.

![image](https://user-images.githubusercontent.com/4550351/75936855-7dd03c80-5ed7-11ea-9cb3-e9c054bdf05e.png)

![image](https://user-images.githubusercontent.com/4550351/75936887-8de81c00-5ed7-11ea-86f0-597d83b6ca9b.png)

I'm not well versed with Varia child themes, so let me know if I missed anything.

#### Related issue(s): Fixes #1837 
