### PR TITLE
Add block styles

### DIFF
--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -80,6 +80,9 @@ function independent_publisher_2_setup() {
 	// Load regular editor styles into the new block-based editor.
 	add_theme_support( 'editor-styles' );
 
+	// Add support for Block Styles.
+	add_theme_support( 'wp-block-styles' );
+
 	// Add support for responsive embeds.
 	add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
## Description
Add function to include block style theme support. This has yet to be added and a few blocks are not displaying correctly. Specifically, the video embeds and caption alignment on a few blocks.

#### Before
[![Screenshot](https://d.pr/i/5LHZy8+)](https://d.pr/i/5LHZy8)
[![Screenshot](https://d.pr/i/IHESSd+)](https://d.pr/i/IHESSd)

#### After
[![Screenshot](https://d.pr/i/SQ2LTc+)](https://d.pr/i/SQ2LTc)
[![Screenshot](https://d.pr/i/JTYmUh+)](https://d.pr/i/JTYmUh)

## Tested
Without block styles ⇢ 
With block styles ⇢ 

*I used Code Snippets to add the block style function on my test site.*

```
// Add support for Block Styles.
		add_theme_support( 'wp-block-styles' );
```

Fixes #2444 
Fixes #2454