### PR TITLE
Penscratch 2: Improve readability of links

### DIFF
--- a/penscratch-2/css/editor-blocks.css
+++ b/penscratch-2/css/editor-blocks.css
@@ -44,7 +44,8 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 /* Colour */
 
-.edit-post-visual-editor .editor-block-list__block {
+.edit-post-visual-editor .editor-block-list__block,
+.edit-post-visual-editor .wp-block-paragraph {
 	color: #666;
 }
 
@@ -149,7 +150,6 @@ Description: Used to style Gutenberg Blocks in the editor.
 .editor-block-list__block a,
 .wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #1c7c7c;
-	text-decoration: none;
 }
 
 /* Table styles */

--- a/penscratch-2/style.css
+++ b/penscratch-2/style.css
@@ -930,7 +930,6 @@ a {
 	   -moz-transition: all .2s ease-in-out;
 		 -o-transition: all .2s ease-in-out;
 			transition: all .2s ease-in-out;
-	text-decoration: none;
 	color: #1c7c7c;
 }
 a:visited {


### PR DESCRIPTION
Fixes #1905 

<table>
<tr>
<td>Editor Before:
<br><br>

![#1905-editor-before](https://user-images.githubusercontent.com/3323310/79122147-36d04380-7dc1-11ea-9e34-d5b6f0746409.png)
</td>
<td>Editor After:
<br><br>

![#1905-editor-after](https://user-images.githubusercontent.com/3323310/79122150-389a0700-7dc1-11ea-846f-6881f627bad6.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Frontend Before:
<br><br>

![#1905-frontend-before](https://user-images.githubusercontent.com/3323310/79122175-464f8c80-7dc1-11ea-9813-bcb9f2b13d5d.png)
</td>
<td>Frontend After:
<br><br>

![#1905-frontend-after](https://user-images.githubusercontent.com/3323310/79122178-48195000-7dc1-11ea-9c9e-c60300de9589.png)
</td>
</tr>
</table>