### PR TITLE
Spearhead: fix unregister block pattern bug

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -5,7 +5,7 @@
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
  * @package WordPress
- * @subpackage Sk8prk
+ * @subpackage Spearhead
  * @since 1.0.0
  */
 

--- a/spearhead/inc/block-patterns.php
+++ b/spearhead/inc/block-patterns.php
@@ -11,8 +11,6 @@
  */
 if ( function_exists( 'register_block_pattern_category' ) ) {
 
-	unregister_block_pattern_category( 'seedlet' );
-
 	register_block_pattern_category(
 		'spearhead',
 		array( 'label' => __( 'Spearhead', 'spearhead' ) )
@@ -23,10 +21,6 @@ if ( function_exists( 'register_block_pattern_category' ) ) {
  * Register Block Patterns.
  */
 if ( function_exists( 'register_block_pattern' ) ) {
-
-	unregister_block_pattern( 'seedlet/group-split-background' );
-	unregister_block_pattern( 'seedlet/group-image-overlap' );
-	unregister_block_pattern( 'seedlet/latest-posts-alternating-grid' );
 
 	register_block_pattern(
 		'spearhead/related-posts',

--- a/spearhead/inc/block-patterns.php
+++ b/spearhead/inc/block-patterns.php
@@ -6,28 +6,52 @@
  * @since   1.0.0
  */
 
-/**
- * Register Block Pattern Category.
- */
-if ( function_exists( 'register_block_pattern_category' ) ) {
+if ( ! function_exists( 'spearhead_register_block_patterns' ) ) :
+	/**
+	 * Sets up support for block patterns and unregisters Seedlet's.
+	 */
+	function spearhead_register_block_patterns() {
+		/**
+		 * Register Block Pattern Category.
+		 */
+		if ( function_exists( 'register_block_pattern_category' ) ) {
 
-	register_block_pattern_category(
-		'spearhead',
-		array( 'label' => __( 'Spearhead', 'spearhead' ) )
-	);
-}
+			register_block_pattern_category(
+				'spearhead',
+				array( 'label' => __( 'Spearhead', 'spearhead' ) )
+			);
+		}
 
-/**
- * Register Block Patterns.
- */
-if ( function_exists( 'register_block_pattern' ) ) {
+		/**
+		 * Register Block Patterns.
+		 */
+		if ( function_exists( 'register_block_pattern' ) ) {
 
-	register_block_pattern(
-		'spearhead/related-posts',
-		array(
-			'title'      => __( 'Related Posts', 'spearhead' ),
-			'categories' => array( 'spearhead' ),
-			'content'    => '<!-- wp:separator {"className":"is-style-wide"} --><hr class="wp-block-separator is-style-wide"/><!-- /wp:separator --><!-- wp:paragraph {"fontSize":"medium"} --><p class="has-medium-font-size">Related</p><!-- /wp:paragraph --><!-- wp:jetpack/related-posts /-->',
-		)
-	);
-}
+			register_block_pattern(
+				'spearhead/related-posts',
+				array(
+					'title'      => __( 'Related Posts', 'spearhead' ),
+					'categories' => array( 'spearhead' ),
+					'content'    => '<!-- wp:separator {"className":"is-style-wide"} --><hr class="wp-block-separator is-style-wide"/><!-- /wp:separator --><!-- wp:paragraph {"fontSize":"medium"} --><p class="has-medium-font-size">Related</p><!-- /wp:paragraph --><!-- wp:jetpack/related-posts /-->',
+				)
+			);
+		}
+
+		/**
+		 * Unregister SeedletBlock Pattern Category.
+		 */
+		if ( function_exists( 'unregister_block_pattern_category' ) ) {
+			unregister_block_pattern_category( 'seedlet' );
+		}
+
+		/**
+		 * Unregister Block Patterns from Seedlet.
+		 */
+		if ( function_exists( 'unregister_block_pattern' ) ) {
+			unregister_block_pattern( 'seedlet/group-split-background' );
+			unregister_block_pattern( 'seedlet/group-image-overlap' );
+			unregister_block_pattern( 'seedlet/latest-posts-alternating-grid' );
+		}
+	}
+endif;
+add_action( 'after_setup_theme', 'spearhead_register_block_patterns', 12 );


### PR DESCRIPTION
This PR addresses the following notice: 

```
Notice: WP_Block_Patterns_Registry::unregister was called incorrectly. 
Pattern "seedlet/latest-posts-alternating-grid" not found. 
Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /Users/maggie/A8c/repos/wp/wp-includes/functions.php on line 5225
```

The unregister calls are not working at the moment and I'm not sure why. Perhaps a child theme cannot unregister a block pattern from its parent theme? This removes them for now.