### PR TITLE
fix for mobile scroll on alignfull galleries

### DIFF
--- a/seedlet/assets/css/ie.css
+++ b/seedlet/assets/css/ie.css
@@ -2406,7 +2406,7 @@ object {
 	padding: 12px 13px;
 }
 
-.wp-block-gallery {
+.wp-block-gallery:not(.alignfull) {
 	margin: 0 auto;
 }
 

--- a/seedlet/assets/sass/blocks/gallery/_style.scss
+++ b/seedlet/assets/sass/blocks/gallery/_style.scss
@@ -1,6 +1,8 @@
 .wp-block-gallery {
 
-	margin: 0 auto;
+	&:not(.alignfull) {
+		margin: 0 auto;
+	}
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1516,7 +1516,7 @@ object {
 	padding: calc(0.5 * var(--button--padding-vertical)) calc(0.5 * var(--button--padding-horizontal));
 }
 
-.wp-block-gallery {
+.wp-block-gallery:not(.alignfull) {
 	margin: 0 auto;
 }
 

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -29,13 +29,13 @@ GNU General Public License for more details.
 Seedlet is derived from Twenty Nineteen. 2018-2020 WordPress.org
 Twenty Nineteen is distributed under the terms of the GNU GPL v2 or later.
 
-Seedlet is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc.
+Seedlet is also based on Underscores https://underscores.me/, (C) 2012-2018 Automattic, Inc. 
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
-Unless otherwise noted, the icons in this theme are derived from the
+Unless otherwise noted, the icons in this theme are derived from the 
 WordPress Icons Library, licensed under the terms of the GNU GPL v2 or later.
 https://github.com/WordPress/gutenberg/tree/master/packages/icons
 
@@ -55,7 +55,7 @@ Included as part of the following classes and functions:
 
 Color Contrast Validation
 Copyright (C) 2016 Per Soderlind
-License: GNU General Public License v3
+License: GNU General Public License v3 
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Source: https://github.com/soderlind/2016-customizer-demo
 Included as part of the following classes and functions:
@@ -1524,7 +1524,7 @@ object {
 	padding: calc(0.5 * var(--button--padding-vertical)) calc(0.5 * var(--button--padding-horizontal));
 }
 
-.wp-block-gallery {
+.wp-block-gallery:not(.alignfull) {
 	margin: 0 auto;
 }
 
@@ -2401,7 +2401,7 @@ table th,
 
 /* Block Alignments */
 /**
- * These selectors set the default max width for content appearing inside a post or page.
+ * These selectors set the default max width for content appearing inside a post or page. 
  */
 /**
  * .alignleft
@@ -2780,8 +2780,8 @@ table th,
 	padding-left: var(--global--spacing-vertical) !important;
 }
 
-/*
- * Custom gradients
+/* 
+ * Custom gradients 
 */
 .has-hard-diagonal-gradient-background {
 	background: linear-gradient(to bottom right, var(--global--color-secondary) 49.9%, var(--global--color-tertiary) 50%);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The margin value for galleries was affecting the responsive style for full width galleries and causing a scroll. I omitted the margin in the case where the gallery is full width so that the `.alignfull` rules will apply to them.

#### To test:

Create a full width gallery and check that you can't scroll horizontally on mobile. The gallery should be full width.

#### Related issue(s):

Closes #2471 