### PR TITLE
Seedlet blocks: update template parts to full width

### DIFF
--- a/seedlet-blocks/block-templates/home.html
+++ b/seedlet-blocks/block-templates/home.html
@@ -1,11 +1,11 @@
 <!-- wp:group {"align":"full","className":"site-header","tagName":"header"} -->
-<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-content /--></div></div>
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-content {"align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer","tagName":"footer"} -->
-<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -1,11 +1,11 @@
 <!-- wp:group {"align":"full","className":"site-header","tagName":"header"} -->
-<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /--></div></div>
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true,"align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer","tagName":"footer"} -->
-<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->

--- a/seedlet-blocks/block-templates/singular.html
+++ b/seedlet-blocks/block-templates/singular.html
@@ -1,13 +1,13 @@
 <!-- wp:group {"align":"full","className":"site-header","tagName":"header"} -->
-<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
 <div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
 <!-- wp:post-title /-->
-<!-- wp:post-content /--></div></div>
+<!-- wp:post-content {"align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer","tagName":"footer"} -->
-<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks"} /--></div></div>
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the Seedlet block template parts and post content in templates to full width. Previously these were constrained to standard width which prevented us from recreating full page layouts, causing issues like this one https://github.com/Automattic/wp-calypso/issues/43640.

@ockham added this capability in core in https://github.com/WordPress/gutenberg/pull/23488 so now we can update the theme to use that.

#### Testing instructions

1. Run latest version of Gutenberg master locally.
2. Map this branch of Seedlet blocks theme to your local install.
3. Delete any existing templates or template parts that you might have saved.
4. Make sure that demo templates experiment is turned off.
5. Open the site editor.
6. Verify that post content and template parts have full width by default.

<img width="1676" alt="Screenshot 2020-07-01 at 14 08 55" src="https://user-images.githubusercontent.com/1182160/86242106-6d3d8380-bba4-11ea-9dfe-3b1a66b09ee1.png">

