### PR TITLE
Varia: Remove negative margins for full-width items within full-width group blocks

### DIFF
--- a/varia/sass/blocks/group/_editor.scss
+++ b/varia/sass/blocks/group/_editor.scss
@@ -12,3 +12,10 @@
 	margin: 0;
 	width: 100%;
 }
+
+// Remove negative margins for full-width children of Group blocks.
+.wp-block-group__inner-container .wp-block.alignfull, 
+.wp-block-group__inner-container .wp-block[data-align="full"] {
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -736,6 +736,12 @@ object {
 	width: 100%;
 }
 
+.wp-block-group__inner-container .wp-block.alignfull,
+.wp-block-group__inner-container .wp-block[data-align="full"] {
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .wp-block-latest-comments {
 	margin-left: 0;
 }


### PR DESCRIPTION
Fixes the editor overflow portion of https://github.com/Automattic/wp-calypso/issues/41719 (for just the Varia parent theme, but this effects all child themes too). 

This removes the negative margins on full-width child blocks that live inside of a full-width group block. To be honest, this doesn't feel like something that should _need_ to be fixed, since those margins come from Gutenberg. I'm also seeing that issue only on WP.com, not on my local install. So we should do some investigation before we commit this — I worry that this will break again someday if this isn't the root of the issue. 

Before: 

![Screen Shot 2020-05-01 at 15 54 42](https://user-images.githubusercontent.com/1202812/80837068-175c5780-8bc4-11ea-948a-b8b665f142f1.png)

After:

![Screen Shot 2020-05-01 at 15 43 25](https://user-images.githubusercontent.com/1202812/80836990-e419c880-8bc3-11ea-83b3-c8a0b7f16e55.png)
