### PR TITLE
Multiple Themes: Fix nested wide/full blocks

### DIFF
--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -62,7 +62,8 @@ body {
 	overflow-x: hidden;
 }
 
-.apostrophe-2-no-sidebar .alignfull {
+.apostrophe-2-no-sidebar .alignfull,
+.apostrophe-2-no-sidebar .wp-block-group .alignfull {
 	width: 100vw;
 	max-width: 100vw;
 	margin-left: 0;
@@ -72,7 +73,8 @@ body {
 	transform: translateX( -50% );
 }
 
-.rtl.apostrophe-2-no-sidebar .alignfull {
+.rtl.apostrophe-2-no-sidebar .alignfull,
+.rtl.apostrophe-2-no-sidebar .wp-block-group .alignfull {
 	left: auto;
 	right: 50%;
 	transform: translateX(50%);
@@ -112,7 +114,8 @@ body {
 /* Wide Width */
 
 @media (min-width: 1024px) {
-	.apostrophe-2-no-sidebar .alignwide {
+	.apostrophe-2-no-sidebar .alignwide,
+	.apostrophe-2-no-sidebar .wp-block-group .alignwide {
 		width: 860px;
 		max-width: 860px;
 		margin-left: -65px;
@@ -134,6 +137,20 @@ body {
 		width: 100%;
 		height: 100%;
 	}
+}
+
+/* Nested Blocks */
+
+.apostrophe-2-no-sidebar *[class^="wp-block"] .alignwide,
+.apostrophe-2-no-sidebar *[class^="wp-block"] .alignfull,
+.rtl.apostrophe-2-no-sidebar *[class^="wp-block"] .alignwide,
+.rtl.apostrophe-2-no-sidebar *[class^="wp-block"] .alignfull {
+	width: inherit;
+	max-width: 100%;
+	margin-left: inherit;
+	margin-right: inherit;
+	left: inherit;
+	transform: inherit;
 }
 
 /* Gallery */

--- a/independent-publisher-2/css/blocks.css
+++ b/independent-publisher-2/css/blocks.css
@@ -30,7 +30,8 @@ Description: Used to style Gutenberg Blocks.
 }
 
 @media (min-width: 1140px) {
-	body:not(.has-sidebar) .alignwide {
+	body:not(.has-sidebar) .alignwide,
+	body:not(.has-sidebar) .wp-block-group.alignfull .alignwide {
 		margin-left: -25%;
 		margin-right: -25%;
 		max-width: 1000%;
@@ -38,7 +39,8 @@ Description: Used to style Gutenberg Blocks.
 	}
 }
 
-body:not(.has-sidebar) .alignfull {
+body:not(.has-sidebar) .alignfull,
+body:not(.has-sidebar) .wp-block-group.alignfull .alignfull {
 	margin-left: calc(50% - 50vw);
 	margin-right: calc(50% - 50vw);
 	max-width: 1000%;
@@ -63,6 +65,13 @@ body:not(.has-sidebar) .wp-block-latest-posts.alignfull {
 .wp-block-embed.is-type-video.alignfull iframe {
 	width: 100% !important;
 	height: 100% !important;
+}
+
+body:not(.has-sidebar) *[class^="wp-block"] .alignwide,
+body:not(.has-sidebar) *[class^="wp-block"] .alignfull {
+	max-width: 100%;
+	margin-left: inherit;
+	margin-right: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/independent-publisher-2/css/blocks.css
+++ b/independent-publisher-2/css/blocks.css
@@ -69,7 +69,7 @@ body:not(.has-sidebar) .wp-block-latest-posts.alignfull {
 
 body:not(.has-sidebar) *[class^="wp-block"] .alignwide,
 body:not(.has-sidebar) *[class^="wp-block"] .alignfull {
-	max-width: 100%;
+	max-width: inherit;
 	margin-left: inherit;
 	margin-right: inherit;
 }

--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -26,7 +26,8 @@ Description: Used to style Gutenberg Blocks.
 
 /* Full Width */
 
-.no-sidebar .alignfull {
+.no-sidebar .alignfull,
+.no-sidebar .wp-block-group .alignfull {
 	position: relative;
 	min-width: 100vw;
 	margin-left: 50%;
@@ -57,7 +58,8 @@ Description: Used to style Gutenberg Blocks.
 /* Wide Width */
 
 @media (min-width: 1024px) {
-	.no-sidebar .alignwide {
+	.no-sidebar .alignwide,
+	.no-sidebar .wp-block-group .alignwide {
 		width: 120%;
 		max-width: 120%;
 		margin-left: -10%;
@@ -69,6 +71,18 @@ Description: Used to style Gutenberg Blocks.
 		width: 100% !important;
 		height: 100% !important;
 	}
+}
+
+/* Nested Blocks */
+
+.no-sidebar *[class^="wp-block"] .alignwide,
+.no-sidebar *[class^="wp-block"] .alignfull {
+	min-width: inherit;
+	max-width: inherit;
+	margin-left: inherit;
+	margin-right: inherit;
+	left: initial;
+	transform: none;
 }
 
 /* Captions */

--- a/libre-2/css/blocks.css
+++ b/libre-2/css/blocks.css
@@ -29,7 +29,8 @@ Description: Used to style Gutenberg Blocks.
 }
 
 @media (min-width: 1140px) {
-	.singular.no-sidebar .alignwide {
+	.singular.no-sidebar .alignwide,
+	.singular.no-sidebar .wp-block-group .alignwide {
 		margin-left: -25%;
 		margin-right: -25%;
 		max-width: 1000%;
@@ -42,7 +43,8 @@ Description: Used to style Gutenberg Blocks.
 	}
 }
 
-.singular.no-sidebar .alignfull {
+.singular.no-sidebar .alignfull,
+.singular.no-sidebar .wp-block-group .alignfull {
 	margin-left: calc(50% - 50vw);
 	margin-right: calc(50% - 50vw);
 	max-width: 1000%;
@@ -67,6 +69,13 @@ Description: Used to style Gutenberg Blocks.
 .singular.no-sidebar .wp-block-embed.is-type-video.alignfull iframe {
 	width: 100% !important;
 	height: 100% !important;
+}
+
+.singular.no-sidebar *[class^="wp-block"] .alignwide,
+.singular.no-sidebar *[class^="wp-block"] .alignfull {
+	max-width: inherit;
+	margin-left: inherit;
+	margin-right: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -52,7 +52,8 @@ p.alignfull {
 }
 
 @media (min-width: 1160px) {
-	.alignwide {
+	.alignwide,
+	.wp-block-group.alignfull .alignwide {
 		margin-left: -25%;
 		margin-right: -25%;
 		width: auto;
@@ -61,7 +62,8 @@ p.alignfull {
 }
 
 @media (min-width: 750px) {
-	.alignfull {
+	.alignfull,
+	.wp-block-group.alignfull .alignfull {
 		margin-left: calc(50% - 50vw);
 		margin-right: calc(50% - 50vw);
 		width: auto;
@@ -92,10 +94,19 @@ p.alignfull {
 	}
 }
 
+/* Nested Blocks */
+
 .alignfull > *,
 .alignwide > * {
 	margin-left: auto;
 	margin-right: auto;
+}
+
+*[class^="wp-block"] .alignwide,
+*[class^="wp-block"] .alignfull {
+	max-width: 100%;
+	margin-left: inherit;
+	margin-right: inherit;
 }
 
 .alignfull img,


### PR DESCRIPTION
Fixes #2076

Unsets the max-width and margin rules for nested blocks (except when they're inside of a full-width group block).

Todo: 

- [x] Independent Publisher 2
- [x] Libre 2
- [x] Ixion
- [x] Apostrophe 2
- [x] Radcliffe 2

Notes: 

- The styles here are a little broader than are actually necessary to fix the problem in #2076. That one seems to deal _only_ with the Media & Text block, but the same problem that causes that exists for all nested blocks. This PR aims to solve that for everything in one go. When testing, check some of the other page templates, and you'll (hopefully) see things improve too.
- A few of these use some `!important` rules on full-width Video embeds. These will likely remain broken with this fix, unless I push some additional changes.