### PR TITLE
Seedlet: Clean up footer navigation

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -4847,14 +4847,10 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-	}
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-direction: column;
 }
 
 .site-footer > .site-info {

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -4848,7 +4848,7 @@ nav a {
 .site-footer {
 	overflow: hidden;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	flex-wrap: wrap;
 	flex-direction: column;
 }
@@ -4907,18 +4907,13 @@ nav a {
 	color: #333333;
 	margin: 0;
 	padding-left: 0;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer > .footer-navigation .footer-menu {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {
-	display: inline;
+	display: inline-block;
 }
 
 .site-footer > .footer-navigation .footer-menu > li:first-of-type > a {
@@ -4930,7 +4925,7 @@ nav a {
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item {
-	padding: 13px;
+	padding: 13px 13px 13px 0;
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item a {

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -4847,10 +4847,6 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-	display: flex;
-	align-items: flex-start;
-	flex-wrap: wrap;
-	flex-direction: column;
 }
 
 .site-footer > .site-info {
@@ -4907,9 +4903,6 @@ nav a {
 	color: #333333;
 	margin: 0;
 	padding-left: 0;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {

--- a/seedlet/assets/sass/components/footer/_footer-branding.scss
+++ b/seedlet/assets/sass/components/footer/_footer-branding.scss
@@ -3,7 +3,7 @@
 .site-footer {
 	overflow: hidden;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	flex-wrap: wrap;
 	flex-direction: column;
 }

--- a/seedlet/assets/sass/components/footer/_footer-branding.scss
+++ b/seedlet/assets/sass/components/footer/_footer-branding.scss
@@ -1,14 +1,11 @@
 // Footer
 
 .site-footer {
-
 	overflow: hidden;
-
-	@include media(desktop) {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-	}
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-direction: column;
 }
 
 // Footer Branding

--- a/seedlet/assets/sass/components/footer/_footer-branding.scss
+++ b/seedlet/assets/sass/components/footer/_footer-branding.scss
@@ -2,10 +2,6 @@
 
 .site-footer {
 	overflow: hidden;
-	display: flex;
-	align-items: flex-start;
-	flex-wrap: wrap;
-	flex-direction: column;
 }
 
 // Footer Branding

--- a/seedlet/assets/sass/components/footer/_footer-navigation.scss
+++ b/seedlet/assets/sass/components/footer/_footer-navigation.scss
@@ -17,9 +17,6 @@
 		color: var(--footer--color-text);
 		margin: 0;
 		padding-left: 0;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-start;
 
 		& > li {
 			display: inline-block;

--- a/seedlet/assets/sass/components/footer/_footer-navigation.scss
+++ b/seedlet/assets/sass/components/footer/_footer-navigation.scss
@@ -17,15 +17,12 @@
 		color: var(--footer--color-text);
 		margin: 0;
 		padding-left: 0;
-
-		@include media(desktop) {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: flex-end;
-		}
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-start;
 
 		& > li {
-			display: inline;
+			display: inline-block;
 
 			&:first-of-type > a {
 				padding-left: 0;
@@ -37,7 +34,7 @@
 		}
 
 		.menu-item {
-			padding: var(--primary-nav--padding);
+			padding: var(--primary-nav--padding) var(--primary-nav--padding) var(--primary-nav--padding) 0;
 
 			a {
 				font-family: var(--primary-nav--font-family);

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -3334,9 +3334,10 @@ nav a {
 
 @media only screen and (min-width: 822px) {
 	.site-footer {
-		align-items: flex-end;
 		display: flex;
+		align-items: center;
 		flex-wrap: wrap;
+		flex-direction: column;
 	}
 }
 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -3330,10 +3330,6 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-	display: flex;
-	align-items: flex-start;
-	flex-wrap: wrap;
-	flex-direction: column;
 }
 
 .site-footer > .site-info {
@@ -3386,9 +3382,6 @@ nav a {
 	color: var(--footer--color-text);
 	margin: 0;
 	padding-right: 0;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -3404,7 +3404,7 @@ nav a {
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item {
-	padding: var(--primary-nav--padding);
+	padding: var(--primary-nav--padding) 0 var(--primary-nav--padding) var(--primary-nav--padding);
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item a {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -3330,15 +3330,10 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer {
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-		flex-direction: column;
-	}
+	display: flex;
+	align-items: flex-start;
+	flex-wrap: wrap;
+	flex-direction: column;
 }
 
 .site-footer > .site-info {
@@ -3391,18 +3386,13 @@ nav a {
 	color: var(--footer--color-text);
 	margin: 0;
 	padding-right: 0;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer > .footer-navigation .footer-menu {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {
-	display: inline;
+	display: inline-block;
 }
 
 .site-footer > .footer-navigation .footer-menu > li:first-of-type > a {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3355,14 +3355,10 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer {
-		align-items: flex-end;
-		display: flex;
-		flex-wrap: wrap;
-	}
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-direction: column;
 }
 
 .site-footer > .site-info {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3355,10 +3355,6 @@ nav a {
 
 .site-footer {
 	overflow: hidden;
-	display: flex;
-	align-items: flex-start;
-	flex-wrap: wrap;
-	flex-direction: column;
 }
 
 .site-footer > .site-info {
@@ -3411,9 +3407,6 @@ nav a {
 	color: var(--footer--color-text);
 	margin: 0;
 	padding-left: 0;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3356,7 +3356,7 @@ nav a {
 .site-footer {
 	overflow: hidden;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	flex-wrap: wrap;
 	flex-direction: column;
 }
@@ -3411,18 +3411,13 @@ nav a {
 	color: var(--footer--color-text);
 	margin: 0;
 	padding-left: 0;
-}
-
-@media only screen and (min-width: 822px) {
-	.site-footer > .footer-navigation .footer-menu {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-	}
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
 }
 
 .site-footer > .footer-navigation .footer-menu > li {
-	display: inline;
+	display: inline-block;
 }
 
 .site-footer > .footer-navigation .footer-menu > li:first-of-type > a {
@@ -3434,7 +3429,7 @@ nav a {
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item {
-	padding: var(--primary-nav--padding);
+	padding: var(--primary-nav--padding) var(--primary-nav--padding) var(--primary-nav--padding) 0;
 }
 
 .site-footer > .footer-navigation .footer-menu .menu-item a {


### PR DESCRIPTION
Cleans up the appearance of the footer menu, for both desktop and mobile screens.

Desktop 

Before|After
---|---
![Screen Shot 2020-08-21 at 2 22 09 PM](https://user-images.githubusercontent.com/1202812/90922298-c57d4e80-e3b9-11ea-8c07-a05a5fbf4f53.png)|![Screen Shot 2020-08-21 at 2 15 43 PM](https://user-images.githubusercontent.com/1202812/90922305-c7dfa880-e3b9-11ea-88d1-8b32e11da029.png)

Mobile

Before|After
---|---
![Screen Shot 2020-08-21 at 2 21 55 PM](https://user-images.githubusercontent.com/1202812/90922327-d0d07a00-e3b9-11ea-86ff-f17448f6549a.png)|![Screen Shot 2020-08-21 at 2 15 57 PM](https://user-images.githubusercontent.com/1202812/90922335-d332d400-e3b9-11ea-9bda-9d423f391c95.png)
