### PR TITLE
Alves: Fixes background-color utility classes in the Cover block.

### DIFF
--- a/alves/inc/wpcom-colors.php
+++ b/alves/inc/wpcom-colors.php
@@ -36,14 +36,6 @@ add_color_rule( 'bg', '#ffffff', array(
 			.wp-block-button__link,
 			.wp-block-button__link:focus,
 			.wp-block-button__link:hover,
-			.wp-block-cover-image.has-background-background-color .wp-block-cover-image-text,
-			.wp-block-cover-image.has-background-background-color .wp-block-cover-text,
-			.wp-block-cover-image.has-background-background-color .wp-block-cover__inner-container,
-			.wp-block-cover.has-background-background-color .wp-block-cover-image-text,
-			.wp-block-cover.has-background-background-color .wp-block-cover-text,
-			.wp-block-cover.has-background-background-color .wp-block-cover__inner-container,
-			.wp-block-cover.has-background-dim,
-			.wp-block-cover-image.has-background-dim,
 			.wp-block-file .wp-block-file__button,
 			.wp-block-file a.wp-block-file__button:active,
 			.wp-block-file a.wp-block-file__button:focus,
@@ -85,11 +77,14 @@ add_color_rule( 'bg', '#ffffff', array(
 			.has-background-dark-color[class],
 			.has-background-light-color[class]', 'color' ),
 	// Background-color
-	array( '.has-background-background-color[class]', 'background-color' ),
+	array( '.has-background-background-color[class],
+			.has-background-background-color.has-background-dim[class]', 'background-color' ),
 	// Background-color darkened
-	array( '.has-background-dark-background-color[class]', 'background-color', '-1' ),
+	array( '.has-background-dark-background-color[class],
+			.has-background-dark-background-color.has-background-dim[class]', 'background-color', '-1' ),
 	// Background-color lightened
-	array( '.has-background-light-background-color[class]', 'background-color', '+1' ),
+	array( '.has-background-light-background-color[class],
+			.has-background-light-background-color.has-background-dim[class]', 'background-color', '+1' ),
 
 	/**
  	 * Grays
@@ -174,7 +169,8 @@ add_color_rule( 'link', '#3E7D98', array(
 	 * Utility Classes
 	 */
 	// Background-color
-	array( '.has-primary-background-color[class]', 'background-color' ),
+	array( '.has-primary-background-color[class],
+			.has-primary-background-color.has-background-dim[class]', 'background-color' ),
 	// Text-color
 	array( '.has-primary-color[class]', 'color' ),
 
@@ -246,17 +242,20 @@ add_color_rule( 'txt', '#394d55', array(
 	 */
 	// Foreground
 	array( '.has-foreground-color[class]', 'color' ),
-	array( '.has-foreground-background-color[class]', 'background-color' ),
+	array( '.has-foreground-background-color[class],
+			.has-foreground-background-color.has-background-dim[class]', 'background-color' ),
 
 	// Text-color darkened
 	array( '.has-foreground-dark-color[class]', 'color', '-1' ),
 	// Background-color darkened
-	array( '.has-foreground-dark-background-color[class]', 'background-color', '-1' ),
+	array( '.has-foreground-dark-background-color[class],
+			.has-foreground-dark-background-color.has-background-dim[class]', 'background-color', '-1' ),
 
 	// Text-color brightened
 	array( '.has-foreground-light-color[class]', 'color', '+2' ),
 	// Background-color brightened
-	array( '.has-foreground-light-background-color[class]', 'background-color', '+2' ),
+	array( '.has-foreground-light-background-color[class],
+			.has-foreground-light-background-color.has-background-dim[class]', 'background-color', '+2' ),
 
 ), __( 'Text Color' ) );
 
@@ -346,7 +345,8 @@ add_color_rule( 'fg1', '#9B6A36', array(
 	array( '.has-secondary-color[class]', 'color' ),
 
 	// Background-color
-	array( '.has-secondary-background-color[class]', 'background-color' ),
+	array( '.has-secondary-background-color[class],
+			.has-secondary-background-color.has-background-dim[class]', 'background-color' ),
 
 ), __( 'Secondary Color' ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request: 

- Cleans up utility classes for background-color so that the frontend matches the backend.

Before|After
------------|------------
![image](https://user-images.githubusercontent.com/709581/87460078-4c305600-c5da-11ea-9a9a-9585ff8e72ff.png)|![image](https://user-images.githubusercontent.com/709581/87460078-4c305600-c5da-11ea-9a9a-9585ff8e72ff.png)
![image](https://user-images.githubusercontent.com/709581/87460485-f14b2e80-c5da-11ea-8382-e8353d1fe6f5.png)|![image](https://user-images.githubusercontent.com/709581/87460353-c06af980-c5da-11ea-89c3-bca7e54c58bf.png)

#### Related issue(s): 

Fixes: #2252 