### PR TITLE
Fix editor styles for verse block for all varia child themes

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #394d55;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #394d55;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.6
+Version: 1.2.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #303030;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #303030;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.6
+Version: 1.2.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.6
+Version: 1.2.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #3C2323;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #3C2323;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #252E36;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #252E36;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1001,6 +1001,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/package-lock.json
+++ b/dalston/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/sass/style-child-theme.scss
+++ b/dalston/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #1e1e1e;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #1e1e1e;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #111111;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #111111;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #303030;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #303030;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.6
+Version: 1.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -1003,6 +1003,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #010101;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #010101;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1019,6 +1019,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #181818;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #181818;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #303030;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #303030;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -1016,6 +1016,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #222222;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #222222;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #f2f2f2;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #f2f2f2;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.5
+Version: 1.2.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.6
+Version: 1.3.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1004,6 +1004,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #74767e;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #74767e;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/varia/sass/blocks/_editor.scss
+++ b/varia/sass/blocks/_editor.scss
@@ -26,4 +26,5 @@
 @import "quote/editor";
 @import "separator/editor";
 @import "table/editor";
+@import "verse/editor";
 @import "utilities/editor"; // Import LAST to cascade properly

--- a/varia/sass/blocks/verse/_editor.scss
+++ b/varia/sass/blocks/verse/_editor.scss
@@ -1,0 +1,4 @@
+pre.wp-block-verse {
+	font-family: monospace, monospace; // Matches front end font-family, which is not set to code.
+	color: #{map-deep-get($config-global, "color", "foreground", "default")};
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1010,6 +1010,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #444444;
 }
 
+pre.wp-block-verse {
+	font-family: monospace, monospace;
+	color: #444444;
+}
+
 /**
  * Editor Post Title
  * - Needs a special styles


### PR DESCRIPTION
Problem: in the front end, the "verse" block uses `pre`, so it is rendered in monospace. A varia style make sure that all pre blocks use monospace.

However in the editor, the verse block inherits the global font family, so it is not monospace.

Solution: make the verse block monospace in the editor styles for varia.

This resolves https://github.com/Automattic/wp-calypso/issues/43487.

with varia active and a verse block:

<img width="2134" alt="Screen Shot 2020-10-20 at 1 44 55 PM" src="https://user-images.githubusercontent.com/6265975/96642189-a7a96880-12da-11eb-83bb-3fe8d7ea4971.png">


wpcom diff: D51536-code