### PR TITLE
Shawburn: Reset the non-aligned button block appearance

### DIFF
--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -239,6 +239,14 @@ hr.wp-block-separator.is-style-wide,
 /**
  * Blocks
  */
+
+// Button
+.entry-content > .wp-block-button:not(.alignleft):not(.alignright) {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
 // Business Hours
 .jetpack-business-hours {
 	dt {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -4185,6 +4185,12 @@ hr.wp-block-separator.is-style-wide,
 /**
  * Blocks
  */
+.entry-content > .wp-block-button:not(.alignleft):not(.alignright) {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
 .jetpack-business-hours dt {
 	font-family: inherit;
 	font-family: var(--font-base, inherit);

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4214,6 +4214,12 @@ hr.wp-block-separator.is-style-wide,
 /**
  * Blocks
  */
+.entry-content > .wp-block-button:not(.alignleft):not(.alignright) {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
 .jetpack-business-hours dt {
 	font-family: inherit;
 	font-family: var(--font-base, inherit);


### PR DESCRIPTION
Fixes #2063

This PR adjusts the margins for non-aligned button blocks so that they don't extend offscreen, causing horizontal scrolling. It also centers the button within the page to match the editor styles. 

## Testing 

1. Switch to Shawburn
2. View the default Shawburn homepage layout. 
3. Ensure that the button is centered, and that there's no horizontal scrolling on the page at breakpoints >1200px. 

## Screenshots

Before: 
<img width="1200" alt="Screen Shot 2020-06-18 at 2 13 26 PM" src="https://user-images.githubusercontent.com/1202812/85057092-42980780-b16e-11ea-9cdf-17e51db2be5d.png">

After: 

<img width="1200" alt="Screen Shot 2020-06-18 at 2 17 08 PM" src="https://user-images.githubusercontent.com/1202812/85057182-66f3e400-b16e-11ea-849b-24a036776feb.png">

Here's a screenshot of the editor appearance for reference too: 

<img width="1201" alt="Screen Shot 2020-06-18 at 2 09 02 PM" src="https://user-images.githubusercontent.com/1202812/85057457-c18d4000-b16e-11ea-877f-81b19e24b1bb.png">
