### PR TITLE
Seedlet: fix primary nav js bug

### DIFF
--- a/seedlet/assets/js/primary-navigation.js
+++ b/seedlet/assets/js/primary-navigation.js
@@ -15,16 +15,18 @@
 		var openButton    	= document.getElementById( `${ id }-open-menu` );
 		var closeButton    	= document.getElementById( `${ id }-close-menu` );
 
-		openButton.onclick = function() {
-			wrapper.classList.add( `${ id }-navigation-open` );
-			wrapper.classList.add( 'lock-scrolling' );
-			closeButton.focus();
-		}
+		if ( openButton && closeButton ){
+			openButton.onclick = function() {
+				wrapper.classList.add( `${ id }-navigation-open` );
+				wrapper.classList.add( 'lock-scrolling' );
+				closeButton.focus();
+			}
 
-		closeButton.onclick = function() {
-			wrapper.classList.remove( `${ id }-navigation-open` );
-			wrapper.classList.remove( 'lock-scrolling' );
-			openButton.focus();
+			closeButton.onclick = function() {
+				wrapper.classList.remove( `${ id }-navigation-open` );
+				wrapper.classList.remove( 'lock-scrolling' );
+				openButton.focus();
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes an issue where if the theme contains no primary or woo nav, a JS error is thrown. 

**To test**
- Activate Seedlet and remove all menus
- Open the console and ensure that no errors are thrown