### PR TITLE
Spearhead: update posts navigation function name

### DIFF
--- a/spearhead/search.php
+++ b/spearhead/search.php
@@ -45,7 +45,7 @@ get_header();
 			endwhile;
 
 			// Previous/next page navigation.
-			seedlet_the_posts_navigation();
+			seedlet_the_post_navigation();
 
 			// If no content, include the "No posts found" template.
 		else :


### PR DESCRIPTION
### Changes proposed in this Pull Request:

D51300-code introduce a typo. `seedlet_the_posts_navigation()` does not exist but `seedlet_the_post_navigation()` [does](https://github.com/Automattic/themes/search?q=seedlet_the_post_navigation).

It's causing the following error report on wpcom-alerts:

```
Uncaught Error: Call to undefined function seedlet_the_posts_navigation()
```
