### PR TITLE
Seedlet: fix woocommerce cart bug

### DIFF
--- a/seedlet/assets/js/primary-navigation.js
+++ b/seedlet/assets/js/primary-navigation.js
@@ -33,7 +33,6 @@
 		 * Trap keyboard navigation in the menu modal.
 		 * Adapted from TwentyTwenty
 		 */
-
 		document.addEventListener( 'keydown', function( event ) {
 			if ( ! wrapper.classList.contains( `${ id }-navigation-open` ) ){
 				return;
@@ -41,9 +40,12 @@
 			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 
 			modal = document.querySelector( `.${ id }-navigation` );
-			selectors = 'input, a, button';
+			selectors = "input, a, button";
 			elements = modal.querySelectorAll( selectors );
 			elements = Array.prototype.slice.call( elements );
+			elements = elements.filter( function( el ) {
+				return ! el.classList.contains( 'woocommerce-cart-link' ); // ignore this element because it's hidden on mobile
+			});
 			tabKey = event.keyCode === 9;
 			shiftKey = event.shiftKey;
 			escKey = event.keyCode === 27;

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -75,9 +75,10 @@
 						<div class="woocommerce-menu-container">
 							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
 							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
+								%7$s
 								<ul class="sub-menu">
-									<li class="woocommerce-cart-widget" title="%7$s">
-										%8$s
+									<li class="woocommerce-cart-widget" title="%8$s">
+										%9$s
 									</li>
 								</ul>
 							</li>',
@@ -87,6 +88,7 @@
 						esc_attr__( 'submenu', 'seedlet' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'seedlet' ),
+						seedlet_cart_link(),
 						esc_attr__( 'View your shopping list', 'seedlet' ),
 						seedlet_cart_widget()
 					) ); ?>


### PR DESCRIPTION
This PR fixes a regression introduced in #2305, where the woocommerce cart was not appearing on desktop. 

**Before**
<img width="676" alt="Screen Shot 2020-08-14 at 1 15 49 PM" src="https://user-images.githubusercontent.com/5375500/90275431-4c697e80-de30-11ea-8f0c-729809a24a45.png">

**After**
<img width="737" alt="Screen Shot 2020-08-14 at 1 15 40 PM" src="https://user-images.githubusercontent.com/5375500/90275436-4ecbd880-de30-11ea-99b4-99c7281818f7.png">
