### PR TITLE
Update Seedlet to Version 1.0.8.

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -6,7 +6,8 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Version: 1.0.6-wpcom
+Requires PHP: 7.3
+Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/assets/sass/child-theme/style-child-theme.scss
+++ b/seedlet/assets/sass/child-theme/style-child-theme.scss
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.4.1
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -6,7 +6,8 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Version: 1.0.6-wpcom
+Requires PHP: 7.3
+Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/readme.txt
+++ b/seedlet/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Automattic
 Requires at least: 5.0
 Tested up to: 5.4.1
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/seedlet/readme.txt
+++ b/seedlet/readme.txt
@@ -18,6 +18,15 @@ Seedlet is a great option for professionals and creatives looking for a sophisti
 
 == Changelog ==
 
+= 1.0.8 =
+* Add block editor theme tags
+* Correct text color rules for nested blocks
+* Tidy up translation functions and comments
+
+= 1.0.7 =
+* Fix is_IE global bug
+* Remove duplicate inclusion of editor CSS variables
+
 = 1.0.6 =
 * Add block patterns 
 * Add support for IE editor styles 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -6,7 +6,8 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Version: 1.0.6-wpcom
+Requires PHP: 7.3
+Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Requires PHP: 7.3
+Requires PHP: 5.2.4
 Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -6,7 +6,8 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 4.9.6
 Tested up to: 5.5
-Version: 1.0.6-wpcom
+Requires PHP: 7.3
+Version: 1.0.8-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet


### PR DESCRIPTION
Version bump for Seedlet. 

This is relatively routine, but with one small adjustment: [In an earlier commit](https://github.com/Automattic/themes/commit/50957b5480c2d4d2c05429c09f1d1b2a7252c13b), the minimum PHP version was removed from `style.css`. This needs to be in there in order to pass ThemeCheck. 

This reinstates the PHP version requirement, but uses `5.2.4` instead of `7.3`. We'd had reports that folks were frustrated that they couldn't install this on servers running below `7.3`, and some light testing showed no errors. I used `5.2.4` because it is the same minimum PHP version used for Twenty Nineteen and Twenty Twenty, and I think it's fine here, but it could use another gut check.  