### PR TITLE
Gazette: changed height to post-thumbnail

### DIFF
--- a/gazette/style.css
+++ b/gazette/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/gazette/
 Author: Automattic
 Author URI: https://wordpress.com/themes/
 Description: A clean and flexible theme perfectly suited for minimalist magazine-style sites, personal blogs, or any content-rich site. It allows you to highlight specific articles on the homepage, and to balance readability with a powerful use of photography — all in a layout that works on any device.
-Version: 1.1.3-wpcom
+Version: 1.1.4-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: gazette

--- a/gazette/style.css
+++ b/gazette/style.css
@@ -2065,7 +2065,7 @@ a:visited {
 .post-thumbnail {
 	background: #000;
 	display: block;
-	height: 100%;
+	height: auto;
 	position: relative;
 	width: 100%;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Changed height of post thumbnail to auto, since the width is already 100%, I don't see a reason why the height should be 100%

#### Screenshots:

<img width="840" alt="Screenshot 2020-09-29 at 12 27 53" src="https://user-images.githubusercontent.com/3593343/94547200-3fbdb000-024f-11eb-89cf-1ab9d724cc4a.png">

#### Related issue(s):

Closes #2504 