### PR TITLE
Ignore rej files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ theme-dev-utils
 vendor/
 *.DS_Store
 *.zip
+*.rej


### PR DESCRIPTION
This PR updates the gitignore to exclude files of type `.rej` that can be passed back and forth between wpcom.