### PR TITLE
Barnsbury: Fixes Comment avatar on amp pages

### DIFF
--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Barnsbury Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82037141-8c9b5280-96c3-11ea-976f-48a6cee8719e.png) |   ![image](https://user-images.githubusercontent.com/12055657/82037165-9329ca00-96c3-11ea-8351-69758aaf185e.png)|

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82037179-991fab00-96c3-11ea-8ebb-52248a8cc3a3.png) |  ![image](https://user-images.githubusercontent.com/12055657/82037197-a046b900-96c3-11ea-9af1-137ea0fc4dac.png) |