### PR TITLE
Defaulted the color of input/textarea elements

### DIFF
--- a/dyad-2/style.css
+++ b/dyad-2/style.css
@@ -698,7 +698,7 @@ button,
 input,
 textarea {
 	border: 1px solid #ddd;
-	color: inherit;
+	color: #6a6c6e;
 	font-family: inherit;
 	font-size: 1.6rem;
 	line-height: 1.5;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The color of input and textarea elements were inheriting, which worked
in most situations.  However when nested in other elements (such as a
cover block) the color was reset to white which caused the form elements
text to be unreadable.

Since this theme doesn't allow for text color changes the color value of
text elements is set to the same value defaulting all text elements.

[Note here](https://github.com/Automattic/themes/blob/trunk/dyad-2/style.css#L284) for reference color value.

#### Testing
Using Dyad-2 theme:
Add cover block to a page
add 'contact form' block inside the cover block
Note the color of the text in the contact form.

#### Related issue(s):
#1833 

Replaces PR #1835 