### PR TITLE
Seedlet/Spearhead: Fix mobile heading word-breaks and spacing rules in Jetpack layout block.

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -121,7 +121,7 @@
 	--layout-grid--gutter-medium: var(--global--spacing-unit);
 	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
 	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
-	--layout-grid--background-offset: calc( var(--global--spacing-unit));
+	--layout-grid--background-offset: var(--global--spacing-unit);
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);

--- a/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_config.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_config.scss
@@ -6,5 +6,5 @@ $layout-gutter-sizes: "none", "small", "medium", "large", "huge";
 	--layout-grid--gutter-medium: var(--global--spacing-unit);           // 16px
 	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2); // 32px
 	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);  // 48px
-	--layout-grid--background-offset: calc( var(--global--spacing-unit)); // 16px
+	--layout-grid--background-offset: var(--global--spacing-unit);       // 16px
 }

--- a/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
@@ -1,9 +1,34 @@
 @import 'config';
 
 .wp-block-jetpack-layout-grid {
+	/* Grid gutter size options */
 	grid-gap: var(--layout-grid--gutter-large) !important;
 	padding-left: var(--layout-grid--gutter-large) !important;
 	padding-right: var(--layout-grid--gutter-large) !important;
+	
+	&.wp-block-jetpack-layout-gutter__small {
+		grid-gap: var(--layout-grid--gutter-small) !important;
+		padding-left: var(--layout-grid--gutter-small) !important;
+		padding-right: var(--layout-grid--gutter-small) !important;
+	}
+
+	&.wp-block-jetpack-layout-gutter__medium {
+		grid-gap: var(--layout-grid--gutter-medium) !important;
+		padding-left: var(--layout-grid--gutter-medium) !important;
+		padding-right: var(--layout-grid--gutter-medium) !important;
+	}
+
+	&.wp-block-jetpack-layout-gutter__large {
+		grid-gap: var(--layout-grid--gutter-large) !important;
+		padding-left: var(--layout-grid--gutter-large) !important;
+		padding-right: var(--layout-grid--gutter-large) !important;
+	}
+
+	&.wp-block-jetpack-layout-gutter__huge {
+		grid-gap: var(--layout-grid--gutter-huge) !important;
+		padding-left: var(--layout-grid--gutter-huge) !important;
+		padding-right: var(--layout-grid--gutter-huge) !important;
+	}
 
 	/* Individual Column Options */
 	.wp-block-jetpack-layout-grid-column {

--- a/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
@@ -5,7 +5,7 @@
 	grid-gap: var(--layout-grid--gutter-large) !important;
 	padding-left: var(--layout-grid--gutter-large) !important;
 	padding-right: var(--layout-grid--gutter-large) !important;
-	
+
 	&.wp-block-jetpack-layout-gutter__small {
 		grid-gap: var(--layout-grid--gutter-small) !important;
 		padding-left: var(--layout-grid--gutter-small) !important;
@@ -60,12 +60,6 @@
 				margin-bottom: 0;
 			}
 		}
-		
-		// Override word-break rules from Jetpack
-		.entry-content & * {
-			word-break: inherit;
-			word-wrap: inherit;
-		}
 	}
 }
 
@@ -106,4 +100,3 @@
 		}
 	}
 }
-

--- a/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/layout-grid/_style.scss
@@ -35,6 +35,12 @@
 				margin-bottom: 0;
 			}
 		}
+		
+		// Override word-break rules from Jetpack
+		.entry-content & * {
+			word-break: inherit;
+			word-wrap: inherit;
+		}
 	}
 }
 

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -4209,6 +4209,11 @@ button[data-load-more-btn],
 	margin-bottom: 0;
 }
 
+.entry-content .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
+	word-break: inherit;
+	word-wrap: inherit;
+}
+
 /* Gutter Options */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
 	grid-gap: var(--layout-grid--gutter-none) !important;

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -187,7 +187,7 @@ Included in theme screenshot and in block patterns.
 	--layout-grid--gutter-medium: var(--global--spacing-unit);
 	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
 	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
-	--layout-grid--background-offset: calc( var(--global--spacing-unit));
+	--layout-grid--background-offset: var(--global--spacing-unit);
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
@@ -4176,10 +4176,35 @@ button[data-load-more-btn],
 }
 
 .wp-block-jetpack-layout-grid {
+	/* Grid gutter size options */
 	grid-gap: var(--layout-grid--gutter-large) !important;
 	padding-right: var(--layout-grid--gutter-large) !important;
 	padding-left: var(--layout-grid--gutter-large) !important;
 	/* Individual Column Options */
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {
+	grid-gap: var(--layout-grid--gutter-small) !important;
+	padding-right: var(--layout-grid--gutter-small) !important;
+	padding-left: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium {
+	grid-gap: var(--layout-grid--gutter-medium) !important;
+	padding-right: var(--layout-grid--gutter-medium) !important;
+	padding-left: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge {
+	grid-gap: var(--layout-grid--gutter-huge) !important;
+	padding-right: var(--layout-grid--gutter-huge) !important;
+	padding-left: var(--layout-grid--gutter-huge) !important;
 }
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column[style^="background-color"] {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -4234,11 +4234,6 @@ button[data-load-more-btn],
 	margin-bottom: 0;
 }
 
-.entry-content .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
-	word-break: inherit;
-	word-wrap: inherit;
-}
-
 /* Gutter Options */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
 	grid-gap: var(--layout-grid--gutter-none) !important;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -4230,6 +4230,11 @@ button[data-load-more-btn],
 	margin-bottom: 0;
 }
 
+.entry-content .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
+	word-break: inherit;
+	word-wrap: inherit;
+}
+
 /* Gutter Options */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
 	grid-gap: var(--layout-grid--gutter-none) !important;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -187,7 +187,7 @@ Included in theme screenshot and in block patterns.
 	--layout-grid--gutter-medium: var(--global--spacing-unit);
 	--layout-grid--gutter-large: calc( var(--global--spacing-unit) * 2);
 	--layout-grid--gutter-huge: calc( var(--global--spacing-unit) * 3);
-	--layout-grid--background-offset: calc( var(--global--spacing-unit));
+	--layout-grid--background-offset: var(--global--spacing-unit);
 	--list--font-family: var(--global--font-secondary);
 	--definition-term--font-family: var(--global--font-primary);
 	--pullquote--font-family: var(--global--font-primary);
@@ -4197,10 +4197,35 @@ button[data-load-more-btn],
 }
 
 .wp-block-jetpack-layout-grid {
+	/* Grid gutter size options */
 	grid-gap: var(--layout-grid--gutter-large) !important;
 	padding-left: var(--layout-grid--gutter-large) !important;
 	padding-right: var(--layout-grid--gutter-large) !important;
 	/* Individual Column Options */
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {
+	grid-gap: var(--layout-grid--gutter-small) !important;
+	padding-left: var(--layout-grid--gutter-small) !important;
+	padding-right: var(--layout-grid--gutter-small) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium {
+	grid-gap: var(--layout-grid--gutter-medium) !important;
+	padding-left: var(--layout-grid--gutter-medium) !important;
+	padding-right: var(--layout-grid--gutter-medium) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__large {
+	grid-gap: var(--layout-grid--gutter-large) !important;
+	padding-left: var(--layout-grid--gutter-large) !important;
+	padding-right: var(--layout-grid--gutter-large) !important;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge {
+	grid-gap: var(--layout-grid--gutter-huge) !important;
+	padding-left: var(--layout-grid--gutter-huge) !important;
+	padding-right: var(--layout-grid--gutter-huge) !important;
 }
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column.has-background, .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column[style^="background-color"] {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -4255,11 +4255,6 @@ button[data-load-more-btn],
 	margin-bottom: 0;
 }
 
-.entry-content .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
-	word-break: inherit;
-	word-wrap: inherit;
-}
-
 /* Gutter Options */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-gutter__none {
 	grid-gap: var(--layout-grid--gutter-none) !important;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

1. Remove word-breaks in Layout Grid block.
2. Clean up small, medium, large, and huge grid spacing option settings. 
3. Some light code tidying.

This solution should be tested in both Seedlet and Spearhead to make sure it works properly in both. 

#### Related issue(s):

Fixes #2666 