### PR TITLE
Seedlet: Add body_open function

### DIFF
--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -20,6 +20,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'seedlet' ); ?></a>
 


### PR DESCRIPTION
Fixes part of https://github.com/Automattic/themes/issues/2136.

> REQUIRED: Could not find wp_body_openaction or function call at the very top of the body just after the opening body tag. See: [wp_body_open](https://developer.wordpress.org/reference/functions/wp_body_open/)

Adds a `body_open` function just after the body tag. This is what `_s` does. 

@allancole is there a reason this wasn't there originally?