### PR TITLE
Varia/Alves/Hever/Morden align site logo with the menu

### DIFF
--- a/alves/sass/_extra-child-theme.scss
+++ b/alves/sass/_extra-child-theme.scss
@@ -197,6 +197,12 @@ body:not(.fse-enabled) {
 			margin-bottom: 0;
 		}
 
+		&.has-logo:not(.has-title-and-tagline) {
+			grid-template-areas:
+				"site-logo main-navigation"
+				"site-logo social-navigation";
+		}
+
 		.site-logo {
 			grid-area: site-logo;
 			margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Varia is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Alves is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4144,6 +4144,9 @@ body:not(.fse-enabled) #masthead {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header .site-logo {
 		grid-area: site-logo;

--- a/alves/style.css
+++ b/alves/style.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Varia is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Alves is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4173,6 +4173,9 @@ body:not(.fse-enabled) #masthead {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header .site-logo {
 		grid-area: site-logo;

--- a/hever/sass/_extra-child-theme.scss
+++ b/hever/sass/_extra-child-theme.scss
@@ -82,6 +82,12 @@ body:not(.fse-enabled) {
 			margin-bottom: 0;
 		}
 
+		&.has-logo:not(.has-title-and-tagline) {
+			grid-template-areas:
+				"site-logo main-navigation"
+				"site-logo social-navigation";
+		}
+
 		.site-logo {
 			grid-area: site-logo;
 			margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -16,7 +16,7 @@ Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custo
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Hever is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Hever is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4076,6 +4076,9 @@ body:not(.fse-enabled) #colophon {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header .site-logo {
 		grid-area: site-logo;

--- a/hever/style.css
+++ b/hever/style.css
@@ -16,7 +16,7 @@ Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custo
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Hever is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Hever is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4105,6 +4105,9 @@ body:not(.fse-enabled) #colophon {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header .site-logo {
 		grid-area: site-logo;

--- a/morden/header.php
+++ b/morden/header.php
@@ -26,7 +26,7 @@
 		wp_body_open();
 	}
 ?>
-	
+
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 

--- a/morden/header.php
+++ b/morden/header.php
@@ -10,6 +10,11 @@
  * @subpackage Varia
  * @since 1.0.0
  */
+$has_primary_nav = has_nav_menu( 'menu-1' );
+$header_classes  = 'site-header-wrap responsive-max-width';
+$header_classes .= has_custom_logo() ? ' has-logo' : '';
+$header_classes .= 1 === get_theme_mod( 'header_text', true ) ? ' has-title-and-tagline' : '';
+$header_classes .= $has_primary_nav ? ' has-menu' : '';
 ?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -32,7 +37,7 @@
 
 	<?php if ( class_exists( 'A8C\FSE\WP_Template' ) ) : // If the FSE plugin is active, use the Header template for content. ?>
 
-		<header class="fse-template-part fse-header entry-content">
+		<header id="masthead" class="fse-template-part fse-header entry-content">
 			<?php
 				$template = new A8C\FSE\WP_Template();
 				$template->output_template_content( A8C\FSE\WP_Template::HEADER );
@@ -40,15 +45,13 @@
 		</header>
 
 	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>
-
-		<header id="masthead" class="site-header">
-
-			<div class="site-header-wrap">
-
+		<header id="masthead" class="site-header" role="banner">
+			<div class="<?php echo $header_classes; ?>">
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-				<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+				<?php if ( $has_primary_nav ) : ?>
 					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varia' ); ?>">
+
 						<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
 						<label for="toggle" id="toggle-menu" class="button">
 							<?php _e( 'Menu', 'varia' ); ?>
@@ -57,6 +60,7 @@
 							<span class="hide-visually expanded-text"><?php _e( 'expanded', 'varia' ); ?></span>
 							<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'varia' ); ?></span>
 						</label>
+
 						<?php
 						wp_nav_menu(
 							array(
@@ -70,7 +74,7 @@
 				<?php endif; ?>
 
 				<?php if ( has_nav_menu( 'social' ) ) : ?>
-					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'varia' ); ?>">
+					<nav class="social-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'varia' ); ?>">
 						<?php
 						wp_nav_menu(
 							array(
@@ -85,7 +89,7 @@
 					</nav><!-- .social-navigation -->
 				<?php endif; ?>
 
-			</div>
+			</div><!-- .site-header-wrap -->
 
 		</header><!-- #masthead -->
 

--- a/morden/sass/_extra-child-theme.scss
+++ b/morden/sass/_extra-child-theme.scss
@@ -116,6 +116,12 @@ body {
 			margin-bottom: 0;
 		}
 
+		&.has-logo:not(.has-title-and-tagline) {
+			grid-template-areas:
+				"site-logo main-navigation"
+				"site-logo social-navigation";
+		}
+
 		.site-logo {
 			grid-area: site-logo;
 			margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Varia is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Morden is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4104,6 +4104,9 @@ p:not(.site-title) a:hover {
 	.site-header-wrap > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header-wrap.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header-wrap .site-logo {
 		grid-area: site-logo;

--- a/morden/style.css
+++ b/morden/style.css
@@ -16,7 +16,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 
-Varia is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
+Morden is a child theme of Varia which is based on Underscores https://underscores.me/, (C) 2012-2019 Automattic, Inc.
 Underscores is distributed under the terms of the GNU GPL v2 or later.
 
 Normalizing styles have been helped along thanks to the fine work of
@@ -4133,6 +4133,9 @@ p:not(.site-title) a:hover {
 	.site-header-wrap > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header-wrap.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-header-wrap .site-logo {
 		grid-area: site-logo;

--- a/varia/header.php
+++ b/varia/header.php
@@ -10,6 +10,11 @@
  * @subpackage Varia
  * @since 1.0.0
  */
+$has_primary_nav = has_nav_menu( 'menu-1' );
+$header_classes  = 'site-header responsive-max-width';
+$header_classes .= has_custom_logo() ? ' has-logo' : '';
+$header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
+$header_classes .= $has_primary_nav ? ' has-menu' : '';
 ?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -26,7 +31,7 @@
 		wp_body_open();
 	}
 ?>
-	
+
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'varia' ); ?></a>
 
@@ -40,13 +45,12 @@
 		</header>
 
 	<?php else : // Otherwise we'll fallback to the default Varia header below. ?>
-
-		<header id="masthead" class="site-header responsive-max-width">
-
+		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 			<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+			<?php if ( $has_primary_nav ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varia' ); ?>">
+
 					<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
 					<label for="toggle" id="toggle-menu" class="button">
 						<?php _e( 'Menu', 'varia' ); ?>
@@ -55,6 +59,7 @@
 						<span class="hide-visually expanded-text"><?php _e( 'expanded', 'varia' ); ?></span>
 						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'varia' ); ?></span>
 					</label>
+
 					<?php
 					wp_nav_menu(
 						array(
@@ -68,7 +73,7 @@
 			<?php endif; ?>
 
 			<?php if ( has_nav_menu( 'social' ) ) : ?>
-				<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'varia' ); ?>">
+				<nav class="social-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'varia' ); ?>">
 					<?php
 					wp_nav_menu(
 						array(

--- a/varia/header.php
+++ b/varia/header.php
@@ -13,7 +13,7 @@
 $has_primary_nav = has_nav_menu( 'menu-1' );
 $header_classes  = 'site-header responsive-max-width';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';
-$header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
+$header_classes .= 1 === get_theme_mod( 'header_text', true ) ? ' has-title-and-tagline' : '';
 $header_classes .= $has_primary_nav ? ' has-menu' : '';
 ?><!doctype html>
 <html <?php language_attributes(); ?>>

--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -18,8 +18,8 @@ function varia_wpcom_setup() {
 	// Disable automatically generated color palettes.
 	add_theme_support( 'wpcom-colors', array(
 	        'only-featured-palettes' => true,
-	) );	
-	
+	) );
+
 	// Set theme colors for third party services.
 	if ( ! isset( $themecolors ) ) {
 		$themecolors = array(

--- a/varia/template-parts/header/site-branding.php
+++ b/varia/template-parts/header/site-branding.php
@@ -6,27 +6,32 @@
  * @subpackage Varia
  * @since 1.0.0
  */
-?>
-<div class="site-branding">
+$blog_info    = get_bloginfo( 'name' );
+$description  = get_bloginfo( 'description', 'display' );
+$show_title   = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
+$header_class = $show_title ? 'site-title' : 'screen-reader-text';
 
-	<?php if ( has_custom_logo() ) : ?>
+?>
+
+<?php if ( has_custom_logo() && $show_title ) : ?>
+	<div class="site-logo"><?php the_custom_logo(); ?></div>
+<?php endif; ?>
+
+<div class="site-branding">
+	<?php if ( has_custom_logo() && ! $show_title ) : ?>
 		<div class="site-logo"><?php the_custom_logo(); ?></div>
 	<?php endif; ?>
-	<?php $blog_info = get_bloginfo( 'name' ); ?>
-	<?php if ( ! empty( $blog_info ) ) : ?>
+	<?php if ( ! empty( $blog_info ) && $show_title ) : ?>
 		<?php if ( is_front_page() && is_home() ) : ?>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<h1 class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></h1>
 		<?php else : ?>
-			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+			<p class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></p>
 		<?php endif; ?>
 	<?php endif; ?>
 
-	<?php
-	$description = get_bloginfo( 'description', 'display' );
-	if ( $description || is_customize_preview() ) :
-		?>
-			<p class="site-description">
-				<?php echo $description; ?>
-			</p>
+	<?php if ( ( $description || is_customize_preview() ) && $show_title ) : ?>
+		<p class="site-description">
+			<?php echo $description; ?>
+		</p>
 	<?php endif; ?>
 </div><!-- .site-branding -->

--- a/varia/template-parts/header/site-branding.php
+++ b/varia/template-parts/header/site-branding.php
@@ -6,32 +6,27 @@
  * @subpackage Varia
  * @since 1.0.0
  */
-$blog_info    = get_bloginfo( 'name' );
-$description  = get_bloginfo( 'description', 'display' );
-$show_title   = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
-$header_class = $show_title ? 'site-title' : 'screen-reader-text';
-
 ?>
-
-<?php if ( has_custom_logo() && $show_title ) : ?>
-	<div class="site-logo"><?php the_custom_logo(); ?></div>
-<?php endif; ?>
-
 <div class="site-branding">
-	<?php if ( has_custom_logo() && ! $show_title ) : ?>
+
+	<?php if ( has_custom_logo() ) : ?>
 		<div class="site-logo"><?php the_custom_logo(); ?></div>
 	<?php endif; ?>
-	<?php if ( ! empty( $blog_info ) && $show_title ) : ?>
+	<?php $blog_info = get_bloginfo( 'name' ); ?>
+	<?php if ( ! empty( $blog_info ) ) : ?>
 		<?php if ( is_front_page() && is_home() ) : ?>
-			<h1 class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></h1>
+			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 		<?php else : ?>
-			<p class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></p>
+			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
 		<?php endif; ?>
 	<?php endif; ?>
 
-	<?php if ( ( $description || is_customize_preview() ) && $show_title ) : ?>
-		<p class="site-description">
-			<?php echo $description; ?>
-		</p>
+	<?php
+	$description = get_bloginfo( 'description', 'display' );
+	if ( $description || is_customize_preview() ) :
+		?>
+			<p class="site-description">
+				<?php echo $description; ?>
+			</p>
 	<?php endif; ?>
 </div><!-- .site-branding -->


### PR DESCRIPTION
As raised in https://github.com/Automattic/themes/issues/1467, we should drop the site logo into the same line as the menu when the site title and tagline are hidden.

#### Changes proposed in this Pull Request:
- Adds site logo and site title/tagline classes to the header
- Displays the site-logo alongside the menu when there site title and tagline are hidden.

#### Testing instructions
Test that when the site title and tagline are hidden the site logo moves to the same line as the menus.

#### Screenshots:
<img width="1097" alt="Screenshot 2020-11-06 at 11 47 15" src="https://user-images.githubusercontent.com/275961/98363205-80ff6780-2026-11eb-9665-b3a6abff3ae8.png">
<img width="1077" alt="Screenshot 2020-11-06 at 11 46 54" src="https://user-images.githubusercontent.com/275961/98363215-8361c180-2026-11eb-8481-57a74b2866fe.png">


#### Related issue(s):
Fixes #1467
