### PR TITLE
Dalston: Fixes Comment avatar on amp pages

### DIFF
--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Dalston Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|    ![image](https://user-images.githubusercontent.com/12055657/82037510-0fbca880-96c4-11ea-8ef4-0ec2fb62279c.png)|   ![image](https://user-images.githubusercontent.com/12055657/82037527-14815c80-96c4-11ea-9df6-087d67aee4cc.png) |

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82037561-1fd48800-96c4-11ea-9d83-3fd09a626844.png) |   ![image](https://user-images.githubusercontent.com/12055657/82037573-2531d280-96c4-11ea-9d1c-9c693fca0718.png) |