### PR TITLE
Alves: Fix Interpolation issue in comment-meta style

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3299,7 +3299,7 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Meta
  */
 .comment-meta {
-	margin-left: calc( $avatar-size + (0.5 * 16px));
+	margin-left: calc( 32px + (0.5 * 16px));
 }
 
 .comment-meta .comment-author {

--- a/alves/style.css
+++ b/alves/style.css
@@ -3316,7 +3316,7 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Meta
  */
 .comment-meta {
-	margin-right: calc( $avatar-size + (0.5 * 16px));
+	margin-right: calc( 32px + (0.5 * 16px));
 }
 
 .comment-meta .comment-author {


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/2020

#### Changes proposed in this Pull Request:
There is an Interpolation issue in comment-meta style. Basically It has no visual effect, it just produces incorrect CSS because of not using proper Interpolation in SASS files!
This PR fixes it.

**Before Fix(Invalid CSS)**
![image](https://user-images.githubusercontent.com/12055657/81377312-0ad98100-9127-11ea-9944-90fcc6dcc70f.png)

**After Fix(Valid CSS, though not applying)**
![image](https://user-images.githubusercontent.com/12055657/81393094-89431c80-9141-11ea-8c6b-9c6c66779875.png)

#### Related issue(s):
None
