### PR TITLE
Seedlet: Correct nested color rules

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -3804,58 +3804,88 @@ table th {
 	color: black;
 }
 
-.has-background:not(.has-background-background-color) a,
+.has-background:not(.has-background-background-color) a:not(.has-text-color),
 .has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }
 
 .has-primary-background-color[class] {
 	background-color: #000000;
+}
+
+.has-primary-background-color[class]:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
 .has-secondary-background-color[class] {
 	background-color: #3C8067;
+}
+
+.has-secondary-background-color[class]:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
 .has-foreground-background-color[class] {
 	background-color: #333333;
+}
+
+.has-foreground-background-color[class]:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: #444444;
+}
+
+.has-foreground-light-background-color[class]:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: #000000;
+}
+
+.has-foreground-dark-background-color[class]:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
 .has-tertiary-background-color[class] {
 	background-color: #FAFBF6;
+}
+
+.has-tertiary-background-color[class]:not(.has-text-color) {
 	color: #333333;
 }
 
 .has-background-dark-background-color[class] {
 	background-color: #DDDDDD;
+}
+
+.has-background-dark-background-color[class]:not(.has-text-color) {
 	color: #333333;
 }
 
 .has-background-background-color[class] {
 	background-color: #FFFFFF;
+}
+
+.has-background-background-color[class]:not(.has-text-color) {
 	color: #333333;
 }
 
 .has-white-background-color[class] {
 	background-color: white;
+}
+
+.has-white-background-color[class]:not(.has-text-color) {
 	color: #3C8067;
 }
 
 .has-black-background-color[class] {
 	background-color: black;
+}
+
+.has-black-background-color[class]:not(.has-text-color) {
 	color: #000000;
 }
 

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -2206,12 +2206,12 @@ object {
 	margin-bottom: 30px;
 }
 
-.wp-block-cover .wp-block-cover__inner-container a,
-.wp-block-cover .wp-block-cover-image-text a,
-.wp-block-cover .wp-block-cover-text a,
-.wp-block-cover-image .wp-block-cover__inner-container a,
-.wp-block-cover-image .wp-block-cover-image-text a,
-.wp-block-cover-image .wp-block-cover-text a {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color) {
 	color: currentColor;
 }
 

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -680,14 +680,14 @@ div[data-type="core/button"] {
 	color: currentColor;
 }
 
-.wp-block-cover .wp-block-cover__inner-container a,
-.wp-block-cover .wp-block-cover-image-text a,
-.wp-block-cover .wp-block-cover-text a,
-.wp-block-cover .block-editor-block-list__block a,
-.wp-block-cover-image .wp-block-cover__inner-container a,
-.wp-block-cover-image .wp-block-cover-image-text a,
-.wp-block-cover-image .wp-block-cover-text a,
-.wp-block-cover-image .block-editor-block-list__block a {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
+.wp-block-cover .block-editor-block-list__block a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color),
+.wp-block-cover-image .block-editor-block-list__block a:not(.has-text-color) {
 	color: currentColor;
 }
 

--- a/seedlet/assets/sass/blocks/cover/_editor.scss
+++ b/seedlet/assets/sass/blocks/cover/_editor.scss
@@ -12,7 +12,7 @@
 	.block-editor-block-list__block {
 		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
 
-		a {
+		a:not(.has-text-color) {
 			color: currentColor;
 		}
 		.has-link-color a {

--- a/seedlet/assets/sass/blocks/cover/_style.scss
+++ b/seedlet/assets/sass/blocks/cover/_style.scss
@@ -13,7 +13,7 @@
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
 
-		a {
+		a:not(.has-text-color) {
 			color: currentColor;
 		}
 		.has-link-color a {

--- a/seedlet/assets/sass/blocks/utilities/_style.scss
+++ b/seedlet/assets/sass/blocks/utilities/_style.scss
@@ -152,7 +152,7 @@
 
 // Gutenberg background-color options
 .has-background {
-	&:not(.has-background-background-color) a,
+	&:not(.has-background-background-color) a:not(.has-text-color),
 	p, h1, h2, h3, h4, h5, h6 {
 		color: currentColor;
 	}
@@ -160,52 +160,83 @@
 
 .has-primary-background-color[class] {
 	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
+	
+	&:not(.has-text-color) {
+		color: var(--global--color-background);
+	}
 }
 
 .has-secondary-background-color[class] {
 	background-color: var(--global--color-secondary);
-	color: var(--global--color-background);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-background);
+	}
 }
 
 .has-foreground-background-color[class] {
 	background-color: var(--global--color-foreground);
-	color: var(--global--color-background);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-background);
+	}
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: var(--global--color-foreground-light);
-	color: var(--global--color-background);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-background);
+	}
 }
+
 
 .has-foreground-dark-background-color[class] {
 	background-color: var(--global--color-foreground-dark);
-	color: var(--global--color-background);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-background);
+	}
 }
 
 .has-tertiary-background-color[class] {
 	background-color: var(--global--color-tertiary);
-	color: var(--global--color-foreground);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-foreground);
+	}
 }
 
 .has-background-dark-background-color[class] {
 	background-color: var(--global--color-background-dark);
-	color: var(--global--color-foreground);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-foreground);
+	}
 }
 
 .has-background-background-color[class] {
 	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-foreground);
+	}
 }
 
 .has-white-background-color[class] {
 	background-color: var(--global--color-white);
-	color: var(--global--color-secondary);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-secondary);
+	}
 }
 
 .has-black-background-color[class] {
 	background-color: var(--global--color-black);
-	color: var(--global--color-primary);
+
+	&:not(.has-text-color) {
+		color: var(--global--color-primary);
+	}
 }
 
 // Gutenberg Font-size options

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -2510,58 +2510,88 @@ table th,
 	color: var(--global--color-black);
 }
 
-.has-background:not(.has-background-background-color) a,
+.has-background:not(.has-background-background-color) a:not(.has-text-color),
 .has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }
 
 .has-primary-background-color[class] {
 	background-color: var(--global--color-primary);
+}
+
+.has-primary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-secondary-background-color[class] {
 	background-color: var(--global--color-secondary);
+}
+
+.has-secondary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-background-color[class] {
 	background-color: var(--global--color-foreground);
+}
+
+.has-foreground-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: var(--global--color-foreground-light);
+}
+
+.has-foreground-light-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: var(--global--color-foreground-dark);
+}
+
+.has-foreground-dark-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-tertiary-background-color[class] {
 	background-color: var(--global--color-tertiary);
+}
+
+.has-tertiary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-background-dark-background-color[class] {
 	background-color: var(--global--color-background-dark);
+}
+
+.has-background-dark-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-background-background-color[class] {
 	background-color: var(--global--color-background);
+}
+
+.has-background-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-white-background-color[class] {
 	background-color: var(--global--color-white);
+}
+
+.has-white-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-secondary);
 }
 
 .has-black-background-color[class] {
 	background-color: var(--global--color-black);
+}
+
+.has-black-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-primary);
 }
 

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1406,12 +1406,12 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-cover .wp-block-cover__inner-container a,
-.wp-block-cover .wp-block-cover-image-text a,
-.wp-block-cover .wp-block-cover-text a,
-.wp-block-cover-image .wp-block-cover__inner-container a,
-.wp-block-cover-image .wp-block-cover-image-text a,
-.wp-block-cover-image .wp-block-cover-text a {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color) {
 	color: currentColor;
 }
 

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -2523,58 +2523,88 @@ table th,
 	color: var(--global--color-black);
 }
 
-.has-background:not(.has-background-background-color) a,
+.has-background:not(.has-background-background-color) a:not(.has-text-color),
 .has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }
 
 .has-primary-background-color[class] {
 	background-color: var(--global--color-primary);
+}
+
+.has-primary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-secondary-background-color[class] {
 	background-color: var(--global--color-secondary);
+}
+
+.has-secondary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-background-color[class] {
 	background-color: var(--global--color-foreground);
+}
+
+.has-foreground-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-light-background-color[class] {
 	background-color: var(--global--color-foreground-light);
+}
+
+.has-foreground-light-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-foreground-dark-background-color[class] {
 	background-color: var(--global--color-foreground-dark);
+}
+
+.has-foreground-dark-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-background);
 }
 
 .has-tertiary-background-color[class] {
 	background-color: var(--global--color-tertiary);
+}
+
+.has-tertiary-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-background-dark-background-color[class] {
 	background-color: var(--global--color-background-dark);
+}
+
+.has-background-dark-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-background-background-color[class] {
 	background-color: var(--global--color-background);
+}
+
+.has-background-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-foreground);
 }
 
 .has-white-background-color[class] {
 	background-color: var(--global--color-white);
+}
+
+.has-white-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-secondary);
 }
 
 .has-black-background-color[class] {
 	background-color: var(--global--color-black);
+}
+
+.has-black-background-color[class]:not(.has-text-color) {
 	color: var(--global--color-primary);
 }
 


### PR DESCRIPTION
Today, Seedlet's background color rules sometimes override text color when it is applied to button text. 

To test this: 

1. Create a cover block OR a group block, and set its background to one of the default palette colors. 
2. Inside that block, add a button block that uses theme palette colors for the text and background. 
3. Observe that it appears as intended in the editor. 
4. On the front end however, notice that the text color is not correct. 

This PR ensures that custom text color always override the background-imposed colors. 

## Screenshots

Editor: 

![Screen Shot 2020-08-31 at 3 37 15 PM](https://user-images.githubusercontent.com/1202812/91760115-c6c02f80-eba0-11ea-910a-fd231b401644.png)

Frontend (Before):

![Screen Shot 2020-08-31 at 3 37 07 PM](https://user-images.githubusercontent.com/1202812/91760212-f2dbb080-eba0-11ea-9d61-fd9848e2f7b6.png)

Frontend (After):

![Screen Shot 2020-08-31 at 3 39 36 PM](https://user-images.githubusercontent.com/1202812/91760220-f53e0a80-eba0-11ea-9f76-ca90c3d2f445.png)
