### PR TITLE
Seedlet: Use WordPress global to detect IE support

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -16,14 +16,6 @@ if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 	return;
 }
 
-/**
- * Determine whether the site is being requested from IE.
- */
-$is_ie = false;
-if ( preg_match( '~MSIE|Internet Explorer~i', $_SERVER['HTTP_USER_AGENT']) || (strpos($_SERVER['HTTP_USER_AGENT'], 'Trident/7.0; rv:11.0') !== false ) ) {
-	$is_ie = true;
-}
-
 if ( ! function_exists( 'seedlet_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
@@ -114,7 +106,9 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		add_theme_support( 'editor-styles' );
 
 		$editor_stylesheet_path = './assets/css/style-editor.css';
-		if ( $is_ie ) {
+
+		global $is_IE;
+		if ( $is_IE ) {
 			$editor_stylesheet_path = './assets/css/ie-editor.css';
 		}
 
@@ -369,7 +363,8 @@ function seedlet_scripts() {
 	wp_enqueue_style( 'seedlet-fonts', seedlet_fonts_url(), array(), null );
 
 	// Theme styles
-	if ( $is_ie ) {
+	global $is_IE;
+	if ( $is_IE ) {
 		// If IE 11 or below, use a flattened stylesheet with static values replacing CSS Variables
 		wp_enqueue_style( 'seedlet-style', get_template_directory_uri() . '/assets/css/ie.css', array(), wp_get_theme()->get( 'Version' ) );
 	} else {

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -107,6 +107,8 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 
 		$editor_stylesheet_path = './assets/css/style-editor.css';
 
+		// Note, the is_IE global variable is defined by WordPress and is used
+		// to detect if the current browser is internet explorer.
 		global $is_IE;
 		if ( $is_IE ) {
 			$editor_stylesheet_path = './assets/css/ie-editor.css';
@@ -363,6 +365,9 @@ function seedlet_scripts() {
 	wp_enqueue_style( 'seedlet-fonts', seedlet_fonts_url(), array(), null );
 
 	// Theme styles
+
+	// Note, the is_IE global variable is defined by WordPress and is used
+	// to detect if the current browser is internet explorer.
 	global $is_IE;
 	if ( $is_IE ) {
 		// If IE 11 or below, use a flattened stylesheet with static values replacing CSS Variables


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixes #2386 by removing the `is_ie` variable in favor of the global `is_IE` variable exposed by WordPress here: https://github.com/WordPress/WordPress/blob/001ffe81fbec4438a9f594f330e18103d21fbcd7/wp-includes/vars.php#L107

#### Related issue(s):
