### PR TITLE
Seedlet: de-register default editor palette correctly

### DIFF
--- a/seedlet/inc/wpcom.php
+++ b/seedlet/inc/wpcom.php
@@ -31,12 +31,6 @@ function seedlet_wpcom_setup() {
 		'only-featured-palettes' => true,
 	) );
 
-	/**
-	 * De-register original editor color palette in favor of the wpcom implementation
-	 */
-	remove_theme_support( 'editor-color-palette' );
-	remove_theme_support( 'editor-gradient-presets' );
-
 	$wpcom_colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $wpcom_colors_array ) ) {
 		$primary    = $wpcom_colors_array['colors']['link'];
@@ -44,6 +38,12 @@ function seedlet_wpcom_setup() {
 		$foreground = $wpcom_colors_array['colors']['txt'];
 		$tertiary   = $wpcom_colors_array['colors']['fg2'];
 		$background = $wpcom_colors_array['colors']['bg'];
+
+		/**
+		 * De-register original editor color palette in favor of the wpcom implementation
+		 */
+		remove_theme_support( 'editor-color-palette' );
+		remove_theme_support( 'editor-gradient-presets' );
 
 		add_theme_support(
 			'editor-color-palette',


### PR DESCRIPTION
This PR addresses #2416. 

This moves Seedlet's default editor palette de-registration into the conditional that verifies the presence of a custom color palette loaded via the colors plugin.

**To Test**
- Check out this PR onto your sandbox
- Spin up a fresh site on wpcom
- Activate Seedlet
- Open up a post and verify that the default Seedlet palette is loaded