### PR TITLE
Photos: Fix invisible audio block

### DIFF
--- a/photos/blocks.css
+++ b/photos/blocks.css
@@ -313,8 +313,13 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-video video,
 .wp-block-audio audio {
-	height: auto;
 	width: 100%;
+}
+
+/* Video */
+
+.wp-block-video video {
+	height: auto;
 }
 
 /* Tables */


### PR DESCRIPTION
Fixes #2057. 

Setting `height: auto` makes the audio block disappear in Chrome. The audio block has a built-in height by default, so it shouldn't need this rule anyway. 

Before: 

![Screen Shot 2020-05-22 at 12 52 17 PM](https://user-images.githubusercontent.com/1202812/82691058-501fa780-9c2b-11ea-85a2-615bb8ced639.png)

After:

![Screen Shot 2020-05-22 at 12 52 11 PM](https://user-images.githubusercontent.com/1202812/82691067-53b32e80-9c2b-11ea-8c1b-e4f03de33286.png)
