### PR TITLE
Seedlet Blocks: Load theme setup with correct priority

### DIFF
--- a/seedlet-blocks/functions.php
+++ b/seedlet-blocks/functions.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'seedlet_blocks_setup' ) ) :
 		add_editor_style( 'style-editor.css' );
 	}
 endif;
-add_action( 'after_setup_theme', 'seedlet_blocks_setup' );
+add_action( 'after_setup_theme', 'seedlet_blocks_setup', 999 );
 
 /**
  * Enqueue scripts and styles.

--- a/seedlet-blocks/functions.php
+++ b/seedlet-blocks/functions.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'seedlet_blocks_setup' ) ) :
 		add_editor_style( 'style-editor.css' );
 	}
 endif;
-add_action( 'after_setup_theme', 'seedlet_blocks_setup', 999 );
+add_action( 'after_setup_theme', 'seedlet_blocks_setup', 11 );
 
 /**
  * Enqueue scripts and styles.
@@ -33,4 +33,4 @@ add_action( 'after_setup_theme', 'seedlet_blocks_setup', 999 );
 function seedlet_blocks_enqueue() {
 	wp_enqueue_style( 'seedlet-blocks-styles', get_stylesheet_uri() );
 }
-add_action( 'wp_enqueue_scripts', 'seedlet_blocks_enqueue' );
+add_action( 'wp_enqueue_scripts', 'seedlet_blocks_enqueue', 11 );


### PR DESCRIPTION
These styles should load _after_ the parent theme in order to correctly override the parent. Hence the priority. I'm not sure if it'll have a noticeable effect on the Editor? I only noticed this when I stole this code to work on the Ibis theme. Worth fixing if only for future code, ahem, borrowers, like myself.

Ref:

https://github.com/Automattic/themes/pull/2313/files#diff-0140ea09b827571eed7227805bc9a4d3R28