### PR TITLE
Spearhead: fix custom colors

### DIFF
--- a/seedlet/inc/wpcom-colors-utils.php
+++ b/seedlet/inc/wpcom-colors-utils.php
@@ -97,7 +97,7 @@ function rgb_to_hsvl( $rgb ) {
 	$min_rgb           = min( $r, $g, $b );
 	$chroma            = $max_rgb - $min_rgb;
 	$v                 = 100 * $max_rgb;
-	if ( 0 == $chroma ) {
+	if ( 0 === (int) $chroma ) {
 		return array( 0, 0, $v, $l );
 	}
 	$s = 100 * ( $chroma / $max_rgb );

--- a/seedlet/inc/wpcom-colors-utils.php
+++ b/seedlet/inc/wpcom-colors-utils.php
@@ -97,7 +97,7 @@ function rgb_to_hsvl( $rgb ) {
 	$min_rgb           = min( $r, $g, $b );
 	$chroma            = $max_rgb - $min_rgb;
 	$v                 = 100 * $max_rgb;
-	if ( 0 === $chroma ) {
+	if ( 0 == $chroma ) {
 		return array( 0, 0, $v, $l );
 	}
 	$s = 100 * ( $chroma / $max_rgb );


### PR DESCRIPTION
This PR addresses #2737. 

Currently, some of our code that converts RGB to HSL causes a php warning to be output to a style tag where the CSS variable overrides are set:

<img width="904" alt="Screen Shot 2020-11-02 at 1 57 38 PM" src="https://user-images.githubusercontent.com/5375500/97907860-e6e0ac00-1d13-11eb-8cbf-862b79a1810c.png">

This would result in invalid style rules, thus custom colors picked via the customizer would not appear.

**To test**
- Activate Spearhead
- Check out this PR onto your sandbox
- Change an individual color from the default palette
- Verify that the color is changed in the view, and that no warnings are generated in the style tag `id="custom-colors-css"`

