### PR TITLE
#2415 Coutoire: Fixed missing bold font on headings 

### DIFF
--- a/coutoire/functions.php
+++ b/coutoire/functions.php
@@ -143,7 +143,7 @@ function coutoire_fonts_url() {
 		}
 
 		if ( 'off' !== $eb_garamond ) {
-			$font_families[] = 'EB Garamond:400,400i';
+			$font_families[] = 'EB Garamond:400,400i,600';
 		}
 
 		$query_args = array(

--- a/coutoire/sass/_config-child-theme-deep.scss
+++ b/coutoire/sass/_config-child-theme-deep.scss
@@ -255,7 +255,7 @@ $config-heading: (
 			"h1": map-deep-get($config-global, "font", "letter-spacing", "xxxl"),
 		),
 		// Font Weight
-		"weight": 200,
+		"weight": 400,
 	),
 );
 

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.3
+Version: 1.3.4
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -665,7 +665,7 @@ object {
 .wp-block-heading h6, h6, .h6 {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-weight: 200;
+	font-weight: 400;
 	clear: both;
 }
 
@@ -745,7 +745,7 @@ object {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: 1.728rem;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 1;
 }
 
@@ -1032,7 +1032,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-weight: 200;
+	font-weight: 400;
 	font-size: 2.48832em;
 	letter-spacing: normal;
 	line-height: 1;
@@ -1166,7 +1166,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: calc(2 * 2.98598em);
-	font-weight: 200;
+	font-weight: 400;
 }
 
 /**

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1709,7 +1709,7 @@ h5, .h5,
 h6, .h6 {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-weight: 200;
+	font-weight: 400;
 	clear: both;
 }
 
@@ -1837,7 +1837,7 @@ img {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: 1.728rem;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 1;
 }
 
@@ -2551,7 +2551,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: calc(2 * 2.98598rem);
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 0.66;
 	text-transform: uppercase;
 	font-style: normal;

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.3
+Version: 1.3.4
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1709,7 +1709,7 @@ h5, .h5,
 h6, .h6 {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-weight: 200;
+	font-weight: 400;
 	clear: both;
 }
 
@@ -1837,7 +1837,7 @@ img {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: 1.728rem;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 1;
 }
 
@@ -2558,7 +2558,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
 	font-size: calc(2 * 2.98598rem);
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 0.66;
 	text-transform: uppercase;
 	font-style: normal;

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.3
+Version: 1.3.4
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Added the bold font weight inside functions.php `coutoire_fonts_url` function because we only had 400 and 400i for Garamond. 

I also had to default the headings to a weight of 400 for the `bolder` rule to pick up the correct weight.

#### Related issue(s):

#2415 