### PR TITLE
Seedlet: remove positive tabindex from skiplink

### DIFF
--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -21,7 +21,7 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content" tabindex="1"><?php _e( 'Skip to content', 'seedlet' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'seedlet' ); ?></a>
 
 		<header id="masthead" class="site-header default-max-width">
 			<div class="menu-button-container">


### PR DESCRIPTION
This PR removes the tabindex value from the skip link in the header.

Positive tabindex values are not allowed in themes: https://make.wordpress.org/themes/handbook/review/accessibility/required/#not-allowed
