### PR TITLE
Seedlet: add landmark roles

### DIFF
--- a/seedlet/footer.php
+++ b/seedlet/footer.php
@@ -14,12 +14,12 @@
 
 	</div><!-- #content -->
 
-	<footer id="colophon" class="site-footer default-max-width">
+	<footer id="colophon" class="site-footer default-max-width" role="contentinfo">
 
 		<?php get_template_part( 'template-parts/footer/footer-widgets' ); ?>
 
 		<?php if ( has_nav_menu( 'footer' ) ) : ?>
-		<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'seedlet' ); ?>">
+		<nav class="footer-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'seedlet' ); ?>">
 			<?php
 			wp_nav_menu(
 				array(

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -23,7 +23,7 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'seedlet' ); ?></a>
 
-		<header id="masthead" class="site-header default-max-width">
+		<header id="masthead" class="site-header default-max-width" role="banner">
 			<div class="menu-button-container">
 				<?php if ( class_exists( 'WooCommerce' ) ) : ?>
 					<button id="woo-open-menu" class="button open">
@@ -41,7 +41,7 @@
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
 			<?php if ( has_nav_menu( 'primary' ) ) : ?>
-				<nav id="site-navigation" class="primary-navigation" aria-label="<?php esc_attr_e( 'Primary Navigation', 'seedlet' ); ?>">
+				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary Navigation', 'seedlet' ); ?>">
 					<button id="primary-close-menu" class="button close">
 						<span class="dropdown-icon close"><?php _e( 'Close', 'seedlet' ); ?> <?php echo seedlet_get_icon_svg( 'close' ) ?></span>
 						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'seedlet' ); ?></span>
@@ -58,7 +58,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
 						)
 					);
 					?>
@@ -66,14 +66,14 @@
 			<?php endif; ?>
 
 			<?php if ( class_exists( 'WooCommerce' ) ) : ?>
-				<nav class="woo-navigation" aria-label="<?php esc_attr_e( 'Woo Minicart', 'seedlet' ); ?>">
+				<nav class="woo-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Woo Minicart', 'seedlet' ); ?>">
 					<?php echo( sprintf(
 						'<button id="woo-close-menu" class="button close">
 							<span class="dropdown-icon close">%1$s %2$s</span>
 							<span class="hide-visually collapsed-text">%3$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
+							<ul id="woocommerce-menu" class="menu-wrapper" role="navigation" aria-label="%4$s">
 							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
 								%7$s
 								<ul class="sub-menu">
@@ -96,7 +96,7 @@
 			<?php endif; ?>
 
 			<?php if ( has_nav_menu( 'social' ) ) : ?>
-				<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'seedlet' ); ?>">
+				<nav class="social-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'seedlet' ); ?>">
 					<?php
 					wp_nav_menu(
 						array(


### PR DESCRIPTION
This PR addresses the following Theme Review accessibility feedback:

> The ARIA landmark roles need to be added with explicit ARIA role attributes.
> This is because there are older screen readers that does not understand HTML5.
> Note that this requirement will possibly be updated soon, as the accessibility team and themes team is planning
> to discuss it during a meeting, but for now, it is required.

It adds landmark roles to elements with aria-labels, including HTML5 elements that have identical meaning. 