### PR TITLE
Add a rebuild tool for varia themes

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.86806rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.86806rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }
@@ -2804,11 +2799,6 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
-	cursor: pointer;
-	z-index: 99999;
-}
-
 .main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
@@ -2819,14 +2809,6 @@ body:not(.fse-enabled) .site-description {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
-	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.main-navigation > div > ul li:hover > ul,
 	.main-navigation > div > ul li:focus-within > ul,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.71818rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }
@@ -2804,11 +2799,6 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
-	cursor: pointer;
-	z-index: 99999;
-}
-
 .main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
@@ -2819,14 +2809,6 @@ body:not(.fse-enabled) .site-description {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
-	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.main-navigation > div > ul li:hover > ul,
 	.main-navigation > div > ul li:focus-within > ul,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.71818rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -546,7 +546,6 @@
       "requires": {
         "bluebird": "3.5.5",
         "chokidar": "3.0.2",
-        "lodash": "^4.17.19",
         "yargs": "13.3.0"
       },
       "dependencies": {
@@ -593,6 +592,11 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "require-main-filename": {
           "version": "2.0.0",
@@ -1520,8 +1524,16 @@
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "^4.17.19",
+        "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -2050,12 +2062,6 @@
         }
       }
     },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -2414,7 +2420,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -2444,6 +2450,12 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -3733,11 +3745,17 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
         "postcss": {
           "version": "7.0.17",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
@@ -4058,9 +4076,17 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "scss-tokenizer": {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1662,11 +1662,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.75614rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.75614rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.6802rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1663,11 +1663,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.75614rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.64rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1525,11 +1525,6 @@ object {
 	font: var(--global--font-size-sm);
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - var(--global--spacing-unit)) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }
@@ -2804,11 +2799,6 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
-	cursor: pointer;
-	z-index: 99999;
-}
-
 .main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
@@ -2819,14 +2809,6 @@ body:not(.fse-enabled) .site-description {
 		display: inherit;
 		width: inherit;
 		/* Submenu display */
-	}
-	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
-	.main-navigation > div > ul li ul:hover,
-	.main-navigation > div > ul li ul:focus {
-		visibility: visible;
-		opacity: 1;
-		display: block;
 	}
 	.main-navigation > div > ul li:hover > ul,
 	.main-navigation > div > ul li:focus-within > ul,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1664,11 +1664,6 @@ button[data-load-more-btn], .button {
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery .blocks-gallery-image,
-.wp-block-gallery .blocks-gallery-item {
-	width: calc( (100% - 16px) / 2);
-}
-
 .wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }

--- a/varia/package.json
+++ b/varia/package.json
@@ -42,6 +42,8 @@
     "build:woocommerce-rtl": "rtlcss style-woocommerce.css style-woocommerce-rtl.css",
     "build": "run-p \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
-    "child-theme": "sh ../theme-dev-utils/build-child-theme.sh"
+    "child-theme": "sh ../theme-dev-utils/build-child-theme.sh",
+    "postinstall": "cd ../alves && npm install",
+    "children": "sh ./rebuild-child-themes.sh"
   }
 }

--- a/varia/package.json
+++ b/varia/package.json
@@ -43,7 +43,6 @@
     "build": "run-p \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "child-theme": "sh ../theme-dev-utils/build-child-theme.sh",
-    "postinstall": "cd ../alves && npm install",
     "children": "sh ./rebuild-child-themes.sh"
   }
 }

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "dalston" "exford" "hever" "leven" "mayland" "maywood" "morden" "redhill" "rivington" "rockfield" "shawburn" "stow" "stratford" )
+
+for child in ${ChildThemes[@]}; do
+	echo 'Rebulding '${child}
+	cd '../'${child}
+	npm install
+	npm run build
+done


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a shell script to make it easy to rebuild all Varia child themes in one go.

Just run `npm run children`
#### Related issue(s):
