### PR TITLE
Seedlet: add a script to package for dotorg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ theme-dev-utils/
 theme-dev-utils
 vendor/
 *.DS_Store
-
+seedlet.zip

--- a/seedlet/dotorg-exclude.txt
+++ b/seedlet/dotorg-exclude.txt
@@ -1,0 +1,12 @@
+seedlet/
+seedlet.zip
+dotorg-exclude.txt
+inc/headstart
+node_modules
+.git
+*.DS_Store
+*.sh
+*.json
+*.map
+*wpcom*
+postcss.config.js

--- a/seedlet/package-dotorg.sh
+++ b/seedlet/package-dotorg.sh
@@ -3,7 +3,7 @@ find assets/sass/*.scss -type f -exec sed -i '' 's/-wpcom//g' {} \;
 find assets/sass/*.scss -type f -exec sed -i '' 's/auto-loading-homepage, //g' {} \; 
 npm run build;
 mkdir seedlet;
-rsync -rv --exclude="seedlet.zip" --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.map" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
+rsync -avz --exclude-from 'dotorg-exclude.txt' ./ seedlet
+find seedlet -type f -name '*.map' -delete # for some reason rsync won't exclude map files
 zip -r -X seedlet.zip seedlet
 rm -rf seedlet
-git restore ./

--- a/seedlet/package-dotorg.sh
+++ b/seedlet/package-dotorg.sh
@@ -2,7 +2,7 @@
 find assets/sass/*.scss -type f -exec sed -i '' 's/-wpcom//g' {} \; 
 npm run build;
 mkdir seedlet;
-rsync -rv --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
+rsync -rv --exclude="seedlet.zip" --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
 zip -r -X seedlet.zip seedlet
 rm -rf seedlet
 git restore ./

--- a/seedlet/package-dotorg.sh
+++ b/seedlet/package-dotorg.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+find assets/sass/*.scss -type f -exec sed -i '' 's/-wpcom//g' {} \; 
+npm run build;
+mkdir seedlet;
+rsync -rv --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
+zip -r -X seedlet.zip seedlet
+rm -rf seedlet

--- a/seedlet/package-dotorg.sh
+++ b/seedlet/package-dotorg.sh
@@ -5,3 +5,4 @@ mkdir seedlet;
 rsync -rv --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
 zip -r -X seedlet.zip seedlet
 rm -rf seedlet
+git restore ./

--- a/seedlet/package-dotorg.sh
+++ b/seedlet/package-dotorg.sh
@@ -1,8 +1,9 @@
 #!/bin/zsh
 find assets/sass/*.scss -type f -exec sed -i '' 's/-wpcom//g' {} \; 
+find assets/sass/*.scss -type f -exec sed -i '' 's/auto-loading-homepage, //g' {} \; 
 npm run build;
 mkdir seedlet;
-rsync -rv --exclude="seedlet.zip" --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
+rsync -rv --exclude="seedlet.zip" --exclude="seedlet" --exclude=".git" --exclude=".DS_Store" --exclude="*.sh" --exclude="*.map" --exclude="*.json" --exclude="postcss.config.js" --exclude="node_modules" --exclude="*wpcom*" --exclude="inc/headstart" ./ seedlet
 zip -r -X seedlet.zip seedlet
 rm -rf seedlet
 git restore ./


### PR DESCRIPTION
This PR adds a shell script that creates a zip processes and packages the theme so that it is ready for submission to the dotorg themes directory. 

To test
- `cd seedlet` and `./package-dotorg.sh`
- Verify that it generates a zip of the theme that does not include wpcom-specific files and features