### PR TITLE
Seedlet: Fix text domain/translation errors

### DIFF
--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -22,12 +22,12 @@ class Seedlet_Custom_Colors {
 		 * Define color variables
 		 */
 		$this->seedlet_custom_color_variables = array(
-			array( '--global--color-background', '#FFFFFF', 'Background Color' ),
-			array( '--global--color-foreground', '#333333', 'Foreground Color' ),
-			array( '--global--color-primary', '#000000', 'Primary Color' ),
-			array( '--global--color-secondary', '#3C8067', 'Secondary Color' ),
-			array( '--global--color-tertiary', '#FAFBF6', 'Tertiary Color' ),
-			array( '--global--color-border', '#EFEFEF', 'Borders Color' )
+			array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
+			array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
+			array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
+			array( '--global--color-secondary', '#3C8067', __( 'Secondary Color', 'seedlet' ) ),
+			array( '--global--color-tertiary', '#FAFBF6', __( 'Tertiary Color', 'seedlet' ) ),
+			array( '--global--color-border', '#EFEFEF', __( 'Borders Color', 'seedlet' ) )
 		);
 
 		/**
@@ -191,7 +191,7 @@ class Seedlet_Custom_Colors {
 				"seedlet_$variable[0]",
 				array(
 					'section'   => 'seedlet_options',
-					'label'     => __( $variable[2], 'seedlet' ),
+					'label'     => $variable[2],
 					'active_callback' => function() use ( $wp_customize ) {
 						return ( 'custom' === $wp_customize->get_setting( 'custom_colors_active' )->value() );
 					},
@@ -292,7 +292,7 @@ class Seedlet_Custom_Colors {
 		wp_script_add_data( $handle, 'data', sprintf( 'var _validateWCAGColorContrastExports = %s;', wp_json_encode( $exports ) ) );
 
 		// Custom color contrast validation text
-		wp_localize_script( $handle, 'validateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.'));
+		wp_localize_script( $handle, 'validateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ));
 	}
 
 	/**

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -205,47 +205,47 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 			'editor-gradient-presets',
 			array(
 				array(
-					'name'     => __( 'Diagonal', 'en' ),
+					'name'     => __( 'Diagonal', 'seedlet' ),
 					'gradient' => 'linear-gradient(to bottom right, ' . $gradient_color_a . ' 49.9%, ' . $gradient_color_b  . ' 50%)',
 					'slug'     => 'hard-diagonal',
 				),
 				array(
-					'name'     => __( 'Diagonal inverted', 'en' ),
+					'name'     => __( 'Diagonal inverted', 'seedlet' ),
 					'gradient' => 'linear-gradient(to top left, ' . $gradient_color_a . ' 49.9%, ' . $gradient_color_b . ' 50%)',
 					'slug'     => 'hard-diagonal-inverted',
 				),
 				array(
-					'name'     => __( 'Horizontal', 'en' ),
+					'name'     => __( 'Horizontal', 'seedlet' ),
 					'gradient' => 'linear-gradient(to bottom, ' . $gradient_color_a . ' 50%, ' . $gradient_color_b . ' 50%)',
 					'slug'     => 'hard-horizontal',
 				),
 				array(
-					'name'     => __( 'Horizontal inverted', 'en' ),
+					'name'     => __( 'Horizontal inverted', 'seedlet' ),
 					'gradient' => 'linear-gradient(to top, ' . $gradient_color_a . ' 50%, ' . $gradient_color_b . ' 50%)',
 					'slug'     => 'hard-horizontal-inverted',
 				),
 				array(
-					'name'     => __( 'Diagonal gradient', 'en' ),
+					'name'     => __( 'Diagonal gradient', 'seedlet' ),
 					'gradient' => 'linear-gradient(to bottom right, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'diagonal',
 				),
 				array(
-					'name'     => __( 'Diagonal inverted gradient', 'en' ),
+					'name'     => __( 'Diagonal inverted gradient', 'seedlet' ),
 					'gradient' => 'linear-gradient(to top left, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'diagonal-inverted',
 				),
 				array(
-					'name'     => __( 'Horizontal gradient', 'en' ),
+					'name'     => __( 'Horizontal gradient', 'seedlet' ),
 					'gradient' => 'linear-gradient(to bottom, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'horizontal',
 				),
 				array(
-					'name'     => __( 'Horizontal inverted gradient', 'en' ),
+					'name'     => __( 'Horizontal inverted gradient', 'seedlet' ),
 					'gradient' => 'linear-gradient(to top, ' . $gradient_color_a . ', ' . $gradient_color_b . ')',
 					'slug'     => 'horizontal-inverted',
 				),
 				array(
-					'name'     => __( 'Stripe', 'en' ),
+					'name'     => __( 'Stripe', 'seedlet' ),
 					'gradient' => 'linear-gradient(to bottom, transparent 20%, ' . $gradient_color_a . ' 20%, ' . $gradient_color_a . ' 80%, transparent 80%)',
 					'slug'     => 'stripe',
 				),


### PR DESCRIPTION
Addresses part of #2136. 

Fixes all of the WARNING messages thrown by the Theme Check plugin: 

- WARNING: More than one text-domain is being used in this theme. This means the theme will not be compatible with WordPress.org language packs. The domains found are seedlet, en
- WARNING: Found a translation function that is missing a text-domain. Function esc_html__, with the arguments This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.
-  WARNING: Found a translation function that is missing a text-domain. Function __, with the arguments seedlet

As well as one RECOMMENDED item: 

- RECOMMENDED: Possible variable $variable found in translation function in seedlet/classes/class-seedlet-custom-colors.php. Translation function calls must NOT contain PHP variables (Line 194)