### PR TITLE
[all themes] Declare HTML5 scripts and styles support for better HTML5 compliance

### DIFF
--- a/affinity/functions.php
+++ b/affinity/functions.php
@@ -79,6 +79,8 @@ function affinity_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/altofocus/functions.php
+++ b/altofocus/functions.php
@@ -71,6 +71,8 @@ function altofocus_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/apostrophe-2/functions.php
+++ b/apostrophe-2/functions.php
@@ -111,7 +111,13 @@ if ( ! function_exists( 'apostrophe_2_setup' ) ) :
 		 * to output valid HTML5.
 		 */
 		add_theme_support( 'html5', array(
-			'comment-list', 'comment-form', 'search-form', 'gallery', 'caption',
+			'comment-list',
+			'comment-form',
+			'search-form',
+			'gallery',
+			'caption',
+			'style',
+			'script',
 		) );
 
 		// Set up the WordPress core custom background feature.

--- a/button-2/functions.php
+++ b/button-2/functions.php
@@ -56,6 +56,8 @@ function button_2_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Enable support for custom logo.

--- a/canard/functions.php
+++ b/canard/functions.php
@@ -116,7 +116,13 @@ function canard_setup() {
 	 * to output valid HTML5.
 	 */
 	add_theme_support( 'html5', array(
-		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption',
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/dara/functions.php
+++ b/dara/functions.php
@@ -113,6 +113,8 @@ function dara_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Add theme support for selective refresh for widgets.

--- a/dyad-2/functions.php
+++ b/dyad-2/functions.php
@@ -81,6 +81,8 @@ if ( ! function_exists( 'dyad_2_setup' ) ) :
 			'comment-form',
 			'gallery',
 			'caption',
+			'style',
+			'script',
 		) );
 
 		// Load default block styles.

--- a/gazette/functions.php
+++ b/gazette/functions.php
@@ -76,7 +76,13 @@ function gazette_setup() {
 	 * to output valid HTML5.
 	 */
 	add_theme_support( 'html5', array(
-		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption',
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/illustratr/functions.php
+++ b/illustratr/functions.php
@@ -142,6 +142,8 @@ function illustratr_setup() {
 		'search-form',
 		'comment-form',
 		'gallery',
+		'style',
+		'script',
 	) );
 
 	// Add support for responsive embeds.

--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -70,6 +70,8 @@ function independent_publisher_2_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/intergalactic-2/functions.php
+++ b/intergalactic-2/functions.php
@@ -122,7 +122,13 @@ function intergalactic_2_setup() {
 	 * to output valid HTML5.
 	 */
 	add_theme_support( 'html5', array(
-		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption',
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+		'style',
+		'script',
 	) );
 
 	// Setup the WordPress core custom background feature.

--- a/ixion/functions.php
+++ b/ixion/functions.php
@@ -120,6 +120,8 @@ if ( ! function_exists( 'ixion_setup' ) ) :
 			'comment-list',
 			'gallery',
 			'caption',
+			'style',
+			'script',
 		) );
 
 		// Set up the WordPress core custom background feature.

--- a/karuna/functions.php
+++ b/karuna/functions.php
@@ -116,6 +116,8 @@ function karuna_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Add theme support for custom logos

--- a/libre-2/functions.php
+++ b/libre-2/functions.php
@@ -66,6 +66,8 @@ function libre_2_setup() {
 		'comment-form',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/libretto/functions.php
+++ b/libretto/functions.php
@@ -132,7 +132,13 @@ if ( ! function_exists( 'libretto_setup' ) ) :
 		 * to output valid HTML5.
 		 */
 		add_theme_support( 'html5', array(
-			'search-form', 'comment-form', 'comment-list', 'gallery', 'caption',
+			'search-form',
+			'comment-form',
+			'comment-list',
+			'gallery',
+			'caption',
+			'style',
+			'script',
 		) );
 
 	} // libretto_setup()

--- a/lodestar/functions.php
+++ b/lodestar/functions.php
@@ -69,6 +69,8 @@ function lodestar_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/penscratch-2/functions.php
+++ b/penscratch-2/functions.php
@@ -54,7 +54,13 @@ function penscratch_2_setup() {
 	 * to output valid HTML5.
 	 */
 	add_theme_support( 'html5', array(
-		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption'
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+		'style',
+		'script',
 	) );
 
 	// Enable support for custom logo.

--- a/photos/functions.php
+++ b/photos/functions.php
@@ -61,6 +61,8 @@ if ( ! function_exists( 'photos_setup' ) ) :
 			'comment-list',
 			'gallery',
 			'caption',
+			'style',
+			'script',
 		) );
 
 		// Set up the WordPress core custom background feature.

--- a/pique/functions.php
+++ b/pique/functions.php
@@ -60,6 +60,8 @@ if ( ! function_exists( 'pique_setup' ) ) :
 			'comment-list',
 			'gallery',
 			'caption',
+			'style',
+			'script',
 		) );
 
 		/*

--- a/publication/functions.php
+++ b/publication/functions.php
@@ -115,6 +115,8 @@ function publication_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 	
 	// Set up the WordPress core custom background feature.

--- a/radcliffe-2/functions.php
+++ b/radcliffe-2/functions.php
@@ -58,6 +58,8 @@ function radcliffe_2_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Add theme support for Custom Logo.

--- a/rebalance/functions.php
+++ b/rebalance/functions.php
@@ -120,6 +120,8 @@ function rebalance_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/scratchpad/functions.php
+++ b/scratchpad/functions.php
@@ -113,6 +113,8 @@ function scratchpad_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/shoreditch/functions.php
+++ b/shoreditch/functions.php
@@ -65,6 +65,8 @@ function shoreditch_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Set up the WordPress core custom background feature.

--- a/sketch/functions.php
+++ b/sketch/functions.php
@@ -80,7 +80,13 @@ function sketch_setup() {
 	 * to output valid HTML5.
 	 */
 	add_theme_support( 'html5', array(
-		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption'
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/textbook/functions.php
+++ b/textbook/functions.php
@@ -65,6 +65,8 @@ function textbook_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Add support for responsive embeds.

--- a/toujours/functions.php
+++ b/toujours/functions.php
@@ -114,6 +114,8 @@ function toujours_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	/*

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -74,6 +74,8 @@ if ( ! function_exists( 'varia_setup' ) ) :
 				'comment-list',
 				'gallery',
 				'caption',
+				'style',
+				'script',
 			)
 		);
 


### PR DESCRIPTION
Hi,

Given all WordPress.com themes are written in HTML5, they should declare HTML5 support for styles and script to avoid using `type` attributes in styles and scripts.

Otherwise, W3C validator will throw a warning because of the `type` attribute.

This option was introduced in WordPress 5.3. For reference, see:
- https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
- https://core.trac.wordpress.org/ticket/42804#comment:32

Cheers,
Jb