### PR TITLE
Illustratr: Solve fixed cover image bug

### DIFF
--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -36,13 +36,12 @@ Description: Used to style Gutenberg Blocks.
 /* Full Width */
 
 .alignfull {
-	width: calc(100vw - 52px); /* subtract 52px for body padding */
-	max-width: calc(100vw - 52px);
-	margin-left: 0;
-	margin-right: 0;
+	margin-left: calc(50% - 50vw + 26px);
+	margin-right: calc(50% - 50vw + 26px);
+	max-width: 100vw;
 	position: relative;
-	left: 50%;
-	transform: translateX( -50% );
+	width: calc(100vw - 52px); /* subtract 52px for body padding */
+
 }
 
 @media (min-width: 768px) {
@@ -569,4 +568,3 @@ hr.wp-block-separator {
 .has-black-background-color:active {
 	background-color: #24282d;
 }
-


### PR DESCRIPTION
This is a different approach to #1451 

I think we can simplify the alignfull CSS and solve this bug at the same time.

To test check that alignfull still works with other blocks.

Fixes #742