### PR TITLE
Add ‘wp_body_open’ hook to Varia Child themes

### DIFF
--- a/balasana/header.php
+++ b/balasana/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'balasana' ); ?></a>
 

--- a/coutoire/header.php
+++ b/coutoire/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 

--- a/dalston/header.php
+++ b/dalston/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 

--- a/morden/header.php
+++ b/morden/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 

--- a/rivington/header.php
+++ b/rivington/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'rivington' ); ?></a>
 

--- a/rockfield/header.php
+++ b/rockfield/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'rockfield' ); ?></a>
 

--- a/stow/header.php
+++ b/stow/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 

--- a/stratford/header.php
+++ b/stratford/header.php
@@ -20,6 +20,13 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	}
+?>
+	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 


### PR DESCRIPTION
RE: #1722 all themes should have the wp_body_open() call made
immediately after the body is opened.

https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook

#### Changes proposed in this Pull Request:
This change adds wp_body_open support to all of the Varia child themes that have
a custom header.  (Varia parent theme had already been enhanced.) 

#### Related issue(s):
#1722 (Though this issue only partially addresses that; many other non-Varia themes remain to have this enhancement made)