### PR TITLE
#2057: Photos: Fix visibility of Audio Block

### DIFF
--- a/photos/blocks.css
+++ b/photos/blocks.css
@@ -314,6 +314,7 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-video video,
 .wp-block-audio audio {
 	height: auto;
+	min-height: 50px;
 	width: 100%;
 }
 

--- a/photos/editor-blocks.css
+++ b/photos/editor-blocks.css
@@ -503,6 +503,7 @@ blockquote p:last-child {
 .wp-block-audio audio,
 .wp-block-video video {
 	height: auto;
+	min-height: 50px;
 	width: 100%;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Make the audio block visible both in the editor and on the frontend when using the Photos theme.

#### Related issue(s):

Fixes #2057 

<table>
<tr>
<td>Editor before:
<br><br>

![#2057-editor-before](https://user-images.githubusercontent.com/3323310/82682006-c3033f80-9c78-11ea-8632-c0972563dc36.png)
</td>
<td>Editor after:
<br><br>

![#2057-editor-after](https://user-images.githubusercontent.com/3323310/82682018-c5fe3000-9c78-11ea-9dd7-88ac26d8defc.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Frontend before:
<br><br>

![#2057-frontend-before](https://user-images.githubusercontent.com/3323310/82682013-c4cd0300-9c78-11ea-95ab-b5e0227f0581.png)
</td>
<td>Frontend after:
<br><br>

![#2057-frontend-after](https://user-images.githubusercontent.com/3323310/82682014-c5659980-9c78-11ea-982b-25fd1ca8c96a.png)
</td>
</tr>
</table>