### PR TITLE
Alves: Reduce specificity on rules to hide extra color palettes

### DIFF
--- a/alves/functions.php
+++ b/alves/functions.php
@@ -223,8 +223,8 @@ function alves_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod('colors_manager', array( 'colors' => true )); // color annotations array()
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );


### PR DESCRIPTION
An attempt to fix #2148 in Alves. If this seems ok, we can do something similar to Coutoire and Rivington. 

Before: 

![Screen Shot 2020-06-18 at 8 19 40 AM](https://user-images.githubusercontent.com/1202812/85019472-e2d53880-b13c-11ea-9c1c-6a82b9444a34.png)

After: 

![Screen Shot 2020-06-18 at 8 21 44 AM](https://user-images.githubusercontent.com/1202812/85019480-e5379280-b13c-11ea-9ef1-51cdc18043b8.png)
