### PR TITLE
Update Radcliffe 2 block.css for blog posts block

### DIFF
--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -924,6 +924,10 @@ ul.wp-block-gallery li {
 	text-decoration: none;
 }
 
+.wp-block-a8c-blog-posts.is-grid .entry-title {
+	width: auto;
+}
+
 @media all and (min-width: 600px) {
 	.a8c-posts-list-item__featured,
 	.a8c-posts-list-item__meta {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->
#### Changes proposed in this Pull Request:
- Adding some CSS to fix broken layout for the Blog Posts block when used in grid view with long titles. 

#### Related issue(s):
#2466