### PR TITLE
Maywood: Fixes Comment avatar on amp pages

### DIFF
--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3368,7 +3368,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3385,7 +3385,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Maywood Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|  ![image](https://user-images.githubusercontent.com/12055657/82038605-9625ba00-96c5-11ea-954c-fa66c73b570f.png) |   ![image](https://user-images.githubusercontent.com/12055657/82038614-9a51d780-96c5-11ea-8eca-e95bc8c4b76e.png)|

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038636-a3db3f80-96c5-11ea-86bf-215bfa6b05aa.png)|   ![image](https://user-images.githubusercontent.com/12055657/82038648-a9388a00-96c5-11ea-86fa-45a180fed80d.png) |