### PR TITLE
Spearhead + Seedlet: make it possible to remove the previous / next post navigation (#2594)

### DIFF
--- a/seedlet/archive.php
+++ b/seedlet/archive.php
@@ -37,8 +37,8 @@ get_header();
 				// End the loop.
 			endwhile;
 
-			// Previous/next page navigation.
-			seedlet_the_posts_navigation();
+			// Numbered pagination.
+			seedlet_the_posts_pagination();
 
 			// If no content, include the "No posts found" template.
 		else :

--- a/seedlet/inc/template-tags.php
+++ b/seedlet/inc/template-tags.php
@@ -154,15 +154,15 @@ if ( ! function_exists( 'seedlet_post_thumbnail' ) ) :
 		}
 
 		if ( is_singular() ) :
-		?>
+			?>
 
 			<figure class="post-thumbnail">
 				<?php the_post_thumbnail(); ?>
 			</figure><!-- .post-thumbnail -->
 
-		<?php
+			<?php
 		else :
-		?>
+			?>
 
 			<figure class="post-thumbnail">
 				<a class="post-thumbnail-inner alignwide" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
@@ -170,7 +170,7 @@ if ( ! function_exists( 'seedlet_post_thumbnail' ) ) :
 				</a>
 			</figure>
 
-		<?php
+			<?php
 		endif; // End is_singular().
 	}
 endif;
@@ -189,11 +189,40 @@ if ( ! function_exists( 'seedlet_comment_avatar' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'seedlet_the_posts_navigation' ) ) :
+if ( ! function_exists( 'seedlet_the_post_navigation' ) ) :
 	/**
 	 * Documentation for function.
 	 */
-	function seedlet_the_posts_navigation() {
+	function seedlet_the_post_navigation() {
+		if ( is_singular( 'attachment' ) ) {
+			// Parent post navigation.
+			the_post_navigation(
+				array(
+					/* translators: %s: parent post link */
+					'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'seedlet' ), '%title' ),
+				)
+			);
+		} elseif ( is_singular( 'post' ) ) {
+			// Previous/next post navigation.
+			the_post_navigation(
+				array(
+					'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next Post', 'seedlet' ) . '</span> ' .
+						'<span class="screen-reader-text">' . __( 'Next post:', 'seedlet' ) . '</span> <br/>' .
+						'<span class="post-title">%title</span>',
+					'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous Post', 'seedlet' ) . '</span> ' .
+						'<span class="screen-reader-text">' . __( 'Previous post:', 'seedlet' ) . '</span> <br/>' .
+						'<span class="post-title">%title</span>',
+				)
+			);
+		}
+	}
+endif;
+
+if ( ! function_exists( 'seedlet_the_posts_pagination' ) ) :
+	/**
+	 * Documentation for function.
+	 */
+	function seedlet_the_posts_pagination() {
 		the_posts_pagination(
 			array(
 				'mid_size'  => 2,

--- a/seedlet/index.php
+++ b/seedlet/index.php
@@ -28,8 +28,8 @@ get_header();
 				get_template_part( 'template-parts/content/content' );
 			}
 
-			// Previous/next page navigation.
-			seedlet_the_posts_navigation();
+			// Numbered pagination.
+			seedlet_the_posts_pagination();
 
 		} else {
 

--- a/seedlet/search.php
+++ b/seedlet/search.php
@@ -42,8 +42,8 @@ get_header();
 				// End the loop.
 			endwhile;
 
-			// Previous/next page navigation.
-			seedlet_the_posts_navigation();
+			// Numbered pagination.
+			seedlet_the_posts_pagination();
 
 			// If no content, include the "No posts found" template.
 		else :

--- a/seedlet/single.php
+++ b/seedlet/single.php
@@ -21,27 +21,7 @@ get_header();
 
 				get_template_part( 'template-parts/content/content-single' );
 
-				if ( is_singular( 'attachment' ) ) {
-					// Parent post navigation.
-					the_post_navigation(
-						array(
-							/* translators: %s: parent post link */
-							'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'seedlet' ), '%title' ),
-						)
-					);
-				} elseif ( is_singular( 'post' ) ) {
-					// Previous/next post navigation.
-					the_post_navigation(
-						array(
-							'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next Post', 'seedlet' ) . '</span> ' .
-								'<span class="screen-reader-text">' . __( 'Next post:', 'seedlet' ) . '</span> <br/>' .
-								'<span class="post-title">%title</span>',
-							'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous Post', 'seedlet' ) . '</span> ' .
-								'<span class="screen-reader-text">' . __( 'Previous post:', 'seedlet' ) . '</span> <br/>' .
-								'<span class="post-title">%title</span>',
-						)
-					);
-				}
+				seedlet_the_post_navigation();
 
 				// If comments are open or we have at least one comment, load up the comment template.
 				if ( comments_open() || get_comments_number() ) {

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -226,7 +226,6 @@ function spearhead_excerpt_more() {
 	return '…';
 }
 
-
 function spearhead_the_excerpt( $excerpt ) {
 	// For cases where the post excerpt is empty
 	// (but the post might have content)
@@ -236,6 +235,15 @@ function spearhead_the_excerpt( $excerpt ) {
 
 	return $excerpt . '<span class="excerpt-more-link">' . spearhead_more_link() . '</span>';
 }
+
+/**
+ * Overwrite Seedlet's post navigation template tag.
+ */
+if ( ! function_exists( 'seedlet_the_post_navigation' ) ) :
+	function seedlet_the_post_navigation() {
+		return null;
+	}
+endif;
 
 // Filter the excerpt more link
 add_filter( 'excerpt_more', 'spearhead_excerpt_more' );


### PR DESCRIPTION
This PR addresses #2594. 

Previously in Seedlet, the post navigation was hardcoded into the template. This PR makes the following changes: 

- Refactors Seedlet's post navigation into a template tag so it can be overwritten in a child theme.
- Overwrites the template tag in Spearhead (disabling previous / next links). 
- Rename's Seedlet's post _pagination_ template tag function to be consistent with the actual WP function it calls, and updates its use respectively in the templates

Test
- Go to a post in Spearhead and confirm the Previous/Next links are gone.
- Go to a post and category / archive page in Seedlet and confirm the pagination and navigation work as they did before.