### PR TITLE
Seedlet Blocks: Use spacer blocks instead of css margins for the site header and footer

### DIFF
--- a/seedlet-blocks/block-template-parts/footer.html
+++ b/seedlet-blocks/block-template-parts/footer.html
@@ -1,3 +1,11 @@
+<!-- wp:spacer -->
+<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size">Proudly powered by <a href="https://wordpress.org">WordPress</a></p>
 <!-- /wp:paragraph -->
+
+<!-- wp:spacer -->
+<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/seedlet-blocks/block-template-parts/footer.html
+++ b/seedlet-blocks/block-template-parts/footer.html
@@ -1,4 +1,4 @@
-<!-- wp:spacer -->
+<!-- wp:spacer {"height":30} -->
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -6,6 +6,6 @@
 <p class="has-text-align-center has-small-font-size">Proudly powered by <a href="https://wordpress.org">WordPress</a></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer -->
+<!-- wp:spacer {"height":30} -->
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:spacer -->
+<!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -16,6 +16,6 @@
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 <!-- /wp:navigation -->
 
-<!-- wp:spacer -->
+<!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,3 +1,7 @@
+<!-- wp:spacer -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:image {"align":"center","width":128,"height":128,"sizeSlug":"large","className":""} -->
 <div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="https://cldup.com/B9dfntUFJE.png" alt="" width="128" height="128"/></figure></div>
 <!-- /wp:image -->
@@ -11,3 +15,7 @@
 <!-- wp:navigation {"itemsJustification":"center"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 <!-- /wp:navigation -->
+
+<!-- wp:spacer -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","className":"site-header","tagName":"header"} -->
-<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
+<!-- wp:group {"align":"full","tagName":"header"} -->
+<div class="wp-block-group alignfull"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
@@ -10,6 +10,6 @@
 <!-- /wp:query-loop --></div></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","className":"site-footer","tagName":"footer"} -->
-<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
+<!-- wp:group {"align":"full","tagName":"footer"} -->
+<div class="wp-block-group alignfull"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->

--- a/seedlet-blocks/block-templates/singular.html
+++ b/seedlet-blocks/block-templates/singular.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","className":"site-header","tagName":"header"} -->
-<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
+<!-- wp:group {"align":"full","tagName":"header"} -->
+<div class="wp-block-group alignfull"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
@@ -8,6 +8,6 @@
 <!-- wp:post-content {"align":"full"} /--></div></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","className":"site-footer","tagName":"footer"} -->
-<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
+<!-- wp:group {"align":"full","tagName":"footer"} -->
+<div class="wp-block-group alignfull"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full"} /--></div></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Fixes #2240. 

Currently, the header in Seedlet Blocks uses a `site-header` class, to bring in some top and bottom margins from the original Seedlet theme. This isn't fully editable (or discoverable) in the site editor, so this PR removes that class and uses spacer blocks in the `header.html` template instead. 

This should have no effect on the header layout whatsoever, as the spacer blocks and native margins mimic what the `site-header` class did before. 

This PR does the same thing for the `site-footer` class too. In that case, it'll get just a little bit more margin than it did before this PR, because of the way Seedlet applies auto-margins. But that doesn't seem like a dealbreaker. 👍 

Theoretically, we shouldn't need those classnames for any semantic reasons, since these group blocks should be getting the `header` and `footer` tags anyway. (They don't appear to be doing that, but I think that's a standing issue)

---

Header Before| Header After
---|---
![Screen Shot 2020-07-09 at 8 33 02 AM](https://user-images.githubusercontent.com/1202812/87040542-ddf52900-c1be-11ea-9cb9-dcc9f53588a1.png)|![Screen Shot 2020-07-09 at 8 33 02 AM](https://user-images.githubusercontent.com/1202812/87040551-e0f01980-c1be-11ea-8b34-2d6a2ffcd2f2.png)

Footer Before| Footer After
---|---
![Screen Shot 2020-07-09 at 8 36 49 AM](https://user-images.githubusercontent.com/1202812/87040887-5eb42500-c1bf-11ea-8464-5d6f69010335.png)|![Screen Shot 2020-07-09 at 8 36 58 AM](https://user-images.githubusercontent.com/1202812/87040893-61167f00-c1bf-11ea-88b1-cc5398a542f7.png)
