### PR TITLE
#2059 - Pique: Blocks with Wide Alignment Displayed Incorrectly When Nested Inside Block with Full Alignment

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -58,6 +58,14 @@ body.archive .alignwide {
 	}
 }
 
+body:not(.pique-sidebar).pique-singular .alignfull .alignwide,
+body.home .alignfull .alignwide,
+body.blog .alignfull .alignwide,
+body.archive .alignfull .alignwide {
+	margin-left: 0;
+	margin-right: 0;
+}
+
 body:not(.pique-sidebar).pique-singular .wp-block-embed.is-type-video.alignfull iframe,
 body:not(.pique-sidebar).pique-singular .wp-block-embed.is-type-video.alignwide iframe,
 body.home .wp-block-embed.is-type-video.alignfull iframe,

--- a/pique/style.css
+++ b/pique/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/pique/
 Author: Automattic
 Author URI: http://wordpress.com/themes/
 Description: A one-page scrolling theme for small businesses.
-Version: 1.4.8-wpcom
+Version: 1.4.9-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: pique


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adding CSS to `/assets/css/blocks.css` to prevent `alignwide` blocks that are inside `alignfull` blocks from going out side of the viewable content area

*Before:*

[![Before CSS](https://d.pr/i/mEupa0+)](https://d.pr/i/mEupa0)

*After:*

[![After CSS](https://d.pr/i/Jbtpqd+)](https://d.pr/i/Jbtpqd)

#### Related issue(s):

#2059 