### PR TITLE
Brompton: Bottom of Site Header is Covered When Cover Block has Transparency Effect Applied

### DIFF
--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -38,6 +38,7 @@
 	min-height: #{100 - map-deep-get($config-global, "spacing", "vertical")};
 	padding-top: #{0.5 * map-deep-get($config-global, "spacing", "vertical")};
 	position: relative;
+	z-index: 2;
 
 	&:before {
 		background: #{map-deep-get($config-global, "color", "foreground", "default")};
@@ -650,7 +651,7 @@ table,
 		padding-left: 0;
 
 		li > ul {
-			padding-left: inherit;			
+			padding-left: inherit;
 		}
 	}
 

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Bromtpon is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Brompton is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4022,6 +4022,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	min-height: 68px;
 	padding-top: 16px;
 	position: relative;
+	z-index: 2;
 }
 
 #masthead:before {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Bromtpon is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Brompton is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4051,6 +4051,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	min-height: 68px;
 	padding-top: 16px;
 	position: relative;
+	z-index: 2;
 }
 
 #masthead:before {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Added CSS to the `_extra-child-theme.scss` file to set a `z-index` for a Cover block that has a overlay with it, which currently goes over the bottom portion of the site header:

[![Before CSS](https://d.pr/i/4nNojF+)](https://d.pr/i/4nNojF)

With the CSS applied, the site header behaves as expected:

[![After CSS](https://d.pr/i/DUq7C6+)](https://d.pr/i/DUq7C6)

#### Related issue(s):

#2184 