### PR TITLE
Seedlet: Add custom units support

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -266,6 +266,9 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 
 		// Add support for experimental cover block spacing.
 		add_theme_support( 'experimental-custom-spacing' );
+
+		// Add support for custom units.
+		add_theme_support( 'custom-units' );
     
 		// Add support for WordPress.com Global Styles.
 		add_theme_support(


### PR DESCRIPTION
This PR adds custom units support to Seedlet. 

To test: Add a cover block, and verify that you're able to change the unit for the min-height control. 

Before: 

<img width="336" alt="Screen Shot 2020-08-27 at 2 16 01 PM" src="https://user-images.githubusercontent.com/1202812/91479806-066cdb80-e870-11ea-9540-f81efc2daa23.png">

After: 

![custom-units-active](https://user-images.githubusercontent.com/1202812/91479876-200e2300-e870-11ea-8235-08a2c58181b5.gif)
