### PR TITLE
Button 2: More Block padding

### DIFF
--- a/button-2/functions.php
+++ b/button-2/functions.php
@@ -116,6 +116,14 @@ function button_2_adjusted_content_width() {
 }
 add_action( 'template_redirect', 'button_2_adjusted_content_width', 0 );
 
+/** 
+ * Wrap more-link inside a paragraph 
+ */
+function button_2_more_link($more) {
+    return '<p>'.$more.'</p>';
+}
+add_filter('the_content_more_link','button_2_more_link');
+
 /**
  * Register widget area.
  *

--- a/button-2/functions.php
+++ b/button-2/functions.php
@@ -116,14 +116,6 @@ function button_2_adjusted_content_width() {
 }
 add_action( 'template_redirect', 'button_2_adjusted_content_width', 0 );
 
-/** 
- * Wrap more-link inside a paragraph 
- */
-function button_2_more_link($more) {
-    return '<p>'.$more.'</p>';
-}
-add_filter('the_content_more_link','button_2_more_link');
-
 /**
  * Register widget area.
  *

--- a/button-2/style.css
+++ b/button-2/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wordpress.com/themes/button-2/
 Author: Automattic
 Author URI: http://automattic.com
 Description: A stylish, lighthearted theme for crafters, hobbyists, and creatives.
-Version: 2.1.5-wpcom
+Version: 2.1.6-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: button

--- a/button-2/style.css
+++ b/button-2/style.css
@@ -1453,13 +1453,10 @@ td#next {
 }
 
 a.more-link {
-	position: absolute;
 	z-index: 1;
 	bottom: -32px;
 	display: block;
 	width: 100%;
-	height: 124px;
-	padding-top: 100px;
 	transition: .3s;
 	font-family: Lora, Garamond, serif;
 	font-weight: bold;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Wrap `more-link` _(added from Block Editor)_ inside a paragraph so that **"Continue Reading →"** does not shift below the post divider.

#### Related issue(s):

#2129 

#### BEFORE:

![#2129-before-site](https://user-images.githubusercontent.com/29238672/89543669-d442fd80-d81e-11ea-824e-7ba2f67ca51b.png)
![#2129-before-html](https://user-images.githubusercontent.com/29238672/89543675-d60cc100-d81e-11ea-92cb-99cc2e46edc5.png)

#### AFTER:

![#2129-after-site](https://user-images.githubusercontent.com/29238672/89544278-8bd80f80-d81f-11ea-8eb7-a3f415bb1202.png)
![#2129-after-html](https://user-images.githubusercontent.com/29238672/89544283-8da1d300-d81f-11ea-8c06-aee298fb400d.png)