### PR TITLE
Varia: Fix CSS interpolation issue in password-strength-meter style

### DIFF
--- a/varia/sass/vendors/woocommerce/elements/_password-strength-meter.scss
+++ b/varia/sass/vendors/woocommerce/elements/_password-strength-meter.scss
@@ -6,7 +6,7 @@ body[class*="woocommerce"] #page { // adding #page here to override default wc s
 	.woocommerce-password-strength {
 		text-align: center;
 		font-weight: 600;
-		padding: #{0.5 * #{map-deep-get($config-woocommerce, "table", "padding")}};
+		padding: (0.5 * map-deep-get($config-woocommerce, "table", "padding"));
 		font-size: map-deep-get($config-global, "font", "size", "sm");
 
 		&.strong {

--- a/varia/style-woocommerce-rtl.css
+++ b/varia/style-woocommerce-rtl.css
@@ -401,7 +401,7 @@ body[class*="woocommerce"] #page .woocommerce-warning:before {
 body[class*="woocommerce"] #page .woocommerce-password-strength {
 	text-align: center;
 	font-weight: 600;
-	padding: 0.5 * 16px;
+	padding: 8px;
 	font-size: 0.83333rem;
 }
 

--- a/varia/style-woocommerce.css
+++ b/varia/style-woocommerce.css
@@ -401,7 +401,7 @@ body[class*="woocommerce"] #page .woocommerce-warning:before {
 body[class*="woocommerce"] #page .woocommerce-password-strength {
 	text-align: center;
 	font-weight: 600;
-	padding: 0.5 * 16px;
+	padding: 8px;
 	font-size: 0.83333rem;
 }
 


### PR DESCRIPTION
Fixes #2011

#### Changes proposed in this Pull Request:
There is an Interpolation issue in password-strength-meter style. it produces incorrect CSS for padding on `woocommerce-password-strength` class because of not using proper Interpolation in SASS files!
This PR fixes it.

Before( incorrect padding )
![image](https://user-images.githubusercontent.com/12055657/81525143-91839d80-9375-11ea-8a15-3162527e6547.png)

After( correct padding )
![image](https://user-images.githubusercontent.com/12055657/81525171-a19b7d00-9375-11ea-9f5e-455ffc942c2c.png)
