### PR TITLE
Stratford: homepage headings in RTL do not align to the right

### DIFF
--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1567,6 +1567,7 @@ button[data-load-more-btn], .button {
 	padding: 0;
 }
 
+.wp-block-group h2.has-text-align-left,
 .wp-block-cover h2.has-text-align-left,
 .wp-block-cover-image h2.has-text-align-left {
 	text-align: right;


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Some of the headings on the stratford homepage do no align right in an RTL locale. This commit ensures that all headings within a block group are right-aligned.


**Before**

![image](https://user-images.githubusercontent.com/6458278/95142595-c3cbe680-07bf-11eb-82ac-ca070e02442e.png)


**After**

![image](https://user-images.githubusercontent.com/6458278/95142600-caf2f480-07bf-11eb-85fe-c653dc85ece9.png)


### Testing

Apply D49467-code patch:

In the site options, change the language to `he` or `ar` (or any RTL language)

Open https://stratforddemo.wordpress.com/

Check that the headings are right aligned. (The content won't be translated of course :) )

## Related issue(s):

First reported p58i-9ow-p2#comment-47478

