### PR TITLE
Shawburn: Fixes Comment avatar on amp pages

### DIFF
--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3367,7 +3367,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-left: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		left: inherit;
 	}
 	.comment-meta .comment-metadata {

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3384,7 +3384,7 @@ body:not(.fse-enabled) .footer-menu a {
 	.comment-meta .comment-author .avatar {
 		margin-right: 16px;
 		display: inherit;
-		position: inherit;
+		position: relative;
 		right: inherit;
 	}
 	.comment-meta .comment-metadata {


### PR DESCRIPTION
Fixes #2009
 #### Changes proposed in this pull request:

Shawburn Theme: Fix comment avatar size for AMP pages.

|  Before on iPad AMP         | After on iPad AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038811-e9980800-96c5-11ea-8a9b-83217cb55758.png)|   ![image](https://user-images.githubusercontent.com/12055657/82038832-eef55280-96c5-11ea-8250-23eb203c83f1.png) |

|  Before on iPad Non AMP         | After on iPad Non AMP           |
| ------------- |:-------------:|
|   ![image](https://user-images.githubusercontent.com/12055657/82038846-f3217000-96c5-11ea-9c5e-95f1ef24b1d0.png) |   ![image](https://user-images.githubusercontent.com/12055657/82038861-f9175100-96c5-11ea-8815-ec3084dc5fde.png) |