### PR TITLE
Seedlet: Restructure the margin/width reset selector for nested groups

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -758,7 +758,7 @@ div[data-type="core/button"] {
 	padding: var(--global--spacing-vertical);
 }
 
-.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+.wp-block-group .wp-block-group.has-background > .block-editor-block-list__layout > [data-align="full"] {
 	margin: 0;
 	width: 100%;
 }

--- a/seedlet/assets/sass/blocks/group/_editor.scss
+++ b/seedlet/assets/sass/blocks/group/_editor.scss
@@ -4,7 +4,7 @@
 	}
 }
 
-.wp-block[data-type="core/group"] > .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align=full] {
+.wp-block-group .wp-block-group.has-background > .block-editor-block-list__layout > [data-align="full"] {
 	margin: 0;
 	width: 100%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Blocks with a background color typically gain a padding.
To avoid stacking paddings, Gutenberg sets a negative margin to nested groups with background color.

Seedlet customizes this by resetting the margin (and consequently the width).
The selector was probably obsolete though, and lots changed in the editor DOM recently.
I couldn't find several of those classes in the editor, so I tried rewriting it a bit.

Given the complexity of the selector, and the fact that the old one is currently untestable, I'd love for some proper smoke testing on this.

| Before | After |
| - | - |
| <img width="1221" alt="Screenshot 2020-08-14 at 16 47 18" src="https://user-images.githubusercontent.com/2070010/90268405-dfb1ac80-de4e-11ea-920e-7b30b312d5d9.png"> | <img width="1222" alt="Screenshot 2020-08-14 at 16 46 33" src="https://user-images.githubusercontent.com/2070010/90268396-dd4f5280-de4e-11ea-8ac9-3f1c2935ef7a.png"> |

As a side note, mostly out of curiosity: I couldn't help but noticing that most (all?) groups in the Vesta layout have an explicitly set background color (e.g. `<!-- wp:group {\"align\":\"full\",\"backgroundColor\":\"background\"} -->`) matching the actual site background color.
Is this intentional? Is there a reason for doing it?

#### Related issue(s):

Fixes https://github.com/Automattic/wp-calypso/issues/44671