### PR TITLE
Hever: Fixes Comment avatar on amp pages

### DIFF
--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/hever/style.css
+++ b/hever/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Hever Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|  ![image](https://user-images.githubusercontent.com/12055657/82038401-4e069780-96c5-11ea-81da-fad9fe4599d6.png)|  ![image](https://user-images.githubusercontent.com/12055657/82038418-5232b500-96c5-11ea-9239-3b622e4ec1e2.png)|

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038428-565ed280-96c5-11ea-9635-f23bdc871704.png) |  ![image](https://user-images.githubusercontent.com/12055657/82038440-5bbc1d00-96c5-11ea-83bd-24725d5963f9.png)|