### PR TITLE
[Multiple Themes] Assign a max-width to containers in group and cover blocks. 

### DIFF
--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -51,6 +51,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	display: flex;
 }
 
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	max-width: 730px;
+	margin: 0 auto;
+}
+
 /* Full Width */
 
 body {
@@ -113,13 +118,6 @@ body {
 		margin-left: -65px;
 		margin-right: -65px;
 		position: relative;
-	}
-
-	/* Child blocks should not get wider than their parent */
-	.apostrophe-2-no-sidebar [class^="wp-block-"] .alignwide {
-		max-width: 100%;
-		margin-left: auto;
-		margin-right: auto;
 	}
 
 	.apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignwide:before {

--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -368,7 +368,7 @@ body {
 
 .wp-block-group.alignfull .wp-block-group__inner-container {
 	max-width: 730px;
-    margin: 0 auto;
+	margin: 0 auto;
 }
 
 /* Seperator */

--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -115,6 +115,13 @@ body {
 		position: relative;
 	}
 
+	/* Child blocks should not get wider than their parent */
+	.apostrophe-2-no-sidebar [class^="wp-block-"] .alignwide {
+		max-width: 100%;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
 	.apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignwide:before {
 		content: "";
 		display: block;

--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -364,6 +364,13 @@ body {
 	border-color: transparent;
 }
 
+/* Group */
+
+.wp-block-group.alignfull .wp-block-group__inner-container {
+	max-width: 730px;
+    margin: 0 auto;
+}
+
 /* Seperator */
 
 hr.wp-block-separator {

--- a/independent-publisher-2/css/blocks.css
+++ b/independent-publisher-2/css/blocks.css
@@ -36,13 +36,6 @@ Description: Used to style Gutenberg Blocks.
 		max-width: 1000%;
 		width: auto;
 	}
-
-	/* Child blocks should not get wider than their parent */
-	body:not(.has-sidebar) [class^="wp-block-"] .alignwide {
-		margin-right: inherit;
-		margin-left: inherit;
-		max-width: 100%;
-	}
 }
 
 body:not(.has-sidebar) .alignfull {
@@ -180,6 +173,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-cover .wp-block-cover-text, .wp-block-cover h2 {
 	font-size: 1.5em;
 	margin-bottom: inherit;
+}
+
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
 }
 
 /* File */

--- a/independent-publisher-2/css/blocks.css
+++ b/independent-publisher-2/css/blocks.css
@@ -36,6 +36,13 @@ Description: Used to style Gutenberg Blocks.
 		max-width: 1000%;
 		width: auto;
 	}
+
+	/* Child blocks should not get wider than their parent */
+	body:not(.has-sidebar) [class^="wp-block-"] .alignwide {
+		margin-right: inherit;
+		margin-left: inherit;
+		max-width: 100%;
+	}
 }
 
 body:not(.has-sidebar) .alignfull {
@@ -319,6 +326,13 @@ body:not(.has-sidebar) .wp-block-table.alignfull {
 	text-decoration: none;
 	color: #fff;
 	background: #767676;
+}
+
+/* Group */
+
+.wp-block-group.alignfull .wp-block-group__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
 }
 
 /* Separator */

--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -175,6 +175,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	display: flex;
 }
 
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	max-width: 712px;
+	margin: 0 auto;
+}
+
 /* File */
 
 .wp-block-file {
@@ -355,6 +360,13 @@ p.has-drop-cap:not(:focus)::first-letter {
 .entry-content .wp-block-button .wp-block-button__link:hover {
 	background: #c1a01e;
 	color: #fff;
+}
+
+/* Group */
+
+.wp-block-group.alignfull .wp-block-group__inner-container {
+	max-width: 712px;
+	margin: 0 auto;
 }
 
 /* Seperator */

--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -36,13 +36,6 @@ Description: Used to style Gutenberg Blocks.
 		width: auto;
 	}
 
-	/* Child blocks should not get wider than their parent */
-	.singular.no-sidebar  [class^="wp-block-"] .alignwide {
-		margin-right: inherit;
-		margin-left: inherit;
-		max-width: 100%;
-	}
-
 	.singular.no-sidebar .wp-block-embed.is-type-video.alignwide iframe {
 		width: 100% !important;
 		height: 100% !important;
@@ -221,6 +214,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-cover .wp-block-cover-text,
 .wp-block-cover h2 {
 	font-size: 1.5em;
+}
+
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
 }
 
 /* File */

--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -36,6 +36,13 @@ Description: Used to style Gutenberg Blocks.
 		width: auto;
 	}
 
+	/* Child blocks should not get wider than their parent */
+	.singular.no-sidebar  [class^="wp-block-"] .alignwide {
+		margin-right: inherit;
+		margin-left: inherit;
+		max-width: 100%;
+	}
+
 	.singular.no-sidebar .wp-block-embed.is-type-video.alignwide iframe {
 		width: 100% !important;
 		height: 100% !important;
@@ -359,7 +366,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	box-shadow: none;
 }
 
-/* Columns */
+/* Group */
+
+.wp-block-group.alignfull .wp-block-group__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
+}
 
 /* Separator */
 

--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -231,6 +231,11 @@ ul.wp-block-gallery li {
 	height: 75vh;
 }
 
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
+}
+
 /* File */
 
 .wp-block-file .wp-block-file__button {
@@ -368,6 +373,13 @@ ul.wp-block-gallery li {
 .wp-block-button.alignfull,
 .wp-block-button.aligncenter {
 	display: block;
+}
+
+/* Group */
+
+.wp-block-group.alignfull .wp-block-group__inner-container {
+	max-width: 740px;
+	margin: 0 auto;
 }
 
 /* Separator */


### PR DESCRIPTION
This PR assigns a `max-width` to the inner wrappers for the Cover and Group blocks. Doing so makes sure that inner blocks take up the proper width by default. This is not complete solution for Group block support in those themes, but it should mostly fix #1848. 

Themes included: 

- Apostrophe 2
- Independent Publisher 2
- Ixion
- Libre 2

To test, try out the Alves and Barnsbury homepage layouts in the themes above.

---

## Screenshots

### Apostrophe: 

Before:

![Screen Shot 2020-03-24 at 3 36 36 PM](https://user-images.githubusercontent.com/1202812/77469321-41607400-6de5-11ea-8520-05cae3528f0e.png)

![Screen Shot 2020-03-24 at 3 37 13 PM](https://user-images.githubusercontent.com/1202812/77469360-56d59e00-6de5-11ea-94d4-192c8de90244.png)


After:

![Screen Shot 2020-03-24 at 3 31 21 PM](https://user-images.githubusercontent.com/1202812/77468886-a071b900-6de4-11ea-9a83-aa2c686e5898.png)

![Screen Shot 2020-03-24 at 3 35 33 PM](https://user-images.githubusercontent.com/1202812/77469206-1bd36a80-6de5-11ea-93ff-d0de67dd5ef4.png)


### Independent Publisher 2

Before:

![Screen Shot 2020-03-24 at 3 37 44 PM](https://user-images.githubusercontent.com/1202812/77469409-694fd780-6de5-11ea-92e9-45a681183f0d.png)

![Screen Shot 2020-03-24 at 3 37 58 PM](https://user-images.githubusercontent.com/1202812/77469431-71a81280-6de5-11ea-95e1-48186a1121fc.png)

After:

![Screen Shot 2020-03-24 at 3 32 42 PM](https://user-images.githubusercontent.com/1202812/77468951-ba130080-6de4-11ea-90a5-a5294aae1ca7.png)

![Screen Shot 2020-03-24 at 3 34 47 PM](https://user-images.githubusercontent.com/1202812/77469121-ffcfc900-6de4-11ea-8438-c2cbfa4fddad.png)


### Ixion

Before:

![Screen Shot 2020-03-24 at 3 38 28 PM](https://user-images.githubusercontent.com/1202812/77469471-8389b580-6de5-11ea-9077-80a29312af0a.png)

![Screen Shot 2020-03-24 at 3 38 44 PM](https://user-images.githubusercontent.com/1202812/77469489-8c7a8700-6de5-11ea-9fdb-ad88b47da3b1.png)

After:

![Screen Shot 2020-03-24 at 3 33 08 PM](https://user-images.githubusercontent.com/1202812/77468987-c72fef80-6de4-11ea-9bdb-433f5db703b8.png)

![Screen Shot 2020-03-24 at 3 34 23 PM](https://user-images.githubusercontent.com/1202812/77469082-f181ad00-6de4-11ea-9dce-ede7abad4c30.png)

### Libre 2

Before:

![Screen Shot 2020-03-24 at 3 39 08 PM](https://user-images.githubusercontent.com/1202812/77469526-9b613980-6de5-11ea-9118-4c79dd8f2e80.png)

![Screen Shot 2020-03-24 at 3 39 20 PM](https://user-images.githubusercontent.com/1202812/77469552-a2884780-6de5-11ea-88e5-cb55a136da4c.png)

After:

![Screen Shot 2020-03-24 at 3 33 30 PM](https://user-images.githubusercontent.com/1202812/77469009-d3b44800-6de4-11ea-9b9b-f4e1d711078d.png)

![Screen Shot 2020-03-24 at 3 33 53 PM](https://user-images.githubusercontent.com/1202812/77469052-e464be00-6de4-11ea-8ca1-008cf4d03f7f.png)


