### PR TITLE
Add padding for blog posts block

### DIFF
--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -86,7 +86,8 @@ body {
 .apostrophe-2-no-sidebar .wp-block-categories.alignfull,
 .apostrophe-2-no-sidebar .wp-block-archives.alignfull,
 .apostrophe-2-no-sidebar .wp-block-latest-posts.alignfull,
-.apostrophe-2-no-sidebar .wp-block-file.alignfull {
+.apostrophe-2-no-sidebar .wp-block-file.alignfull,
+.apostrophe-2-no-sidebar .wp-block-newspack-blocks-homepage-articles.alignfull {
 	padding-left: 2em;
 	padding-right: 2em;
 }


### PR DESCRIPTION
Changes proposed in this Pull Request:

Edits blocks.css to add class for the blog posts block so that it gets padding like other blocks when no sidebar is active.
Related issue(s):

Fix for issue #2440