### PR TITLE
Fix version numbers for Varia child themes

### DIFF
--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -5,7 +5,5 @@ declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "da
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}
 	echo 'Rebulding '${child}
-	perl -pi -e 's/Version: ((\d+\.)*)(\d+)(.*)$/"Version: ".$1.($3+1).$4/ge' sass/style-child-theme.scss
-	npm install
-	npm run build
+	perl -pi -e 's/\"version\": \"((\d+\.)*)(\d+)\"(.*)$/"\"version\": \"".$1.($3+1)."\"".$4/ge' package.json
 done

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -5,5 +5,8 @@ declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "da
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}
 	echo 'Rebulding '${child}
+	perl -pi -e 's/Version: ((\d+\.)*)(\d+)(.*)$/"Version: ".$1.($3+1).$4/ge' sass/style-child-theme.scss
 	perl -pi -e 's/\"version\": \"((\d+\.)*)(\d+)\"(.*)$/"\"version\": \"".$1.($3+1)."\"".$4/ge' package.json
+	npm install
+	npm run build
 done


### PR DESCRIPTION
In https://github.com/Automattic/themes/pull/2461 I only updated the version number in the style.css not in the package.json. This adds a line to also update the package.json version. They should now be in sync.