### PR TITLE
Apostrophe 2: Fix list view in editor

### DIFF
--- a/apostrophe-2/css/editor-blocks.css
+++ b/apostrophe-2/css/editor-blocks.css
@@ -183,15 +183,6 @@
 
 .edit-post-visual-editor ul:not(.wp-block-gallery),
 .editor-block-list__block ul:not(.wp-block-gallery),
-.block-library-list ul,
-.edit-post-visual-editor ol,
-.editor-block-list__block ol,
-.block-library-list ol {
-	margin: 0 0 1.5em;
-}
-
-.edit-post-visual-editor ul:not(.wp-block-gallery),
-.editor-block-list__block ul:not(.wp-block-gallery),
 .block-library-list ul {
 	list-style: disc;
 }


### PR DESCRIPTION
Related #1866

<table>
<tr>
<td>Before:
<br><br>

![#1866-apostrophe-2-before](https://user-images.githubusercontent.com/3323310/77725791-f8006680-7028-11ea-8903-3e186593c844.png)
</td>
<td>After:
<br><br>

![#1866-apostrophe-2-after](https://user-images.githubusercontent.com/3323310/77725782-f3d44900-7028-11ea-8059-11378520e2ab.png)
</td>
</tr>
</table>