### PR TITLE
Update Seedlet foreground color

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -1510,7 +1510,7 @@ body {
 	font-size: 1em;
 	/* 1em; */
 	font-weight: normal;
-	color: #333333;
+	color: #292929;
 	text-align: left;
 	background-color: #FFFFFF;
 }
@@ -1577,7 +1577,7 @@ a {
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	clip-path: none;
-	color: #333333;
+	color: #292929;
 	display: block;
 	font-size: 18px;
 	font-weight: bold;
@@ -1673,13 +1673,13 @@ blockquote p {
 }
 
 blockquote cite {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	letter-spacing: normal;
 }
 
 blockquote footer {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	letter-spacing: normal;
 }
@@ -1736,7 +1736,7 @@ blockquote.alignright footer {
 input[type="text"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1744,7 +1744,7 @@ input[type="text"] {
 input[type="email"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1752,7 +1752,7 @@ input[type="email"] {
 input[type="url"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1760,7 +1760,7 @@ input[type="url"] {
 input[type="password"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1768,7 +1768,7 @@ input[type="password"] {
 input[type="search"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1776,7 +1776,7 @@ input[type="search"] {
 input[type="number"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1784,7 +1784,7 @@ input[type="number"] {
 input[type="tel"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1792,7 +1792,7 @@ input[type="tel"] {
 input[type="range"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1800,7 +1800,7 @@ input[type="range"] {
 input[type="date"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1808,7 +1808,7 @@ input[type="date"] {
 input[type="month"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1816,7 +1816,7 @@ input[type="month"] {
 input[type="week"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1824,7 +1824,7 @@ input[type="week"] {
 input[type="time"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1832,7 +1832,7 @@ input[type="time"] {
 input[type="datetime"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1840,7 +1840,7 @@ input[type="datetime"] {
 input[type="datetime-local"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1848,7 +1848,7 @@ input[type="datetime-local"] {
 input[type="color"] {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
@@ -1856,88 +1856,88 @@ input[type="color"] {
 textarea {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	padding: 10px;
 }
 
 input[type="text"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="email"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="url"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="password"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="search"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="number"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="tel"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="range"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="date"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="month"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="week"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="time"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="datetime"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="datetime-local"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 input[type="color"]:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
 textarea:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
@@ -1957,7 +1957,7 @@ input[type=checkbox] + label {
 
 /* Media captions */
 figcaption {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	line-height: 1.7;
 	margin-top: 10px;
@@ -1965,7 +1965,7 @@ figcaption {
 	text-align: center;
 }
 .wp-caption {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	line-height: 1.7;
 	margin-top: 10px;
@@ -1973,7 +1973,7 @@ figcaption {
 	text-align: center;
 }
 .wp-caption-text {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	line-height: 1.7;
 	margin-top: 10px;
@@ -2085,14 +2085,14 @@ object {
 }
 
 .wp-block-code {
-	color: #333333;
+	color: #292929;
 	font-size: 16px;
 	padding: 20px;
 	border-color: #EFEFEF;
 }
 
 .wp-block-code pre {
-	color: #333333;
+	color: #292929;
 }
 
 .wp-block-columns {
@@ -2661,7 +2661,7 @@ h6 {
 }
 
 .wp-block-image figcaption {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	line-height: 1.7;
 	margin-top: 10px;
@@ -2719,7 +2719,7 @@ img {
 }
 
 .wp-block-latest-comments .wp-block-latest-comments__comment-date {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 
@@ -2788,7 +2788,7 @@ img {
 }
 
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 	line-height: 1.7;
 }
@@ -3085,7 +3085,7 @@ p.has-text-color a {
 }
 
 .a8c-posts-list__item .a8c-posts-list-item__meta {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 
@@ -3116,7 +3116,7 @@ p.has-text-color a {
 	border-top-width: 0;
 	border-bottom-color: transparent;
 	border-bottom-width: 0;
-	color: #333333;
+	color: #292929;
 	/**
 	 * Block Options
 	 */
@@ -3244,7 +3244,7 @@ p.has-text-color a {
 }
 
 .wp-block-pullquote.is-style-solid-color {
-	background-color: #333333;
+	background-color: #292929;
 	color: #FFFFFF;
 	padding: 40px;
 }
@@ -3289,17 +3289,17 @@ p.has-text-color a {
 }
 
 .wp-block-quote .wp-block-quote__citation {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote cite {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote footer {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
@@ -3380,32 +3380,32 @@ p.has-text-color a {
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote.is-style-large cite {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote.is-style-large footer {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote.is-large .wp-block-quote__citation {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote.is-large cite {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
 .wp-block-quote.is-large footer {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 }
 
@@ -3458,7 +3458,7 @@ p.has-text-color a {
 .wp-block-search .wp-block-search__input {
 	border: 2px solid #EFEFEF;
 	border-radius: 0;
-	color: #333333;
+	color: #292929;
 	line-height: 1.7;
 	max-width: inherit;
 	margin-right: 17px;
@@ -3466,7 +3466,7 @@ p.has-text-color a {
 }
 
 .wp-block-search .wp-block-search__input:focus {
-	color: #333333;
+	color: #292929;
 	border-color: #EFEFEF;
 }
 
@@ -3577,7 +3577,7 @@ table th {
 }
 
 .wp-block-video figcaption {
-	color: #444444;
+	color: #333333;
 	font-size: 14px;
 	margin-top: 10px;
 	margin-bottom: 20px;
@@ -3740,11 +3740,11 @@ table th {
 }
 
 .has-foreground-color[class] {
-	color: #333333;
+	color: #292929;
 }
 
 .has-foreground-light-color[class] {
-	color: #444444;
+	color: #333333;
 }
 
 .has-foreground-dark-color[class] {
@@ -3787,12 +3787,12 @@ table th {
 }
 
 .has-foreground-background-color[class] {
-	background-color: #333333;
+	background-color: #292929;
 	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color[class] {
-	background-color: #444444;
+	background-color: #333333;
 	color: #FFFFFF;
 }
 
@@ -3803,17 +3803,17 @@ table th {
 
 .has-tertiary-background-color[class] {
 	background-color: #FAFBF6;
-	color: #333333;
+	color: #292929;
 }
 
 .has-background-dark-background-color[class] {
 	background-color: #DDDDDD;
-	color: #333333;
+	color: #292929;
 }
 
 .has-background-background-color[class] {
 	background-color: #FFFFFF;
-	color: #333333;
+	color: #292929;
 }
 
 .has-white-background-color[class] {
@@ -4072,7 +4072,7 @@ table th {
  * - Similar to Blocks but exist outside of the "current" editor context
  */
 .site-branding {
-	color: #333333;
+	color: #292929;
 	text-align: center;
 }
 
@@ -4306,7 +4306,7 @@ nav a {
 	position: absolute;
 	top: 0;
 	right: 0;
-	color: #333333;
+	color: #292929;
 	font-size: 16px;
 	margin-top: 0;
 	margin-bottom: 0;
@@ -4316,7 +4316,7 @@ nav a {
 	position: absolute;
 	top: 0;
 	right: 0;
-	color: #333333;
+	color: #292929;
 	font-size: 16px;
 	margin-top: 0;
 	margin-bottom: 0;
@@ -4748,7 +4748,7 @@ nav a {
 }
 
 .social-navigation a {
-	color: #333333;
+	color: #292929;
 	display: inline-block;
 	padding: 0 7px;
 }
@@ -4762,7 +4762,7 @@ nav a {
 }
 
 .social-navigation a:active {
-	color: #333333;
+	color: #292929;
 }
 
 .social-navigation svg {
@@ -4783,7 +4783,7 @@ nav a {
 }
 
 .site-footer > .site-info {
-	color: #333333;
+	color: #292929;
 	font-family: 'Playfair Display', Georgia, Times, serif;
 	font-size: 16px;
 	line-height: 1.7;
@@ -4833,7 +4833,7 @@ nav a {
 }
 
 .site-footer > .footer-navigation .footer-menu {
-	color: #333333;
+	color: #292929;
 	margin: 0;
 	padding-left: 0;
 }
@@ -4957,7 +4957,7 @@ nav a {
 }
 
 .entry-meta {
-	color: #333333;
+	color: #292929;
 	clear: both;
 	float: none;
 	font-size: 14px;
@@ -4965,7 +4965,7 @@ nav a {
 }
 
 .entry-footer {
-	color: #333333;
+	color: #292929;
 	clear: both;
 	float: none;
 	font-size: 14px;
@@ -5116,7 +5116,7 @@ nav a {
 
 /* Next/Previous navigation */
 .navigation {
-	color: #333333;
+	color: #292929;
 }
 
 .navigation a {
@@ -5166,7 +5166,7 @@ nav a {
 .post-navigation .meta-nav {
 	font-size: 14px;
 	line-height: 1.7;
-	color: #333333;
+	color: #292929;
 }
 
 .post-navigation .post-title {
@@ -5202,7 +5202,7 @@ nav a {
 }
 
 .pagination .nav-links > * {
-	color: #333333;
+	color: #292929;
 	font-family: 'Fira Sans', Helvetica, Arial, sans-serif;
 	font-size: 16px;
 	font-weight: normal;
@@ -5211,7 +5211,7 @@ nav a {
 }
 
 .pagination .nav-links > *.current {
-	border-bottom: 1px solid #333333;
+	border-bottom: 1px solid #292929;
 }
 
 .pagination .nav-links > *:first-child {
@@ -5348,7 +5348,7 @@ nav a {
 }
 
 .comment-meta .comment-metadata {
-	color: #333333;
+	color: #292929;
 	font-size: 14px;
 	padding-left: 60px;
 }
@@ -5881,22 +5881,22 @@ img#wpstats {
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .cat-links {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 
 .wp-block-a8c-blog-posts article .entry-meta {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 
 .wp-block-a8c-blog-posts article .cat-links {
-	color: #444444;
+	color: #333333;
 	font-size: 16px;
 }
 

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -31,8 +31,8 @@
 	--global--color-secondary-hover: #336D58;
 	--global--color-black: black;
 	--global--color-white: white;
-	--global--color-foreground: #333333;
-	--global--color-foreground-light: #444444;
+	--global--color-foreground: #292929;
+	--global--color-foreground-light: #333333;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
 	--global--color-tertiary: #FAFBF6;
@@ -227,8 +227,8 @@
 	--global--color-secondary-hover: #336D58;
 	--global--color-black: black;
 	--global--color-white: white;
-	--global--color-foreground: #333333;
-	--global--color-foreground-light: #444444;
+	--global--color-foreground: #292929;
+	--global--color-foreground-light: #333333;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
 	--global--color-tertiary: #FAFBF6;

--- a/seedlet/assets/sass/abstracts/_config.scss
+++ b/seedlet/assets/sass/abstracts/_config.scss
@@ -38,8 +38,8 @@ $typescale-ratio: 1.2; // Run ratio math on 1em == $typescale-base * $typescale-
 	--global--color-secondary-hover: #336D58;
 	--global--color-black: black;
 	--global--color-white: white;
-	--global--color-foreground: #333333;
-	--global--color-foreground-light: #444444;
+	--global--color-foreground: #292929;
+	--global--color-foreground-light: #333333;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
 	--global--color-tertiary: #FAFBF6;

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -22,7 +22,7 @@ class Seedlet_Custom_Colors {
 		 */
 		$this->seedlet_custom_color_variables = array(
 			array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
-			array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
+			array( '--global--color-foreground', '#292929', __( 'Foreground Color', 'seedlet' ) ),
 			array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
 			array( '--global--color-secondary', '#3C8067', __( 'Secondary Color', 'seedlet' ) ),
 			array( '--global--color-tertiary', '#FAFBF6', __( 'Tertiary Color', 'seedlet' ) ),

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -166,7 +166,7 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		$colors_theme_mod = get_theme_mod( 'custom_colors_active' );
 		$primary          = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-primary' ) ) ) ? '#000000' : get_theme_mod( 'seedlet_--global--color-primary' );
 		$secondary        = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-secondary' ) ) ) ? '#3C8067' : get_theme_mod( 'seedlet_--global--color-secondary' );
-		$foreground       = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-foreground' ) ) ) ? '#333333' : get_theme_mod( 'seedlet_--global--color-foreground' );
+		$foreground       = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-foreground' ) ) ) ? '#292929' : get_theme_mod( 'seedlet_--global--color-foreground' );
 		$tertiary         = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-tertiary' ) ) ) ? '#FAFBF6' : get_theme_mod( 'seedlet_--global--color-tertiary' );
 		$background       = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-background' ) ) ) ? '#FFFFFF' : get_theme_mod( 'seedlet_--global--color-background' );
 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -97,8 +97,8 @@ Included in theme screenshot.
 	--global--color-secondary-hover: #336D58;
 	--global--color-black: black;
 	--global--color-white: white;
-	--global--color-foreground: #333333;
-	--global--color-foreground-light: #444444;
+	--global--color-foreground: #292929;
+	--global--color-foreground-light: #333333;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
 	--global--color-tertiary: #FAFBF6;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -97,8 +97,8 @@ Included in theme screenshot.
 	--global--color-secondary-hover: #336D58;
 	--global--color-black: black;
 	--global--color-white: white;
-	--global--color-foreground: #333333;
-	--global--color-foreground-light: #444444;
+	--global--color-foreground: #292929;
+	--global--color-foreground-light: #333333;
 	--global--color-foreground-dark: #000000;
 	--global--color-background: #FFFFFF;
 	--global--color-tertiary: #FAFBF6;


### PR DESCRIPTION
This PR addresses recent feedback about the hover states throughout the theme: 

> the contrast ratio between the default state and the hover state for several links, 
> that are missing a text decoration, is not enough.
> 
> `#333333` and `#3C8067` only has a contrast ratio of 2.69:1.
> 
> The easiest way to indicate the different link states is with a text decoration, and not only rely on color. For example if a link is not underlined in its default state, you can add an underline for the hover state. Or a border, outline, box shadow, background color etc.

The [WCAG guidelines suggest](https://webaim.org/blog/wcag-2-0-and-link-colors/) that text must have: 

> - A 4.5:1 contrast between the non-link text color and the background.
> - A 4.5:1 contrast between the link text color and the background.
> - A 3:1 contrast between the link text color and the surrounding non-link text color.

Our current text has: 

- ✅ A 12.63:1 contrast between the non-link text color and the background.
- ✅ A 4.69:1 contrast between the link text color and the background.
- ❌ A 2.69:1 contrast between the link text color and the surrounding non-link text color.

This PR updates the `--global--color-foreground` value from `#333333` to `#292929` which provides a 3.1:1 contrast ratio.

@melchoyce, should this satisfy the guidelines, or do we need something visual too? 