### PR TITLE
Spearhead: show audio block on the excerpt

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -227,13 +227,26 @@ function spearhead_excerpt_more() {
 }
 
 function spearhead_the_excerpt( $excerpt ) {
+
+	$audio_block = '';
+	if ( has_block( 'audio' ) ) {
+		$post   = get_post();
+		$blocks = parse_blocks( $post->post_content );
+		foreach ( $blocks as $block ) {
+			if ( 'core/audio' === $block['blockName'] ) {
+				$audio_block .= '<div class="excerpt-audio-block">' . $block['innerHTML'] . '</div>';
+				break;
+			}
+		}
+	}
+
 	// For cases where the post excerpt is empty
 	// (but the post might have content)
 	if ( 0 === strlen( $excerpt ) ) {
-		return $excerpt;
+		return $excerpt . $audio_block;
 	}
 
-	return $excerpt . '<span class="excerpt-more-link">' . spearhead_more_link() . '</span>';
+	return $excerpt . '<span class="excerpt-more-link">' . spearhead_more_link() . '</span>' . $audio_block;
 }
 
 /**

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -234,7 +234,7 @@ function spearhead_the_excerpt( $excerpt ) {
 		$blocks = parse_blocks( $post->post_content );
 		foreach ( $blocks as $block ) {
 			if ( 'core/audio' === $block['blockName'] ) {
-				$audio_block .= '<div class="excerpt-audio-block">' . $block['innerHTML'] . '</div>';
+				$audio_block .= '<div class="excerpt-audio-block">' . wp_kses_post( $block['innerHTML'] ) . '</div>';
 				break;
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This is my attempt at showing the audio block on the excerpt of a post. 

To test:

* Create a post and add an audio block
* Set the home page and/or archive pages to show only summary of posts
* The audio block should show up after the content of the post

Also note that:

* If there is no other content but the audio block, the block should show up on the excerpt
* If there is multiple blocks on the post (audio or otherwise) the only block that should show up on the excerpt is the first audio block from the post.
* If no audio block is present the excerpt should look just like before.

<img width="936" alt="Screenshot 2020-10-29 at 11 32 07" src="https://user-images.githubusercontent.com/3593343/97557230-cb576780-19da-11eb-97da-89fb72b1e048.png">


#### Related issue(s):

Fixes #2578
