### PR TITLE
Remove padding attributes from Dark Mode variables

### DIFF
--- a/spearhead/variables.css
+++ b/spearhead/variables.css
@@ -113,7 +113,5 @@
 		--sticky-posts--alt-color-background: #2d3139;
 		--primary-nav--color-background: var(--sticky-posts--alt-color-background);
 		--primary-nav--dropdown-color-link: var(--global--color-foreground);
-		--button--padding-vertical: 24px;
-		--button--padding-horizontal: 32px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
At some point in development some padding variables were added to the 'dark mode' media query block duplicating values that were since changed.

Rather than bringing these into sync these padding-related values are being removed from the dark mode query.

#### Testing
There shouldn't be any testing necessary, or any that would be obvious; no change is expected.

#### Related issue(s):
#2718 