### PR TITLE
Update the primary-nav--padding to use a px variable so that the types match

### DIFF
--- a/spearhead/variables.css
+++ b/spearhead/variables.css
@@ -39,7 +39,7 @@
 	--heading--line-height-h1: 1.2;
 	--heading--line-height-h2: 1.4;
 	--heading--line-height-h3: 1.4;
-	
+
 	--entry-header--font-size: var(--heading--font-size-h1);
 	--entry-header--color: var(--global--color-foreground);
 
@@ -57,7 +57,7 @@
 
 	--primary-nav--justify-content: space-between;
 	--primary-nav--color-link: var(--global--color-secondary);
-	--primary-nav--padding: 0;
+	--primary-nav--padding: 0px;
 	--primary-nav--font-family-mobile: var(--global--font-family-secondary);
 	--primary-nav--font-size-mobile: var(--global--font-size-sm);
 


### PR DESCRIPTION
Without this the sub menus don't align correctly


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
