### PR TITLE
Seedlet Blocks: Center-align the site title

### DIFF
--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -2,7 +2,7 @@
 <div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="https://cldup.com/B9dfntUFJE.png" alt="" width="128" height="128"/></figure></div>
 <!-- /wp:image -->
 
-<!-- wp:site-title /-->
+<!-- wp:site-title {"align":"center"} /-->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size">is a curious botanist</p>

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -28,11 +28,6 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 */
 
-/* Center the site title. */
-.site-header h1 {
-	text-align: center;
-}
-
 /* Set up alignments */
 .wp-block-group .wp-block-group__inner-container > * {
 	max-width: var(--responsive--aligndefault-width);


### PR DESCRIPTION
The site title now comes with an alignment control, so there's no need to center-align it via CSS.

Should look the same before & after: 

![Screen Shot 2020-06-22 at 1 59 57 PM](https://user-images.githubusercontent.com/1202812/85320174-a8e39980-b490-11ea-83a6-001f1e2abcaf.png)
