### PR TITLE
Seedlet: Declare support for HTML5 navigation widgets

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -75,6 +75,7 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 				'caption',
 				'style',
 				'script',
+				'navigation-widgets',
 			)
 		);
 


### PR DESCRIPTION
Fixes #2464

#### Changes proposed in this Pull Request:

Declare support for HTML5 navigation widgets.
This feature was added in WordPress 5.5.
For reference: https://make.wordpress.org/core/2020/07/09/accessibility-improvements-to-widgets-outputting-lists-of-links-in-5-5/

#### Related issue(s):
https://github.com/Automattic/themes/issues/2464