### PR TITLE
Exford: Fixes Comment avatar on amp pages

### DIFF
--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/exford/style.css
+++ b/exford/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Exford Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038170-f49e6880-96c4-11ea-9506-4c9625c4f9d3.png) |  ![image](https://user-images.githubusercontent.com/12055657/82038182-f8ca8600-96c4-11ea-8588-dbae1f63bb14.png) |

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038196-fd8f3a00-96c4-11ea-92b7-eb79bd99b040.png)|   ![image](https://user-images.githubusercontent.com/12055657/82038206-0122c100-96c5-11ea-84b5-a0fc1389376d.png)|