### PR TITLE
Add sourcemaps to Spearhead

### DIFF
--- a/spearhead/package.json
+++ b/spearhead/package.json
@@ -2,7 +2,6 @@
   "name": "spearhead",
   "version": "1.0.0",
   "description": "a podcast theme",
-  "main": "index.js",
   "keywords": [
     "gutenberg",
     "blocks",
@@ -20,7 +19,7 @@
   },
   "scripts": {
     "start": "npm run watch",
-    "build:style": "node-sass assets/sass/style.scss style.css --output-style expanded --indent-type tab --indent-width 1",
+    "build:style": "node-sass assets/sass/style.scss style.css --output-style expanded --indent-type tab --indent-width 1  --source-map true",
     "build:rtl": "rtlcss style.css style-rtl.css",
     "build": "run-s \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"


### PR DESCRIPTION
In the same way that we added source maps to Seedlet, we should add them to Spearhead.