### PR TITLE
Seedlet: fix two custom color panels loading on wpcom

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -416,7 +416,7 @@ require get_template_directory() . '/classes/class-seedlet-svg-icons.php';
 /**
  * Custom colors class.
  */
-if ( empty( get_theme_mod( 'colors_manager' ) ) ) { // If the theme is on wpcom, we bypass the theme's built in custom colors, because wpcom uses a different custom color implementation.
+if ( ! class_exists( 'Colors_Manager' ) ) { // Check for presence of wpcom color manager to avoid duplicate color customization functionality.
 	require get_template_directory() . '/classes/class-seedlet-custom-colors.php';
 }
 


### PR DESCRIPTION
This PR addresses #2391.

Previously, the theme looked to see if `colors_manager` theme mod had been set to determine the presence of wpcom color annotations plugin. This would fail the condition if the colors hadn't been altered yet. 

This fix checks for the existence of the class at all h/t @jeffikus.

**To test**
- Proxy seedletdemo.wordpress.com and verify two panels appear
- Check out this PR onto your sandbox
- Verify that only the color annotations panel appears