### PR TITLE
#2538: Spearhead: Dark mode contrast

### DIFF
--- a/spearhead/variables.css
+++ b/spearhead/variables.css
@@ -41,7 +41,7 @@
 	--heading--line-height-h3: 1.4;
 
 	--entry-header--font-size: var(--heading--font-size-h1);
-	--entry-header--color: var(--global--color-foreground);
+	--entry-header--color: var(--global--color-foreground-light);
 
 	--button--border-radius: 0px;
 	--button--color-text: var(--global--color-background);
@@ -75,13 +75,13 @@
 
 @media ( prefers-color-scheme: dark ) {
 	:root {
-		--global--color-primary: #DB0042;
+		--global--color-primary: #f00048;
 		--global--color-primary-hover: #ffffff;
 		--global--color-secondary: #c0c0c0;
 		--global--color-secondary-hover: #cccccc;
-		--global--color-foreground: #f0f0f0;
+		--global--color-foreground: #b2b2b2;
 		--global--color-foreground-light: #ffffff;
-		--global--color-background: #333333;
+		--global--color-background: #080b11;
 		--global--color-text-selection: #000000;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Update dark mode colors with the following values to improve contrast _(for accessibility reasons)_:

`#080b11` for background
`#b2b2b2` for the foreground _(body text)_
`#f00048` for the accent color

As proposed [here](https://github.com/Automattic/themes/issues/2538#issuecomment-703129124)

Furthermore, updated entry header color to white: `--global--color-foreground-light`

#### Here's a before-after comparison:

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![before_spearhead_contrast](https://user-images.githubusercontent.com/29238672/95466350-e44f9880-0999-11eb-9d10-849dfc46e143.png) | ![after_spearhead_contrast](https://user-images.githubusercontent.com/29238672/95466388-ec0f3d00-0999-11eb-98c8-54eb872a5cd3.png) |

#### Related issue(s):

#2538 