### PR TITLE
#2218: Varia: Comment reply title skips heading hierarchy

### DIFF
--- a/varia/comments.php
+++ b/varia/comments.php
@@ -69,7 +69,12 @@ if ( post_password_required() ) {
 
 	endif; // Check for have_comments().
 
-	comment_form();
+	comment_form(
+		array(
+			'title_reply_before' => '<h2 id="reply-title" class="comment-reply-title">',
+			'title_reply_after'  => '</h2>',
+		)
+	);
 	?>
 
 </div><!-- #comments -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Change comment form title from h3 to h2 due to accessibility reason.

#### Related issue(s):

#2218 

#### Before:

<img width="1431" alt="#2218-before" src="https://user-images.githubusercontent.com/3323310/87572190-7746a280-c6cb-11ea-9c42-7ba7b081cbcc.png">

#### After:

<img width="1425" alt="#2218-after" src="https://user-images.githubusercontent.com/3323310/87572182-74e44880-c6cb-11ea-8349-f31e038496af.png">