### PR TITLE
Seedlet: Allow all blocks with a link color to override the text color value set by custom background colors

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -1520,15 +1520,19 @@ a:focus {
 }
 
 a:active {
-	color: undefined;
-}
-
-p.has-background.has-link-color:not(.has-background-background-color) a {
 	color: #000000;
 }
 
 .has-link-color a {
 	border-bottom: 1px solid #000000;
+}
+
+.has-background:not(.has-background-background-color) .has-link-color a {
+	color: #000000;
+}
+
+.has-background:not(.has-background-background-color).has-link-color a {
+	color: #000000;
 }
 
 *:focus {
@@ -2194,6 +2198,30 @@ object {
 .wp-block-cover-image .wp-block-cover-image-text a,
 .wp-block-cover-image .wp-block-cover-text a {
 	color: currentColor;
+}
+
+.wp-block-cover .wp-block-cover__inner-container .has-link-color a {
+	color: #000000;
+}
+
+.wp-block-cover .wp-block-cover-image-text .has-link-color a {
+	color: #000000;
+}
+
+.wp-block-cover .wp-block-cover-text .has-link-color a {
+	color: #000000;
+}
+
+.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a {
+	color: #000000;
+}
+
+.wp-block-cover-image .wp-block-cover-image-text .has-link-color a {
+	color: #000000;
+}
+
+.wp-block-cover-image .wp-block-cover-text .has-link-color a {
+	color: #000000;
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container {
@@ -2874,6 +2902,14 @@ dd {
 }
 
 .wp-block-media-text {
+	/*&[class*="background-color"]:not(.has-background-background-color),
+	&[style*="background-color"] {
+		.wp-block-media-text__content {
+			a {
+				color: currentColor;
+			}
+		}
+	}*/
 	/**
 	 * Block Options
 	 */
@@ -2907,10 +2943,6 @@ dd {
 
 .wp-block-media-text .wp-block-media-text__content > *:last-child {
 	margin-bottom: 0;
-}
-
-.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -2995,6 +3027,10 @@ p {
 
 p.has-background {
 	padding: 20px;
+}
+
+p.has-text-color a {
+	color: #000000;
 }
 
 .a8c-posts-list__listing {

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -2902,14 +2902,6 @@ dd {
 }
 
 .wp-block-media-text {
-	/*&[class*="background-color"]:not(.has-background-background-color),
-	&[style*="background-color"] {
-		.wp-block-media-text__content {
-			a {
-				color: currentColor;
-			}
-		}
-	}*/
 	/**
 	 * Block Options
 	 */

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -303,26 +303,27 @@ body {
 	font-size: var(--global--font-size-root);
 }
 
-a {
+.wp-block a {
 	border-bottom: 1px solid var(--global--color-secondary);
 	color: var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
 }
 
-a:hover, a:focus {
+.wp-block a:hover, .wp-block a:focus {
 	color: var(--global--color-primary-hover);
 }
 
-a:active {
+.wp-block a:active {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
-p.has-background.has-link-color:not(.has-background-background-color) a {
-	color: var(--wp--style--color--link, var(--global--color-primary));
-}
-
-.has-link-color a {
+.has-link-color .wp-block a {
 	border-bottom: 1px solid var(--wp--style--color--link);
+}
+
+.has-background:not(.has-background-background-color) .has-link-color a,
+.has-background:not(.has-background-background-color).has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 button,
@@ -482,6 +483,17 @@ div[data-type="core/button"] {
 .wp-block-cover-image .wp-block-cover-text a,
 .wp-block-cover-image .block-editor-block-list__block a {
 	color: currentColor;
+}
+
+.wp-block-cover .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover .wp-block-cover-text .has-link-color a,
+.wp-block-cover .block-editor-block-list__block .has-link-color a,
+.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover-image .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover-image .wp-block-cover-text .has-link-color a,
+.wp-block-cover-image .block-editor-block-list__block .has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
@@ -774,10 +786,6 @@ dt {
 	padding-left: var(--global--spacing-horizontal);
 }
 
-.wp-block-media-text[style*="background-color"]:not(.has-background-background-color) a {
-	color: currentColor;
-}
-
 .wp-block-navigation .wp-block-navigation__container {
 	background: var(--global--color-background);
 	padding: 0;
@@ -811,10 +819,6 @@ p {
 
 p.has-background {
 	padding: var(--global--spacing-unit);
-}
-
-p.has-background:not(.has-background-background-color) a {
-	color: currentColor;
 }
 
 .a8c-posts-list {

--- a/seedlet/assets/sass/base/_editor.scss
+++ b/seedlet/assets/sass/base/_editor.scss
@@ -17,7 +17,7 @@ body {
 }
 
 // Links styles
-a {
+.wp-block a {
 	border-bottom: 1px solid var(--global--color-secondary);
 	color: var( --wp--style--color--link, var(--global--color-primary) );
 	text-decoration: none;
@@ -31,16 +31,19 @@ a {
 		color: var( --wp--style--color--link, var(--global--color-primary) );
 	}
 
-	// Enforce the custom link color even if a custom background color has been set.
-	// The extra specificity here is required to override the background color styles.
-	p.has-background.has-link-color:not(.has-background-background-color) & {
-		color: var( --wp--style--color--link, var(--global--color-primary) );
-	}
-
 	// If a custom link color has been assigned,
 	// switch the color of the bottom border too. 
 	.has-link-color & {
 		border-bottom: 1px solid var(--wp--style--color--link);
+	}
+}
+// Enforce the custom link color even if a custom background color has been set.
+// The extra specificity here is required to override the background color styles.
+.has-background:not(.has-background-background-color) {
+	// Target both current level and nested block.
+	.has-link-color a,
+	&.has-link-color a {
+		color: var( --wp--style--color--link, var(--global--color-primary) );
 	}
 }
 

--- a/seedlet/assets/sass/base/_reset.scss
+++ b/seedlet/assets/sass/base/_reset.scss
@@ -90,12 +90,6 @@ a {
 	}
 
 	&:active {
-		color: var(--wp--style--color--link);
-	}
-
-	// Enforce the custom link color even if a custom background color has been set.
-	// The extra specificity here is required to override the background color styles.
-	p.has-background.has-link-color:not(.has-background-background-color) & {
 		color: var( --wp--style--color--link, var(--global--color-primary) );
 	}
 
@@ -103,6 +97,15 @@ a {
 	// switch the color of the bottom border too. 
 	.has-link-color & {
 		border-bottom: 1px solid var( --wp--style--color--link, var(--global--color-primary) );
+	}
+}
+// Enforce the custom link color even if a custom background color has been set.
+// The extra specificity here is required to override the background color styles.
+.has-background:not(.has-background-background-color) {
+	// Target both current level and nested block.
+	.has-link-color a,
+	&.has-link-color a {
+		color: var( --wp--style--color--link, var(--global--color-primary) );
 	}
 }
 

--- a/seedlet/assets/sass/blocks/cover/_editor.scss
+++ b/seedlet/assets/sass/blocks/cover/_editor.scss
@@ -15,6 +15,9 @@
 		a {
 			color: currentColor;
 		}
+		.has-link-color a {
+			color: var( --wp--style--color--link, var(--global--color-primary) );
+		}
 	}
 
 	// Default & custom background-color

--- a/seedlet/assets/sass/blocks/cover/_style.scss
+++ b/seedlet/assets/sass/blocks/cover/_style.scss
@@ -16,6 +16,9 @@
 		a {
 			color: currentColor;
 		}
+		.has-link-color a {
+			color: var( --wp--style--color--link, var(--global--color-primary) );
+		}
 	}
 
 	/* default & custom background-color */

--- a/seedlet/assets/sass/blocks/media-text/_editor.scss
+++ b/seedlet/assets/sass/blocks/media-text/_editor.scss
@@ -3,10 +3,4 @@
 		padding-right: var(--global--spacing-horizontal);
 		padding-left: var(--global--spacing-horizontal);
 	}
-
-	&[style*="background-color"]:not(.has-background-background-color) {
-		a {
-			color: currentColor;
-		}
-	}
 }

--- a/seedlet/assets/sass/blocks/media-text/_style.scss
+++ b/seedlet/assets/sass/blocks/media-text/_style.scss
@@ -25,15 +25,15 @@
 			}
 		}
 	}
-
-	&[class*="background-color"]:not(.has-background-background-color),
+	
+	/*&[class*="background-color"]:not(.has-background-background-color),
 	&[style*="background-color"] {
 		.wp-block-media-text__content {
 			a {
 				color: currentColor;
 			}
 		}
-	}
+	}*/
 
 	/**
 	 * Block Options

--- a/seedlet/assets/sass/blocks/media-text/_style.scss
+++ b/seedlet/assets/sass/blocks/media-text/_style.scss
@@ -25,15 +25,6 @@
 			}
 		}
 	}
-	
-	/*&[class*="background-color"]:not(.has-background-background-color),
-	&[style*="background-color"] {
-		.wp-block-media-text__content {
-			a {
-				color: currentColor;
-			}
-		}
-	}*/
 
 	/**
 	 * Block Options

--- a/seedlet/assets/sass/blocks/paragraph/_editor.scss
+++ b/seedlet/assets/sass/blocks/paragraph/_editor.scss
@@ -3,9 +3,5 @@ p {
 
 	&.has-background {
 		padding: var(--global--spacing-unit);
-
-		&:not(.has-background-background-color) a {
-			color: currentColor;
-		}
 	}
 }

--- a/seedlet/assets/sass/blocks/paragraph/_style.scss
+++ b/seedlet/assets/sass/blocks/paragraph/_style.scss
@@ -6,4 +6,9 @@ p {
 	&.has-background {
 		padding: var(--global--spacing-unit);
 	}
+
+	// Override `color: inherit` from Core styles.
+	&.has-text-color a {
+		color: var( --wp--style--color--link, var(--global--color-primary) );
+	}
 }

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1858,14 +1858,6 @@ dd {
 }
 
 .wp-block-media-text {
-	/*&[class*="background-color"]:not(.has-background-background-color),
-	&[style*="background-color"] {
-		.wp-block-media-text__content {
-			a {
-				color: currentColor;
-			}
-		}
-	}*/
 	/**
 	 * Block Options
 	 */

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -983,15 +983,16 @@ a:hover, a:focus {
 }
 
 a:active {
-	color: var(--wp--style--color--link);
-}
-
-p.has-background.has-link-color:not(.has-background-background-color) a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .has-link-color a {
 	border-bottom: 1px solid var(--wp--style--color--link, var(--global--color-primary));
+}
+
+.has-background:not(.has-background-background-color) .has-link-color a,
+.has-background:not(.has-background-background-color).has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 *:focus {
@@ -1389,6 +1390,15 @@ object {
 .wp-block-cover-image .wp-block-cover-image-text a,
 .wp-block-cover-image .wp-block-cover-text a {
 	color: currentColor;
+}
+
+.wp-block-cover .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover .wp-block-cover-text .has-link-color a,
+.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover-image .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover-image .wp-block-cover-text .has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
@@ -1848,6 +1858,14 @@ dd {
 }
 
 .wp-block-media-text {
+	/*&[class*="background-color"]:not(.has-background-background-color),
+	&[style*="background-color"] {
+		.wp-block-media-text__content {
+			a {
+				color: currentColor;
+			}
+		}
+	}*/
 	/**
 	 * Block Options
 	 */
@@ -1881,10 +1899,6 @@ dd {
 
 .wp-block-media-text .wp-block-media-text__content > *:last-child {
 	margin-bottom: 0;
-}
-
-.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -1965,6 +1979,10 @@ p {
 
 p.has-background {
 	padding: var(--global--spacing-unit);
+}
+
+p.has-text-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .a8c-posts-list__listing {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -991,15 +991,16 @@ a:hover, a:focus {
 }
 
 a:active {
-	color: var(--wp--style--color--link);
-}
-
-p.has-background.has-link-color:not(.has-background-background-color) a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .has-link-color a {
 	border-bottom: 1px solid var(--wp--style--color--link, var(--global--color-primary));
+}
+
+.has-background:not(.has-background-background-color) .has-link-color a,
+.has-background:not(.has-background-background-color).has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 *:focus {
@@ -1397,6 +1398,15 @@ object {
 .wp-block-cover-image .wp-block-cover-image-text a,
 .wp-block-cover-image .wp-block-cover-text a {
 	color: currentColor;
+}
+
+.wp-block-cover .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover .wp-block-cover-text .has-link-color a,
+.wp-block-cover-image .wp-block-cover__inner-container .has-link-color a,
+.wp-block-cover-image .wp-block-cover-image-text .has-link-color a,
+.wp-block-cover-image .wp-block-cover-text .has-link-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
@@ -1856,6 +1866,14 @@ dd {
 }
 
 .wp-block-media-text {
+	/*&[class*="background-color"]:not(.has-background-background-color),
+	&[style*="background-color"] {
+		.wp-block-media-text__content {
+			a {
+				color: currentColor;
+			}
+		}
+	}*/
 	/**
 	 * Block Options
 	 */
@@ -1889,10 +1907,6 @@ dd {
 
 .wp-block-media-text .wp-block-media-text__content > *:last-child {
 	margin-bottom: 0;
-}
-
-.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
-	color: currentColor;
 }
 
 @media only screen and (min-width: 482px) {
@@ -1973,6 +1987,10 @@ p {
 
 p.has-background {
 	padding: var(--global--spacing-unit);
+}
+
+p.has-text-color a {
+	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 .a8c-posts-list__listing {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1866,14 +1866,6 @@ dd {
 }
 
 .wp-block-media-text {
-	/*&[class*="background-color"]:not(.has-background-background-color),
-	&[style*="background-color"] {
-		.wp-block-media-text__content {
-			a {
-				color: currentColor;
-			}
-		}
-	}*/
 	/**
 	 * Block Options
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- When using a custom background color that changes the text color (e.g. picking a black background sets the text white), only change the link color if it's not specified by the block.
- Remove the override that only worked for blocks with `p` as root element (e.g. the Paragraph block).
- Add a missing fallback color for the `--wp--style--color--link` variable.

This change originates from a [discussion in Gutenberg](https://github.com/WordPress/gutenberg/pull/23945#discussion_r455596699), where we noticed that the theme's style specificity was getting in the way with the link colors on non-Paragraph blocks.

The missing fallback color was throwing a `postcss-css-variable` working when building the theme style.
The `--wp--style--color--link` variable is defined by Gutenberg, and it's supported by all current browsers.
For older browsers, the build system uses a fallback color.
Without providing one, the `ie.css` style showed something like this:
```css
a:active { color: undefined; }
```

It's not very clear by the diff because the change was mixed up with the `p` override removal, but basically I just did this:
```diff
&:active {
-	color: var(--wp--style--color--link);	
+	color: var( --wp--style--color--link, var(--global--color-primary) );	
}	
```