### PR TITLE
Coutoire: Fix sticky header on AMP page

### DIFF
--- a/coutoire/functions.php
+++ b/coutoire/functions.php
@@ -161,8 +161,10 @@ function coutoire_scripts() {
 	// enqueue child RTL styles
 	wp_style_add_data( 'coutoire-style', 'rtl', 'replace' );
 
-	// enqueue header spacing JS
-	wp_enqueue_script('coutoire-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	if ( ! coutoire_is_amp() ) {
+		// enqueue header spacing JS.
+		wp_enqueue_script( 'coutoire-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	}
 
 }
 add_action( 'wp_enqueue_scripts', 'coutoire_scripts', 99 );
@@ -176,3 +178,10 @@ function coutoire_editor_styles() {
 	wp_enqueue_style( 'coutoire-editor-fonts', coutoire_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'coutoire_editor_styles' );
+
+/**
+ * Checks whether the endpoint is AMP.
+ */
+function coutoire_is_amp() {
+	return ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() );
+}

--- a/coutoire/sass/_extra-child-theme.scss
+++ b/coutoire/sass/_extra-child-theme.scss
@@ -327,3 +327,29 @@ a.wp-block-file__button {
 @include media(desktop) {
 
 }
+
+/**
+ * AMP Support
+ */
+ html[amp] {
+
+	@include media( tablet ) {
+		.site-header {
+			position: sticky;
+			top: 0;
+		}
+
+		.logged-in .site-header {
+			top: 32px;
+		}
+
+		.content-area {
+			margin: 0;
+		}
+	}
+	@media screen and ( max-width: 782px ) {
+		.logged-in .site-header {
+			top: 46px;
+		}
+	}
+}

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -4251,3 +4251,25 @@ a.wp-block-file__button {
 		text-align: right;
 	}
 }
+
+/**
+ * AMP Support
+ */
+@media only screen and (min-width: 640px) {
+	html[amp] .site-header {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in .site-header {
+		top: 32px;
+	}
+	html[amp] .content-area {
+		margin: 0;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in #masthead {
+		top: 46px;
+	}
+}

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -4280,3 +4280,25 @@ a.wp-block-file__button {
 		text-align: left;
 	}
 }
+
+/**
+ * AMP Support
+ */
+@media only screen and (min-width: 640px) {
+	html[amp] .site-header {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in .site-header {
+		top: 32px;
+	}
+	html[amp] .content-area {
+		margin: 0;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in .site-header {
+		top: 46px;
+	}
+}


### PR DESCRIPTION
Fixes: #2038

#### Changes proposed in this Pull Request:
Fix sticky header for the Coutoire theme on the AMP page.
In non-AMP mode, the JavaScript is used to calculate dynamic margin for the content wrapper as this JS is removed in the AMP page the content is not visible because of header. This PR adds a sticky position to the site header.

Sticky header Before on the AMP page (before fixes).
![image](https://user-images.githubusercontent.com/32839217/82225790-448a6300-9943-11ea-8220-c4d635a8b2a2.png)

Sticky header after on the AMP page (after fixes).
![image](https://user-images.githubusercontent.com/32839217/82225804-494f1700-9943-11ea-8cdb-c7403d17ffbd.png)

