### PR TITLE
Fix incorrect font name

### DIFF
--- a/hever/functions.php
+++ b/hever/functions.php
@@ -136,7 +136,7 @@ function hever_fonts_url() {
 	if ( 'off' !== $ptsans ) {
 		$font_families = array();
 
-		$font_families[] = 'PT+Sans:400,400i,700,700i';
+		$font_families[] = 'PT Sans:400,400i,700,700i';
 
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),


### PR DESCRIPTION
Using a `+` instead of a space here will cause the font name to be doubly encoded (as `PT%2BSans`), resulting in an error 400 when loading from Google Fonts.

@josephscott kindly validated the fix by testing on his sandbox.

#### Changes proposed in this Pull Request:

Fix Google Font loading. Validate by checking in DevTools that it no longer produces an error 400 when attempting to load the font CSS.