### PR TITLE
Rockfield: Fix sticky header on AMP page

### DIFF
--- a/rockfield/functions.php
+++ b/rockfield/functions.php
@@ -171,8 +171,10 @@ function rockfield_scripts() {
 	// enqueue child RTL styles
 	wp_style_add_data( 'rockfield-style', 'rtl', 'replace' );
 
-	// enqueue header spacing JS
-	wp_enqueue_script('rockfield-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	if ( ! rockfield_is_amp() ) {
+		// enqueue header spacing JS.
+		wp_enqueue_script( 'rockfield-fixed-header-spacing', get_stylesheet_directory_uri() . '/js/fixed-header-spacing.js', array(), wp_get_theme()->get( 'Version' ), true );
+	}
 
 }
 add_action( 'wp_enqueue_scripts', 'rockfield_scripts', 99 );
@@ -186,3 +188,10 @@ function rockfield_editor_styles() {
 	wp_enqueue_style( 'rockfield-editor-fonts', rockfield_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'rockfield_editor_styles' );
+
+/**
+ * Checks whether the endpoint is AMP.
+ */
+function rockfield_is_amp() {
+	return ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() );
+}

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -755,3 +755,25 @@ input[type="submit"] {
 		border-radius: 100px;
 	}
 }
+
+/**
+ * AMP Support
+ */
+html[amp] {
+
+	@include media( tablet ) {
+		#masthead {
+			position: sticky;
+			top: 0;
+		}
+
+		.logged-in #masthead {
+			top: 32px;
+		}
+	}
+	@media screen and ( max-width: 782px ) {
+		.logged-in #masthead {
+			top: 46px;
+		}
+	}
+}

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -4688,3 +4688,22 @@ input[type="submit"] {
 .is-style-circular .wp-block-button__link:before {
 	border-radius: 100px;
 }
+
+/**
+ * AMP Support
+ */
+@media only screen and (min-width: 640px) {
+	html[amp] #masthead {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in #masthead {
+		top: 32px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in #masthead {
+		top: 46px;
+	}
+}

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -4717,3 +4717,22 @@ input[type="submit"] {
 .is-style-circular .wp-block-button__link:before {
 	border-radius: 100px;
 }
+
+/**
+ * AMP Support
+ */
+@media only screen and (min-width: 640px) {
+	html[amp] #masthead {
+		position: sticky;
+		top: 0;
+	}
+	html[amp] .logged-in #masthead {
+		top: 32px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	html[amp] .logged-in #masthead {
+		top: 46px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Addresses: #2038 

Fix sticky header for rockfield theme on the AMP page.
In non-AMP mode, the JavaScript is used to calculate dynamic margin for the content wrapper as this JS is removed in the AMP page the content is not visible because of header. This PR adds a sticky position to the site header.

Sticky header Before on the AMP page.
![image](https://user-images.githubusercontent.com/32839217/82227127-fb3b1300-9944-11ea-9e10-74e00b68eec7.png)

Sticky header after on the AMP page.
![image](https://user-images.githubusercontent.com/32839217/82227148-ff673080-9944-11ea-92d9-613b0d9886d6.png)

