### PR TITLE
Seedlet blocks: fix group block padding in site editor

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -559,11 +559,6 @@ div[data-type="core/button"] {
 	padding: var(--global--spacing-vertical);
 }
 
-.wp-block-group:not(.has-background) .wp-block-group__inner-container {
-	padding-left: var(--global--spacing-horizontal);
-	padding-right: var(--global--spacing-horizontal);
-}
-
 .wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
 	margin: 0;
 	width: 100%;

--- a/seedlet/assets/sass/blocks/group/_editor.scss
+++ b/seedlet/assets/sass/blocks/group/_editor.scss
@@ -2,12 +2,6 @@
 	&.has-background {
 		padding: var(--global--spacing-vertical);
 	}
-	&:not(.has-background) {
-		.wp-block-group__inner-container {
-			padding-left: var(--global--spacing-horizontal);
-			padding-right: var(--global--spacing-horizontal);
-		}
-	}
 }
 
 .wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Seedlet blocks parent theme was declaring padding on group block which was interfering with full width display in site editor.

#### Screenshots

Before:

<img width="1680" alt="Screenshot 2020-07-01 at 15 14 52" src="https://user-images.githubusercontent.com/1182160/86248068-a5958f80-bbad-11ea-8dd2-c5abe70a81f5.png">


After:

<img width="1679" alt="Screenshot 2020-07-01 at 15 03 46" src="https://user-images.githubusercontent.com/1182160/86247985-8a2a8480-bbad-11ea-96f7-79ac58fd8548.png">
