### PR TITLE
Varia: Ensure full-width items inside of columns do not overlap.

### DIFF
--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -10,6 +10,7 @@
 @import "blog-posts/editor";
 @import "button/editor";
 @import "code/editor";
+@import "columns/editor";
 @import "cover/editor";
 @import "heading/editor";
 @import "image/editor";

--- a/varia/sass/blocks/columns/_editor.scss
+++ b/varia/sass/blocks/columns/_editor.scss
@@ -1,0 +1,9 @@
+.wp-block-columns {
+
+	// Ignore full-width margins when inside of a column. 
+	.wp-block[data-align=full],
+	.alignfull {
+		margin-left: inherit;
+		margin-right: inherit;
+	}
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -583,6 +583,12 @@ object {
 	background-color: indigo;
 }
 
+.wp-block-columns .wp-block[data-align=full],
+.wp-block-columns .alignfull {
+	margin-left: inherit;
+	margin-right: inherit;
+}
+
 .wp-block-cover,
 .wp-block-cover-image {
 	background-color: black;


### PR DESCRIPTION
Fixes #40719

This PR adds some editor styles to Varia that ensure that full-width blocks inside of columns do not expand beyond the width they're allowed. It accomplishes this by asking those blocks to inherit the standard margins instead of the full-width margins. 

Before:

<img width="1274" alt="Screen Shot 2020-04-06 at 2 31 00 PM" src="https://user-images.githubusercontent.com/1202812/78593378-88525e80-7814-11ea-8529-cfd79d5aa2cb.png">
<img width="1276" alt="Screen Shot 2020-04-06 at 2 37 27 PM" src="https://user-images.githubusercontent.com/1202812/78593490-b2a41c00-7814-11ea-8732-6e16ccbfcded.png">

After:

<img width="1276" alt="Screen Shot 2020-04-06 at 2 35 03 PM" src="https://user-images.githubusercontent.com/1202812/78593405-943e2080-7814-11ea-9aa8-092b5cb0055c.png">

<img width="1276" alt="Screen Shot 2020-04-06 at 2 37 06 PM" src="https://user-images.githubusercontent.com/1202812/78593465-a9b34a80-7814-11ea-9675-210f5f27eabe.png">

