### PR TITLE
Add Block Style to Independent 2

### DIFF
--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -80,6 +80,9 @@ function independent_publisher_2_setup() {
 	// Load regular editor styles into the new block-based editor.
 	add_theme_support( 'editor-styles' );
 
+	// Add support for Block Styles.
+	add_theme_support( 'wp-block-styles' );
+
 	// Add support for responsive embeds.
 	add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
#### Fixes
#2444 
#2454 

This addresses a few issues with Independent Publisher 2. Specifically captions and embeds.

#### Test
Before: https://llamaeatsagiraffe.wordpress.com/331-2/
After: https://business-plan.blog/sample-page/

I used Code Snippets to test the block style function.

```
// Add support for Block Styles.
		add_theme_support( 'wp-block-styles' );
```