### PR TITLE
Seedlet blocks: replace paragraph with Site Tagline block in header

### DIFF
--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,7 @@
 
 <!-- wp:site-title {"align":"center"} /-->
 
-<!-- wp:site-tagline {"align":"center","fontSize":"small"} /-->
+<!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
 <!-- wp:navigation {"itemsJustification":"center"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,9 +8,7 @@
 
 <!-- wp:site-title {"align":"center"} /-->
 
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size">is a curious botanist</p>
-<!-- /wp:paragraph -->
+<!-- wp:site-tagline {"align":"center","fontSize":"small"} /-->
 
 <!-- wp:navigation {"itemsJustification":"center"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Replace static paragraph text in header template part with newly introduced Site Tagline block from core.

#### Testing instructions

1. Use a local wp-env instal with latest Gutenberg version and Site Editor experiment enabled.
2. Map this branch to your themes folder and enabled the Seedlet blocks theme.
3. Open the Site Editor and verify that site tagline appears in the header.
