### PR TITLE
Canard: Remove reference to HEADER_TEXT

### DIFF
--- a/canard/inc/custom-header.php
+++ b/canard/inc/custom-header.php
@@ -33,10 +33,8 @@ if ( ! function_exists( 'canard_header_style' ) ) :
 function canard_header_style() {
 	$header_text_color = get_header_textcolor();
 
-	/*
-	 * If no custom options for text are set, let's bail.
-	 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
-	 */
+	// If no custom options for text are set, let's bail.
+	// get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
 	if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
 		return;
 	}

--- a/canard/inc/custom-header.php
+++ b/canard/inc/custom-header.php
@@ -33,10 +33,11 @@ if ( ! function_exists( 'canard_header_style' ) ) :
 function canard_header_style() {
 	$header_text_color = get_header_textcolor();
 
-	preg_match( '/^(?:[0-9a-fA-F]{3}){1,2}$/', $header_text_color, $hex_match );
-
-	// If no custom options for text are set, let's bail
-	if ( 'blank' !== $header_text_color && count( $hex_match ) === 0 ) {
+	/*
+	 * If no custom options for text are set, let's bail.
+	 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
+	 */
+	if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
 		return;
 	}
 

--- a/canard/inc/custom-header.php
+++ b/canard/inc/custom-header.php
@@ -33,9 +33,10 @@ if ( ! function_exists( 'canard_header_style' ) ) :
 function canard_header_style() {
 	$header_text_color = get_header_textcolor();
 
+	preg_match( '/^(?:[0-9a-fA-F]{3}){1,2}$/', $header_text_color, $hex_match );
+
 	// If no custom options for text are set, let's bail
-	// get_header_textcolor() options: HEADER_TEXTCOLOR is default, hide text (returns 'blank') or any hex value
-	if ( HEADER_TEXTCOLOR == $header_text_color ) {
+	if ( 'blank' !== $header_text_color && count( $hex_match ) === 0 ) {
 		return;
 	}
 


### PR DESCRIPTION
This PR addresses #2116. There should be no visual changes.

**How to Test**

- Install Canard.
- Change the header color and verify that it works.
- Install ThemeCheck plugin.
- Run the check and verify that there are no errors.

Tested on:
WordPress 5.4.2
PHP 7.3.5