### PR TITLE
Seedlet: Fix Theme Review bugs

### DIFF
--- a/seedlet/404.php
+++ b/seedlet/404.php
@@ -4,8 +4,7 @@
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/archive.php
+++ b/seedlet/archive.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Seedlet
-Theme URI: https://github.com/Automattic/themes/seedlet
+Theme URI: https://github.com/Automattic/themes/tree/master/seedlet
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column theme.

--- a/seedlet/assets/js/customizer-validate-wcag-color-contrast.js
+++ b/seedlet/assets/js/customizer-validate-wcag-color-contrast.js
@@ -2,7 +2,7 @@
  * @author Per Soderlind
  * @link https://github.com/soderlind/2016-customizer-demo
  * global wp, seedletValidateWCAGColorContrastExports
- * global validateContrastText
+ * global seedletValidateContrastText
  * exported validateWCAGColorContrast
 **/
 ( function( $, api, exports ) {
@@ -49,7 +49,7 @@
 			});
 
 			if ( failsWCAG ){
-				var validationWarning = new api.Notification( code, { message: validateContrastText, type: 'warning' } );
+				var validationWarning = new api.Notification( code, { message: seedletValidateContrastText, type: 'warning' } );
 				setTimeout( function(){
 					self.custom_colors_setting.notifications.add( code, validationWarning );
 				}, 400);

--- a/seedlet/assets/js/customizer-validate-wcag-color-contrast.js
+++ b/seedlet/assets/js/customizer-validate-wcag-color-contrast.js
@@ -1,7 +1,7 @@
 /**
  * @author Per Soderlind
  * @link https://github.com/soderlind/2016-customizer-demo
- * global wp, _validateWCAGColorContrastExports
+ * global wp, seedletValidateWCAGColorContrastExports
  * global validateContrastText
  * exported validateWCAGColorContrast
 **/
@@ -210,4 +210,4 @@
 
 	return self;
 
-} )( jQuery, wp.customize, _validateWCAGColorContrastExports );
+} )( jQuery, wp.customize, seedletValidateWCAGColorContrastExports );

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Seedlet
-Theme URI: https://github.com/Automattic/themes/seedlet
+Theme URI: https://github.com/Automattic/themes/tree/master/seedlet
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column theme.

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -7,8 +7,7 @@
  * Each variable that needs to be updated is defined in the $seedlet_custom_color_variables array below.
  * A customizer setting is created for each color, and custom CSS-variables are enqueued in the front and back end.
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 
@@ -278,7 +277,7 @@ class Seedlet_Custom_Colors {
 	 * @link https://github.com/soderlind/2016-customizer-demo
 	 */
 	function on_customize_controls_enqueue_scripts() {
-		$handle = 'wcag-validate-customizer-color-contrast';
+		$handle = 'seedlet-wcag-validate-customizer-color-contrast';
 		$src    = get_template_directory_uri() . '/assets/js/customizer-validate-wcag-color-contrast.js';
 		$deps 	= [ 'customize-controls' ];
 
@@ -293,7 +292,7 @@ class Seedlet_Custom_Colors {
 		];
 
 		wp_enqueue_script( $handle, $src, $deps );
-		wp_script_add_data( $handle, 'data', sprintf( 'var _validateWCAGColorContrastExports = %s;', wp_json_encode( $exports ) ) );
+		wp_script_add_data( $handle, 'data', sprintf( 'var seedletValidateWCAGColorContrastExports = %s;', wp_json_encode( $exports ) ) );
 
 		// Custom color contrast validation text
 		wp_localize_script( $handle, 'validateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ));

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -295,7 +295,7 @@ class Seedlet_Custom_Colors {
 		wp_script_add_data( $handle, 'data', sprintf( 'var seedletValidateWCAGColorContrastExports = %s;', wp_json_encode( $exports ) ) );
 
 		// Custom color contrast validation text
-		wp_localize_script( $handle, 'validateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ));
+		wp_localize_script( $handle, 'seedletValidateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ));
 	}
 
 	/**

--- a/seedlet/classes/class-seedlet-svg-icons.php
+++ b/seedlet/classes/class-seedlet-svg-icons.php
@@ -2,8 +2,7 @@
 /**
  * SVG Icons class
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/footer.php
+++ b/seedlet/footer.php
@@ -6,8 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 
@@ -259,7 +258,7 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		add_theme_support( 'custom-line-height' );
 
 		// Add support for experimental link color control.
-		add_theme_support( 'experimental-link-color' );
+		// add_theme_support( 'experimental-link-color' );
     
 		// Add support for WordPress.com Global Styles.
 		add_theme_support(

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -258,7 +258,7 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		add_theme_support( 'custom-line-height' );
 
 		// Add support for experimental link color control.
-		// add_theme_support( 'experimental-link-color' );
+		add_theme_support( 'experimental-link-color' );
     
 		// Add support for WordPress.com Global Styles.
 		add_theme_support(

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -6,8 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 ?><!doctype html>

--- a/seedlet/image.php
+++ b/seedlet/image.php
@@ -2,8 +2,7 @@
 /**
  * The template for displaying image attachments
  *
- * @package WordPress
- * @subpackage Varia
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/back-compat.php
+++ b/seedlet/inc/back-compat.php
@@ -6,8 +6,7 @@
  * since this theme is not meant to be backward compatible beyond that and
  * relies on many newer functions and markup changes introduced in 4.7.
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since seedlet 1.0.0
  */
 

--- a/seedlet/inc/block-patterns.php
+++ b/seedlet/inc/block-patterns.php
@@ -2,8 +2,7 @@
 /**
  * Seedlet Theme: Block Patterns
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/customizer.php
+++ b/seedlet/inc/customizer.php
@@ -2,8 +2,7 @@
 /**
  * Seedlet Theme: Customizer
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/icon-functions.php
+++ b/seedlet/inc/icon-functions.php
@@ -2,8 +2,7 @@
 /**
  * SVG icons related functions
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/template-functions.php
+++ b/seedlet/inc/template-functions.php
@@ -2,8 +2,7 @@
 /**
  * Functions which enhance the theme by hooking into WordPress
  *
- * @package WordPress
- * @subpackage Varia
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/template-tags.php
+++ b/seedlet/inc/template-tags.php
@@ -2,8 +2,7 @@
 /**
  * Custom template tags for this theme
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/inc/woocommerce.php
+++ b/seedlet/inc/woocommerce.php
@@ -87,7 +87,7 @@ function seedlet_category_image() {
 		$thumbnail_id = get_term_meta( $cat->term_id, 'thumbnail_id', true );
 		$image = wp_get_attachment_url( $thumbnail_id );
 		if ( $image ) {
-			echo '<img src="' . $image . '" alt="' . $cat->name . '" />';
+			echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $cat->name ) . '" />';
 		}
 	}
 }

--- a/seedlet/index.php
+++ b/seedlet/index.php
@@ -9,8 +9,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/page.php
+++ b/seedlet/page.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/search.php
+++ b/seedlet/search.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/single.php
+++ b/seedlet/single.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Seedlet
-Theme URI: https://github.com/Automattic/themes/seedlet
+Theme URI: https://github.com/Automattic/themes/tree/master/seedlet
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column theme.

--- a/seedlet/template-parts/content/content-excerpt.php
+++ b/seedlet/template-parts/content/content-excerpt.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/content/content-page.php
+++ b/seedlet/template-parts/content/content-page.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/content/content-single.php
+++ b/seedlet/template-parts/content/content-single.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/content/content.php
+++ b/seedlet/template-parts/content/content.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/footer/footer-widgets.php
+++ b/seedlet/template-parts/footer/footer-widgets.php
@@ -2,8 +2,7 @@
 /**
  * Displays the footer widget area
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 

--- a/seedlet/template-parts/header/entry-header.php
+++ b/seedlet/template-parts/header/entry-header.php
@@ -2,8 +2,7 @@
 /**
  * Displays the post header
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 ?>

--- a/seedlet/template-parts/header/site-branding.php
+++ b/seedlet/template-parts/header/site-branding.php
@@ -2,8 +2,7 @@
 /**
  * Displays header site branding
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 ?>

--- a/seedlet/template-parts/post/author-bio.php
+++ b/seedlet/template-parts/post/author-bio.php
@@ -9,7 +9,8 @@
 if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-bio">
 	<?php
-	_e(__( 'Published by', 'seedlet' )); ?>
+	_e( 'Published by', 'seedlet' );
+	?>
 	<h2 class="author-title">
 		<span class="author-heading">
 			<?php

--- a/seedlet/template-parts/post/author-bio.php
+++ b/seedlet/template-parts/post/author-bio.php
@@ -9,8 +9,7 @@
 if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-bio">
 	<?php
-	_e(__( 'Published by', 'seedlet' ));
-	?>
+	_e(__( 'Published by', 'seedlet' )); ?>
 	<h2 class="author-title">
 		<span class="author-heading">
 			<?php

--- a/seedlet/template-parts/post/author-bio.php
+++ b/seedlet/template-parts/post/author-bio.php
@@ -2,8 +2,7 @@
 /**
  * The template for displaying Author info
  *
- * @package WordPress
- * @subpackage Seedlet
+ * @package Seedlet
  * @since 1.0.0
  */
 


### PR DESCRIPTION
This PR addresses the first half of [this feedback](https://themes.trac.wordpress.org/ticket/85664#comment:6). Specifically it:

- Adds missing escaping to attributes in `woocommerce.php`
- Prefixes handles in the custom colors class
- Replaces `@package WordPress` with `@package Seedlet` 

I'm adding comments in line where I'm not sure what needs to be done.