### PR TITLE
Adds headstart auto loading homepage tag

### DIFF
--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -11,7 +11,7 @@ Version: 1.0.3-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
Adds auto-loading-homepage tag so that the headstart homepage creation feature works on WordPress.com


#### Changes proposed in this Pull Request:
Adds auto-loading-homepage tag to main stylesheet.