### PR TITLE
Seedlet Blocks - Update header site title block text alignment attribute

### DIFF
--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -6,7 +6,7 @@
 <div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="https://cldup.com/B9dfntUFJE.png" alt="" width="128" height="128"/></figure></div>
 <!-- /wp:image -->
 
-<!-- wp:site-title {"align":"center"} /-->
+<!-- wp:site-title {"textAlign":"center"} /-->
 
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size">is a curious botanist</p>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Updates the site-title block used in the header to use `textAlign` for the text alignment attribute.

**Background**
FSE blocks in core have been updated so that text alignment settings will be saved under the `textAlign` attribute instead of `align`.  This was for compatibility and clarity since the `align` hook uses this attribute to save block alignment settings. The site-title block seems to be the only block used in seedlet Template and Template Parts that was effected.

As a result this attribute was not being set and the header looked like:

![Screen Shot 2020-07-27 at 12 25 15 PM](https://user-images.githubusercontent.com/28742426/88593072-ff626b80-d02c-11ea-9389-1d85055783be.png)

After this update:

![Screen Shot 2020-07-27 at 5 09 18 PM](https://user-images.githubusercontent.com/28742426/88593095-09846a00-d02d-11ea-8c37-100cef4d704f.png)


#### Related issue(s):
