### PR TITLE
fixed height of blog post thumbnail

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -2172,6 +2172,10 @@ a.post-thumbnail:hover img {
 	transform: translateY(-50%);
 }
 
+.wpnbha .post-thumbnail {
+	height: auto;
+}
+
 /* Page Links */
 .page-links {
 	border-top: 1px solid #eee;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR addresses an issue with post thumbnails on the Blog posts block. 
I have considered making this a PR for the actual block but I'm unsure if that is the right way to go about this since the issue seems to be caused by the theme's css. The `.post-thumbnail {height: 100%; }` rule is valid in other cases that are not this block (I haven't found a case that would break if we removed this rule but I see the `.post-thumbnail` class used a lot throughout the stylesheet), and the block itself does declare `height: auto;` for the image inside the post-thumbnail container, so I don't think the block should be responsible for what the theme is breaking (for other purposes).

Before | After 
--- | ---
<img width="577" alt="Screenshot 2020-11-03 at 11 29 26" src="https://user-images.githubusercontent.com/3593343/97974453-e6a1e880-1dc7-11eb-9972-1c8ad8b7c0b7.png"> | <img width="597" alt="Screenshot 2020-11-03 at 11 29 21" src="https://user-images.githubusercontent.com/3593343/97974458-e9044280-1dc7-11eb-8bcc-b3864d09de16.png">


#### Related issue(s):

Closes #1926
