### PR TITLE
Varia: Fix overlapping issue in latest post block

### DIFF
--- a/varia/sass/blocks/latest-posts/_style.scss
+++ b/varia/sass/blocks/latest-posts/_style.scss
@@ -2,6 +2,7 @@
 	padding-left: 0;
 
 	& > li {
+		word-wrap: break-word;
 		/* Vertical margins logic */
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1839,6 +1839,7 @@ img {
 }
 
 .wp-block-latest-posts > li {
+	word-wrap: break-word;
 	/* Vertical margins logic */
 	margin-top: 32px;
 	margin-bottom: 32px;

--- a/varia/style.css
+++ b/varia/style.css
@@ -1839,6 +1839,7 @@ img {
 }
 
 .wp-block-latest-posts > li {
+	word-wrap: break-word;
 	/* Vertical margins logic */
 	margin-top: 32px;
 	margin-bottom: 32px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/2045

#### Changes proposed in this Pull Request:
If the **Latest Posts** block is set to Grid view and the column number is high like 5/6, the post titles are overlapping in both AMP & non-AMP versions. This PR aims to fix this by wrapping the post titles.

**"Latest Posts" block in Grid view in AMP Paired browsing mode (Before Fix)**

![image](https://user-images.githubusercontent.com/12055657/82325360-f2a61380-99fc-11ea-82c6-cf60013ea93d.png)

**"Latest Posts" block in Grid view in AMP Paired browsing mode (After Fix)**

![image](https://user-images.githubusercontent.com/12055657/82326754-26823880-99ff-11ea-9aa3-3b78672eba08.png)


#### Related issue(s):
