### PR TITLE
Dalston: Fix Interpolation issue in password-strength-meter style

### DIFF
--- a/dalston/style-woocommerce-rtl.css
+++ b/dalston/style-woocommerce-rtl.css
@@ -441,7 +441,7 @@ body[class*="woocommerce"] #page .woocommerce-warning:before {
 body[class*="woocommerce"] #page .woocommerce-password-strength {
 	text-align: center;
 	font-weight: 600;
-	padding: 0.5 * 16px;
+	padding: 8px;
 	font-size: 0.86957rem;
 }
 

--- a/dalston/style-woocommerce.css
+++ b/dalston/style-woocommerce.css
@@ -441,7 +441,7 @@ body[class*="woocommerce"] #page .woocommerce-warning:before {
 body[class*="woocommerce"] #page .woocommerce-password-strength {
 	text-align: center;
 	font-weight: 600;
-	padding: 0.5 * 16px;
+	padding: 8px;
 	font-size: 0.86957rem;
 }
 


### PR DESCRIPTION
Fixes #2011
#### Changes proposed in this Pull Request:

There is an Interpolation issue in password-strength-meter style. it produces incorrect CSS for padding on `woocommerce-password-strength` class because of not using proper Interpolation in SASS files!
This PR fixes it.

Before( incorrect padding )
![image](https://user-images.githubusercontent.com/12055657/81525143-91839d80-9375-11ea-8a15-3162527e6547.png)

After( correct padding )
![image](https://user-images.githubusercontent.com/12055657/81525171-a19b7d00-9375-11ea-9f5e-455ffc942c2c.png)

