### PR TITLE
Dalston: Enqueue Block Scripts only in non-AMP

### DIFF
--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -196,37 +196,36 @@ add_action( 'enqueue_block_editor_assets', 'dalston_editor_styles' );
  */
 function dalston_block_extends() {
 
-	// Cover Block Tweaks
-	if ( ! dalston_is_amp() ) {
-		wp_enqueue_script( 'dalston-extend-cover-block',
-			get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.js',
-			array( 'wp-blocks' )
-		);
+	// Bail out early while in AMP endpoint.
+	if ( dalston_is_amp() ) {
+		return;
 	}
+
+	// Cover Block Tweaks
+	wp_enqueue_script( 'dalston-extend-cover-block',
+		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.js',
+		array( 'wp-blocks' )
+	);
 
 	wp_enqueue_style( 'dalston-extend-cover-block-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'
 	);
 
 	// Columns Block Tweaks
-	if ( ! dalston_is_amp() ) {
-		wp_enqueue_script( 'dalston-extend-columns-block',
-			get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.js',
-			array( 'wp-blocks' )
-		);
-	}
+	wp_enqueue_script( 'dalston-extend-columns-block',
+		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.js',
+		array( 'wp-blocks' )
+	);
 
 	wp_enqueue_style( 'dalston-extend-cover-columns-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.css'
 	);
 
 	// Columns Block Tweaks
-	if ( ! dalston_is_amp() ) {
-		wp_enqueue_script( 'dalston-extend-media-text-block',
-			get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.js',
-			array( 'wp-blocks' )
-		);
-	}
+	wp_enqueue_script( 'dalston-extend-media-text-block',
+		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.js',
+		array( 'wp-blocks' )
+	);
 
 	wp_enqueue_style( 'dalston-extend-cover-media-text-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.css'

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -197,33 +197,50 @@ add_action( 'enqueue_block_editor_assets', 'dalston_editor_styles' );
 function dalston_block_extends() {
 
 	// Cover Block Tweaks
-	wp_enqueue_script( 'dalston-extend-cover-block',
-		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.js',
-		array( 'wp-blocks' )
-	);
+	if ( ! dalston_is_amp() ) {
+		wp_enqueue_script( 'dalston-extend-cover-block',
+			get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.js',
+			array( 'wp-blocks' )
+		);
+	}
 
 	wp_enqueue_style( 'dalston-extend-cover-block-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'
 	);
 
 	// Columns Block Tweaks
-	wp_enqueue_script( 'dalston-extend-columns-block',
-		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.js',
-		array( 'wp-blocks' )
-	);
+	if ( ! dalston_is_amp() ) {
+		wp_enqueue_script( 'dalston-extend-columns-block',
+			get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.js',
+			array( 'wp-blocks' )
+		);
+	}
 
 	wp_enqueue_style( 'dalston-extend-cover-columns-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.css'
 	);
 
 	// Columns Block Tweaks
-	wp_enqueue_script( 'dalston-extend-media-text-block',
-		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.js',
-		array( 'wp-blocks' )
-	);
+	if ( ! dalston_is_amp() ) {
+		wp_enqueue_script( 'dalston-extend-media-text-block',
+			get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.js',
+			array( 'wp-blocks' )
+		);
+	}
 
 	wp_enqueue_style( 'dalston-extend-cover-media-text-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.css'
 	);
 }
 add_action( 'enqueue_block_assets', 'dalston_block_extends' );
+
+/**
+ * Whether this is an AMP endpoint.
+ *
+ * @see https://github.com/Automattic/amp-wp/blob/e4472bfa5c304b6c1b968e533819e3fa96579ad4/includes/amp-helper-functions.php#L248
+ * @return bool
+ */
+function dalston_is_amp() {
+	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+}
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As JS <script> tags cannot be used in AMP version unless they are for loading AMP components. In order for a page to be served as AMP, the custom JS codes must be removed from the page. In this case the enqueue_block_assets hook is used to load the block scripts in both admin and frontend which is causing validation errors. This PR checks for whether is on AMP endpoint and if not then enqueues the Block scripts.

#### Related issue(s):
Fixes #2230 
