### PR TITLE
Dyad 2: fixed menu to work with marketing bar

### DIFF
--- a/dyad-2/style.css
+++ b/dyad-2/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wordpress.com/themes/dyad-2/
 Author: Automattic
 Author URI: http://wordpress.com/themes
 Description: Dyad pairs your written content and images together in perfect balance. The theme is geared towards photographers, foodies, artists, and anyone who is looking for a strong photographic presence on their website.
-Version: 2.0.8-wpcom
+Version: 2.0.9-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: art, artwork, blog, blue, classic-menu, custom-colors, custom-header, custom-menu, dark, design, editor-style, featured-images, food, grid-layout, infinite-scroll, photoblogging, photography, post-slider, responsive-layout, rtl-language-support, site-logo, social-menu, sticky-post, threaded-comments, translation-ready, yellow
@@ -892,9 +892,19 @@ footer.comment-footer:after,
 	background-color: rgba(36,38,41,0.4);
 }
 
+.has-marketing-bar .site-header,
+.has-marketing-bar.is-singular .site-header {
+	top: 49px;
+}
+
 .admin-bar .site-header,
 .admin-bar.is-singular .site-header {
 	top: 32px;
+}
+
+.admin-bar.has-marketing-bar .site-header,
+.admin-bar.has-marketing-bar.is-singular .site-header {
+	top: 78px;
 }
 
 /**
@@ -3584,6 +3594,10 @@ object {
 	 * Site Header
 	 */
 	.site-header,
+	.has-marketing-bar .site-header,
+	.has-marketing-bar.is-singular .site-header,
+	.admin-bar.has-marketing-bar .site-header, 
+	.admin-bar.has-marketing-bar.is-singular .site-header,
 	.admin-bar .site-header,
 	.admin-bar.is-singular .site-header {
 		position: absolute;
@@ -3928,6 +3942,8 @@ object {
 
 	.site-header,
 	.is-singular .site .site-header,
+	.admin-bar.has-marketing-bar .site-header,
+	.admin-bar.has-marketing-bar.is-singular .site-header,
 	.admin-bar .site-header,
 	.admin-bar.is-singular .site-header {
 		display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updated styles on Dyad 2 to fit with the new marketing bar.

#### How to test:

* Update your sandbox with the contents of this PR.
* Modify the following file on your sandbox:
`https://opengrok.a8c.com/source/xref/trunk/wp-content/blog-plugins/marketing-bar.php`
* If your site is older than 2018-05-16 change this line:
`const SHOW_MARKETING_BAR_FOR_BLOGS_REGISTERED_ON_OR_AFTER = '2018-05-16';`
* If modulo of your user id is not 7, change the `!===` to `==`
`if ( is_user_logged_in() && 7 !== (int) $blog_owner % 10 ) {`

#### Screenshots:

Dyad 2 with wp admin bar:

https://d.pr/i/YojCOL

![](https://d.pr/i/YojCOL+)

Dyad 2 without wp admin bar:

https://d.pr/i/3ujg5Y

![](https://d.pr/i/3ujg5Y+)

#### Related issue(s):

#2629
