### PR TITLE
Spearhead: Add Global Styles CSS variables

### DIFF
--- a/spearhead/variables.css
+++ b/spearhead/variables.css
@@ -1,8 +1,8 @@
 :root {
 	/* Globals */
 	/* Font Family */
-	--global--font-primary: 'IBM Plex Mono', sans-serif;
-	--global--font-secondary: 'Libre Franklin', sans-serif;
+	--global--font-primary: var(--font-headings,'IBM Plex Mono', sans-serif);
+	--global--font-secondary: var(--font-base,'Libre Franklin', sans-serif);
 	/* Colors */
 	--global--color-primary: #DB0042;
 	--global--color-primary-hover: #DB0042;


### PR DESCRIPTION
Fixes #2743. 

Spearhead just needed to declare the variables that global styles hooks into. 

![global-styles](https://user-images.githubusercontent.com/1202812/97730202-f52b8f80-1aa9-11eb-9207-adda90fb9491.gif)
