### PR TITLE
Varia-based themes: Reduce specificity on rules to hide extra color palettes

### DIFF
--- a/alves/functions.php
+++ b/alves/functions.php
@@ -204,7 +204,7 @@ function alves_scripts() {
 	wp_dequeue_style( 'varia-style' );
 
 	// enqueue child styles
-	wp_enqueue_style('alves-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ));
+	wp_enqueue_style( 'alves-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 
 	// enqueue child RTL styles
 	wp_style_add_data( 'alves-style', 'rtl', 'replace' );
@@ -221,10 +221,10 @@ function alves_editor_styles() {
 	wp_enqueue_style( 'alves-editor-fonts', alves_fonts_url(), array(), null );
 
 	// Hide duplicate palette colors
-	$colors_array = get_theme_mod('colors_manager', array( 'colors' => true )); // color annotations array()
+	$colors_array = get_theme_mod( 'colors_manager', array( 'colors' => true ) ); // color annotations array()
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#394d55' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/coutoire/functions.php
+++ b/coutoire/functions.php
@@ -189,6 +189,16 @@ function coutoire_editor_styles() {
 
 	// Enqueue Google fonts in the editor, if necessary
 	wp_enqueue_style( 'coutoire-editor-fonts', coutoire_fonts_url(), array(), null );
+
+	// Hide duplicate palette colors
+	$colors_array = get_theme_mod( 'colors_manager', array( 'colors' => true ) ); // color annotations array()
+	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#767676' ) { // $config-global--color-foreground-light-default;
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
+				display: none;
+			}';
+		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );
+	}
 }
 add_action( 'enqueue_block_editor_assets', 'coutoire_editor_styles' );
 

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -196,8 +196,8 @@ function dalston_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod('colors_manager', array( 'colors' => true )); // color annotations array()
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#1E1E1E' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/exford/functions.php
+++ b/exford/functions.php
@@ -191,8 +191,8 @@ function exford_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#6E6E6E' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/leven/functions.php
+++ b/leven/functions.php
@@ -186,8 +186,8 @@ function leven_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#767676' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/mayland/functions.php
+++ b/mayland/functions.php
@@ -176,8 +176,8 @@ function mayland_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#666666' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/maywood/functions.php
+++ b/maywood/functions.php
@@ -180,8 +180,8 @@ function maywood_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#686868' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/redhill/functions.php
+++ b/redhill/functions.php
@@ -166,8 +166,8 @@ function redhill_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager' );
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#666666' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );

--- a/rivington/functions.php
+++ b/rivington/functions.php
@@ -185,8 +185,8 @@ function rivington_editor_styles() {
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod('colors_manager', array( 'colors' => true )); // color annotations array()
 	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#F2F2F2' ) { // $config-global--color-foreground-light-default;
-		$inline_palette_css = '.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(5),
-			.block-editor-color-gradient-control .components-circular-option-picker__option-wrapper:nth-child(6) {
+		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
+			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;
 			}';
 		wp_add_inline_style( 'wp-edit-blocks', $inline_palette_css );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR continues #2149, and adds the specificity fix to other Varia-based themes that have this same code snippet as outlined below.

Adds the fix for the following themes: 

- [x] Alves
- [x] Coutoire
- [x] Dalston
- [x] Exford
- [x] Leven
- [x] Mayland
- [x] Maywood
- [x] Redhill
- [x] Rivington

The other Varia-based themes that aren’t listed here either don’t have their color-annotations PRs merged yet, or already have this solution on the `trunk` branch. 

#### Related issue(s):

Closes: #2149
Fixes:  #2148 