### PR TITLE
Fixes galleries in Pique

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -1954,8 +1954,6 @@ blockquote
 
 .content-area {
 	content: '';
-	display: table;
-	table-layout: fixed;
 	/* Prevent stuff from getting spilly on mobile */
 	width: 100%;
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes some CSS selectors that were breaking galleries. It looks like this was added in 30932-wpcom-themes, to centre align the content when there is only one column, but it seems to work regardless of these lines. I have also tested in IE11.

Before:
<img width="899" alt="Screenshot 2020-08-24 at 14 13 05" src="https://user-images.githubusercontent.com/275961/91048707-f3f66600-e613-11ea-8b6f-ebd451320b97.png">

After:
<img width="1050" alt="Screenshot 2020-08-24 at 14 12 37" src="https://user-images.githubusercontent.com/275961/91048763-083a6300-e614-11ea-975d-05cbed50594f.png">


#### Related issue(s):
Fixes #2371