### PR TITLE
Stratford: Fix sticky header on AMP page

### DIFF
--- a/stratford/functions.php
+++ b/stratford/functions.php
@@ -183,8 +183,10 @@ function stratford_scripts() {
 	// enqueue child RTL styles
 	wp_style_add_data( 'stratford-style', 'rtl', 'replace' );
 
-	// enqueue header spacing JS
-	wp_enqueue_script('stratford-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	if ( ! stratford_is_amp() ) {
+		// enqueue header spacing JS.
+		wp_enqueue_script( 'stratford-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'stratford_scripts', 99 );
 
@@ -197,3 +199,10 @@ function stratford_editor_styles() {
 	wp_enqueue_style( 'stratford-editor-fonts', stratford_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'stratford_editor_styles' );
+
+/**
+ * Checks whether the endpoint is AMP.
+ */
+function stratford_is_amp() {
+	return ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() );
+}

--- a/stratford/sass/_extra-child-theme.scss
+++ b/stratford/sass/_extra-child-theme.scss
@@ -16,6 +16,7 @@
  * 6.7. Posts List Block
  * 6.8. Search Block
  * 7. Widgets
+ * 8. AMP Support
  */
 
 $color_background: #{map-deep-get($config-global, "color", "background", "default")};
@@ -489,4 +490,25 @@ button[data-load-more-btn] {
 .wp-block-verse {
 	font-family: $font_family_code;
 	font-size: $font_size_base;
+}
+
+/**
+ * 8. AMP Support
+ */
+html[amp] {
+	@include media( mobile ) {
+		.site-header {
+			position: sticky;
+			top: 0;
+		}
+
+		.logged-in .site-header {
+			top: 32px;
+		}
+	}
+	@media screen and ( max-width: 782px ) {
+		.logged-in .site-header {
+			top: 46px;
+		}
+	}
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -3972,6 +3972,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * 6.7. Posts List Block
  * 6.8. Search Block
  * 7. Widgets
+ * 8. AMP Support
  */
 /**
  * 1. General Styles
@@ -4393,4 +4394,23 @@ button[data-load-more-btn].has-background:visited {
 .wp-block-verse {
 	font-family: "Inconsolata", monospace;
 	font-size: 1rem;
+}
+
+/**
+ * 8. AMP Support
+ */
+@media only screen and (min-width: 560px) {
+	html[amp] .site-header {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in .site-header {
+		top: 32px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in .site-header {
+		top: 46px;
+	}
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4001,6 +4001,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * 6.7. Posts List Block
  * 6.8. Search Block
  * 7. Widgets
+ * 8. AMP Support
  */
 /**
  * 1. General Styles
@@ -4422,4 +4423,23 @@ button[data-load-more-btn].has-background:visited {
 .wp-block-verse {
 	font-family: "Inconsolata", monospace;
 	font-size: 1rem;
+}
+
+/**
+ * 8. AMP Support
+ */
+@media only screen and (min-width: 560px) {
+	html[amp] .site-header {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in .site-header {
+		top: 32px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in .site-header {
+		top: 46px;
+	}
 }


### PR DESCRIPTION
Fixes: #2038

#### Changes proposed in this Pull Request:
Fix sticky header for Stratford theme on the AMP page.
In non-AMP mode, the JavaScript is used to calculate dynamic margin for the content wrapper as this JS is removed in the AMP page the content is not visible because of header. This PR adds a sticky position to the site header.

Sticky header Before on the AMP page (before fixes).
![image](https://user-images.githubusercontent.com/32839217/82032934-9fa92500-96b9-11ea-9567-135b944b332c.png)

Sticky header after on the AMP page (after fixes).
![image](https://user-images.githubusercontent.com/32839217/82032982-b485b880-96b9-11ea-911b-1221273e39b8.png)
