### PR TITLE
Update Dyad 2 Editor Styles

### DIFF
--- a/dyad-2/css/editor-blocks.css
+++ b/dyad-2/css/editor-blocks.css
@@ -18,14 +18,11 @@ Description: Used to style Gutenberg Blocks in the editor.
 1.0 General Typography
 --------------------------------------------------------------*/
 
-.editor-styles-wrapper .wp-block,
-.editor-styles-wrapper .wp-block p,
+.editor-styles-wrapper,
+.editor-styles-wrapper p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 17px;
-}
-
-.editor-styles-wrapper .wp-block {
 	color: #6a6c6e;
 }
 
@@ -128,27 +125,30 @@ h6.wp-block,
 
 /* Quote styles */
 
-.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+.wp-block-freeform.block-library-rich-text__tinymce blockquote,
+.wp-block-quote {
 	border-left: 3px solid #ddd;
 	margin-left: 1.5em;
 	padding-left: 1.5em;
 }
 
 .wp-block-freeform.block-library-rich-text__tinymce blockquote,
-.wp-block-freeform.block-library-rich-text__tinymce blockquote > p {
+.wp-block-freeform.block-library-rich-text__tinymce blockquote > p,
+.wp-block-quote {
 	color: #393d41;
 	font-family: "Noto Serif", Georgia, serif;
 	font-size: 1.05em;
 	font-style: italic;
 }
 
-.wp-block-freeform.block-library-rich-text__tinymce blockquote cite {
-	color: #444;
+.wp-block-freeform.block-library-rich-text__tinymce blockquote cite,
+.wp-block-quote .wp-block-quote__citation {
+	color: #6c7781;
 	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: 0.9em;
 }
 
-.rtl .wp-block-freeform.block-library-rich-text__tinymce blockquote {
+.rtl .wp-block-freeform.block-library-rich-text__tinymce blockquote,
+.rtl .wp-block-quote {
 	border-left: 0;
 	border-right: 3px solid #ddd;
 	margin-left: 0;
@@ -284,7 +284,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-right: 0;
 }
 
-.editor-styles-wrapper .wp-block .wp-block-quote p {
+.editor-styles-wrapper .wp-block-quote p {
 	color: #393d41;
 	font-family: "Noto Serif", Georgia, serif;
 	font-size: 1.05em;
@@ -303,8 +303,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding-right: 1.5em;
 }
 
-.editor-styles-wrapper .wp-block .wp-block-quote.is-large p,
-.editor-styles-wrapper .wp-block .wp-block-quote.is-style-large p {
+.editor-styles-wrapper .wp-block-quote.is-large p,
+.editor-styles-wrapper .wp-block-quote.is-style-large p {
 	font-size: 24px;
 }
 
@@ -325,8 +325,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Cover */
 
-.editor-styles-wrapper .wp-block .wp-block-cover p,
-.editor-styles-wrapper .wp-block .wp-block-cover-image p {
+.editor-styles-wrapper .wp-block-cover p,
+.editor-styles-wrapper .wp-block-cover-image p {
 	font-size: 24px;
 }
 
@@ -337,6 +337,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-file .wp-block-file__button {
+	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	background-color: #678db8;
 	border-color: #678db8;
 	border-radius: 0;
@@ -434,6 +435,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-pullquote .wp-block-pullquote__citation {
+	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	color: #6c7781;
 	font-size: 13px;
 	text-transform: none;
@@ -527,6 +529,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Button */
 
 .wp-block-button .wp-block-button__link {
+	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	background-color: #678db8;
 	color: #fff;
 	font-size: 14px;

--- a/dyad-2/css/editor-blocks.css
+++ b/dyad-2/css/editor-blocks.css
@@ -18,14 +18,14 @@ Description: Used to style Gutenberg Blocks in the editor.
 1.0 General Typography
 --------------------------------------------------------------*/
 
-.edit-post-visual-editor .editor-block-list__block,
-.edit-post-visual-editor .editor-block-list__block p,
+.editor-styles-wrapper .wp-block,
+.editor-styles-wrapper .wp-block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 17px;
 }
 
-.edit-post-visual-editor .editor-block-list__block {
+.editor-styles-wrapper .wp-block {
 	color: #6a6c6e;
 }
 
@@ -35,17 +35,17 @@ Description: Used to style Gutenberg Blocks in the editor.
 	font-size: 40px;
 }
 
-.edit-post-visual-editor .editor-block-list__block h1,
-.edit-post-visual-editor .editor-block-list__block h2,
-.edit-post-visual-editor .editor-block-list__block h3,
-.edit-post-visual-editor .editor-block-list__block h4 {
+.editor-styles-wrapper h1.wp-block,
+.editor-styles-wrapper h2.wp-block,
+.editor-styles-wrapper h3.wp-block,
+.editor-styles-wrapper h4.wp-block {
 	clear: both;
 	color: #1a1c1e;
 	font-family: "Noto Serif", Georgia, serif;
 }
 
-.edit-post-visual-editor .editor-block-list__block h5,
-.edit-post-visual-editor .editor-block-list__block h6 {
+.editor-styles-wrapper h5.wp-block,
+.editor-styles-wrapper h6.wp-block {
 	clear: both;
 	color: #1a1c1e;
 	font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -53,32 +53,32 @@ Description: Used to style Gutenberg Blocks in the editor.
 	text-transform: uppercase;
 }
 
-.wp-block-heading h1,
+h1.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h1 {
 	font-size: 36px;
 }
 
-.wp-block-heading h2,
+h2.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h2 {
 	font-size: 26px;
 }
 
-.wp-block-heading h3,
+h3.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h3 {
 	font-size: 22px;
 }
 
-.wp-block-heading h4,
+h4.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h4 {
 	font-size: 20px;
 }
 
-.wp-block-heading h5,
+h5.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h5 {
 	font-size: 17px;
 }
 
-.wp-block-heading h6,
+h6.wp-block,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-size: 15px;
 }
@@ -114,15 +114,15 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 /* Link styles */
 
-.edit-post-visual-editor a,
-.editor-block-list__block a,
+.editor-styles-wrapper a,
+.wp-block a,
 .wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #6a6c6e;
 }
 
 /* Paragraph styles */
 
-.edit-post-visual-editor .editor-block-list__block p {
+.editor-styles-wrapper .wp-block p {
 	margin-top: 0;
 }
 
@@ -284,7 +284,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-right: 0;
 }
 
-.edit-post-visual-editor .editor-block-list__block .wp-block-quote p {
+.editor-styles-wrapper .wp-block .wp-block-quote p {
 	color: #393d41;
 	font-family: "Noto Serif", Georgia, serif;
 	font-size: 1.05em;
@@ -303,8 +303,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding-right: 1.5em;
 }
 
-.edit-post-visual-editor .editor-block-list__block .wp-block-quote.is-large p,
-.edit-post-visual-editor .editor-block-list__block .wp-block-quote.is-style-large p {
+.editor-styles-wrapper .wp-block .wp-block-quote.is-large p,
+.editor-styles-wrapper .wp-block .wp-block-quote.is-style-large p {
 	font-size: 24px;
 }
 
@@ -325,8 +325,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Cover */
 
-.edit-post-visual-editor .editor-block-list__block .wp-block-cover p,
-.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image p {
+.editor-styles-wrapper .wp-block .wp-block-cover p,
+.editor-styles-wrapper .wp-block .wp-block-cover-image p {
 	font-size: 24px;
 }
 
@@ -558,9 +558,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* General Widget styles */
 
-.edit-post-visual-editor [data-align="center"] .wp-block-categories__list,
-.edit-post-visual-editor [data-align="center"] .wp-block-archives,
-.edit-post-visual-editor [data-align="center"] .wp-block-lastest-posts {
+.editor-styles-wrapper [data-align="center"] .wp-block-categories__list,
+.editor-styles-wrapper [data-align="center"] .wp-block-archives,
+.editor-styles-wrapper [data-align="center"] .wp-block-lastest-posts {
 	list-style-position: inside;
 }
 


### PR DESCRIPTION
Dyad 2's editor styles were targeting outdated selectors. This PR updates them to use `editor-styles-wrapper` and `wp-block`. (Really though, we should be enquing the editor styles via `add_editor_style()` instead of the way we're doing it here, but that can be left to a separate PR). 

Here's a front end screenshot for reference: 

![Screen Shot 2020-05-14 at 8 10 06 AM](https://user-images.githubusercontent.com/1202812/81933954-27106e80-95bc-11ea-9a7d-3296ec41bf72.png)

Here's how that looked in the editor before this PR: 

![Screen Shot 2020-05-14 at 8 21 35 AM](https://user-images.githubusercontent.com/1202812/81933990-34c5f400-95bc-11ea-96f9-8c77014a760f.png)

... and here's how it looks _after_ this PR: 

![Screen Shot 2020-05-14 at 8 21 04 AM](https://user-images.githubusercontent.com/1202812/81933974-2ed01300-95bc-11ea-976b-c32a7b27a468.png)
