### PR TITLE
Alves: Fix custom colors logic

### DIFF
--- a/alves/functions.php
+++ b/alves/functions.php
@@ -58,13 +58,13 @@ if ( ! function_exists( 'alves_setup' ) ) :
 		 *
 		 * - if the customizer color is empty, use the default
 		 */
-		$colors_array = get_theme_mod('colors_manager', array( 'colors' => true )); // color annotations array()
+		$colors_array     = get_theme_mod( 'colors_manager' ); // color annotations array()
 		$primary          = ! empty( $colors_array ) ? $colors_array['colors']['link'] : '#3E7D98'; // $config-global--color-primary-default;
 		$secondary        = ! empty( $colors_array ) ? $colors_array['colors']['fg1'] : '#9B6A36';  // $config-global--color-secondary-default;
 		$background       = ! empty( $colors_array ) ? $colors_array['colors']['bg'] : '#FFFFFF';   // $config-global--color-background-default;
 		$foreground       = ! empty( $colors_array ) ? $colors_array['colors']['txt'] : '#394d55';  // $config-global--color-foreground-default;
-		$foreground_light = ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ? $colors_array['colors']['txt'] : '#4d6974';  // $config-global--color-foreground-light-default;
-		$foreground_dark  = ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ? $colors_array['colors']['txt'] : '#253136';  // $config-global--color-foreground-dark-default;
+		$foreground_light = ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ) ? $colors_array['colors']['txt'] : '#4d6974';  // $config-global--color-foreground-light-default;
+		$foreground_dark  = ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ) ? $colors_array['colors']['txt'] : '#253136';  // $config-global--color-foreground-dark-default;
 
 		// Editor color palette.
 		add_theme_support(


### PR DESCRIPTION
Fixes #2146 by syncing up the custom colors logic with the code used in Coutoire and Rivington.

Previously, sites using Alves that had not previously tried out custom colors had their colors all appear black. The issue when away once users tried a different palette, or tried a different palette and then reverted back to the default. 

Before: 

![Screen Shot 2020-06-18 at 7 57 46 AM](https://user-images.githubusercontent.com/1202812/85017400-6856e980-b139-11ea-930f-91e9c453bc39.png)

After:

![Screen Shot 2020-06-18 at 7 50 45 AM](https://user-images.githubusercontent.com/1202812/85017411-6c830700-b139-11ea-9a3b-b7c3613c0eec.png)
