### PR TITLE
Coutoire: Fixes Comment avatar on amp pages

### DIFF
--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3366,7 +3366,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -3383,7 +3383,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Coutoire Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82037888-96718580-96c4-11ea-8086-626cf23df4ed.png) | ![image](https://user-images.githubusercontent.com/12055657/82037908-9cfffd00-96c4-11ea-8e17-aaefef6bd2df.png) |

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|  ![image](https://user-images.githubusercontent.com/12055657/82037920-a1c4b100-96c4-11ea-9aa1-d1180d862b66.png) |  ![image](https://user-images.githubusercontent.com/12055657/82037938-a5f0ce80-96c4-11ea-86d2-4f8d07a529ae.png) |