### PR TITLE
Seedlet: Update the color annotations

### DIFF
--- a/seedlet/inc/wpcom-colors.php
+++ b/seedlet/inc/wpcom-colors.php
@@ -91,7 +91,7 @@ add_color_rule( 'bg', '#FFFFFF', array(
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-foreground-light
+// --global--color-background
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color
@@ -102,6 +102,7 @@ add_color_rule( 'txt', '#444444', array(
 			.has-background-dark-background-color[class],
 			.has-foreground-color[class],
 			.has-tertiary-background-color[class],
+			.has-tertiary-background-color[class]:not(.has-text-color),
 			.navigation,
 			.pagination .nav-links > *,
 			.post-navigation .meta-nav,
@@ -118,6 +119,8 @@ add_color_rule( 'txt', '#444444', array(
 			.wp-block-pullquote,
 			.wp-block-search .wp-block-search__input,
 			.wp-block-search .wp-block-search__input:focus,
+			.wp-block-latest-posts .wp-block-latest-posts__post-author,
+			.wp-block-latest-posts .wp-block-latest-posts__post-date,
 			body,
 			input[type="color"],
 			input[type="color"]:focus,
@@ -464,18 +467,8 @@ add_color_rule( 'fg2', '#FAFBF6', array(
 function seedlet_custom_colors_extra_css() {
 	$colors_array = get_theme_mod( 'colors_manager' );
 	$color_bg = $colors_array['colors']['bg'];
-	$color_bg = $colors_array['colors']['txt'];
-	$color_bg = $colors_array['colors']['link'];
 	$color_fg1 = $colors_array['colors']['fg1'];
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
-
-	:root {
-		--global--color-background: <?php echo $colors_array['colors']['bg']; ?>;
-		--global--color-foreground: <?php echo $colors_array['colors']['txt']; ?>;
-		--global--color-primary: <?php echo $colors_array['colors']['link']; ?>;
-		--global--color-secondary: <?php echo $colors_array['colors']['fg1']; ?>;
-		--global--color-tertiary: <?php echo $colors_array['colors']['fg2']; ?>;
-	}
 
 	/*
 	 * Site title text shadow.
@@ -545,7 +538,7 @@ add_color_palette( array(
 	'#C8133E',
 	'#4E2F4B',
 	'#F9F9F9',
-), 'Light' );
+), /* translators: This is the name for a color scheme */ 'Light' );
 // Medium
 add_color_palette( array(
 	'#EEF4F7',
@@ -553,7 +546,7 @@ add_color_palette( array(
 	'#35845D',
 	'#233252',
 	'#F9F9F9',
-), 'Medium' );
+), /* translators: This is the name for a color scheme */ 'Medium' );
 // Dark
 add_color_palette( array(
 	'#1F2527',
@@ -561,4 +554,4 @@ add_color_palette( array(
 	'#9FD3E8',
 	'#FBE6AA',
 	'#364043',
-), 'Dark' );
+), /* translators: This is the name for a color scheme */ 'Dark' );

--- a/seedlet/inc/wpcom-colors.php
+++ b/seedlet/inc/wpcom-colors.php
@@ -91,7 +91,7 @@ add_color_rule( 'bg', '#FFFFFF', array(
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-background
+// --global--color-foreground-light
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color

--- a/seedlet/inc/wpcom-colors.php
+++ b/seedlet/inc/wpcom-colors.php
@@ -1,10 +1,10 @@
-<?php 
+<?php
 
 /*
  * Custom Colors: Seedlet
  */
 
-// Background Color 
+// Background Color
 // --global--color-background
 add_color_rule( 'bg', '#FFFFFF', array(
 
@@ -91,7 +91,7 @@ add_color_rule( 'bg', '#FFFFFF', array(
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-background
+// --global--color-foreground-light
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color
@@ -154,7 +154,7 @@ add_color_rule( 'txt', '#444444', array(
 
 	// Background-color
 	array( '.wp-block-pullquote.is-style-solid-color,
-			.wp-block-cover-image.has-background-dim, 
+			.wp-block-cover-image.has-background-dim,
 			.wp-block-cover.has-background-dim', 'background-color' ),
 
 	// Border-bottom-color
@@ -302,7 +302,7 @@ add_color_rule( 'fg1', '#3C8067', array(
 			input[type="submit"]', 'background-color' ),
 
 	// Border-color
-	array( '.primary-navigation .menu-item > a:hover, 
+	array( '.primary-navigation .menu-item > a:hover,
 			.woo-navigation .menu-item > a:hover,
 			.entry-meta a:hover,
 			.entry-footer a:hover,
@@ -320,10 +320,10 @@ add_color_rule( 'fg1', '#3C8067', array(
 
 	// Outline-color
 	array( '.site :focus', 'outline-color' ),
-	
+
 	// Background-image
 	array( '.site-title a', 'Background-image' ),
-	
+
 	// Text-decoration-color
 	array( '.site-title > a', 'text-decoration-color' ),
 
@@ -458,7 +458,7 @@ add_color_rule( 'fg2', '#FAFBF6', array(
 ), __( 'Tertiary Color' ) );
 
 /**
- * Custom CSS. 
+ * Custom CSS.
  * The plugin takes the body of this function and applies it in a style tag in the document head.
  */
 function seedlet_custom_colors_extra_css() {
@@ -467,24 +467,24 @@ function seedlet_custom_colors_extra_css() {
 	$color_fg1 = $colors_array['colors']['fg1'];
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
 
-	/* 
-	 * Site title text shadow. 
+	/*
+	 * Site title text shadow.
 	*/
 	.site-title a {
 		background-image: linear-gradient(to right, <?php echo $color_fg1; ?> 100%, transparent 100%);
-		text-shadow: 1px 0px <?php echo $color_bg; ?>, 
-					 -1px 0px <?php echo $color_bg; ?>, 
-					 -2px 0px <?php echo $color_bg; ?>, 
-					 2px 0px <?php echo $color_bg; ?>, 
-					 -3px 0px <?php echo $color_bg; ?>, 
-					 3px 0px <?php echo $color_bg; ?>, 
-					 -4px 0px <?php echo $color_bg; ?>, 
-					 4px 0px <?php echo $color_bg; ?>, 
-					 -5px 0px <?php echo $color_bg; ?>, 
+		text-shadow: 1px 0px <?php echo $color_bg; ?>,
+					 -1px 0px <?php echo $color_bg; ?>,
+					 -2px 0px <?php echo $color_bg; ?>,
+					 2px 0px <?php echo $color_bg; ?>,
+					 -3px 0px <?php echo $color_bg; ?>,
+					 3px 0px <?php echo $color_bg; ?>,
+					 -4px 0px <?php echo $color_bg; ?>,
+					 4px 0px <?php echo $color_bg; ?>,
+					 -5px 0px <?php echo $color_bg; ?>,
 					 5px 0px <?php echo $color_bg; ?>;
 	}
 
-	/* 
+	/*
 	 * Custom gradients.
 	*/
 	.has-hard-diagonal-gradient-background {

--- a/seedlet/inc/wpcom-colors.php
+++ b/seedlet/inc/wpcom-colors.php
@@ -464,8 +464,18 @@ add_color_rule( 'fg2', '#FAFBF6', array(
 function seedlet_custom_colors_extra_css() {
 	$colors_array = get_theme_mod( 'colors_manager' );
 	$color_bg = $colors_array['colors']['bg'];
+	$color_bg = $colors_array['colors']['txt'];
+	$color_bg = $colors_array['colors']['link'];
 	$color_fg1 = $colors_array['colors']['fg1'];
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
+
+	:root {
+		--global--color-background: <?php echo $colors_array['colors']['bg']; ?>;
+		--global--color-foreground: <?php echo $colors_array['colors']['txt']; ?>;
+		--global--color-primary: <?php echo $colors_array['colors']['link']; ?>;
+		--global--color-secondary: <?php echo $colors_array['colors']['fg1']; ?>;
+		--global--color-tertiary: <?php echo $colors_array['colors']['fg2']; ?>;
+	}
 
 	/*
 	 * Site title text shadow.

--- a/seedlet/inc/wpcom-customize-preview.js
+++ b/seedlet/inc/wpcom-customize-preview.js
@@ -22,16 +22,10 @@
 	// we need to manually override the "extra CSS" when a user selects a different color palette.
 	wp.customize( 'colors_manager[colors]', function( value ) {
 		value.bind( function( to ) {
-			const { bg, fg1, fg2, txt, link } = to;
-			const extraCSS = `
-				:root {
-					--global--color-background: ${ bg };
-					--global--color-foreground: ${ txt };
-					--global--color-primary: ${ link };
-					--global--color-secondary: ${ fg1 };
-					--global--color-tertiary: ${ fg2 };
-				}
-
+			const { bg, fg1, fg2 } = to;
+			const extraCSS = `/*
+				* Site title text shadow.
+				*/
 				.site-title a {
 					background-image: linear-gradient(to right, ${ fg1 } 100%, transparent 100%);
 					text-shadow: 1px 0px ${ bg },

--- a/seedlet/inc/wpcom-customize-preview.js
+++ b/seedlet/inc/wpcom-customize-preview.js
@@ -22,10 +22,16 @@
 	// we need to manually override the "extra CSS" when a user selects a different color palette.
 	wp.customize( 'colors_manager[colors]', function( value ) {
 		value.bind( function( to ) {
-			const { bg, fg1, fg2 } = to;
-			const extraCSS = `/*
-				* Site title text shadow.
-				*/
+			const { bg, fg1, fg2, txt, link } = to;
+			const extraCSS = `
+				:root {
+					--global--color-background: ${ bg };
+					--global--color-foreground: ${ txt };
+					--global--color-primary: ${ link };
+					--global--color-secondary: ${ fg1 };
+					--global--color-tertiary: ${ fg2 };
+				}
+
 				.site-title a {
 					background-image: linear-gradient(to right, ${ fg1 } 100%, transparent 100%);
 					text-shadow: 1px 0px ${ bg },

--- a/seedlet/inc/wpcom-editor-colors.php
+++ b/seedlet/inc/wpcom-editor-colors.php
@@ -4,7 +4,7 @@
  * Custom Editor Colors: Seedlet
  */
 
-// Background Color 
+// Background Color
 // --global--color-background
 add_color_rule( 'bg', '#FFFFFF', array(
 
@@ -67,7 +67,7 @@ add_color_rule( 'bg', '#FFFFFF', array(
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-background
+// --global--color-foreground-light
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color
@@ -175,7 +175,7 @@ add_color_rule( 'fg1', '#3C8067', array(
 	// border-bottom-color
 	array( '#editor .editor-styles-wrapper .wp-block-file .wp-block-file__textlink,
 			#editor .editor-styles-wrapper a', 'border-bottom-color' ),
-	
+
 	// border-left-color
 	array( '#editor .editor-styles-wrapper .wp-block-quote,
 			#editor .editor-styles-wrapper .wp-block-quote.is-large,
@@ -226,10 +226,37 @@ add_color_rule( 'fg2', '#FAFBF6', array(
 function seedlet_custom_colors_extra_css() {
 	$colors_array = get_theme_mod( 'colors_manager' );
 	$color_bg = $colors_array['colors']['bg'];
+	$color_bg = $colors_array['colors']['txt'];
+	$color_bg = $colors_array['colors']['link'];
 	$color_fg1 = $colors_array['colors']['fg1'];
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
 
-	/* 
+	:root {
+		--global--color-background: <?php echo $colors_array['colors']['bg']; ?>;
+		--global--color-foreground: <?php echo $colors_array['colors']['txt']; ?>;
+		--global--color-primary: <?php echo $colors_array['colors']['link']; ?>;
+		--global--color-secondary: <?php echo $colors_array['colors']['fg1']; ?>;
+		--global--color-tertiary: <?php echo $colors_array['colors']['fg2']; ?>;
+	}
+
+	/*
+	 * Site title text shadow.
+	*/
+	.site-title a {
+		background-image: linear-gradient(to right, <?php echo $color_fg1; ?> 100%, transparent 100%);
+		text-shadow: 1px 0px <?php echo $color_bg; ?>,
+					 -1px 0px <?php echo $color_bg; ?>,
+					 -2px 0px <?php echo $color_bg; ?>,
+					 2px 0px <?php echo $color_bg; ?>,
+					 -3px 0px <?php echo $color_bg; ?>,
+					 3px 0px <?php echo $color_bg; ?>,
+					 -4px 0px <?php echo $color_bg; ?>,
+					 4px 0px <?php echo $color_bg; ?>,
+					 -5px 0px <?php echo $color_bg; ?>,
+					 5px 0px <?php echo $color_bg; ?>;
+	}
+
+	/*
 	 * Custom gradients.
 	*/
 	#editor .editor-styles-wrapper .has-hard-diagonal-gradient-background {

--- a/seedlet/inc/wpcom-editor-colors.php
+++ b/seedlet/inc/wpcom-editor-colors.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Custom Colors: Seedlet
+ * Custom Editor Colors: Seedlet
  */
 
 // Background Color

--- a/seedlet/inc/wpcom-editor-colors.php
+++ b/seedlet/inc/wpcom-editor-colors.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Custom Editor Colors: Seedlet
+ * Custom Colors: Seedlet
  */
 
 // Background Color
@@ -9,141 +9,232 @@
 add_color_rule( 'bg', '#FFFFFF', array(
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .wp-block-navigation .wp-block-navigation__container,
-			#editor .editor-styles-wrapper', 'background-color' ),
+	array( '.primary-navigation > div,
+			.screen-reader-text:focus,
+			.woo-navigation > div,
+			.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container,
+			body,
+			.primary-navigation > div > ul > li > .sub-menu,
+			.woo-navigation > div > ul > li > .sub-menu', 'background-color' ),
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:active,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:focus,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:hover,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .has-focus.button,
-			#editor .editor-styles-wrapper .wp-block-button__link,
-			#editor .editor-styles-wrapper .wp-block-button__link.has-focus,
-			#editor .editor-styles-wrapper .wp-block-button__link:focus,
-			#editor .editor-styles-wrapper .wp-block-button__link:hover,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button.has-focus,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button:focus,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button:hover,
-			#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color,
-			#editor .editor-styles-wrapper .wp-block-search .has-focus.wp-block-search__button,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:active,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:focus,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:hover', 'color' ),
+	array( '.a8c-posts-list-item__featured span,
+			.a8c-posts-list__view-all,
+			.a8c-posts-list__view-all:active,
+			.a8c-posts-list__view-all:focus,
+			.a8c-posts-list__view-all:hover,
+			.button,
+			.button:active,
+			.button:focus,
+			.button:hover,
+			.has-focus.a8c-posts-list__view-all,
+			.has-focus.button,
+			.has-focus.wp-block-button__link,
+			.reply a,
+			.reply a.has-focus,
+			.reply a:focus,
+			.reply a:hover,
+			.sticky-post,
+			.wp-block-button__link,
+			.wp-block-button__link:active,
+			.wp-block-button__link:focus,
+			.wp-block-button__link:hover,
+			.wp-block-file .has-focus.wp-block-file__button,
+			.wp-block-file .wp-block-file__button,
+			.wp-block-file .wp-block-file__button:active,
+			.wp-block-file .wp-block-file__button:focus,
+			.wp-block-file .wp-block-file__button:hover,
+			.wp-block-file a.wp-block-file__button:active,
+			.wp-block-file a.wp-block-file__button:focus,
+			.wp-block-file a.wp-block-file__button:hover,
+			.wp-block-file a.wp-block-file__button:visited,
+			.wp-block-pullquote.is-style-solid-color,
+			button,
+			button.has-focus,
+			button:active,
+			button:focus,
+			button:hover,
+			button[data-load-more-btn],
+			input.has-focus[type="submit"],
+			input:active[type="submit"],
+			input:focus[type="submit"],
+			input:hover[type="submit"],
+			input[type="submit"]', 'color' ),
+
+	// Text-shadow
+	array( '.site-title a', 'text-shadow' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .has-primary-background-color,
-			#editor .editor-styles-wrapper .has-secondary-background-color,
-			#editor .editor-styles-wrapper .has-foreground-background-color,
-			#editor .editor-styles-wrapper .has-foreground-dark-background-color,
-			#editor .editor-styles-wrapper .has-foreground-light-background-color,
-			#editor .editor-styles-wrapper .has-background-color,
-			#editor .editor-styles-wrapper .has-background:not(.has-background-background-color) a', 'color' ),
+	array( '.has-primary-background-color[class],
+			.has-secondary-background-color[class],
+			.has-foreground-background-color[class],
+			.has-foreground-dark-background-color[class],
+			.has-foreground-light-background-color[class],
+			.has-background-color[class]', 'color' ),
 
 	// Border-bottom-color
-	array( '#editor .editor-styles-wrapper .has-secondary-background-color[class] a', 'border-bottom-color' ),
+	array( '.has-secondary-background-color[class] a', 'border-bottom-color' ),
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .has-background-background-color[class]', 'background-color' ),
+	array( '.has-background-background-color[class]', 'background-color' ),
 
 	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .has-background-dark-color[class]', 'color', '-1'  ),
+	array( '.has-background-dark-color[class]', 'color', '-1'  ),
 
 	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .has-background-dark-background-color[class]', 'background-color', '-1' ),
-
-	// Text-color lightened
-	array( '#editor .editor-styles-wrapper .has-background-light-color[class]', 'color', '+1'  ),
-
-	// Background-color lightened
-	array( '#editor .editor-styles-wrapper .has-background-light-background-color[class]', 'background-color', '+1' ),
+	array( '.has-background-dark-background-color[class]', 'background-color', '-1' ),
 
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-foreground-light
+// --global--color-background
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta,
-			#editor .editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-date,
-			#editor .editor-styles-wrapper .wp-block-pullquote .wp-block-pullquote__citation,
-			#editor .editor-styles-wrapper .wp-block-pullquote cite,
-			#editor .editor-styles-wrapper .wp-block-pullquote footer,
-			#editor .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation,
-			#editor .editor-styles-wrapper .wp-caption,
-			#editor .editor-styles-wrapper .wp-caption-text,
-			#editor .editor-styles-wrapper blockquote cite,
-			#editor .editor-styles-wrapper blockquote footer,
-			#editor .editor-styles-wrapper figcaption,
-			#editor .editor-styles-wrapper .editor-post-title .editor-post-title__input,
-			#editor .editor-styles-wrapper .editor-post-title .editor-post-title__input::placeholder', 'color' ),
+	array( '.comment-meta .comment-metadata,
+			.entry-footer,
+			.entry-meta,
+			.has-background-background-color[class],
+			.has-background-dark-background-color[class],
+			.has-foreground-color[class],
+			.has-tertiary-background-color[class],
+			.has-tertiary-background-color[class]:not(.has-text-color),
+			.navigation,
+			.pagination .nav-links > *,
+			.post-navigation .meta-nav,
+			.primary-navigation,
+			.screen-reader-text:focus,
+			.site-branding,
+			.site-footer > .footer-navigation .footer-menu,
+			.site-footer > .site-info,
+			.social-navigation a,
+			.social-navigation a:active,
+			.woo-navigation,
+			.wp-block-code,
+			.wp-block-code pre,
+			.wp-block-pullquote,
+			.wp-block-search .wp-block-search__input,
+			.wp-block-search .wp-block-search__input:focus,
+			.wp-block-latest-posts .wp-block-latest-posts__post-author,
+			.wp-block-latest-posts .wp-block-latest-posts__post-date,
+			body,
+			input[type="color"],
+			input[type="color"]:focus,
+			input[type="date"],
+			input[type="date"]:focus,
+			input[type="datetime"],
+			input[type="datetime"]:focus,
+			input[type="datetime-local"],
+			input[type="datetime-local"]:focus,
+			input[type="email"],
+			input[type="email"]:focus,
+			input[type="month"],
+			input[type="month"]:focus,
+			input[type="number"],
+			input[type="number"]:focus,
+			input[type="password"],
+			input[type="password"]:focus,
+			input[type="range"],
+			input[type="range"]:focus,
+			input[type="search"],
+			input[type="search"]:focus,
+			input[type="tel"],
+			input[type="tel"]:focus,
+			input[type="text"],
+			input[type="text"]:focus,
+			input[type="time"],
+			input[type="time"]:focus,
+			input[type="url"],
+			input[type="url"]:focus,
+			input[type="week"],
+			input[type="week"]:focus,
+			textarea,
+			textarea:focus', 'color' ),
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .wp-block-cover,
-			#editor .editor-styles-wrapper .wp-block-cover-image', 'background-color' ),
+	array( '.wp-block-pullquote.is-style-solid-color,
+			.wp-block-cover-image.has-background-dim,
+			.wp-block-cover.has-background-dim', 'background-color' ),
+
+	// Border-bottom-color
+	array( '.pagination .nav-links > *.current', 'border-bottom-color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
-	// Text-color
-	array( '#editor .editor-styles-wrapper .has-background-background-color[class],
-			#editor .editor-styles-wrapper .has-background-dark-background-color[class],
-			#editor .editor-styles-wrapper .has-background-light-background-color[class],
-			#editor .editor-styles-wrapper .has-foreground-color[class],
-			#editor .editor-styles-wrapper .has-background-background-color[class] a', 'color' ),
+	// Foreground
+	array( '.has-foreground-color[class],
+			.has-background-background-color[class],
+			.has-background-dark-background-color[class],
+			.has-background-light-background-color[class]', 'color' ),
 
-	// Background-color
-	array( '#editor .editor-styles-wrapper .has-foreground-background-color[class]', 'background-color' ),
+	// Background
+	array( '.has-foreground-background-color[class]', 'background-color' ),
 
 	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .has-foreground-dark-color[class]', 'color', '-1' ),
+	array( '.has-foreground-dark-color[class]', 'color', '-1' ),
 
 	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .has-foreground-dark-background-color[class]', 'background-color', '-1' ),
+	array( '.has-foreground-dark-background-color[class]', 'background-color', '-1' ),
 
 	// Text-color brightened
-	array( '#editor .editor-styles-wrapper .has-foreground-light-color[class]', 'color', '+2' ),
+	array( '.has-foreground-light-color[class]', 'color', '+2' ),
 
 	// Background-color brightened
-	array( '#editor .editor-styles-wrapper .has-foreground-light-background-color[class]', 'background-color', '+2' ),
+	array( '.has-foreground-light-background-color[class]', 'background-color', '+2' ),
 
-), __( 'Text Color' ) );
+), __( 'Foreground Color' ) );
 
 // Primary Color
 // --global--color-primary
 add_color_rule( 'link', '#000000', array(
 
-	// Background-color
-	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:active,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:active', 'background-color' ),
-
 	// Text-color
-	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__textlink,
-			#editor .editor-styles-wrapper a,
-			#editor .editor-styles-wrapper a:active', 'color' ),
+	array( '.entry-title,
+			.navigation a,
+			.navigation a:active,
+			.primary-navigation .menu-item > a,
+			.primary-navigation .menu-item > a:active,
+			.primary-navigation > .button,
+			.site-footer > .site-info a:focus,
+			.site-footer > .site-info a:hover,
+			.site-title,
+			.woo-navigation .menu-item > a,
+			.woo-navigation .menu-item > a:active,
+			.woo-navigation > .button,
+			.wp-block-a8c-blog-posts article .entry-title a,
+			.wp-block-a8c-blog-posts article .entry-title a:active,
+			.wp-block-newspack-blocks-homepage-articles article .entry-title a,
+			.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
+			a,
+			a:active', 'color' ),
+
+	// Background-color
+	array( '.a8c-posts-list-item__featured span,
+			.a8c-posts-list__view-all:active,
+			.button:active,
+			.wp-block-button__link:active,
+			.wp-block-cover,
+			.wp-block-cover-image,
+			.wp-block-file .wp-block-file__button:active,
+			button:active,
+			input:active[type="submit"]', 'background-color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .has-primary-background-color[class]', 'background-color' ),
+	array( '.has-primary-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .has-primary-color[class],
-			#editor .editor-styles-wrapper .has-black-background-color[class],
-			#editor .editor-styles-wrapper .has-foreground-dark-color[class]', 'color' ),
+	array( '.has-black-background-color[class],
+			.has-primary-color[class]', 'color' ),
 
 ), __( 'Primary Color' ) );
 
@@ -152,50 +243,138 @@ add_color_rule( 'link', '#000000', array(
 add_color_rule( 'fg1', '#3C8067', array(
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a:hover,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active,
-			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover,
-			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline,
-			#editor .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus,
-			#editor .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover,
-			#editor .editor-styles-wrapper a:focus,
-			#editor .editor-styles-wrapper a:hover', 'color' ),
+	array( '.a8c-posts-list__item .a8c-posts-list-item__meta a:active,
+			.a8c-posts-list__item .a8c-posts-list-item__meta a:hover,
+			.comment-meta .comment-metadata a:focus,
+			.comment-meta .comment-metadata a:hover,
+			.entry-footer a:focus,
+			.entry-footer a:hover,
+			.entry-meta a:focus,
+			.entry-meta a:hover,
+			.entry-title a:focus,
+			.entry-title a:hover,
+			.navigation a:focus,
+			.navigation a:hover,
+			.pagination .nav-links > a:hover,
+			.site-footer > .footer-navigation .footer-menu a:focus,
+			.site-footer > .footer-navigation .footer-menu a:hover,
+			.site-title a:focus,
+			.site-title a:hover,
+			.social-navigation a:focus,
+			.social-navigation a:hover,
+			.woo-navigation .menu-item > a:focus,
+			.woo-navigation .menu-item > a:hover,
+			.woo-navigation .primary-menu > .menu-item:hover > a,
+			.woo-navigation > .button:hover,
+			.wp-block-a8c-blog-posts article .cat-links a:active,
+			.wp-block-a8c-blog-posts article .cat-links a:hover,
+			.wp-block-a8c-blog-posts article .entry-meta a:active,
+			.wp-block-a8c-blog-posts article .entry-meta a:hover,
+			.wp-block-a8c-blog-posts article .entry-title a:focus,
+			.wp-block-a8c-blog-posts article .entry-title a:hover,
+			.wp-block-button.is-style-outline .wp-block-button__link,
+			.wp-block-button.is-style-outline .wp-block-button__link:active,
+			.wp-block-button.is-style-outline.wp-block-button__link,
+			.wp-block-button.is-style-outline.wp-block-button__link:active,
+			.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus,
+			.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover,
+			.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+			.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+			.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+			.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+			.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
+			.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+			.primary-navigation .menu-item > a:focus,
+			.primary-navigation .menu-item > a:hover,
+			.primary-navigation .primary-menu > .menu-item:hover > a,
+			.primary-navigation > .button:hover,
+			a:focus,
+			a:hover,
+			.site-footer > .footer-navigation .footer-menu .menu-item a:hover', 'color' ),
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button,
-			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button,
-			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button', 'background-color' ),
+	array( '.a8c-posts-list__view-all,
+			.button,
+			.has-secondary-background-color[class],
+			.reply a,
+			.sticky-post,
+			.wp-block-button__link,
+			.wp-block-file .wp-block-file__button,
+			button,
+			button[data-load-more-btn],
+			input[type="submit"]', 'background-color' ),
 
-	// border-bottom-color
-	array( '#editor .editor-styles-wrapper .wp-block-file .wp-block-file__textlink,
-			#editor .editor-styles-wrapper a', 'border-bottom-color' ),
+	// Border-color
+	array( '.primary-navigation .menu-item > a:hover,
+			.woo-navigation .menu-item > a:hover,
+			.entry-meta a:hover,
+			.entry-footer a:hover,
+			.site-footer > .footer-navigation .footer-menu .menu-item a:hover', 'border-color' ),
 
-	// border-left-color
-	array( '#editor .editor-styles-wrapper .wp-block-quote,
-			#editor .editor-styles-wrapper .wp-block-quote.is-large,
-			#editor .editor-styles-wrapper .wp-block-quote.is-style-large', 'border-left-color' ),
+	// Border-bottom-color
+	array( 'a', 'border-bottom-color' ),
 
-	// border-right-color
-	array( '#editor .editor-styles-wrapper .wp-block-quote.has-text-align-right,
-			#editor .editor-styles-wrapper .wp-block-quote.is-large.has-text-align-right,
-			#editor .editor-styles-wrapper .wp-block-quote.is-style-large.has-text-align-right', 'border-right-color' ),
+	// Border-left-color
+	array( '.wp-block-pullquote.is-style-large,
+			.wp-block-quote', 'border-left-color' ),
+
+	// Border-right-color
+	array( '.wp-block-quote.has-text-align-right', 'border-right-color' ),
+
+	// Outline-color
+	array( '.site :focus', 'outline-color' ),
+
+	// Background-image
+	array( '.site-title a', 'Background-image' ),
+
+	// Text-decoration-color
+	array( '.site-title > a', 'text-decoration-color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Background-color
-	array( '#editor .editor-styles-wrapper .has-secondary-background-color[class]', 'background-color' ),
+	array( '.has-secondary-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .has-secondary-color[class],
-			#editor .editor-styles-wrapper .has-white-background-color[class]', 'color' ),
+	array( '.has-secondary-color[class],
+			.has-white-background-color[class],', 'color' ),
+
+	/**
+	 * Button Hover Colors
+	 */
+
+	// Background Color
+	array( '.a8c-posts-list__view-all:focus,
+			.a8c-posts-list__view-all:hover,
+			.button:focus,
+			.button:hover,
+			.has-focus.a8c-posts-list__view-all,
+			.has-focus.button,
+			.has-focus.wp-block-button__link,
+			.reply a.has-focus,
+			.reply a:focus,
+			.reply a:hover,
+			.wp-block-button__link:focus,
+			.wp-block-button__link:hover,
+			.wp-block-file .has-focus.wp-block-file__button,
+			.wp-block-file .wp-block-file__button:focus,
+			.wp-block-file .wp-block-file__button:hover,
+			button.has-focus,
+			button:focus,
+			button:hover,
+			input.has-focus[type="submit"],
+			input:focus[type="submit"],
+			input:hover[type="submit"]', 'background-color', '-1' ),
+
+	// Text Color
+	array( '.wp-block-button.is-style-outline .wp-block-button__link.has-focus,
+			.wp-block-button.is-style-outline .wp-block-button__link:focus,
+			.wp-block-button.is-style-outline .wp-block-button__link:hover,
+			.wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+			.wp-block-button.is-style-outline.wp-block-button__link:focus,
+			.wp-block-button.is-style-outline.wp-block-button__link:hover', 'color', '-1' ),
 
 ), __( 'Secondary Color' ) );
 
@@ -203,41 +382,93 @@ add_color_rule( 'fg1', '#3C8067', array(
 // --global--color-tertiary
 add_color_rule( 'fg2', '#FAFBF6', array(
 
+	// Text-color
+	array( '.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-image-text,
+			.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-text,
+			.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover__inner-container,
+			.wp-block-cover:not([class*="background-color"]) .wp-block-cover-image-text,
+			.wp-block-cover:not([class*="background-color"]) .wp-block-cover-text,
+			.wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container', 'color' ),
+
+	/**
+	 * Utility Classes
+	 */
+
 	// Background-color
-	array( '#editor .editor-styles-wrapper .has-tertiary-background-color[class]', 'background-color' ),
+	array( '.has-tertiary-background-color[class],
+			.has-background-light-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '#editor .editor-styles-wrapper .has-tertiary-color[class],
-			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .block-editor-block-list__block,
-			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-image-text,
-			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-text,
-			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover__inner-container,
-			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .block-editor-block-list__block,
-			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover-image-text,
-			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover-text,
-			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container', 'color' ),
+	array( '.has-tertiary-color[class],
+			.has-background-light-color[class]', 'color' ),
+
+	/**
+	 * Border Colors
+	 * --global--color-border
+	 */
+
+	// Border-color
+	array( '.comment-meta .comment-author .avatar,
+			.wp-block-code,
+			.wp-block-search .wp-block-search__input,
+			.wp-block-search .wp-block-search__input:focus,
+			input[type="color"],
+			input[type="color"]:focus,
+			input[type="date"],
+			input[type="date"]:focus,
+			input[type="datetime"],
+			input[type="datetime"]:focus,
+			input[type="datetime-local"],
+			input[type="datetime-local"]:focus,
+			input[type="email"],
+			input[type="email"]:focus,
+			input[type="month"],
+			input[type="month"]:focus,
+			input[type="number"],
+			input[type="number"]:focus,
+			input[type="password"],
+			input[type="password"]:focus,
+			input[type="range"],
+			input[type="range"]:focus,
+			input[type="search"],
+			input[type="search"]:focus,
+			input[type="tel"],
+			input[type="tel"]:focus,
+			input[type="text"],
+			input[type="text"]:focus,
+			input[type="time"],
+			input[type="time"]:focus,
+			input[type="url"],
+			input[type="url"]:focus,
+			input[type="week"],
+			input[type="week"]:focus,
+			select,
+			textarea,
+			textarea:focus', 'border-color' ),
+
+	// Border-bottom-color
+	array( '.comment-list > li:not(first-child),
+			hr,
+			hr.wp-block-separator', 'border-bottom-color' ),
+
+	// Border-top-color
+	array( '.comment-list .children > li,
+			.site-main > article > .entry-footer', 'border-top-color' ),
+
+	// Color
+	array( 'hr.wp-block-separator.is-style-dots:before', 'color' ),
 
 ), __( 'Tertiary Color' ) );
 
 /**
- * Custom CSS
+ * Custom CSS.
  * The plugin takes the body of this function and applies it in a style tag in the document head.
  */
 function seedlet_custom_colors_extra_css() {
 	$colors_array = get_theme_mod( 'colors_manager' );
 	$color_bg = $colors_array['colors']['bg'];
-	$color_bg = $colors_array['colors']['txt'];
-	$color_bg = $colors_array['colors']['link'];
 	$color_fg1 = $colors_array['colors']['fg1'];
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
-
-	:root {
-		--global--color-background: <?php echo $colors_array['colors']['bg']; ?>;
-		--global--color-foreground: <?php echo $colors_array['colors']['txt']; ?>;
-		--global--color-primary: <?php echo $colors_array['colors']['link']; ?>;
-		--global--color-secondary: <?php echo $colors_array['colors']['fg1']; ?>;
-		--global--color-tertiary: <?php echo $colors_array['colors']['fg2']; ?>;
-	}
 
 	/*
 	 * Site title text shadow.
@@ -259,39 +490,39 @@ function seedlet_custom_colors_extra_css() {
 	/*
 	 * Custom gradients.
 	*/
-	#editor .editor-styles-wrapper .has-hard-diagonal-gradient-background {
+	.has-hard-diagonal-gradient-background {
 		background: linear-gradient(to bottom right, <?php echo $color_fg1; ?> 49.9%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	#editor .editor-styles-wrapper .has-hard-diagonal-inverted-gradient-background {
+	.has-hard-diagonal-inverted-gradient-background {
 		background: linear-gradient(to top left, <?php echo $color_fg1; ?> 49.9%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	#editor .editor-styles-wrapper .has-diagonal-gradient-background {
+	.has-diagonal-gradient-background {
 		background: linear-gradient(to bottom right, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	#editor .editor-styles-wrapper .has-diagonal-inverted-gradient-background {
+	.has-diagonal-inverted-gradient-background {
 		background: linear-gradient(to top left, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	#editor .editor-styles-wrapper .has-hard-horizontal-gradient-background {
+	.has-hard-horizontal-gradient-background {
 		background: linear-gradient(to bottom, <?php echo $color_fg1; ?> 50%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	#editor .editor-styles-wrapper .has-hard-horizontal-inverted-gradient-background {
+	.has-hard-horizontal-inverted-gradient-background {
 		background: linear-gradient(to top, <?php echo $color_fg1; ?> 50%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	#editor .editor-styles-wrapper .has-horizontal-gradient-background {
+	.has-horizontal-gradient-background {
 		background: linear-gradient(to bottom, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	#editor .editor-styles-wrapper .has-horizontal-inverted-gradient-background {
+	.has-horizontal-inverted-gradient-background {
 		background: linear-gradient(to top, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	#editor .editor-styles-wrapper .has-stripe-gradient-background {
+	.has-stripe-gradient-background {
 		background: linear-gradient(to bottom, transparent 20%, <?php echo $color_fg1; ?> 20%, <?php echo $color_fg1; ?> 80%, transparent 80%);
 	}
 <?php }

--- a/seedlet/inc/wpcom-editor-colors.php
+++ b/seedlet/inc/wpcom-editor-colors.php
@@ -9,232 +9,145 @@
 add_color_rule( 'bg', '#FFFFFF', array(
 
 	// Background-color
-	array( '.primary-navigation > div,
-			.screen-reader-text:focus,
-			.woo-navigation > div,
-			.wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container,
-			body,
-			.primary-navigation > div > ul > li > .sub-menu,
-			.woo-navigation > div > ul > li > .sub-menu', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .wp-block-navigation .wp-block-navigation__container,
+			#editor .editor-styles-wrapper', 'background-color' ),
 
 	// Text-color
-	array( '.a8c-posts-list-item__featured span,
-			.a8c-posts-list__view-all,
-			.a8c-posts-list__view-all:active,
-			.a8c-posts-list__view-all:focus,
-			.a8c-posts-list__view-all:hover,
-			.button,
-			.button:active,
-			.button:focus,
-			.button:hover,
-			.has-focus.a8c-posts-list__view-all,
-			.has-focus.button,
-			.has-focus.wp-block-button__link,
-			.reply a,
-			.reply a.has-focus,
-			.reply a:focus,
-			.reply a:hover,
-			.sticky-post,
-			.wp-block-button__link,
-			.wp-block-button__link:active,
-			.wp-block-button__link:focus,
-			.wp-block-button__link:hover,
-			.wp-block-file .has-focus.wp-block-file__button,
-			.wp-block-file .wp-block-file__button,
-			.wp-block-file .wp-block-file__button:active,
-			.wp-block-file .wp-block-file__button:focus,
-			.wp-block-file .wp-block-file__button:hover,
-			.wp-block-file a.wp-block-file__button:active,
-			.wp-block-file a.wp-block-file__button:focus,
-			.wp-block-file a.wp-block-file__button:hover,
-			.wp-block-file a.wp-block-file__button:visited,
-			.wp-block-pullquote.is-style-solid-color,
-			button,
-			button.has-focus,
-			button:active,
-			button:focus,
-			button:hover,
-			button[data-load-more-btn],
-			input.has-focus[type="submit"],
-			input:active[type="submit"],
-			input:focus[type="submit"],
-			input:hover[type="submit"],
-			input[type="submit"]', 'color' ),
-
-	// Text-shadow
-	array( '.site-title a', 'text-shadow' ),
+	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:active,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:focus,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:hover,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .has-focus.button,
+			#editor .editor-styles-wrapper .wp-block-button__link,
+			#editor .editor-styles-wrapper .wp-block-button__link.has-focus,
+			#editor .editor-styles-wrapper .wp-block-button__link:focus,
+			#editor .editor-styles-wrapper .wp-block-button__link:hover,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button.has-focus,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button:focus,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button:hover,
+			#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color,
+			#editor .editor-styles-wrapper .wp-block-search .has-focus.wp-block-search__button,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:active,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:focus,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:hover', 'color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Text-color
-	array( '.has-primary-background-color[class],
-			.has-secondary-background-color[class],
-			.has-foreground-background-color[class],
-			.has-foreground-dark-background-color[class],
-			.has-foreground-light-background-color[class],
-			.has-background-color[class]', 'color' ),
+	array( '#editor .editor-styles-wrapper .has-primary-background-color,
+			#editor .editor-styles-wrapper .has-secondary-background-color,
+			#editor .editor-styles-wrapper .has-foreground-background-color,
+			#editor .editor-styles-wrapper .has-foreground-dark-background-color,
+			#editor .editor-styles-wrapper .has-foreground-light-background-color,
+			#editor .editor-styles-wrapper .has-background-color,
+			#editor .editor-styles-wrapper .has-background:not(.has-background-background-color) a', 'color' ),
 
 	// Border-bottom-color
-	array( '.has-secondary-background-color[class] a', 'border-bottom-color' ),
+	array( '#editor .editor-styles-wrapper .has-secondary-background-color[class] a', 'border-bottom-color' ),
 
 	// Background-color
-	array( '.has-background-background-color[class]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .has-background-background-color[class]', 'background-color' ),
 
 	// Text-color darkened
-	array( '.has-background-dark-color[class]', 'color', '-1'  ),
+	array( '#editor .editor-styles-wrapper .has-background-dark-color[class]', 'color', '-1'  ),
 
 	// Background-color darkened
-	array( '.has-background-dark-background-color[class]', 'background-color', '-1' ),
+	array( '#editor .editor-styles-wrapper .has-background-dark-background-color[class]', 'background-color', '-1' ),
+
+	// Text-color lightened
+	array( '#editor .editor-styles-wrapper .has-background-light-color[class]', 'color', '+1'  ),
+
+	// Background-color lightened
+	array( '#editor .editor-styles-wrapper .has-background-light-background-color[class]', 'background-color', '+1' ),
 
 ), __( 'Background Color' ) );
 
 // Foreground Color
-// --global--color-background
+// --global--color-foreground-light
 add_color_rule( 'txt', '#444444', array(
 
 	// Text-color
-	array( '.comment-meta .comment-metadata,
-			.entry-footer,
-			.entry-meta,
-			.has-background-background-color[class],
-			.has-background-dark-background-color[class],
-			.has-foreground-color[class],
-			.has-tertiary-background-color[class],
-			.has-tertiary-background-color[class]:not(.has-text-color),
-			.navigation,
-			.pagination .nav-links > *,
-			.post-navigation .meta-nav,
-			.primary-navigation,
-			.screen-reader-text:focus,
-			.site-branding,
-			.site-footer > .footer-navigation .footer-menu,
-			.site-footer > .site-info,
-			.social-navigation a,
-			.social-navigation a:active,
-			.woo-navigation,
-			.wp-block-code,
-			.wp-block-code pre,
-			.wp-block-pullquote,
-			.wp-block-search .wp-block-search__input,
-			.wp-block-search .wp-block-search__input:focus,
-			.wp-block-latest-posts .wp-block-latest-posts__post-author,
-			.wp-block-latest-posts .wp-block-latest-posts__post-date,
-			body,
-			input[type="color"],
-			input[type="color"]:focus,
-			input[type="date"],
-			input[type="date"]:focus,
-			input[type="datetime"],
-			input[type="datetime"]:focus,
-			input[type="datetime-local"],
-			input[type="datetime-local"]:focus,
-			input[type="email"],
-			input[type="email"]:focus,
-			input[type="month"],
-			input[type="month"]:focus,
-			input[type="number"],
-			input[type="number"]:focus,
-			input[type="password"],
-			input[type="password"]:focus,
-			input[type="range"],
-			input[type="range"]:focus,
-			input[type="search"],
-			input[type="search"]:focus,
-			input[type="tel"],
-			input[type="tel"]:focus,
-			input[type="text"],
-			input[type="text"]:focus,
-			input[type="time"],
-			input[type="time"]:focus,
-			input[type="url"],
-			input[type="url"]:focus,
-			input[type="week"],
-			input[type="week"]:focus,
-			textarea,
-			textarea:focus', 'color' ),
+	array( '#editor .editor-styles-wrapper,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta,
+			#editor .editor-styles-wrapper .wp-block-latest-posts .wp-block-latest-posts__post-date,
+			#editor .editor-styles-wrapper .wp-block-pullquote .wp-block-pullquote__citation,
+			#editor .editor-styles-wrapper .wp-block-pullquote cite,
+			#editor .editor-styles-wrapper .wp-block-pullquote footer,
+			#editor .editor-styles-wrapper .wp-block-quote .wp-block-quote__citation,
+			#editor .editor-styles-wrapper .wp-caption,
+			#editor .editor-styles-wrapper .wp-caption-text,
+			#editor .editor-styles-wrapper blockquote cite,
+			#editor .editor-styles-wrapper blockquote footer,
+			#editor .editor-styles-wrapper figcaption,
+			#editor .editor-styles-wrapper .editor-post-title .editor-post-title__input,
+			#editor .editor-styles-wrapper .editor-post-title .editor-post-title__input::placeholder
+			#editor .editor-styles-wrapper .has-tertiary-background-color[class],
+			#editor .editor-styles-wrapper .has-tertiary-background-color[class] a,
+			#editor .editor-styles-wrapper .has-tertiary-background-color[class]:not(.has-text-color)
+			#editor .editor-styles-wrapper .has-tertiary-background-color[class]:not(.has-text-color) a', 'color' ),
 
 	// Background-color
-	array( '.wp-block-pullquote.is-style-solid-color,
-			.wp-block-cover-image.has-background-dim,
-			.wp-block-cover.has-background-dim', 'background-color' ),
-
-	// Border-bottom-color
-	array( '.pagination .nav-links > *.current', 'border-bottom-color' ),
+	array( '#editor .editor-styles-wrapper .wp-block-cover,
+			#editor .editor-styles-wrapper .wp-block-cover-image', 'background-color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
-	// Foreground
-	array( '.has-foreground-color[class],
-			.has-background-background-color[class],
-			.has-background-dark-background-color[class],
-			.has-background-light-background-color[class]', 'color' ),
+	// Text-color
+	array( '#editor .editor-styles-wrapper .has-background-background-color[class],
+			#editor .editor-styles-wrapper .has-background-dark-background-color[class],
+			#editor .editor-styles-wrapper .has-background-light-background-color[class],
+			#editor .editor-styles-wrapper .has-foreground-color[class],
+			#editor .editor-styles-wrapper .has-background-background-color[class] a', 'color' ),
 
-	// Background
-	array( '.has-foreground-background-color[class]', 'background-color' ),
+	// Background-color
+	array( '#editor .editor-styles-wrapper .has-foreground-background-color[class]', 'background-color' ),
 
 	// Text-color darkened
-	array( '.has-foreground-dark-color[class]', 'color', '-1' ),
+	array( '#editor .editor-styles-wrapper .has-foreground-dark-color[class]', 'color', '-1' ),
 
 	// Background-color darkened
-	array( '.has-foreground-dark-background-color[class]', 'background-color', '-1' ),
+	array( '#editor .editor-styles-wrapper .has-foreground-dark-background-color[class]', 'background-color', '-1' ),
 
 	// Text-color brightened
-	array( '.has-foreground-light-color[class]', 'color', '+2' ),
+	array( '#editor .editor-styles-wrapper .has-foreground-light-color[class]', 'color', '+2' ),
 
 	// Background-color brightened
-	array( '.has-foreground-light-background-color[class]', 'background-color', '+2' ),
+	array( '#editor .editor-styles-wrapper .has-foreground-light-background-color[class]', 'background-color', '+2' ),
 
-), __( 'Foreground Color' ) );
+), __( 'Text Color' ) );
 
 // Primary Color
 // --global--color-primary
 add_color_rule( 'link', '#000000', array(
 
-	// Text-color
-	array( '.entry-title,
-			.navigation a,
-			.navigation a:active,
-			.primary-navigation .menu-item > a,
-			.primary-navigation .menu-item > a:active,
-			.primary-navigation > .button,
-			.site-footer > .site-info a:focus,
-			.site-footer > .site-info a:hover,
-			.site-title,
-			.woo-navigation .menu-item > a,
-			.woo-navigation .menu-item > a:active,
-			.woo-navigation > .button,
-			.wp-block-a8c-blog-posts article .entry-title a,
-			.wp-block-a8c-blog-posts article .entry-title a:active,
-			.wp-block-newspack-blocks-homepage-articles article .entry-title a,
-			.wp-block-newspack-blocks-homepage-articles article .entry-title a:active,
-			a,
-			a:active', 'color' ),
-
 	// Background-color
-	array( '.a8c-posts-list-item__featured span,
-			.a8c-posts-list__view-all:active,
-			.button:active,
-			.wp-block-button__link:active,
-			.wp-block-cover,
-			.wp-block-cover-image,
-			.wp-block-file .wp-block-file__button:active,
-			button:active,
-			input:active[type="submit"]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button:active,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button:active', 'background-color' ),
+
+	// Text-color
+	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__textlink,
+			#editor .editor-styles-wrapper a,
+			#editor .editor-styles-wrapper a:active', 'color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Background-color
-	array( '.has-primary-background-color[class]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .has-primary-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '.has-black-background-color[class],
-			.has-primary-color[class]', 'color' ),
+	array( '#editor .editor-styles-wrapper .has-primary-color[class],
+			#editor .editor-styles-wrapper .has-black-background-color[class],
+			#editor .editor-styles-wrapper .has-foreground-dark-color[class]', 'color' ),
 
 ), __( 'Primary Color' ) );
 
@@ -243,138 +156,50 @@ add_color_rule( 'link', '#000000', array(
 add_color_rule( 'fg1', '#3C8067', array(
 
 	// Text-color
-	array( '.a8c-posts-list__item .a8c-posts-list-item__meta a:active,
-			.a8c-posts-list__item .a8c-posts-list-item__meta a:hover,
-			.comment-meta .comment-metadata a:focus,
-			.comment-meta .comment-metadata a:hover,
-			.entry-footer a:focus,
-			.entry-footer a:hover,
-			.entry-meta a:focus,
-			.entry-meta a:hover,
-			.entry-title a:focus,
-			.entry-title a:hover,
-			.navigation a:focus,
-			.navigation a:hover,
-			.pagination .nav-links > a:hover,
-			.site-footer > .footer-navigation .footer-menu a:focus,
-			.site-footer > .footer-navigation .footer-menu a:hover,
-			.site-title a:focus,
-			.site-title a:hover,
-			.social-navigation a:focus,
-			.social-navigation a:hover,
-			.woo-navigation .menu-item > a:focus,
-			.woo-navigation .menu-item > a:hover,
-			.woo-navigation .primary-menu > .menu-item:hover > a,
-			.woo-navigation > .button:hover,
-			.wp-block-a8c-blog-posts article .cat-links a:active,
-			.wp-block-a8c-blog-posts article .cat-links a:hover,
-			.wp-block-a8c-blog-posts article .entry-meta a:active,
-			.wp-block-a8c-blog-posts article .entry-meta a:hover,
-			.wp-block-a8c-blog-posts article .entry-title a:focus,
-			.wp-block-a8c-blog-posts article .entry-title a:hover,
-			.wp-block-button.is-style-outline .wp-block-button__link,
-			.wp-block-button.is-style-outline .wp-block-button__link:active,
-			.wp-block-button.is-style-outline.wp-block-button__link,
-			.wp-block-button.is-style-outline.wp-block-button__link:active,
-			.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus,
-			.wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover,
-			.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
-			.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
-			.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
-			.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
-			.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
-			.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
-			.primary-navigation .menu-item > a:focus,
-			.primary-navigation .menu-item > a:hover,
-			.primary-navigation .primary-menu > .menu-item:hover > a,
-			.primary-navigation > .button:hover,
-			a:focus,
-			a:hover,
-			.site-footer > .footer-navigation .footer-menu .menu-item a:hover', 'color' ),
+	array( '#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:hover,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:active,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-meta a:hover,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a:hover,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:active,
+			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .more-link:hover,
+			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline,
+			#editor .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:focus,
+			#editor .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link > a:hover,
+			#editor .editor-styles-wrapper a:focus,
+			#editor .editor-styles-wrapper a:hover', 'color' ),
 
 	// Background-color
-	array( '.a8c-posts-list__view-all,
-			.button,
-			.has-secondary-background-color[class],
-			.reply a,
-			.sticky-post,
-			.wp-block-button__link,
-			.wp-block-file .wp-block-file__button,
-			button,
-			button[data-load-more-btn],
-			input[type="submit"]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button,
+			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link,
+			#editor .editor-styles-wrapper .wp-block-file .wp-block-file__button,
+			#editor .editor-styles-wrapper .wp-block-search .wp-block-search__button', 'background-color' ),
 
-	// Border-color
-	array( '.primary-navigation .menu-item > a:hover,
-			.woo-navigation .menu-item > a:hover,
-			.entry-meta a:hover,
-			.entry-footer a:hover,
-			.site-footer > .footer-navigation .footer-menu .menu-item a:hover', 'border-color' ),
+	// border-bottom-color
+	array( '#editor .editor-styles-wrapper .wp-block-file .wp-block-file__textlink,
+			#editor .editor-styles-wrapper a', 'border-bottom-color' ),
 
-	// Border-bottom-color
-	array( 'a', 'border-bottom-color' ),
+	// border-left-color
+	array( '#editor .editor-styles-wrapper .wp-block-quote,
+			#editor .editor-styles-wrapper .wp-block-quote.is-large,
+			#editor .editor-styles-wrapper .wp-block-quote.is-style-large', 'border-left-color' ),
 
-	// Border-left-color
-	array( '.wp-block-pullquote.is-style-large,
-			.wp-block-quote', 'border-left-color' ),
-
-	// Border-right-color
-	array( '.wp-block-quote.has-text-align-right', 'border-right-color' ),
-
-	// Outline-color
-	array( '.site :focus', 'outline-color' ),
-
-	// Background-image
-	array( '.site-title a', 'Background-image' ),
-
-	// Text-decoration-color
-	array( '.site-title > a', 'text-decoration-color' ),
+	// border-right-color
+	array( '#editor .editor-styles-wrapper .wp-block-quote.has-text-align-right,
+			#editor .editor-styles-wrapper .wp-block-quote.is-large.has-text-align-right,
+			#editor .editor-styles-wrapper .wp-block-quote.is-style-large.has-text-align-right', 'border-right-color' ),
 
 	/**
 	 * Utility Classes
 	 */
 
 	// Background-color
-	array( '.has-secondary-background-color[class]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .has-secondary-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '.has-secondary-color[class],
-			.has-white-background-color[class],', 'color' ),
-
-	/**
-	 * Button Hover Colors
-	 */
-
-	// Background Color
-	array( '.a8c-posts-list__view-all:focus,
-			.a8c-posts-list__view-all:hover,
-			.button:focus,
-			.button:hover,
-			.has-focus.a8c-posts-list__view-all,
-			.has-focus.button,
-			.has-focus.wp-block-button__link,
-			.reply a.has-focus,
-			.reply a:focus,
-			.reply a:hover,
-			.wp-block-button__link:focus,
-			.wp-block-button__link:hover,
-			.wp-block-file .has-focus.wp-block-file__button,
-			.wp-block-file .wp-block-file__button:focus,
-			.wp-block-file .wp-block-file__button:hover,
-			button.has-focus,
-			button:focus,
-			button:hover,
-			input.has-focus[type="submit"],
-			input:focus[type="submit"],
-			input:hover[type="submit"]', 'background-color', '-1' ),
-
-	// Text Color
-	array( '.wp-block-button.is-style-outline .wp-block-button__link.has-focus,
-			.wp-block-button.is-style-outline .wp-block-button__link:focus,
-			.wp-block-button.is-style-outline .wp-block-button__link:hover,
-			.wp-block-button.is-style-outline.wp-block-button__link.has-focus,
-			.wp-block-button.is-style-outline.wp-block-button__link:focus,
-			.wp-block-button.is-style-outline.wp-block-button__link:hover', 'color', '-1' ),
+	array( '#editor .editor-styles-wrapper .has-secondary-color[class],
+			#editor .editor-styles-wrapper .has-white-background-color[class]', 'color' ),
 
 ), __( 'Secondary Color' ) );
 
@@ -382,86 +207,24 @@ add_color_rule( 'fg1', '#3C8067', array(
 // --global--color-tertiary
 add_color_rule( 'fg2', '#FAFBF6', array(
 
-	// Text-color
-	array( '.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-image-text,
-			.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-text,
-			.wp-block-cover-image:not([class*="background-color"]) .wp-block-cover__inner-container,
-			.wp-block-cover:not([class*="background-color"]) .wp-block-cover-image-text,
-			.wp-block-cover:not([class*="background-color"]) .wp-block-cover-text,
-			.wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container', 'color' ),
-
-	/**
-	 * Utility Classes
-	 */
-
 	// Background-color
-	array( '.has-tertiary-background-color[class],
-			.has-background-light-background-color[class]', 'background-color' ),
+	array( '#editor .editor-styles-wrapper .has-tertiary-background-color[class]', 'background-color' ),
 
 	// Text-color
-	array( '.has-tertiary-color[class],
-			.has-background-light-color[class]', 'color' ),
-
-	/**
-	 * Border Colors
-	 * --global--color-border
-	 */
-
-	// Border-color
-	array( '.comment-meta .comment-author .avatar,
-			.wp-block-code,
-			.wp-block-search .wp-block-search__input,
-			.wp-block-search .wp-block-search__input:focus,
-			input[type="color"],
-			input[type="color"]:focus,
-			input[type="date"],
-			input[type="date"]:focus,
-			input[type="datetime"],
-			input[type="datetime"]:focus,
-			input[type="datetime-local"],
-			input[type="datetime-local"]:focus,
-			input[type="email"],
-			input[type="email"]:focus,
-			input[type="month"],
-			input[type="month"]:focus,
-			input[type="number"],
-			input[type="number"]:focus,
-			input[type="password"],
-			input[type="password"]:focus,
-			input[type="range"],
-			input[type="range"]:focus,
-			input[type="search"],
-			input[type="search"]:focus,
-			input[type="tel"],
-			input[type="tel"]:focus,
-			input[type="text"],
-			input[type="text"]:focus,
-			input[type="time"],
-			input[type="time"]:focus,
-			input[type="url"],
-			input[type="url"]:focus,
-			input[type="week"],
-			input[type="week"]:focus,
-			select,
-			textarea,
-			textarea:focus', 'border-color' ),
-
-	// Border-bottom-color
-	array( '.comment-list > li:not(first-child),
-			hr,
-			hr.wp-block-separator', 'border-bottom-color' ),
-
-	// Border-top-color
-	array( '.comment-list .children > li,
-			.site-main > article > .entry-footer', 'border-top-color' ),
-
-	// Color
-	array( 'hr.wp-block-separator.is-style-dots:before', 'color' ),
+	array( '#editor .editor-styles-wrapper .has-tertiary-color[class],
+			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .block-editor-block-list__block,
+			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-image-text,
+			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover-text,
+			#editor .editor-styles-wrapper .wp-block-cover-image:not([class*="background-color"]) .wp-block-cover__inner-container,
+			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .block-editor-block-list__block,
+			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover-image-text,
+			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover-text,
+			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .wp-block-cover__inner-container', 'color' ),
 
 ), __( 'Tertiary Color' ) );
 
 /**
- * Custom CSS.
+ * Custom CSS
  * The plugin takes the body of this function and applies it in a style tag in the document head.
  */
 function seedlet_custom_colors_extra_css() {
@@ -471,58 +234,41 @@ function seedlet_custom_colors_extra_css() {
 	$color_fg2 = $colors_array['colors']['fg2']; ?>
 
 	/*
-	 * Site title text shadow.
-	*/
-	.site-title a {
-		background-image: linear-gradient(to right, <?php echo $color_fg1; ?> 100%, transparent 100%);
-		text-shadow: 1px 0px <?php echo $color_bg; ?>,
-					 -1px 0px <?php echo $color_bg; ?>,
-					 -2px 0px <?php echo $color_bg; ?>,
-					 2px 0px <?php echo $color_bg; ?>,
-					 -3px 0px <?php echo $color_bg; ?>,
-					 3px 0px <?php echo $color_bg; ?>,
-					 -4px 0px <?php echo $color_bg; ?>,
-					 4px 0px <?php echo $color_bg; ?>,
-					 -5px 0px <?php echo $color_bg; ?>,
-					 5px 0px <?php echo $color_bg; ?>;
-	}
-
-	/*
 	 * Custom gradients.
 	*/
-	.has-hard-diagonal-gradient-background {
+	#editor .editor-styles-wrapper .has-hard-diagonal-gradient-background {
 		background: linear-gradient(to bottom right, <?php echo $color_fg1; ?> 49.9%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	.has-hard-diagonal-inverted-gradient-background {
+	#editor .editor-styles-wrapper .has-hard-diagonal-inverted-gradient-background {
 		background: linear-gradient(to top left, <?php echo $color_fg1; ?> 49.9%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	.has-diagonal-gradient-background {
+	#editor .editor-styles-wrapper .has-diagonal-gradient-background {
 		background: linear-gradient(to bottom right, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	.has-diagonal-inverted-gradient-background {
+	#editor .editor-styles-wrapper .has-diagonal-inverted-gradient-background {
 		background: linear-gradient(to top left, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	.has-hard-horizontal-gradient-background {
+	#editor .editor-styles-wrapper .has-hard-horizontal-gradient-background {
 		background: linear-gradient(to bottom, <?php echo $color_fg1; ?> 50%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	.has-hard-horizontal-inverted-gradient-background {
+	#editor .editor-styles-wrapper .has-hard-horizontal-inverted-gradient-background {
 		background: linear-gradient(to top, <?php echo $color_fg1; ?> 50%, <?php echo $color_fg2; ?> 50%);
 	}
 
-	.has-horizontal-gradient-background {
+	#editor .editor-styles-wrapper .has-horizontal-gradient-background {
 		background: linear-gradient(to bottom, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	.has-horizontal-inverted-gradient-background {
+	#editor .editor-styles-wrapper .has-horizontal-inverted-gradient-background {
 		background: linear-gradient(to top, <?php echo $color_fg1; ?>, <?php echo $color_fg2; ?>);
 	}
 
-	.has-stripe-gradient-background {
+	#editor .editor-styles-wrapper .has-stripe-gradient-background {
 		background: linear-gradient(to bottom, transparent 20%, <?php echo $color_fg1; ?> 20%, <?php echo $color_fg1; ?> 80%, transparent 80%);
 	}
 <?php }

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -29,13 +29,13 @@ GNU General Public License for more details.
 Seedlet is derived from Twenty Nineteen. 2018-2020 WordPress.org
 Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Seedlet is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
+Seedlet is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Unless otherwise noted, the icons in this theme are derived from the 
+Unless otherwise noted, the icons in this theme are derived from the
 WordPress Icons Library, licensed under the terms of the GNU GPL v2 or later.
 https://github.com/WordPress/gutenberg/tree/master/packages/icons
 
@@ -55,7 +55,7 @@ Included as part of the following classes and functions:
 
 Color Contrast Validation
 Copyright (C) 2016 Per Soderlind
-License: GNU General Public License v3 
+License: GNU General Public License v3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Source: https://github.com/soderlind/2016-customizer-demo
 Included as part of the following classes and functions:
@@ -2399,7 +2399,7 @@ table th,
 
 /* Block Alignments */
 /**
- * These selectors set the default max width for content appearing inside a post or page. 
+ * These selectors set the default max width for content appearing inside a post or page.
  */
 /**
  * .alignleft
@@ -2778,8 +2778,8 @@ table th,
 	padding-left: var(--global--spacing-vertical) !important;
 }
 
-/* 
- * Custom gradients 
+/*
+ * Custom gradients
 */
 .has-hard-diagonal-gradient-background {
 	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);


### PR DESCRIPTION
I noticed an issue in Seedlet in the dark color scheme:

In the dark color scheme some of the contrast isn't very strong:
<img width="788" alt="Screenshot 2020-09-25 at 18 17 51" src="https://user-images.githubusercontent.com/275961/94297624-b65f6280-ff5c-11ea-81e4-3126d0a74f7f.png">
<img width="939" alt="Screenshot 2020-09-25 at 18 17 45" src="https://user-images.githubusercontent.com/275961/94297627-b8292600-ff5c-11ea-95ef-5fa935723adc.png">

Rather than creating more selectors to deal with this, this PR proposes that we just update the CSS variables for this color scheme.

To test, apply this patch to your wpcom sandbox, set the site to Seedlet and then open the customizer.

When you switch to the dark color, you should see text with higher contrast, like this:

<img width="935" alt="Screenshot 2020-09-25 at 18 29 16" src="https://user-images.githubusercontent.com/275961/94297820-0a6a4700-ff5d-11ea-91f3-d678af6a8f72.png">
<img width="632" alt="Screenshot 2020-09-25 at 18 29 07" src="https://user-images.githubusercontent.com/275961/94297832-0f2efb00-ff5d-11ea-85c0-a1e6cf55561a.png">

Also check that this looks the same when you edit the homepage.
