### PR TITLE
Spearhead & Seedlet: Re-sort stylesheets for proper variable cascading. 

### DIFF
--- a/seedlet/assets/css/custom-color-overrides.css
+++ b/seedlet/assets/css/custom-color-overrides.css
@@ -1,5 +1,0 @@
-/**
- * Custom Color Overrides
- * 
- * This file is automatically populated if the user chooses custom colors in the Customzier.
- */

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -14,14 +14,14 @@
 class Seedlet_Custom_Colors {
 
 	private $seedlet_custom_color_variables = array();
-	private $default_background             = '#FFFFFF';
-	private $default_foreground             = '#333333';
-	private $default_primary                = '#000000';
-	private $default_secondary              = '#3C8067';
-	private $default_tertiary               = '#FAFBF6';
-	private $default_border                 = '#EFEFEF';
+	private $default_background;
+	private $default_foreground;
+	private $default_primary;
+	private $default_secondary;
+	private $default_tertiary;
+	private $default_border;
 
-	function __construct( $background = $default_background, $foreground = $default_foreground, $primary = $default_primary, $secondary = $default_secondary, $tertiary = $default_tertiary, $border = $default_border ) {
+	function __construct( $background, $foreground, $primary, $secondary, $tertiary, $border ) {
 
 		/**
 		 * Define defaults
@@ -341,5 +341,15 @@ class Seedlet_Custom_Colors {
 
 // Instantiate Custom Colors if this is a parent theme
 if ( get_template_directory() === get_stylesheet_directory() ) {
-	new Seedlet_Custom_Colors;
+	/**
+	 * Set Seedlet Custom Color Defaults
+	 */
+	new Seedlet_Custom_Colors(
+		'#FFFFFF', // background
+		'#333333', // foreground
+		'#000000', // primary
+		'#3C8067', // secondary
+		'#FAFBF6', // tertiary
+		'#EFEFEF'  // border
+	);
 }

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -263,7 +263,9 @@ class Seedlet_Custom_Colors {
 	 */
 	function seedlet_custom_color_variables() {
 		if ( 'default' !== get_theme_mod( 'custom_colors_active' ) ) {
-			wp_add_inline_style( 'seedlet-style', $this->seedlet_generate_custom_color_variables() );
+			wp_register_style( 'seedlet-variable-overrides', false );
+			wp_enqueue_style( 'seedlet-variable-overrides' );
+			wp_add_inline_style( 'seedlet-variable-overrides', $this->seedlet_generate_custom_color_variables() );
 		}
 	}
 

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -14,19 +14,35 @@
 class Seedlet_Custom_Colors {
 
 	private $seedlet_custom_color_variables = array();
+	private $default_background             = '#FFFFFF';
+	private $default_foreground             = '#333333';
+	private $default_primary                = '#000000';
+	private $default_secondary              = '#3C8067';
+	private $default_tertiary               = '#FAFBF6';
+	private $default_border                 = '#EFEFEF';
 
-	function __construct() {
+	function __construct( $background, $foreground, $primary, $secondary, $tertiary, $border ) {
 
 		/**
-		 * Define color variables
+		 * Define defaults
+		 */
+		$this->default_background = $background;
+		$this->default_foreground = $foreground;
+		$this->default_primary    = $primary;
+		$this->default_secondary  = $secondary;
+		$this->default_tertiary   = $tertiary;
+		$this->default_border     = $border;
+
+		/**
+		 * Define color variables with defaults
 		 */
 		$this->seedlet_custom_color_variables = array(
-			array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
-			array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
-			array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
-			array( '--global--color-secondary', '#3C8067', __( 'Secondary Color', 'seedlet' ) ),
-			array( '--global--color-tertiary', '#FAFBF6', __( 'Tertiary Color', 'seedlet' ) ),
-			array( '--global--color-border', '#EFEFEF', __( 'Borders Color', 'seedlet' ) ),
+			array( '--global--color-background', $background, __( 'Background Color', 'seedlet' ) ),
+			array( '--global--color-foreground', $foreground, __( 'Foreground Color', 'seedlet' ) ),
+			array( '--global--color-primary', $primary, __( 'Primary Color', 'seedlet' ) ),
+			array( '--global--color-secondary', $secondary, __( 'Secondary Color', 'seedlet' ) ),
+			array( '--global--color-tertiary', $tertiary, __( 'Tertiary Color', 'seedlet' ) ),
+			array( '--global--color-border', $border, __( 'Borders Color', 'seedlet' ) ),
 		);
 
 		/**
@@ -232,7 +248,7 @@ class Seedlet_Custom_Colors {
 				$opacity_integer         = 70;
 				$adjusted_color          = $this->seedlet_color_blend_by_opacity( $theme_mod_custom_color, $opacity_integer, $theme_mod_bg_color );
 
-				$theme_css .= $theme_mod_variable_name . ':' . $theme_mod_custom_color . ';';
+				$theme_css .= $theme_mod_variable_name . ': ' . $theme_mod_custom_color . ';';
 
 				if ( $theme_mod_variable_name === '--global--color-primary' && $theme_mod_default_color !== $theme_mod_custom_color ) {
 					$theme_css .= '--global--color-primary-hover: ' . $adjusted_color . ';';
@@ -323,4 +339,7 @@ class Seedlet_Custom_Colors {
 
 }
 
-new Seedlet_Custom_Colors;
+// Instantiate Custom Colors if this is a parent theme
+if ( get_template_directory() === get_stylesheet_directory() ) {
+	new Seedlet_Custom_Colors;
+}

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -53,12 +53,12 @@ class Seedlet_Custom_Colors {
 		/**
 		 * Enqueue color variables for customizer & frontend.
 		 */
-		add_action( 'wp_enqueue_scripts', array( $this, 'seedlet_custom_color_variables' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'seedlet_enqueue_custom_color_variables' ) );
 
 		/**
 		 * Enqueue color variables for editor.
 		 */
-		add_action( 'enqueue_block_editor_assets', array( $this, 'seedlet_editor_custom_color_variables' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'seedlet_enqueue_editor_custom_color_variables' ) );
 
 		/**
 		 * Enqueue contrast checking.
@@ -277,7 +277,7 @@ class Seedlet_Custom_Colors {
 	/**
 	 * Customizer & frontend custom color variables.
 	 */
-	function seedlet_custom_color_variables() {
+	function seedlet_enqueue_custom_color_variables() {
 		if ( 'default' !== get_theme_mod( 'custom_colors_active' ) ) {
 			wp_register_style( 'seedlet-variable-overrides', false );
 			wp_enqueue_style( 'seedlet-variable-overrides' );
@@ -288,7 +288,7 @@ class Seedlet_Custom_Colors {
 	/**
 	 * Editor custom color variables.
 	 */
-	function seedlet_editor_custom_color_variables() {
+	function seedlet_enqueue_editor_custom_color_variables() {
 		wp_enqueue_style( 'seedlet-custom-color-overrides', get_template_directory_uri() . '/assets/css/custom-color-overrides.css', array(), wp_get_theme()->get( 'Version' ) );
 		if ( 'default' !== get_theme_mod( 'custom_colors_active' ) ) {
 			wp_add_inline_style( 'seedlet-custom-color-overrides', $this->seedlet_generate_custom_color_variables( 'editor' ) );

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -289,9 +289,10 @@ class Seedlet_Custom_Colors {
 	 * Editor custom color variables.
 	 */
 	function seedlet_enqueue_editor_custom_color_variables() {
-		wp_enqueue_style( 'seedlet-custom-color-overrides', get_template_directory_uri() . '/assets/css/custom-color-overrides.css', array(), wp_get_theme()->get( 'Version' ) );
 		if ( 'default' !== get_theme_mod( 'custom_colors_active' ) ) {
-			wp_add_inline_style( 'seedlet-custom-color-overrides', $this->seedlet_generate_custom_color_variables( 'editor' ) );
+			wp_register_style( 'seedlet-editor-variable-overrides', false );
+			wp_enqueue_style( 'seedlet-editor-variable-overrides' );
+			wp_add_inline_style( 'seedlet-editor-variable-overrides', $this->seedlet_generate_custom_color_variables( 'editor' ) );
 		}
 	}
 

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -21,7 +21,7 @@ class Seedlet_Custom_Colors {
 	private $default_tertiary               = '#FAFBF6';
 	private $default_border                 = '#EFEFEF';
 
-	function __construct( $background, $foreground, $primary, $secondary, $tertiary, $border ) {
+	function __construct( $background = $default_background, $foreground = $default_foreground, $primary = $default_primary, $secondary = $default_secondary, $tertiary = $default_tertiary, $border = $default_border ) {
 
 		/**
 		 * Define defaults

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -75,27 +75,46 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 			)
 		);
 
-		// Add child theme editor color pallete to match Sass-map variables in `_config-child-theme-deep.scss`.
+		// Add child theme editor color pallete to match CSS-variables
+		// Editor color palette.
+		$colors_theme_mod = get_theme_mod( 'custom_colors_active' );
+		$primary          = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-primary' ) ) ) ? '#DB0042' : get_theme_mod( 'seedlet_--global--color-primary' );
+		$secondary        = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-secondary' ) ) ) ? '#555555' : get_theme_mod( 'seedlet_--global--color-secondary' );
+		$foreground       = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-foreground' ) ) ) ? '#000000' : get_theme_mod( 'seedlet_--global--color-foreground' );
+		$tertiary         = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-tertiary' ) ) ) ? '#FAFBF6' : get_theme_mod( 'seedlet_--global--color-tertiary' );
+		$background       = ( ! empty( $colors_theme_mod ) && 'default' === $colors_theme_mod || empty( get_theme_mod( 'seedlet_--global--color-background' ) ) ) ? '#FFFFFF' : get_theme_mod( 'seedlet_--global--color-background' );
+
 		add_theme_support(
 			'editor-color-palette',
 			array(
 				array(
 					'name'  => __( 'Primary', 'spearhead' ),
 					'slug'  => 'primary',
-					'color' => '#DB0042',
+					'color' => $primary,
+				),
+				array(
+					'name'  => __( 'Secondary', 'spearhead' ),
+					'slug'  => 'secondary',
+					'color' => $secondary,
 				),
 				array(
 					'name'  => __( 'Foreground', 'spearhead' ),
 					'slug'  => 'foreground',
-					'color' => '#000000',
+					'color' => $foreground,
+				),
+				array(
+					'name'  => __( 'Tertiary', 'spearhead' ),
+					'slug'  => 'tertiary',
+					'color' => $tertiary,
 				),
 				array(
 					'name'  => __( 'Background', 'spearhead' ),
 					'slug'  => 'background',
-					'color' => '#FFFFFF',
+					'color' => $background,
 				),
 			)
 		);
+
 		remove_filter( 'excerpt_more', 'seedlet_continue_reading_link' );
 		remove_filter( 'the_content_more_link', 'seedlet_continue_reading_link' );
 
@@ -107,7 +126,7 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 			'#000000', // foreground
 			'#DB0042', // primary
 			'#555555', // secondary
-			'#555555', // tertiary
+			'#FAFBF6', // tertiary
 			'#555555'  // border
 		);
 

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -115,6 +115,7 @@ add_filter( 'seedlet_content_width', 'spearhead_content_width' );
  */
 function spearhead_scripts() {
 	// dequeue parent styles
+	wp_dequeue_style( 'seedlet-style' ); // remove parent stylesheet
 	wp_dequeue_style( 'seedlet-style-navigation' );
 
 	// enqueue Google fonts, if necessary
@@ -122,6 +123,9 @@ function spearhead_scripts() {
 
 	// Child theme variables
 	wp_enqueue_style( 'spearhead-variables-style', get_stylesheet_directory_uri() . '/variables.css', array(), wp_get_theme()->get( 'Version' ) );
+
+	// Re-enqueue parent stylesheet to sort it properly with inline styles
+	wp_enqueue_style( 'seedlet-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
 
 	// enqueue child styles
 	wp_enqueue_style( 'spearhead-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -98,6 +98,19 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 		);
 		remove_filter( 'excerpt_more', 'seedlet_continue_reading_link' );
 		remove_filter( 'the_content_more_link', 'seedlet_continue_reading_link' );
+
+		/**
+		 * Set Spearhead Custom Color Defaults
+		 */
+		new Seedlet_Custom_Colors(
+			'#FFFFFF', // background
+			'#000000', // foreground
+			'#DB0042', // primary
+			'#555555', // secondary
+			'#555555', // tertiary
+			'#555555'  // border
+		);
+
 	}
 endif;
 add_action( 'after_setup_theme', 'spearhead_setup', 12 );

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -115,7 +115,7 @@ add_filter( 'seedlet_content_width', 'spearhead_content_width' );
  */
 function spearhead_scripts() {
 	// dequeue parent styles
-	wp_dequeue_style( 'seedlet-variable-overrides' ); // remove parent stylesheet
+	wp_dequeue_style( 'seedlet-variable-overrides' ); // remove parent variables
 	wp_dequeue_style( 'seedlet-style-navigation' );
 
 	// enqueue Google fonts, if necessary
@@ -124,7 +124,7 @@ function spearhead_scripts() {
 	// Child theme variables
 	wp_enqueue_style( 'spearhead-variables-style', get_stylesheet_directory_uri() . '/variables.css', array(), wp_get_theme()->get( 'Version' ) );
 
-	// Re-enqueue parent stylesheet to sort it properly with inline styles
+	// Re-enqueue parent variables to sort them properly with custom inline styles
 	wp_enqueue_style( 'seedlet-variable-overrides' );
 
 	// enqueue child styles

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -115,7 +115,7 @@ add_filter( 'seedlet_content_width', 'spearhead_content_width' );
  */
 function spearhead_scripts() {
 	// dequeue parent styles
-	wp_dequeue_style( 'seedlet-style' ); // remove parent stylesheet
+	wp_dequeue_style( 'seedlet-variable-overrides' ); // remove parent stylesheet
 	wp_dequeue_style( 'seedlet-style-navigation' );
 
 	// enqueue Google fonts, if necessary
@@ -125,7 +125,7 @@ function spearhead_scripts() {
 	wp_enqueue_style( 'spearhead-variables-style', get_stylesheet_directory_uri() . '/variables.css', array(), wp_get_theme()->get( 'Version' ) );
 
 	// Re-enqueue parent stylesheet to sort it properly with inline styles
-	wp_enqueue_style( 'seedlet-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'seedlet-variable-overrides' );
 
 	// enqueue child styles
 	wp_enqueue_style( 'spearhead-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -156,7 +156,7 @@ function spearhead_scripts() {
 	// Child theme variables
 	wp_enqueue_style( 'spearhead-variables-style', get_stylesheet_directory_uri() . '/variables.css', array(), wp_get_theme()->get( 'Version' ) );
 
-	// Re-enqueue parent variables to sort them properly with custom inline styles
+	// Re-enqueue parent variables to sort them properly with custom-color inline styles
 	wp_enqueue_style( 'seedlet-variable-overrides' );
 
 	// enqueue child styles


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Seedlet: Enqueue an empty stylesheet to decouple parent styles and the CSS variables.
- Spearhead: Re-sort the empty stylesheet to allows parent styles/variables and child CSS-variables to cascade properly.
- Makes the custom color options work properly on the frontend and customizer.

Before|After
------------|------------
![2020-11-05 12 28 47](https://user-images.githubusercontent.com/709581/98275305-809d9880-1f62-11eb-8769-be446e3ecca5.gif)|![2020-11-05 12 26 23](https://user-images.githubusercontent.com/709581/98275048-30bed180-1f62-11eb-96b2-c18b9295f81a.gif)

#### To Do: 

- [ ] Replace the Seedlet default colors with the Spearhead defaults. 

See here: 
https://github.com/Automattic/themes/blob/fb71c3713afe7cd962cb0bdb62e82c672a82d5bb/seedlet/classes/class-seedlet-custom-colors.php#L23-L30

We may need to make this array in the Seedlet custom-colors class filterable by child themes. I have no idea if that’s actually possible though. 

#### Related issue(s):

#2701 