### PR TITLE
Use display=swap for Google Fonts

### DIFF
--- a/hever/functions.php
+++ b/hever/functions.php
@@ -141,6 +141,7 @@ function hever_fonts_url() {
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),
+			'display' => 'swap'
 		);
 
 		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );


### PR DESCRIPTION
Using `display=swap` allows text to show up right away while waiting for the font to load, then swaps once it is finished.

You can see the type of difference this can make: https://www.webpagetest.org/video/compare.php?tests=200708_64_a5c3e57fdad44be3f5e98a618c78aca6%2C200708_7Y_27106d14550289c4ccc296ee0d819bbd&thumbSize=200&ival=100&end=visual


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
