### PR TITLE
Maywood: Only apply cover image text shadow if there's a background image or video.

### DIFF
--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -228,8 +228,9 @@ b, strong {
 		font-weight: 300;
 	}
 
-	// Only use a text shadow if there's a background image.
-	&[style*="background-image"] {
+	// Only use a text shadow if there's a background image or video.
+	&[style*="background-image"],
+	video + .wp-block-cover__inner-container {
 		p {
 			text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
 		}

--- a/maywood/sass/_extra-child-theme.scss
+++ b/maywood/sass/_extra-child-theme.scss
@@ -223,13 +223,20 @@ b, strong {
 // Cover
 .wp-block-cover,
 .wp-block-cover-image {
-	p {
-		text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
-	}
 
 	h1,h2,h3,h4,h5,h6 {
 		font-weight: 300;
-		text-shadow: 0 0 10px map-deep-get($config-global, "color", "black");
+	}
+
+	// Only use a text shadow if there's a background image.
+	&[style*="background-image"] {
+		p {
+			text-shadow: 0 0 6px map-deep-get($config-global, "color", "black");
+		}
+		
+		h1,h2,h3,h4,h5,h6 {
+			text-shadow: 0 0 10px map-deep-get($config-global, "color", "black");
+		}
 	}
 
 	@include media(desktop) {

--- a/maywood/sass/style-child-theme-editor.scss
+++ b/maywood/sass/style-child-theme-editor.scss
@@ -64,13 +64,21 @@ b, strong {
 
 .wp-block-cover,
 .wp-block-cover-image {
-	p {
-		text-shadow: 0 0 6px #000;
-	}
 
 	h1,h2,h3,h4,h5,h6 {
 		font-weight: 300;
-		text-shadow: 0 0 12px #000;
+	}
+
+	// Only use a text shadow if there's a background image.
+	&[style*="background-image"] { 
+		p {
+			text-shadow: 0 0 6px #000
+		}
+
+		h1,h2,h3,h4,h5,h6 {
+			font-weight: 300;
+			text-shadow: 0 0 12px #000;
+		}
 	}
 
 	@include media(desktop) {

--- a/maywood/sass/style-child-theme-editor.scss
+++ b/maywood/sass/style-child-theme-editor.scss
@@ -69,8 +69,9 @@ b, strong {
 		font-weight: 300;
 	}
 
-	// Only use a text shadow if there's a background image.
-	&[style*="background-image"] { 
+	// Only use a text shadow if there's a background image or video.
+	&[style*="background-image"],
+	video + .wp-block-cover__inner-container { 
 		p {
 			text-shadow: 0 0 6px #000
 		}

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1296,11 +1296,6 @@ b, strong {
 	}
 }
 
-.wp-block-cover p,
-.wp-block-cover-image p {
-	text-shadow: 0 0 6px #000;
-}
-
 .wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
 .wp-block-cover-image h1,
 .wp-block-cover-image h2,
@@ -1308,6 +1303,21 @@ b, strong {
 .wp-block-cover-image h4,
 .wp-block-cover-image h5,
 .wp-block-cover-image h6 {
+	font-weight: 300;
+}
+
+.wp-block-cover[style*="background-image"] p,
+.wp-block-cover-image[style*="background-image"] p {
+	text-shadow: 0 0 6px #000;
+}
+
+.wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover-image[style*="background-image"] h1,
+.wp-block-cover-image[style*="background-image"] h2,
+.wp-block-cover-image[style*="background-image"] h3,
+.wp-block-cover-image[style*="background-image"] h4,
+.wp-block-cover-image[style*="background-image"] h5,
+.wp-block-cover-image[style*="background-image"] h6 {
 	font-weight: 300;
 	text-shadow: 0 0 12px #000;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1307,17 +1307,31 @@ b, strong {
 }
 
 .wp-block-cover[style*="background-image"] p,
-.wp-block-cover-image[style*="background-image"] p {
+.wp-block-cover video + .wp-block-cover__inner-container p,
+.wp-block-cover-image[style*="background-image"] p,
+.wp-block-cover-image video + .wp-block-cover__inner-container p {
 	text-shadow: 0 0 6px #000;
 }
 
 .wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover video + .wp-block-cover__inner-container h1,
+.wp-block-cover video + .wp-block-cover__inner-container h2,
+.wp-block-cover video + .wp-block-cover__inner-container h3,
+.wp-block-cover video + .wp-block-cover__inner-container h4,
+.wp-block-cover video + .wp-block-cover__inner-container h5,
+.wp-block-cover video + .wp-block-cover__inner-container h6,
 .wp-block-cover-image[style*="background-image"] h1,
 .wp-block-cover-image[style*="background-image"] h2,
 .wp-block-cover-image[style*="background-image"] h3,
 .wp-block-cover-image[style*="background-image"] h4,
 .wp-block-cover-image[style*="background-image"] h5,
-.wp-block-cover-image[style*="background-image"] h6 {
+.wp-block-cover-image[style*="background-image"] h6,
+.wp-block-cover-image video + .wp-block-cover__inner-container h1,
+.wp-block-cover-image video + .wp-block-cover__inner-container h2,
+.wp-block-cover-image video + .wp-block-cover__inner-container h3,
+.wp-block-cover-image video + .wp-block-cover__inner-container h4,
+.wp-block-cover-image video + .wp-block-cover__inner-container h5,
+.wp-block-cover-image video + .wp-block-cover__inner-container h6 {
 	font-weight: 300;
 	text-shadow: 0 0 12px #000;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4175,18 +4175,18 @@ strong {
 	text-align: right;
 }
 
-.wp-block-cover p,
-.wp-block-cover-image p {
+.wp-block-cover[style*="background-image"] p,
+.wp-block-cover-image[style*="background-image"] p {
 	text-shadow: 0 0 6px black;
 }
 
-.wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
-.wp-block-cover-image h1,
-.wp-block-cover-image h2,
-.wp-block-cover-image h3,
-.wp-block-cover-image h4,
-.wp-block-cover-image h5,
-.wp-block-cover-image h6 {
+.wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover-image[style*="background-image"] h1,
+.wp-block-cover-image[style*="background-image"] h2,
+.wp-block-cover-image[style*="background-image"] h3,
+.wp-block-cover-image[style*="background-image"] h4,
+.wp-block-cover-image[style*="background-image"] h5,
+.wp-block-cover-image[style*="background-image"] h6 {
 	font-weight: 300;
 	text-shadow: 0 0 10px black;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4175,19 +4175,42 @@ strong {
 	text-align: right;
 }
 
+.wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
+.wp-block-cover-image h1,
+.wp-block-cover-image h2,
+.wp-block-cover-image h3,
+.wp-block-cover-image h4,
+.wp-block-cover-image h5,
+.wp-block-cover-image h6 {
+	font-weight: 300;
+}
+
 .wp-block-cover[style*="background-image"] p,
-.wp-block-cover-image[style*="background-image"] p {
+.wp-block-cover video + .wp-block-cover__inner-container p,
+.wp-block-cover-image[style*="background-image"] p,
+.wp-block-cover-image video + .wp-block-cover__inner-container p {
 	text-shadow: 0 0 6px black;
 }
 
 .wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover video + .wp-block-cover__inner-container h1,
+.wp-block-cover video + .wp-block-cover__inner-container h2,
+.wp-block-cover video + .wp-block-cover__inner-container h3,
+.wp-block-cover video + .wp-block-cover__inner-container h4,
+.wp-block-cover video + .wp-block-cover__inner-container h5,
+.wp-block-cover video + .wp-block-cover__inner-container h6,
 .wp-block-cover-image[style*="background-image"] h1,
 .wp-block-cover-image[style*="background-image"] h2,
 .wp-block-cover-image[style*="background-image"] h3,
 .wp-block-cover-image[style*="background-image"] h4,
 .wp-block-cover-image[style*="background-image"] h5,
-.wp-block-cover-image[style*="background-image"] h6 {
-	font-weight: 300;
+.wp-block-cover-image[style*="background-image"] h6,
+.wp-block-cover-image video + .wp-block-cover__inner-container h1,
+.wp-block-cover-image video + .wp-block-cover__inner-container h2,
+.wp-block-cover-image video + .wp-block-cover__inner-container h3,
+.wp-block-cover-image video + .wp-block-cover__inner-container h4,
+.wp-block-cover-image video + .wp-block-cover__inner-container h5,
+.wp-block-cover-image video + .wp-block-cover__inner-container h6 {
 	text-shadow: 0 0 10px black;
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4204,11 +4204,6 @@ strong {
 	text-align: left;
 }
 
-.wp-block-cover p,
-.wp-block-cover-image p {
-	text-shadow: 0 0 6px black;
-}
-
 .wp-block-cover h1, .wp-block-cover h2, .wp-block-cover h3, .wp-block-cover h4, .wp-block-cover h5, .wp-block-cover h6,
 .wp-block-cover-image h1,
 .wp-block-cover-image h2,
@@ -4217,6 +4212,20 @@ strong {
 .wp-block-cover-image h5,
 .wp-block-cover-image h6 {
 	font-weight: 300;
+}
+
+.wp-block-cover[style*="background-image"] p,
+.wp-block-cover-image[style*="background-image"] p {
+	text-shadow: 0 0 6px black;
+}
+
+.wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover-image[style*="background-image"] h1,
+.wp-block-cover-image[style*="background-image"] h2,
+.wp-block-cover-image[style*="background-image"] h3,
+.wp-block-cover-image[style*="background-image"] h4,
+.wp-block-cover-image[style*="background-image"] h5,
+.wp-block-cover-image[style*="background-image"] h6 {
 	text-shadow: 0 0 10px black;
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4215,17 +4215,31 @@ strong {
 }
 
 .wp-block-cover[style*="background-image"] p,
-.wp-block-cover-image[style*="background-image"] p {
+.wp-block-cover video + .wp-block-cover__inner-container p,
+.wp-block-cover-image[style*="background-image"] p,
+.wp-block-cover-image video + .wp-block-cover__inner-container p {
 	text-shadow: 0 0 6px black;
 }
 
 .wp-block-cover[style*="background-image"] h1, .wp-block-cover[style*="background-image"] h2, .wp-block-cover[style*="background-image"] h3, .wp-block-cover[style*="background-image"] h4, .wp-block-cover[style*="background-image"] h5, .wp-block-cover[style*="background-image"] h6,
+.wp-block-cover video + .wp-block-cover__inner-container h1,
+.wp-block-cover video + .wp-block-cover__inner-container h2,
+.wp-block-cover video + .wp-block-cover__inner-container h3,
+.wp-block-cover video + .wp-block-cover__inner-container h4,
+.wp-block-cover video + .wp-block-cover__inner-container h5,
+.wp-block-cover video + .wp-block-cover__inner-container h6,
 .wp-block-cover-image[style*="background-image"] h1,
 .wp-block-cover-image[style*="background-image"] h2,
 .wp-block-cover-image[style*="background-image"] h3,
 .wp-block-cover-image[style*="background-image"] h4,
 .wp-block-cover-image[style*="background-image"] h5,
-.wp-block-cover-image[style*="background-image"] h6 {
+.wp-block-cover-image[style*="background-image"] h6,
+.wp-block-cover-image video + .wp-block-cover__inner-container h1,
+.wp-block-cover-image video + .wp-block-cover__inner-container h2,
+.wp-block-cover-image video + .wp-block-cover__inner-container h3,
+.wp-block-cover-image video + .wp-block-cover__inner-container h4,
+.wp-block-cover-image video + .wp-block-cover__inner-container h5,
+.wp-block-cover-image video + .wp-block-cover__inner-container h6 {
 	text-shadow: 0 0 10px black;
 }
 


### PR DESCRIPTION
As suggested in #1837, this PR changes Maywood's behavior so that it only applies a text shadow to inner blocks if there's a background image in the color block.

Before: 

![Screen Shot 2020-04-29 at 1 04 49 PM](https://user-images.githubusercontent.com/1202812/80624794-2e5f4600-8a1a-11ea-8aff-4795692644f0.png)
![Screen Shot 2020-04-29 at 1 12 43 PM](https://user-images.githubusercontent.com/1202812/80625392-2522a900-8a1b-11ea-99b4-a997a88bbe8c.png)



After: 

![Screen Shot 2020-04-29 at 1 03 52 PM](https://user-images.githubusercontent.com/1202812/80624803-315a3680-8a1a-11ea-90c7-2925002c1a19.png)
![Screen Shot 2020-04-29 at 1 12 51 PM](https://user-images.githubusercontent.com/1202812/80625403-27850300-8a1b-11ea-8fe1-f7fef5e2fca9.png)
