### PR TITLE
Add a sanitize callback for the custom colors function.

### DIFF
--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -183,7 +183,8 @@ class Seedlet_Custom_Colors {
 			$wp_customize->add_setting(
 				"seedlet_$variable[0]",
 				array(
-					'default'	=> esc_html( $variable[1] )
+					'default'	=> esc_html( $variable[1] ),
+					'sanitize_callback' => 'sanitize_hex_color'
 				)
 			);
 			$wp_customize->add_control( new WP_Customize_Color_Control(


### PR DESCRIPTION
Fixes part of https://github.com/Automattic/themes/issues/2136. 

> REQUIRED: Found a Customizer setting called "seedlet_$variable[0]" in seedlet/classes/class-seedlet-custom-colors.php that did not have a sanitization callback function. Every call to the add_setting() method needs to have a sanitization callback function passed.

Since these are supposed to be hex colors, This PR uses the global [`sanitize_hex_color`](https://developer.wordpress.org/reference/functions/sanitize_hex_color/) check. 