### PR TITLE
Trying to access array offset on value of type bool

### DIFF
--- a/dyad-2/inc/jetpack.php
+++ b/dyad-2/inc/jetpack.php
@@ -174,8 +174,7 @@ function dyad_2_get_attachment_image_src( $post_id, $post_thumbnail_id, $size ) 
 	if ( function_exists( 'jetpack_featured_images_fallback_get_image_src' ) ) {
 		return jetpack_featured_images_fallback_get_image_src( $post_id, $post_thumbnail_id, $size );
 	} else {
-		$attachment = wp_get_attachment_image_src( $post_thumbnail_id, $size ); // Attachment array
-		$url = $attachment[0]; // Attachment URL
-		return $url;
+		$attachment = wp_get_attachment_image_src( $post_thumbnail_id, $size ); // Attachment array or false
+		return $attachment ? $attachment[0] : '';
 	}
 }


### PR DESCRIPTION
Get rid of PHP notices that occur when there is no featured image and jetpack is not available.

#### Changes proposed in this Pull Request:
Make sure wp_get_attachment_image_src() did not return false.
