### PR TITLE
Seedlet: Add support for spacing overrides

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -984,6 +984,120 @@ pre.wp-block-verse {
 /**
  * Spacing Overrides
  */
+/*
+ * Margins
+ */
+.margin-top-none {
+	margin-top: 0 !important;
+}
+
+.margin-top-half {
+	margin-top: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.margin-top-default {
+	margin-top: var(--global--spacing-vertical) !important;
+}
+
+.margin-right-none {
+	/*rtl:ignore*/
+	margin-right: 0 !important;
+}
+
+.margin-right-half {
+	/*rtl:ignore*/
+	margin-right: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.margin-right-default {
+	/*rtl:ignore*/
+	margin-right: var(--global--spacing-vertical) !important;
+}
+
+.margin-bottom-none {
+	margin-bottom: 0 !important;
+}
+
+.margin-bottom-half {
+	margin-bottom: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.margin-bottom-default {
+	margin-bottom: var(--global--spacing-vertical) !important;
+}
+
+.margin-left-none {
+	/*rtl:ignore*/
+	margin-left: 0 !important;
+}
+
+.margin-left-half {
+	/*rtl:ignore*/
+	margin-left: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.margin-left-default {
+	/*rtl:ignore*/
+	margin-left: var(--global--spacing-vertical) !important;
+}
+
+/*
+ * Padding
+ */
+.padding-top-none {
+	padding-top: 0 !important;
+}
+
+.padding-top-half {
+	padding-top: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.padding-top-default {
+	padding-top: var(--global--spacing-vertical) !important;
+}
+
+.padding-right-none {
+	/*rtl:ignore*/
+	padding-right: 0 !important;
+}
+
+.padding-right-half {
+	/*rtl:ignore*/
+	padding-right: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.padding-right-default {
+	/*rtl:ignore*/
+	padding-right: var(--global--spacing-vertical) !important;
+}
+
+.padding-bottom-none {
+	padding-bottom: 0 !important;
+}
+
+.padding-bottom-half {
+	padding-bottom: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.padding-bottom-default {
+	padding-bottom: var(--global--spacing-vertical) !important;
+}
+
+.padding-left-none {
+	/*rtl:ignore*/
+	padding-left: 0 !important;
+}
+
+.padding-left-half {
+	/*rtl:ignore*/
+	padding-left: calc(0.5 * var(--global--spacing-vertical)) !important;
+}
+
+.padding-left-default {
+	/*rtl:ignore*/
+	padding-left: var(--global--spacing-vertical) !important;
+}
+
 [data-block] {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);

--- a/seedlet/assets/sass/blocks/utilities/_editor.scss
+++ b/seedlet/assets/sass/blocks/utilities/_editor.scss
@@ -159,6 +159,8 @@
  * Spacing Overrides
  */
 
+ @import "spacing-overrides";
+
 [data-block] {
 	margin-top: var(--global--spacing-vertical);
 	margin-bottom: var(--global--spacing-vertical);


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Varia child themes (and many others like [Mayland](https://github.com/Automattic/themes/blob/master/mayland/style-editor.css#L1190) and [Redhill](https://github.com/Automattic/themes/blob/master/redhill/style.css#L2597))  have a few classes built-in that help to control the spacing. This PR introduces the same spacing override classes to seedlet and seedlet-blocks. 

#### Related issue(s):
Addresses #2191

#### Testing:
1. Checkout this branch
2. Zip the seedlet and seedlet-blocks theme to upload to a `jurassic.ninja` website (for a mac `zip -r seedlet.zip seedlet && zip -r seedlet-blocks.zip seedlet-blocks`)
3. [Import both themes](https://wordpress.com/support/themes/uploading-setting-up-custom-themes/) into a WordPress [jurassic.ninja site](http://jurassic.ninja/create?gutenberg)
4. Activate the `seedlet-blocks` theme
5. Open the Gutenberg editor and add two blocks. There should be a margin between them.
6. Open the HTML element inspector and modify the classname of either or both blocks
7. Include variations of spacing overrides introduced in this PR, like `margin-top-none`, `margin-bottom-none`, `margin-top-half`, etc.
8. Verify that the margins on the blocks are modified
