### PR TITLE
Update the query loop for Seedlet blocks.

### DIFF
--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -3,11 +3,21 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:query-loop -->
-<!-- wp:post-title /-->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
+<!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query-loop -->
+<!-- wp:post-title {"isLink":true} /-->
 
 <!-- wp:post-content /-->
-<!-- /wp:query-loop --></div></div>
+
+<!-- wp:post-date {"fontSize":"tiny"} /-->
+
+<!-- wp:spacer {"height":60} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- /wp:query-loop -->
+<!-- /wp:query --></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","tagName":"footer"} -->


### PR DESCRIPTION
Updates the Query loop for Seedlet Blocks so that each post is more in line with what Seedlet shows by default. 

- Each post title is now clickable. 
- Each post shows the post date beneath the content. 
- There is now appropriate spacing beneath each post in the feed.

Before|After
---|---
<img width="873" alt="Screen Shot 2020-11-05 at 9 07 47 AM" src="https://user-images.githubusercontent.com/1202812/98251263-7f5e7280-1f46-11eb-949a-f1b0d98d8f98.png">|<img width="937" alt="Screen Shot 2020-11-05 at 9 06 50 AM" src="https://user-images.githubusercontent.com/1202812/98251266-808f9f80-1f46-11eb-80b9-64999e308979.png">
