### PR TITLE
Restore foreground color rules

### DIFF
--- a/rivington/inc/wpcom-colors.php
+++ b/rivington/inc/wpcom-colors.php
@@ -278,6 +278,11 @@ add_color_rule( 'txt', '#f2f2f2', array(
 	array( '.has-foreground-color[class]', 'color' ),
 	array( '.has-foreground-background-color[class]', 'background-color' ),
 
+	// Text color
+	array( '.has-background-background-color[class],
+			.has-background-light-background-color[class],
+			.has-background-dark-background-color[class]', 'color' ),
+
 	// Text-color darkened
 	array( '.has-foreground-dark-color[class]', 'color', '-1' ),
 	// Background-color darkened

--- a/rivington/inc/wpcom-editor-colors.php
+++ b/rivington/inc/wpcom-editor-colors.php
@@ -129,7 +129,10 @@ add_editor_color_rule( 'txt', '#f2f2f2', array(
 	 * Utility Classes
 	 */
 	// Text-color
-	array( '#editor .editor-styles-wrapper .has-foreground-color[class]', 'color' ),
+	array( '#editor .editor-styles-wrapper .has-foreground-color[class],
+			#editor .editor-styles-wrapper .has-background-background-color[class],
+			#editor .editor-styles-wrapper .has-background-dark-background-color[class],
+			#editor .editor-styles-wrapper .has-background-light-background-color[class]', 'color' ),
 	// Background-color
 	array( '#editor .editor-styles-wrapper .has-foreground-background-color[class]', 'background-color' ),
 	// Text-color darkened

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1082,7 +1082,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
-.has-background a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),
@@ -1096,6 +1095,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #CAAB57;
+	color: #060f29;
 }
 
 .wp-block .has-secondary-background-color,

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1101,36 +1101,43 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #EE4266;
+	color: #060f29;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #f2f2f2;
+	color: #060f29;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: white;
+	color: #060f29;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #8F8F8F;
+	color: #060f29;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #0d1f55;
+	color: #f2f2f2;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #030713;
+	color: #f2f2f2;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2452,7 +2452,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
-.has-background a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),
@@ -2466,42 +2465,50 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CAAB57;
+	color: #060f29;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #EE4266;
+	color: #060f29;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #f2f2f2;
+	color: #060f29;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: white;
+	color: #060f29;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #8F8F8F;
+	color: #060f29;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #0d1f55;
+	color: #f2f2f2;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #030713;
+	color: #f2f2f2;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2457,7 +2457,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
-.has-background a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),
@@ -2471,42 +2470,50 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CAAB57;
+	color: #060f29;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #EE4266;
+	color: #060f29;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #f2f2f2;
+	color: #060f29;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: white;
+	color: #060f29;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #8F8F8F;
+	color: #060f29;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #0d1f55;
+	color: #f2f2f2;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #030713;
+	color: #f2f2f2;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .is-small-text,


### PR DESCRIPTION
#1966 and #1944 made some changes to foreground color rules when a preset background color was selected. This led to existing sites changing appearance, even when custom colors were not active. 

This PR restores some of those rules, in order to restore the previous appearance. It also modifies the custom color rules to properly override these changes. 

**If this looks right, we should apply these same changes to Varia as well as to Coutoire and Alves. I can spin up PRs for those after this one lands.**

## Screenshot

The following screenshots were taken with the Rivington default homepage.

Before (Default Colors)

![kjellreigstad wordpress com_ (6)](https://user-images.githubusercontent.com/1202812/85075830-0b851e80-b18d-11ea-9e00-e0f62dfa01f2.png)

After (Default Colors)

![kjellreigstad wordpress com_ (2)](https://user-images.githubusercontent.com/1202812/85075674-b21cef80-b18c-11ea-8a23-0d3df9f5940e.png)

---

Before (Custom Colors)

![kjellreigstad wordpress com_ (5)](https://user-images.githubusercontent.com/1202812/85075769-e7c1d880-b18c-11ea-94a0-ff1549d5d88c.png)


After (Custom Colors)

![kjellreigstad wordpress com_ (7)](https://user-images.githubusercontent.com/1202812/85075944-4d15c980-b18d-11ea-95ae-c29a4ec71f5f.png)

