### PR TITLE
Seedlet: add customizer toggle for excerpts on home and archive pages

### DIFF
--- a/seedlet/archive.php
+++ b/seedlet/archive.php
@@ -32,7 +32,7 @@ get_header();
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content/content-excerpt' );
+				get_template_part( 'template-parts/content/content', get_theme_mod( 'archive_display_excerpt_or_full_post', 'full' ) );
 
 				// End the loop.
 			endwhile;

--- a/seedlet/inc/customizer.php
+++ b/seedlet/inc/customizer.php
@@ -6,20 +6,146 @@
  * @since 1.0.0
  */
 
-/**
- * Render the site title for the selective refresh partial.
- *
- * @return void
- */
-function seedlet_customize_partial_blogname() {
-	bloginfo( 'name' );
-}
+if ( ! class_exists( 'Seedlet_Customize' ) ) {
+	/**
+	 * Customizer Settings.
+	 *
+	 * @since 1.0.0
+	 */
+	class Seedlet_Customize {
 
-/**
- * Render the site tagline for the selective refresh partial.
- *
- * @return void
- */
-function seedlet_customize_partial_blogdescription() {
-	bloginfo( 'description' );
+		/**
+		 * Constructor. Instantiate the object.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 */
+		public function __construct() {
+			add_action( 'customize_register', array( $this, 'register' ) );
+		}
+
+		/**
+		 * Register customizer options.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+		 *
+		 * @return void
+		 */
+		public function register( $wp_customize ) {
+
+			// Change site-title & description to postMessage.
+			$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage';
+			$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
+
+			// Add partial for blogname.
+			$wp_customize->selective_refresh->add_partial(
+				'blogname',
+				array(
+					'selector'        => '.site-title',
+					'render_callback' => array( $this, 'partial_blogname' ),
+				)
+			);
+
+			// Add partial for blogdescription.
+			$wp_customize->selective_refresh->add_partial(
+				'blogdescription',
+				array(
+					'selector'        => '.site-description',
+					'render_callback' => array( $this, 'partial_blogdescription' ),
+				)
+			);
+
+			/**
+			 * Add excerpt or full text selector to customizer
+			 */
+			$wp_customize->add_section(
+				'excerpt_settings',
+				array(
+					'title'    => esc_html__( 'Excerpt Settings', 'seedlet' ),
+					'priority' => 120,
+				)
+			);
+
+			$wp_customize->add_setting(
+				'index_display_excerpt_or_full_post',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => 'full',
+					'sanitize_callback' => function( $value ) {
+						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt';
+					},
+				)
+			);
+
+			$wp_customize->add_setting(
+				'archive_display_excerpt_or_full_post',
+				array(
+					'capability'        => 'edit_theme_options',
+					'default'           => 'full',
+					'sanitize_callback' => function( $value ) {
+						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt';
+					},
+				)
+			);
+
+			$wp_customize->add_control(
+				'index_display_excerpt_or_full_post',
+				array(
+					'type'    => 'radio',
+					'section' => 'excerpt_settings',
+					'label'   => esc_html__( 'On the home page, posts show:', 'seedlet' ),
+					'choices' => array(
+						'excerpt' => esc_html__( 'Summary', 'seedlet' ),
+						'full'    => esc_html__( 'Full text', 'seedlet' ),
+					),
+				)
+			);
+
+			$wp_customize->add_control(
+				'archive_display_excerpt_or_full_post',
+				array(
+					'type'    => 'radio',
+					'section' => 'excerpt_settings',
+					'label'   => esc_html__( 'On archive pages, posts show:', 'seedlet' ),
+					'choices' => array(
+						'excerpt' => esc_html__( 'Summary', 'seedlet' ),
+						'full'    => esc_html__( 'Full text', 'seedlet' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Render the site title for the selective refresh partial.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return void
+		 */
+		public function partial_blogname() {
+			bloginfo( 'name' );
+		}
+
+		/**
+		 * Render the site tagline for the selective refresh partial.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return void
+		 */
+		public function partial_blogdescription() {
+			bloginfo( 'description' );
+		}
+	}
+
+	new Seedlet_Customize();
 }

--- a/seedlet/index.php
+++ b/seedlet/index.php
@@ -25,7 +25,7 @@ get_header();
 			// Load posts loop.
 			while ( have_posts() ) {
 				the_post();
-				get_template_part( 'template-parts/content/content' );
+				get_template_part( 'template-parts/content/content', get_theme_mod( 'index_display_excerpt_or_full_post', 'full' ) );
 			}
 
 			// Numbered pagination.


### PR DESCRIPTION
This PR partially addresses #2652. 

It adds a toggle to the customizer, allowing users to show a summary (excerpt) or full post when the home page is set to display Latest Posts. It adds the same toggle for archive pages. Much of the implementation was borrowed from TT1. 

<img width="1904" alt="Screen Shot 2020-10-22 at 2 23 40 PM" src="https://user-images.githubusercontent.com/5375500/96914176-a743d580-1472-11eb-9cab-702b7f835eec.png">

Note the default is set to "Full Post", as to not interfere with the current Seedlet behavior.

Screen recording: https://cloudup.com/cZE1PEpx_VJ

**To Test**
- Check out this PR and visit the Customizer > Excerpt Settings in Seedlet or Spearhead
- Change the option to show a Summary instead of Full Post
- Verify the excerpt is shown