### PR TITLE
#2382 swaped the z-index of the menu buttons to avoid flash

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -4265,13 +4265,13 @@ nav a {
 .primary-navigation .button.open,
 .woo-navigation .button.open {
 	display: flex;
-	z-index: 499;
 }
 
 .menu-button-container .button.close,
 .primary-navigation .button.close,
 .woo-navigation .button.close {
 	display: none;
+	z-index: 501;
 }
 
 .menu-button-container .button#woo-open-menu {

--- a/seedlet/assets/sass/components/header/_primary-navigation.scss
+++ b/seedlet/assets/sass/components/header/_primary-navigation.scss
@@ -35,10 +35,10 @@
 
 		&.open {
 			display: flex;
-			z-index: 499;
 		}
 		&.close {
 			display: none;
+			z-index: 501;
 		}
 
 		&#woo-open-menu {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -2918,13 +2918,13 @@ nav a {
 .primary-navigation .button.open,
 .woo-navigation .button.open {
 	display: flex;
-	z-index: 499;
 }
 
 .menu-button-container .button.close,
 .primary-navigation .button.close,
 .woo-navigation .button.close {
 	display: none;
+	z-index: 501;
 }
 
 .menu-button-container .button#woo-open-menu,

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -2943,13 +2943,13 @@ nav a {
 .primary-navigation .button.open,
 .woo-navigation .button.open {
 	display: flex;
-	z-index: 499;
 }
 
 .menu-button-container .button.close,
 .primary-navigation .button.close,
 .woo-navigation .button.close {
 	display: none;
+	z-index: 501;
 }
 
 .menu-button-container .button#woo-open-menu,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The flash was caused by the buttons changing state faster than the menu was disappearing. First I thought about having the buttons change state with the same transition time as the menu but their state changes instantly because the property affected is display: none;

So I thought having the Menu button over the actual menu but behind the close button would do the trick and avoid the flickering with a minimal change.

![Screen Capture on 2020-09-17 at 17-30-12](https://user-images.githubusercontent.com/3593343/93493087-d1522700-f90b-11ea-9192-850c979b9728.gif )

#### Related issue(s):

#2382 