### PR TITLE
TextBook: Center image captions

### DIFF
--- a/textbook/assets/css/blocks.css
+++ b/textbook/assets/css/blocks.css
@@ -25,6 +25,7 @@ Description: Used to style Gutenberg Blocks.
 	font-size: 0.875rem;
 	font-weight: 400;
 	line-height: 1.65em;
+	text-align: center;
 }
 
 /* Video */


### PR DESCRIPTION
Fixes #2007 

<table>
<tr>
<td>Before (left aligned):
<br><br>

![#2007-before-left](https://user-images.githubusercontent.com/3323310/81942466-55299900-9624-11ea-956c-76e45f1f2c2f.png)
</td>
<td>After (left aligned):
<br><br>

![#2007-after-left](https://user-images.githubusercontent.com/3323310/81942471-56f35c80-9624-11ea-89f6-85372afe75cb.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Before (centred):
<br><br>

![#2007-before-center](https://user-images.githubusercontent.com/3323310/81942459-52c73f00-9624-11ea-9237-06c6b66dfed5.png)
</td>
<td>After (centred):
<br><br>

![#2007-after-center](https://user-images.githubusercontent.com/3323310/81942478-58bd2000-9624-11ea-8647-28ed5203f092.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Before (right aligned):
<br><br>

![#2007-before-right](https://user-images.githubusercontent.com/3323310/81942446-5064e500-9624-11ea-881b-1ff151377c74.png)
</td>
<td>After (right aligned):
<br><br>

![#2007-after-right](https://user-images.githubusercontent.com/3323310/81942487-5a86e380-9624-11ea-9767-56d644ff4557.png)
</td>
</tr>
</table>