### PR TITLE
Seedlet: fix landmark roles

### DIFF
--- a/seedlet/404.php
+++ b/seedlet/404.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main default-max-width">
+		<main id="main" class="site-main default-max-width" role="main">
 
 			<div class="error-404 not-found">
 				<header class="page-header">

--- a/seedlet/archive.php
+++ b/seedlet/archive.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/seedlet/footer.php
+++ b/seedlet/footer.php
@@ -14,7 +14,7 @@
 
 	</div><!-- #content -->
 
-	<footer id="colophon" class="site-footer default-max-width" role="contentinfo">
+	<footer id="colophon" class="site-footer default-max-width" role="contentinfo" aria-label="<?php esc_attr_e( 'Footer', 'seedlet' ); ?>">
 
 		<?php get_template_part( 'template-parts/footer/footer-widgets' ); ?>
 

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -58,7 +58,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
 						)
 					);
 					?>
@@ -73,18 +73,19 @@
 							<span class="hide-visually collapsed-text">%3$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-							<ul id="woocommerce-menu" class="menu-wrapper">
-							<li class="menu-item woocommerce-menu-item %4$s" title="%5$s">
-								%6$s
+							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
+							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
+								%7$s
 								<ul class="sub-menu">
-									<li class="woocommerce-cart-widget" title="%7$s">
-										%8$s
+									<li class="woocommerce-cart-widget" title="%8$s">
+										%9$s
 									</li>
 								</ul>
 							</li>',
 						esc_html__( 'Close', 'seedlet' ),
 						seedlet_get_icon_svg( 'close' ),
 						esc_html__( 'collapsed', 'seedlet' ),
+						esc_attr__( 'submenu', 'seedlet' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'seedlet' ),
 						seedlet_cart_link(),

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -41,7 +41,7 @@
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
 			<?php if ( has_nav_menu( 'primary' ) ) : ?>
-				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Primary Navigation', 'seedlet' ); ?>">
+				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Main', 'seedlet' ); ?>">
 					<button id="primary-close-menu" class="button close">
 						<span class="dropdown-icon close"><?php _e( 'Close', 'seedlet' ); ?> <?php echo seedlet_get_icon_svg( 'close' ) ?></span>
 						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'seedlet' ); ?></span>
@@ -58,7 +58,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 						)
 					);
 					?>
@@ -73,19 +73,18 @@
 							<span class="hide-visually collapsed-text">%3$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
-							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
-								%7$s
+							<ul id="woocommerce-menu" class="menu-wrapper"">
+							<li class="menu-item woocommerce-menu-item %4$s" title="%5$s">
+								%6$s
 								<ul class="sub-menu">
-									<li class="woocommerce-cart-widget" title="%8$s">
-										%9$s
+									<li class="woocommerce-cart-widget" title="%7$s">
+										%8$s
 									</li>
 								</ul>
 							</li>',
 						esc_html__( 'Close', 'seedlet' ),
 						seedlet_get_icon_svg( 'close' ),
 						esc_html__( 'collapsed', 'seedlet' ),
-						esc_attr__( 'submenu', 'seedlet' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'seedlet' ),
 						seedlet_cart_link(),

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -58,7 +58,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
 						)
 					);
 					?>
@@ -73,7 +73,7 @@
 							<span class="hide-visually collapsed-text">%3$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-							<ul id="woocommerce-menu" class="menu-wrapper" role="navigation" aria-label="%4$s">
+							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
 							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
 								%7$s
 								<ul class="sub-menu">

--- a/seedlet/header.php
+++ b/seedlet/header.php
@@ -58,7 +58,7 @@
 							'theme_location'  => 'primary',
 							'menu_class'      => 'menu-wrapper',
 							'container_class' => 'primary-menu-container',
-							'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="' . esc_attr__( 'submenu', 'seedlet' ) . '">%3$s</ul>',
+							'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 						)
 					);
 					?>
@@ -73,19 +73,18 @@
 							<span class="hide-visually collapsed-text">%3$s</span>
 						</button>
 						<div class="woocommerce-menu-container">
-							<ul id="woocommerce-menu" class="menu-wrapper" aria-label="%4$s">
-							<li class="menu-item woocommerce-menu-item %5$s" title="%6$s">
-								%7$s
+							<ul id="woocommerce-menu" class="menu-wrapper">
+							<li class="menu-item woocommerce-menu-item %4$s" title="%5$s">
+								%6$s
 								<ul class="sub-menu">
-									<li class="woocommerce-cart-widget" title="%8$s">
-										%9$s
+									<li class="woocommerce-cart-widget" title="%7$s">
+										%8$s
 									</li>
 								</ul>
 							</li>',
 						esc_html__( 'Close', 'seedlet' ),
 						seedlet_get_icon_svg( 'close' ),
 						esc_html__( 'collapsed', 'seedlet' ),
-						esc_attr__( 'submenu', 'seedlet' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'seedlet' ),
 						seedlet_cart_link(),

--- a/seedlet/image.php
+++ b/seedlet/image.php
@@ -10,7 +10,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 			<?php
 			// Start the loop.

--- a/seedlet/index.php
+++ b/seedlet/index.php
@@ -17,7 +17,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 		<?php
 		if ( have_posts() ) {

--- a/seedlet/page.php
+++ b/seedlet/page.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 			<?php
 			/* Start the Loop */

--- a/seedlet/search.php
+++ b/seedlet/search.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/seedlet/single.php
+++ b/seedlet/single.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<main id="main" class="site-main" role="main">
 
 			<?php
 			/* Start the Loop */

--- a/seedlet/template-parts/content/content-page.php
+++ b/seedlet/template-parts/content/content-page.php
@@ -16,7 +16,7 @@
 		<?php get_template_part( 'template-parts/header/entry-header' ); ?>
 	</header>
 
-	<div class="entry-content" role="main">
+	<div class="entry-content">
 		<?php
 		the_content();
 

--- a/seedlet/template-parts/content/content.php
+++ b/seedlet/template-parts/content/content.php
@@ -26,7 +26,7 @@
 
 	<?php seedlet_post_thumbnail(); ?>
 
-	<div class="entry-content" role="main">
+	<div class="entry-content">
 		<?php
 		the_content(
 			sprintf(

--- a/seedlet/template-parts/footer/footer-widgets.php
+++ b/seedlet/template-parts/footer/footer-widgets.php
@@ -8,7 +8,7 @@
 
 if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
 
-	<aside class="widget-area" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'seedlet' ); ?>">
+	<div class="widget-area">
 		<?php
 		if ( is_active_sidebar( 'sidebar-1' ) ) {
 			?>
@@ -18,6 +18,6 @@ if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
 				<?php
 		}
 		?>
-	</aside><!-- .widget-area -->
+	</div><!-- .widget-area -->
 
 <?php endif; ?>


### PR DESCRIPTION
This PR addresses the following Theme Review accessibility [feedback](https://themes.trac.wordpress.org/ticket/85664#comment:23): 

- The UL items inside the nav, in items_wrap, should not have the navigation role:
- Aside must not be contained in another landmark ("Aside is used for the widget area inside the footer landmark")
- The role="main" should be placed on the `main` element only, one per document

The one thing I'm unsure of is whether to remove the `aria-label` completely from the `ul` in the nav:

https://github.com/Automattic/themes/blob/b3c4428a023a737c0e23b37fde8058d7130ab8ce/seedlet/header.php#L61