### PR TITLE
Seedlet: Add focus styles

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -113,8 +113,12 @@ a {
 	text-decoration: none;
 }
 
-a:hover {
+a:hover, a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+a:active {
+	color: var(--global--color-primary);
 }
 
 button,

--- a/seedlet/assets/sass/base/_editor.scss
+++ b/seedlet/assets/sass/base/_editor.scss
@@ -22,8 +22,13 @@ a {
 	color: var(--global--color-primary);
 	text-decoration: none;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: var(--global--color-primary-hover);
+	}
+
+	&:active {
+		color: var(--global--color-primary);
 	}
 }
 

--- a/seedlet/assets/sass/base/_reset.scss
+++ b/seedlet/assets/sass/base/_reset.scss
@@ -83,9 +83,14 @@ a {
 	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--global--color-primary);
 	text-decoration: none;
-
-	&:hover {
+	
+	&:hover,
+	&:focus {
 		color: var(--global--color-primary-hover);
+	}
+
+	&:active {
+		color: var(--global--color-primary);
 	}
 }
 

--- a/seedlet/assets/sass/base/_reset.scss
+++ b/seedlet/assets/sass/base/_reset.scss
@@ -94,6 +94,13 @@ a {
 	}
 }
 
+// Focus styles
+*:focus {
+	outline-width: 1px;
+	outline-style: dotted;
+	outline-color: var(--global--color-secondary);
+}
+
 button,
 a {
   cursor: pointer;

--- a/seedlet/assets/sass/blocks/blog-posts/_style.scss
+++ b/seedlet/assets/sass/blocks/blog-posts/_style.scss
@@ -88,7 +88,8 @@
 					color: currentColor;
 				}
 
-				&:hover {
+				&:hover,
+				&:focus {
 					color: var(--global--color-primary-hover);
 					text-decoration: underline;
 
@@ -97,6 +98,10 @@
 					[style*="background-color"] & {
 						color: currentColor;
 					}
+				}
+
+				&:active {
+					color: var(--global--color-primary);
 				}
 			}
 		}

--- a/seedlet/assets/sass/components/comments/_comments.scss
+++ b/seedlet/assets/sass/components/comments/_comments.scss
@@ -87,7 +87,7 @@
 
 	.comment-author {
 		line-height: var(--global--line-height-heading);
-		margin-bottom: calc(0.25 * var(--global--spacing-unit);
+		margin-bottom: calc(0.25 * var(--global--spacing-unit));
 		padding-right: calc(2.5 * var(--global--spacing-horizontal));
 		max-width: calc(100% - (3 * var(--global--spacing-horizontal)));
 
@@ -124,8 +124,12 @@
 			color: currentColor;
 
 			&:hover,
-			&:active {
+			&:focus {
 				color: var(--global--color-primary-hover);
+			}
+
+			&:active {
+				color: currentColor;
 			}
 		}
 

--- a/seedlet/assets/sass/components/entry/_header.scss
+++ b/seedlet/assets/sass/components/entry/_header.scss
@@ -14,8 +14,12 @@
 		color: var(--entry-header--color-link);
 
 		&:hover,
-		&:active {
+		&:focus {
 			color: var(--entry-header--color-hover);
+		}
+
+		&:active {
+			color: var(--entry-header--color-link);
 		}
 	}
 }

--- a/seedlet/assets/sass/components/entry/_meta.scss
+++ b/seedlet/assets/sass/components/entry/_meta.scss
@@ -31,8 +31,12 @@
 		color: var(--entry-meta--color-link);
 
 		&:hover,
-		&:active {
+		&:focus {
 			color: var(--entry-meta--color-hover);
+		}
+
+		&:active {
+			color: var(--entry-meta--color-link);
 		}
 	}
 

--- a/seedlet/assets/sass/components/footer/_footer-branding.scss
+++ b/seedlet/assets/sass/components/footer/_footer-branding.scss
@@ -33,11 +33,13 @@
 		color: currentColor;
 
 		&:link,
-		&:visited {
+		&:visited,
+		&:active {
 			color: currentColor;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--footer--color-link);
 		}
 	}

--- a/seedlet/assets/sass/components/footer/_footer-navigation.scss
+++ b/seedlet/assets/sass/components/footer/_footer-navigation.scss
@@ -45,11 +45,13 @@
 			color: currentColor;
 
 			&:link,
-			&:visited {
+			&:visited,
+			&:active {
 				color: currentColor;
 			}
 
-			&:hover {
+			&:hover,
+			&:focus {
 				color: var(--footer--color-link-hover);
 			}
 		}

--- a/seedlet/assets/sass/components/header/_header-branding.scss
+++ b/seedlet/assets/sass/components/header/_header-branding.scss
@@ -37,11 +37,13 @@
 			5px 0px var(--global--color-background);
 
 		&:link,
-		&:visited {
+		&:visited,
+		&:active {
 			color: currentColor;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--branding--color-link-hover);
 		}
 

--- a/seedlet/assets/sass/components/header/_primary-navigation.scss
+++ b/seedlet/assets/sass/components/header/_primary-navigation.scss
@@ -229,8 +229,13 @@
 	.menu-item > a {
 		color: var(--primary-nav--color-link);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--primary-nav--color-link-hover);
+		}
+
+		&:active {
+			color: var(--primary-nav--color-link);
 		}
 	}
 

--- a/seedlet/assets/sass/components/header/_social-navigation.scss
+++ b/seedlet/assets/sass/components/header/_social-navigation.scss
@@ -27,8 +27,13 @@
 		display: inline-block;
 		padding: 0 var(--social-nav--padding);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--social-nav--color-link-hover);
+		}
+
+		&:active {
+			color: var(--social-nav--color-link);
 		}
 	}
 

--- a/seedlet/assets/sass/components/pagination/_style.scss
+++ b/seedlet/assets/sass/components/pagination/_style.scss
@@ -10,8 +10,13 @@
 	a {
 		color: var(--global--color-primary);
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: var(--global--color-primary-hover);
+		}
+
+		&:active {
+			color: var(--global--color-primary);
 		}
 	}
 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -758,13 +758,23 @@ a {
 	text-decoration: none;
 }
 
-a:hover {
+a:hover, a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+a:active {
+	color: var(--global--color-primary);
 }
 
 button,
 a {
 	cursor: pointer;
+}
+
+*:focus {
+	outline-width: 1px;
+	outline-style: dotted;
+	outline-color: var(--global--color-secondary);
 }
 
 /* Text meant only for screen readers. */

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -766,15 +766,15 @@ a:active {
 	color: var(--global--color-primary);
 }
 
-button,
-a {
-	cursor: pointer;
-}
-
 *:focus {
 	outline-width: 1px;
 	outline-style: dotted;
 	outline-color: var(--global--color-secondary);
+}
+
+button,
+a {
+	cursor: pointer;
 }
 
 /* Text meant only for screen readers. */
@@ -1115,15 +1115,21 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
 	color: var(--global--color-primary-hover);
 	text-decoration: underline;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
 	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active {
+	color: var(--global--color-primary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -2759,11 +2765,11 @@ table th,
 	text-shadow: -1px 0px var(--global--color-background), 1px 0px var(--global--color-background), 2px 0px var(--global--color-background), -2px 0px var(--global--color-background), 3px 0px var(--global--color-background), -3px 0px var(--global--color-background), 4px 0px var(--global--color-background), -4px 0px var(--global--color-background), 5px 0px var(--global--color-background), -5px 0px var(--global--color-background);
 }
 
-.site-title a:link, .site-title a:visited {
+.site-title a:link, .site-title a:visited, .site-title a:active {
 	color: currentColor;
 }
 
-.site-title a:hover {
+.site-title a:hover, .site-title a:focus {
 	color: var(--branding--color-link-hover);
 }
 
@@ -3084,9 +3090,15 @@ nav a {
 	color: var(--primary-nav--color-link);
 }
 
-.primary-navigation .menu-item > a:hover,
-.woo-navigation .menu-item > a:hover {
+.primary-navigation .menu-item > a:hover, .primary-navigation .menu-item > a:focus,
+.woo-navigation .menu-item > a:hover,
+.woo-navigation .menu-item > a:focus {
 	color: var(--primary-nav--color-link-hover);
+}
+
+.primary-navigation .menu-item > a:active,
+.woo-navigation .menu-item > a:active {
+	color: var(--primary-nav--color-link);
 }
 
 .primary-navigation a,
@@ -3207,8 +3219,12 @@ nav a {
 	padding: 0 var(--social-nav--padding);
 }
 
-.social-navigation a:hover {
+.social-navigation a:hover, .social-navigation a:focus {
 	color: var(--social-nav--color-link-hover);
+}
+
+.social-navigation a:active {
+	color: var(--social-nav--color-link);
 }
 
 .social-navigation svg {
@@ -3250,11 +3266,11 @@ nav a {
 	color: currentColor;
 }
 
-.site-footer > .site-info a:link, .site-footer > .site-info a:visited {
+.site-footer > .site-info a:link, .site-footer > .site-info a:visited, .site-footer > .site-info a:active {
 	color: currentColor;
 }
 
-.site-footer > .site-info a:hover {
+.site-footer > .site-info a:hover, .site-footer > .site-info a:focus {
 	color: var(--footer--color-link);
 }
 
@@ -3308,11 +3324,11 @@ nav a {
 	color: currentColor;
 }
 
-.site-footer > .footer-navigation .footer-menu a:link, .site-footer > .footer-navigation .footer-menu a:visited {
+.site-footer > .footer-navigation .footer-menu a:link, .site-footer > .footer-navigation .footer-menu a:visited, .site-footer > .footer-navigation .footer-menu a:active {
 	color: currentColor;
 }
 
-.site-footer > .footer-navigation .footer-menu a:hover {
+.site-footer > .footer-navigation .footer-menu a:hover, .site-footer > .footer-navigation .footer-menu a:focus {
 	color: var(--footer--color-link-hover);
 }
 
@@ -3331,8 +3347,12 @@ nav a {
 	color: var(--entry-header--color-link);
 }
 
-.entry-title a:hover, .entry-title a:active {
+.entry-title a:hover, .entry-title a:focus {
 	color: var(--entry-header--color-hover);
+}
+
+.entry-title a:active {
+	color: var(--entry-header--color-link);
 }
 
 /**
@@ -3423,10 +3443,15 @@ nav a {
 	color: var(--entry-meta--color-link);
 }
 
-.entry-meta a:hover, .entry-meta a:active,
+.entry-meta a:hover, .entry-meta a:focus,
 .entry-footer a:hover,
-.entry-footer a:active {
+.entry-footer a:focus {
 	color: var(--entry-meta--color-hover);
+}
+
+.entry-meta a:active,
+.entry-footer a:active {
+	color: var(--entry-meta--color-link);
 }
 
 .entry-meta .svg-icon,
@@ -3486,8 +3511,12 @@ nav a {
 	color: var(--global--color-primary);
 }
 
-.navigation a:hover {
+.navigation a:hover, .navigation a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+.navigation a:active {
+	color: var(--global--color-primary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -3700,8 +3729,12 @@ nav a {
 	color: currentColor;
 }
 
-.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:active {
+.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+.comment-meta .comment-metadata a:active {
+	color: currentColor;
 }
 
 .comment-meta .comment-metadata .edit-link {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -766,8 +766,12 @@ a {
 	text-decoration: none;
 }
 
-a:hover {
+a:hover, a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+a:active {
+	color: var(--global--color-primary);
 }
 
 button,

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -774,6 +774,12 @@ a:active {
 	color: var(--global--color-primary);
 }
 
+*:focus {
+	outline-width: 1px;
+	outline-style: dotted;
+	outline-color: var(--global--color-secondary);
+}
+
 button,
 a {
 	cursor: pointer;
@@ -1117,15 +1123,21 @@ object {
 	color: currentColor;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
 	color: var(--global--color-primary-hover);
 	text-decoration: underline;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
-[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:focus {
 	color: currentColor;
+}
+
+.wp-block-newspack-blocks-homepage-articles article .entry-title a:active {
+	color: var(--global--color-primary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -2778,11 +2790,11 @@ table th,
 	text-shadow: 1px 0px var(--global--color-background), -1px 0px var(--global--color-background), -2px 0px var(--global--color-background), 2px 0px var(--global--color-background), -3px 0px var(--global--color-background), 3px 0px var(--global--color-background), -4px 0px var(--global--color-background), 4px 0px var(--global--color-background), -5px 0px var(--global--color-background), 5px 0px var(--global--color-background);
 }
 
-.site-title a:link, .site-title a:visited {
+.site-title a:link, .site-title a:visited, .site-title a:active {
 	color: currentColor;
 }
 
-.site-title a:hover {
+.site-title a:hover, .site-title a:focus {
 	color: var(--branding--color-link-hover);
 }
 
@@ -3103,9 +3115,15 @@ nav a {
 	color: var(--primary-nav--color-link);
 }
 
-.primary-navigation .menu-item > a:hover,
-.woo-navigation .menu-item > a:hover {
+.primary-navigation .menu-item > a:hover, .primary-navigation .menu-item > a:focus,
+.woo-navigation .menu-item > a:hover,
+.woo-navigation .menu-item > a:focus {
 	color: var(--primary-nav--color-link-hover);
+}
+
+.primary-navigation .menu-item > a:active,
+.woo-navigation .menu-item > a:active {
+	color: var(--primary-nav--color-link);
 }
 
 .primary-navigation a,
@@ -3226,8 +3244,12 @@ nav a {
 	padding: 0 var(--social-nav--padding);
 }
 
-.social-navigation a:hover {
+.social-navigation a:hover, .social-navigation a:focus {
 	color: var(--social-nav--color-link-hover);
+}
+
+.social-navigation a:active {
+	color: var(--social-nav--color-link);
 }
 
 .social-navigation svg {
@@ -3269,11 +3291,11 @@ nav a {
 	color: currentColor;
 }
 
-.site-footer > .site-info a:link, .site-footer > .site-info a:visited {
+.site-footer > .site-info a:link, .site-footer > .site-info a:visited, .site-footer > .site-info a:active {
 	color: currentColor;
 }
 
-.site-footer > .site-info a:hover {
+.site-footer > .site-info a:hover, .site-footer > .site-info a:focus {
 	color: var(--footer--color-link);
 }
 
@@ -3327,11 +3349,11 @@ nav a {
 	color: currentColor;
 }
 
-.site-footer > .footer-navigation .footer-menu a:link, .site-footer > .footer-navigation .footer-menu a:visited {
+.site-footer > .footer-navigation .footer-menu a:link, .site-footer > .footer-navigation .footer-menu a:visited, .site-footer > .footer-navigation .footer-menu a:active {
 	color: currentColor;
 }
 
-.site-footer > .footer-navigation .footer-menu a:hover {
+.site-footer > .footer-navigation .footer-menu a:hover, .site-footer > .footer-navigation .footer-menu a:focus {
 	color: var(--footer--color-link-hover);
 }
 
@@ -3350,8 +3372,12 @@ nav a {
 	color: var(--entry-header--color-link);
 }
 
-.entry-title a:hover, .entry-title a:active {
+.entry-title a:hover, .entry-title a:focus {
 	color: var(--entry-header--color-hover);
+}
+
+.entry-title a:active {
+	color: var(--entry-header--color-link);
 }
 
 /**
@@ -3442,10 +3468,15 @@ nav a {
 	color: var(--entry-meta--color-link);
 }
 
-.entry-meta a:hover, .entry-meta a:active,
+.entry-meta a:hover, .entry-meta a:focus,
 .entry-footer a:hover,
-.entry-footer a:active {
+.entry-footer a:focus {
 	color: var(--entry-meta--color-hover);
+}
+
+.entry-meta a:active,
+.entry-footer a:active {
+	color: var(--entry-meta--color-link);
 }
 
 .entry-meta .svg-icon,
@@ -3505,8 +3536,12 @@ nav a {
 	color: var(--global--color-primary);
 }
 
-.navigation a:hover {
+.navigation a:hover, .navigation a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+.navigation a:active {
+	color: var(--global--color-primary);
 }
 
 @media only screen and (min-width: 482px) {
@@ -3719,8 +3754,12 @@ nav a {
 	color: currentColor;
 }
 
-.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:active {
+.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:focus {
 	color: var(--global--color-primary-hover);
+}
+
+.comment-meta .comment-metadata a:active {
+	color: currentColor;
 }
 
 .comment-meta .comment-metadata .edit-link {


### PR DESCRIPTION
Fixes #2140.

Seedlet was missing custom focus styles. This PR adds those in, using the design in the original design comps. 

![84944006-2be0aa80-b0b3-11ea-9f05-ec61ad19f2d6](https://user-images.githubusercontent.com/1202812/85302121-be4bca00-b476-11ea-9729-df4235194603.png)

It also cleans up the active styles.

Still todo: 

- ~~Add the 2px bottom border on hover/focus.~~


## Screenshots:

Before (Default browser focus styles):

![focus-before](https://user-images.githubusercontent.com/1202812/85302452-2ac6c900-b477-11ea-82ef-c648b4750706.gif)

After: 

![focus-after](https://user-images.githubusercontent.com/1202812/85302484-34503100-b477-11ea-8fba-df8d140551cc.gif)
