### PR TITLE
Alves: Fixes Comment avatar on amp pages

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/alves/style.css
+++ b/alves/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Alves Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/12055657/82035793-da16c000-96c1-11ea-85ca-d587b285f274.png) |  ![image](https://user-images.githubusercontent.com/12055657/82036239-76d95d80-96c2-11ea-8c92-200e9f332955.png)|

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82035835-e733af00-96c1-11ea-9ec5-f846ea8d5374.png)    |  ![image](https://user-images.githubusercontent.com/12055657/82036265-7fca2f00-96c2-11ea-9065-7cc8605467d7.png)|