### PR TITLE
Remove full width block margins in the editor

### DIFF
--- a/seedlet-blocks/style-editor.css
+++ b/seedlet-blocks/style-editor.css
@@ -16,3 +16,8 @@ body {
 	--global--color-secondary: var(--wp--preset--color--secondary);
 	--global--color-tertiary: var(--wp--preset--color--tertiary);
 }
+
+.site-content .wp-block[data-align="full"] > [data-block], .site-content .wp-block.alignfull > [data-block] {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/seedlet-blocks/style-editor.css
+++ b/seedlet-blocks/style-editor.css
@@ -18,6 +18,6 @@ body {
 }
 
 .site-content .wp-block[data-align="full"] > [data-block], .site-content .wp-block.alignfull > [data-block] {
-    margin-top: 0;
-    margin-bottom: 0;
+	margin-top: 0;
+	margin-bottom: 0;
 }

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1163,6 +1163,11 @@ pre.wp-block-verse {
 	max-width: none;
 }
 
+.block-editor-block-list__layout:not(.edit-site-block-editor__block-list) .wp-block[data-align="full"] > [data-block], .block-editor-block-list__layout:not(.edit-site-block-editor__block-list) .wp-block.alignfull > [data-block] {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .alignleft {
 	margin: 0;
 	margin-right: var(--global--spacing-horizontal);

--- a/seedlet/assets/sass/blocks/utilities/_editor.scss
+++ b/seedlet/assets/sass/blocks/utilities/_editor.scss
@@ -233,6 +233,19 @@
 	}
 }
 
+// Selects the post editor and not the site editor
+.block-editor-block-list__layout:not(.edit-site-block-editor__block-list){
+	.wp-block {
+		&[data-align="full"],
+		&.alignfull {
+			&>[data-block] {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
 .alignleft {
 	margin: 0;
 	margin-right: var(--global--spacing-horizontal);

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -355,7 +355,8 @@ Included in theme screenshot.
 /**
  * Extends
  */
-.default-max-width, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
+.default-max-width, hr.wp-block-separator.is-style-wide, .page-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
+.entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.entry-attachment):not(.woocommerce),
 .entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-thumbnail, .navigation {
 	max-width: var(--responsive--aligndefault-width);
 	margin-right: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

## Changes proposed in this Pull Request:
This PR removes the margins for full-width blocks in Seedlet.

The Seedlet frontend has [styling](https://github.com/Automattic/themes/blob/master/seedlet/style.css#L613-L621) that removes top and bottom margins from full-width blocks within entry content. The `.entry-content` class, however, does not exist in the block editor. In order to implement the same behavior in the editor, we target full-width blocks by leveraging the the `[data-align="full"]` selector.

One thing to note is that the selectors to remove margins are different between `seedlet` and `seedlet blocks`. This is meant to accommodate full site editing. We don't want to remove the margins for _all_ full width blocks in the site editor (otherwise the header, content, and footer would have no spacing between them)

## Screenshots
### Block Editor Before:
![wordpress com_block-editor_page_bigmacsiteeditor5 wpcomstaging com_1541](https://user-images.githubusercontent.com/5414230/86986908-9ed8c080-c149-11ea-9298-a45bfeeccf08.png)

### Block Editor After:
![localhost_8888_wp-admin_post php_post=11 action=edit](https://user-images.githubusercontent.com/5414230/86986912-a13b1a80-c149-11ea-8dc9-4f7b63328475.png)

## Related issue(s):
Fixes https://github.com/Automattic/wp-calypso/issues/43883