### PR TITLE
Seedlet: Opt in to line custom-line-height

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -255,6 +255,9 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 
+		// Add support for custom line height controls.
+		add_theme_support( 'custom-line-height' );
+
 		// Add support for experimental link color control.
 		add_theme_support( 'experimental-link-color' );
     


### PR DESCRIPTION
Fixes #2265. [Seedlet already supports this](https://github.com/Automattic/themes-workspace/pull/44), but custom line height has turned into an opt-in rather than a default. 

Before:

![Screen Shot 2020-07-16 at 6 42 46 PM](https://user-images.githubusercontent.com/1202812/87729852-4a11f700-c794-11ea-844b-51a7fd287478.png)

After: 

![Screen Shot 2020-07-16 at 6 21 39 PM](https://user-images.githubusercontent.com/1202812/87729858-4c745100-c794-11ea-844b-934cddb490cc.png)
