### PR TITLE
Varia: Disable automatically generated color palettes.

### DIFF
--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -15,6 +15,11 @@
 function varia_wpcom_setup() {
 	global $themecolors;
 
+	// Disable automatically generated color palettes.
+	add_theme_support( 'wpcom-colors', array(
+	        'only-featured-palettes' => true,
+	) );	
+	
 	// Set theme colors for third party services.
 	if ( ! isset( $themecolors ) ) {
 		$themecolors = array(


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- This change was applied via trac directly with an update to the color-annotations plugin. 
- It never got synced back to Github, so its being added now. 

#### Related issue(s):

n/a