### PR TITLE
Karuna: Use proper HTML5 syntax for enqueues

### DIFF
--- a/karuna/functions.php
+++ b/karuna/functions.php
@@ -116,6 +116,8 @@ function karuna_setup() {
 		'comment-list',
 		'gallery',
 		'caption',
+		'style',
+		'script',
 	) );
 
 	// Add theme support for custom logos


### PR DESCRIPTION
Hi,

Given WordPress.com themes are written in HTML5, they should declare HTML5 support for styles and script to avoid using type attributes in styles and scripts.

Otherwise, W3C validator will throw a warning because of the type attribute.

This option was introduced in WordPress 5.3. For reference, see:
https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
https://core.trac.wordpress.org/ticket/42804#comment:32

Related (closed) PR: #1917

Cheers,
Jb