### PR TITLE
Add Alternating Grid block style to the Blog Posts block.

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -5837,18 +5837,22 @@ img#wpstats {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title {
-	font-size: 1em;
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title {
+	font-size: 24px;
+	letter-spacing: normal;
+	line-height: 1.3;
 	margin-bottom: 15px;
 }
 
-.wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+.wp-block-a8c-blog-posts h2.article-section-title {
+	font-size: 24px;
+	letter-spacing: normal;
+	line-height: 1.3;
 	margin-bottom: 15px;
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title + article,
-.wp-block-a8c-blog-posts .article-section-title + article {
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title + article,
+.wp-block-a8c-blog-posts h2.article-section-title + article {
 	margin-top: 0;
 }
 
@@ -6144,7 +6148,7 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
-	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-left: calc(50% + 13px);
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
@@ -6164,6 +6168,9 @@ img#wpstats {
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
+		display: inline-block;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -6063,7 +6063,6 @@ img#wpstats {
 .wp-block-a8c-blog-posts article .entry-meta a,
 .wp-block-a8c-blog-posts article .cat-links a {
 	color: currentColor;
-	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover {
@@ -6142,6 +6141,37 @@ img#wpstats {
 [style*="background-color"]
 .wp-block-a8c-blog-posts article .cat-links a:active {
 	color: currentColor;
+}
+
+@media only screen and (min-width: 592px) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+		margin-left: calc(50% + 13px);
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
+		width: calc(50% - 13px);
+		max-width: calc(50% - 13px);
+		margin-top: 0;
+		margin-bottom: 30px;
+		text-align: right;
+		clear: both;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
+		justify-content: flex-end;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
+		float: right;
+		text-align: left;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
+		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
+		display: inherit;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
+		clear: both;
+		margin: 30px auto;
+	}
 }
 
 button {

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -6148,8 +6148,19 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .article-section-title {
+		margin-left: calc(50% + 13px);
+	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-left: calc(50% + 13px);
+	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article {
+		width: calc(50% - 13px);
+		max-width: calc(50% - 13px);
+		margin-top: 0;
+		margin-bottom: 30px;
+		text-align: right;
+		clear: both;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
 		width: calc(50% - 13px);
@@ -6159,21 +6170,30 @@ img#wpstats {
 		text-align: right;
 		clear: both;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
 		justify-content: flex-end;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1),
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
 		float: right;
 		text-align: left;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .more-link,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
 		display: inline-block;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid.wpnbha.is-grid > div,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;
+	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid button {
+		clear: both;
+		margin: 30px auto;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
 		clear: both;

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1753,7 +1753,6 @@ pre.wp-block-verse {
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
 	color: currentColor;
-	text-decoration: underline;
 }
 
 .wp-block-a8c-blog-posts .entry-meta a:hover, .wp-block-a8c-blog-posts .entry-meta a:active,
@@ -1779,6 +1778,39 @@ pre.wp-block-verse {
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
 	color: currentColor;
+}
+
+@media only screen and (min-width: 592px) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
+		overflow: hidden;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+		margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
+		width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		margin-top: 0;
+		margin-bottom: var(--global--spacing-vertical);
+		text-align: right;
+		clear: both;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
+		justify-content: flex-end;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
+		float: right;
+		text-align: left;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
+		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
+		display: inherit;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid + .wpnbha__wp-block-button__wrapper {
+		text-align: center;
+	}
 }
 
 .wp-block-search .wp-block-search__button, .wp-block-a8c-blog-posts + .button {

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1651,7 +1651,9 @@ pre.wp-block-verse {
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: var(--global--font-size-base);
+	font-size: var(--heading--font-size-h4);
+	letter-spacing: var(--heading--letter-spacing-h4);
+	line-height: var(--heading--line-height-h4);
 	margin-top: 0;
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
@@ -1784,7 +1786,7 @@ pre.wp-block-verse {
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
 		overflow: hidden;
 	}
-	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
@@ -1804,6 +1806,9 @@ pre.wp-block-verse {
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .more-link {
+		display: inline-block;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
@@ -32,7 +32,9 @@
 	}
 
 	.article-section-title {
-		font-size: var(--global--font-size-base);
+		font-size: var(--heading--font-size-h4);
+		letter-spacing: var(--heading--letter-spacing-h4);
+		line-height: var(--heading--line-height-h4);
 		margin-top: 0;
 		margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 	}
@@ -153,7 +155,7 @@
 		// Necessary so that the block boundaries are respected.
 		overflow: hidden;
 
-		h2 {
+		.article-section-title {
 			margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 		}
 
@@ -176,6 +178,10 @@
 				.entry-meta {
 					justify-content: flex-start;
 				}
+			}
+
+			.more-link {
+				display: inline-block;
 			}
 		}
 

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
@@ -129,7 +129,6 @@
 
 		a {
 			color: currentColor;
-			text-decoration: underline;
 
 			&:hover,
 			&:active {
@@ -142,6 +141,51 @@
 					color: currentColor;
 				}
 			}
+		}
+	}
+}
+
+// Block Style
+
+@include media(tablet) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
+
+		// Necessary so that the block boundaries are respected.
+		overflow: hidden;
+
+		h2 {
+			margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
+		}
+
+		article {
+			width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+			max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+			margin-top: 0;
+			margin-bottom: var(--global--spacing-vertical);
+			text-align: right;
+			clear: both;
+
+			.entry-meta {
+				justify-content: flex-end;
+			}
+
+			&:nth-of-type(2n + 1) {
+				float: right;
+				text-align: left;
+
+				.entry-meta {
+					justify-content: flex-start;
+				}
+			}
+		}
+
+		// Remove the styles that enforce the grid setting.
+		&.wpnbha.is-grid > div {
+			display: inherit;
+		}
+
+		+ .wpnbha__wp-block-button__wrapper {
+			text-align: center;
 		}
 	}
 }

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
@@ -159,6 +159,7 @@
 // Block Style
 
 @include media(tablet) {
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
 
 		.article-section-title {

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
@@ -137,7 +137,6 @@
 
 			a {
 				color: currentColor;
-				text-decoration: underline;
 
 				&:hover,
 				&:active {
@@ -151,6 +150,49 @@
 					}
 				}
 			}
+		}
+	}
+}
+
+// Block Style
+
+@include media(tablet) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
+
+		h2 {
+			margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
+		}
+
+		article {
+			width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+			max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+			margin-top: 0;
+			margin-bottom: var(--global--spacing-vertical);
+			text-align: right;
+			clear: both;
+
+			.entry-meta {
+				justify-content: flex-end;
+			}
+
+			&:nth-of-type(2n + 1) {
+				float: right;
+				text-align: left;
+
+				.entry-meta {
+					justify-content: flex-start;
+				}
+			}
+		}
+
+		// Remove the styles that enforce the grid setting.
+		&.wpnbha.is-grid > div {
+			display: inherit;
+		}
+
+		button {
+			clear: both;
+			margin: var(--global--spacing-vertical) auto;
 		}
 	}
 }

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_style.scss
@@ -32,8 +32,10 @@
 		}
 	}
 
-	.article-section-title {
-		font-size: var(--global--font-size-base);
+	h2.article-section-title {
+		font-size: var(--heading--font-size-h4);
+		letter-spacing: var(--heading--letter-spacing-h4);
+		line-height: var(--heading--line-height-h4);
 		margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 
 		& + article {
@@ -159,7 +161,7 @@
 @include media(tablet) {
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
 
-		h2 {
+		.article-section-title {
 			margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 		}
 
@@ -183,6 +185,10 @@
 					justify-content: flex-start;
 				}
 			}
+		}
+
+		.more-link {
+			display: inline-block;
 		}
 
 		// Remove the styles that enforce the grid setting.

--- a/seedlet/inc/block-styles.php
+++ b/seedlet/inc/block-styles.php
@@ -10,10 +10,18 @@ if ( function_exists( 'register_block_style' ) ) {
 	function seedlet_register_block_styles() {
 
 		/**
-		 * Register block style
+		 * Register block styles
 		 */
 		register_block_style(
 			'core/latest-posts',
+			array(
+				'name'         => 'seedlet-alternating-grid',
+				'label'        => 'Alternating Grid',
+				'style_handle' => 'seedlet-alternating-grid',
+			)
+		);
+		register_block_style(
+			'a8c/blog-posts',
 			array(
 				'name'         => 'seedlet-alternating-grid',
 				'label'        => 'Alternating Grid',

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -4142,7 +4142,9 @@ img#wpstats {
 
 .wp-block-newspack-blocks-homepage-articles .article-section-title,
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: var(--global--font-size-base);
+	font-size: var(--heading--font-size-h4);
+	letter-spacing: var(--heading--letter-spacing-h4);
+	line-height: var(--heading--line-height-h4);
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
@@ -4358,10 +4360,7 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
-	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
-		overflow: hidden;
-	}
-	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-right: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
@@ -4381,6 +4380,9 @@ img#wpstats {
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
+		display: inline-block;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -4306,7 +4306,6 @@ img#wpstats {
 .wp-block-a8c-blog-posts article .entry-meta a,
 .wp-block-a8c-blog-posts article .cat-links a {
 	color: currentColor;
-	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
@@ -4356,6 +4355,40 @@ img#wpstats {
 [style*="background-color"]
 .wp-block-a8c-blog-posts article .cat-links a:active {
 	color: currentColor;
+}
+
+@media only screen and (min-width: 592px) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid {
+		overflow: hidden;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+		margin-right: calc(50% + (0.5 * var(--global--spacing-horizontal)));
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
+		width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		margin-top: 0;
+		margin-bottom: var(--global--spacing-vertical);
+		text-align: left;
+		clear: both;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
+		justify-content: flex-end;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
+		float: left;
+		text-align: right;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
+		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
+		display: inherit;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
+		clear: both;
+		margin: var(--global--spacing-vertical) auto;
+	}
 }
 
 button,

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -4140,16 +4140,16 @@ img#wpstats {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title,
-.wp-block-a8c-blog-posts .article-section-title {
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title,
+.wp-block-a8c-blog-posts h2.article-section-title {
 	font-size: var(--heading--font-size-h4);
 	letter-spacing: var(--heading--letter-spacing-h4);
 	line-height: var(--heading--line-height-h4);
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title + article,
-.wp-block-a8c-blog-posts .article-section-title + article {
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title + article,
+.wp-block-a8c-blog-posts h2.article-section-title + article {
 	margin-top: 0;
 }
 
@@ -4360,9 +4360,11 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .article-section-title,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-right: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
 		width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
 		max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
@@ -4371,22 +4373,28 @@ img#wpstats {
 		text-align: left;
 		clear: both;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
 		justify-content: flex-end;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1),
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
 		float: left;
 		text-align: right;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .more-link,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
 		display: inline-block;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid.wpnbha.is-grid > div,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid button,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
 		clear: both;
 		margin: var(--global--spacing-vertical) auto;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -4165,14 +4165,16 @@ img#wpstats {
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title,
-.wp-block-a8c-blog-posts .article-section-title {
-	font-size: var(--global--font-size-base);
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title,
+.wp-block-a8c-blog-posts h2.article-section-title {
+	font-size: var(--heading--font-size-h4);
+	letter-spacing: var(--heading--letter-spacing-h4);
+	line-height: var(--heading--line-height-h4);
 	margin-bottom: calc(0.5 * var(--global--spacing-vertical));
 }
 
-.wp-block-newspack-blocks-homepage-articles .article-section-title + article,
-.wp-block-a8c-blog-posts .article-section-title + article {
+.wp-block-newspack-blocks-homepage-articles h2.article-section-title + article,
+.wp-block-a8c-blog-posts h2.article-section-title + article {
 	margin-top: 0;
 }
 
@@ -4383,7 +4385,7 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
-	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
@@ -4403,6 +4405,9 @@ img#wpstats {
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
+		display: inline-block;
 	}
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -4331,7 +4331,6 @@ img#wpstats {
 .wp-block-a8c-blog-posts article .entry-meta a,
 .wp-block-a8c-blog-posts article .cat-links a {
 	color: currentColor;
-	text-decoration: underline;
 }
 
 .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
@@ -4381,6 +4380,37 @@ img#wpstats {
 [style*="background-color"]
 .wp-block-a8c-blog-posts article .cat-links a:active {
 	color: currentColor;
+}
+
+@media only screen and (min-width: 592px) {
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid h2 {
+		margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
+		width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
+		margin-top: 0;
+		margin-bottom: var(--global--spacing-vertical);
+		text-align: right;
+		clear: both;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
+		justify-content: flex-end;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
+		float: right;
+		text-align: left;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
+		justify-content: flex-start;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
+		display: inherit;
+	}
+	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
+		clear: both;
+		margin: var(--global--spacing-vertical) auto;
+	}
 }
 
 button,

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -4385,9 +4385,11 @@ img#wpstats {
 }
 
 @media only screen and (min-width: 592px) {
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .article-section-title,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .article-section-title {
 		margin-left: calc(50% + (0.5 * var(--global--spacing-horizontal)));
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article {
 		width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
 		max-width: calc(50% - (0.5 * var(--global--spacing-horizontal)));
@@ -4396,22 +4398,28 @@ img#wpstats {
 		text-align: right;
 		clear: both;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article .entry-meta {
 		justify-content: flex-end;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1),
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) {
 		float: right;
 		text-align: left;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid article:nth-of-type(2n + 1) .entry-meta {
 		justify-content: flex-start;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid .more-link,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid .more-link {
 		display: inline-block;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid.wpnbha.is-grid > div,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid.wpnbha.is-grid > div {
 		display: inherit;
 	}
+	.wp-block-newspack-blocks-homepage-articles.is-style-seedlet-alternating-grid button,
 	.wp-block-a8c-blog-posts.is-style-seedlet-alternating-grid button {
 		clear: both;
 		margin: var(--global--spacing-vertical) auto;


### PR DESCRIPTION
Followup to https://github.com/Automattic/themes/pull/2399. This PR adds an alternating grid block style to the Automattic Blog Posts block as well. Looks & works basically the same. 

This PR also removes the erroneous [double underline](https://cloudup.com/cb5lAfepVxi) that was showing up for post meta in the Blog Posts block. 

## Screenshot

![dotorgthemes test_wp-admin_post php_post=2864 action=edit](https://user-images.githubusercontent.com/1202812/91214548-3afe5d00-e6e1-11ea-9e18-a6ae790e1480.png)
