### PR TITLE
Seedlet/Seedlet Blocks: Add default top/bottom margins to items within template parts

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -795,6 +795,10 @@ hr.wp-block-separator.is-style-wide {
 	margin-top: 20px;
 	margin-bottom: 20px;
 }
+.wp-block-template-part > * {
+	margin-top: 20px;
+	margin-bottom: 20px;
+}
 .widget-area > * {
 	margin-top: 20px;
 	margin-bottom: 20px;
@@ -825,6 +829,10 @@ hr.wp-block-separator.is-style-wide {
 		margin-top: 30px;
 		margin-bottom: 30px;
 	}
+	.wp-block-template-part > * {
+		margin-top: 30px;
+		margin-bottom: 30px;
+	}
 	.widget-area > * {
 		margin-top: 30px;
 		margin-bottom: 30px;
@@ -840,6 +848,7 @@ hr.wp-block-separator.is-style-wide {
 .site-main > .not-found > *:first-child,
 .entry-content > *:first-child,
 [class*="inner-container"] > *:first-child,
+.wp-block-template-part > *:first-child,
 .widget-area > *:first-child,
 .widget-column > *:first-child {
 	margin-top: 0;
@@ -850,6 +859,7 @@ hr.wp-block-separator.is-style-wide {
 .site-main > .not-found > *:last-child,
 .entry-content > *:last-child,
 [class*="inner-container"] > *:last-child,
+.wp-block-template-part > *:last-child,
 .widget-area > *:last-child,
 .widget-column > *:last-child {
 	margin-bottom: 0;

--- a/seedlet/assets/sass/structure/_vertical-margins.scss
+++ b/seedlet/assets/sass/structure/_vertical-margins.scss
@@ -109,6 +109,7 @@
 .site-main > .not-found > *, // apply vertical margins to article level
 .entry-content > *,
 [class*="inner-container"] > *,
+.wp-block-template-part > *,
 .widget-area > *,
 .widget-column > * {
 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Seedlet
-Theme URI: https://github.com/Automattic/themes/seedlet
+Theme URI: https://github.com/Automattic/themes/tree/master/seedlet
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column theme.
@@ -519,6 +519,7 @@ Included in theme screenshot.
 .site-main > .not-found > *,
 .entry-content > *,
 [class*="inner-container"] > *,
+.wp-block-template-part > *,
 .widget-area > *,
 .widget-column > * {
 	margin-top: calc( 0.666 * var(--global--spacing-vertical));
@@ -531,6 +532,7 @@ Included in theme screenshot.
 	.site-main > .not-found > *,
 	.entry-content > *,
 	[class*="inner-container"] > *,
+	.wp-block-template-part > *,
 	.widget-area > *,
 	.widget-column > * {
 		margin-top: var(--global--spacing-vertical);
@@ -543,6 +545,7 @@ Included in theme screenshot.
 .site-main > .not-found > *:first-child,
 .entry-content > *:first-child,
 [class*="inner-container"] > *:first-child,
+.wp-block-template-part > *:first-child,
 .widget-area > *:first-child,
 .widget-column > *:first-child {
 	margin-top: 0;
@@ -553,6 +556,7 @@ Included in theme screenshot.
 .site-main > .not-found > *:last-child,
 .entry-content > *:last-child,
 [class*="inner-container"] > *:last-child,
+.wp-block-template-part > *:last-child,
 .widget-area > *:last-child,
 .widget-column > *:last-child {
 	margin-bottom: 0;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -527,6 +527,7 @@ Included in theme screenshot.
 .site-main > .not-found > *,
 .entry-content > *,
 [class*="inner-container"] > *,
+.wp-block-template-part > *,
 .widget-area > *,
 .widget-column > * {
 	margin-top: calc( 0.666 * var(--global--spacing-vertical));
@@ -539,6 +540,7 @@ Included in theme screenshot.
 	.site-main > .not-found > *,
 	.entry-content > *,
 	[class*="inner-container"] > *,
+	.wp-block-template-part > *,
 	.widget-area > *,
 	.widget-column > * {
 		margin-top: var(--global--spacing-vertical);
@@ -551,6 +553,7 @@ Included in theme screenshot.
 .site-main > .not-found > *:first-child,
 .entry-content > *:first-child,
 [class*="inner-container"] > *:first-child,
+.wp-block-template-part > *:first-child,
 .widget-area > *:first-child,
 .widget-column > *:first-child {
 	margin-top: 0;
@@ -561,6 +564,7 @@ Included in theme screenshot.
 .site-main > .not-found > *:last-child,
 .entry-content > *:last-child,
 [class*="inner-container"] > *:last-child,
+.wp-block-template-part > *:last-child,
 .widget-area > *:last-child,
 .widget-column > *:last-child {
 	margin-bottom: 0;


### PR DESCRIPTION
This PR adds `wp-block-template-part` to the list of parents that should provide children with the default top/bottom margins for blocks. This is primarily a change for use in Seedlet Blocks, but the change itself has been made in Seedlet to avoid repeating styles unnecessarily. 

Template parts appear to provide their own wrapper now on the front end: 

![Screen Shot 2020-08-10 at 3 02 49 PM](https://user-images.githubusercontent.com/1202812/89820393-f12b4980-db1a-11ea-957e-7158107cffe9.png)


---

Before (Seedlet Blocks default header, front-end): 

![Screen Shot 2020-08-10 at 3 02 24 PM](https://user-images.githubusercontent.com/1202812/89820350-e1ac0080-db1a-11ea-934c-45deaac2d211.png)

After:

![Screen Shot 2020-08-10 at 3 00 38 PM](https://user-images.githubusercontent.com/1202812/89820357-e53f8780-db1a-11ea-82bd-8b90b145a32b.png)


