### PR TITLE
Seedlet: address missing translations for aria-labels in header.php

### DIFF
--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -48,7 +48,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container menu-'. $menu->slug .'-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
 						)
 					);
 					?>
@@ -65,12 +65,12 @@
 							<span class="hide-visually collapsed-text">%6$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-						<ul id="woocommerce-menu" class="menu-wrapper" aria-label="submenu">
-						<li class="menu-item woocommerce-menu-item %7$s" title="%8$s">
-							%9$s
+						<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%7$s">
+						<li class="menu-item woocommerce-menu-item %8$s" title="%9$s">
+							%10$s
 							<ul class="sub-menu">
-								<li class="woocommerce-cart-widget" title="%10$s">
-									%11$s
+								<li class="woocommerce-cart-widget" title="%11$s">
+									%12$s
 								</li>
 							</ul>
 						</li>',
@@ -80,6 +80,7 @@
 						seedlet_get_icon_svg( 'close' ),
 						esc_html__( 'expanded', 'seedlet' ),
 						esc_html__( 'collapsed', 'seedlet' ),
+						esc_attr__( 'submenu', 'seedlet' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'seedlet' ),
 						seedlet_cart_link(),

--- a/seedlet/languages/seedlet.pot
+++ b/seedlet/languages/seedlet.pot
@@ -221,23 +221,27 @@ msgstr ""
 msgid "collapsed"
 msgstr ""
 
-#: header.php:58
+#: header.php:51
+msgid "submenu"
+msgstr ""
+
+#: header.php:59
 msgid "Woo Minicart"
 msgstr ""
 
-#: header.php:77
+#: header.php:78
 msgid "Cart"
 msgstr ""
 
-#: header.php:83 inc/woocommerce.php:135
+#: header.php:85 inc/woocommerce.php:135
 msgid "View your shopping cart"
 msgstr ""
 
-#: header.php:85
+#: header.php:87
 msgid "View your shopping list"
 msgstr ""
 
-#: header.php:92
+#: header.php:94
 msgid "Social Links Menu"
 msgstr ""
 


### PR DESCRIPTION
This PR addresses #2192.

To test, check out this PR and verify that the `submenu` aria-label still exists on the WooCommerce navigation element.