### PR TITLE
fixed z-index of header semicircle

### DIFF
--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -19,7 +19,7 @@
 		position: absolute;
 		top: -#{map-deep-get($config-global, "spacing", "vertical") + 5px};
 		width: 200px;
-		z-index: 1;
+		z-index: 3;
 	}
 }
 

--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -3,26 +3,6 @@
  */
 // @import "";
 
-// Pgae
-#page {
-	position: relative;
-
-	&:before {
-		background: #{map-deep-get($config-global, "color", "foreground", "default")};
-		border-top-left-radius: 200px;
-		border-top-right-radius: 200px;
-		content: "";
-		display: block;
-		height: 100px;
-		left: 50%;
-		margin-left: -100px;
-		position: absolute;
-		top: -#{map-deep-get($config-global, "spacing", "vertical") + 5px};
-		width: 200px;
-		z-index: 3;
-	}
-}
-
 // Header
 #masthead {
 	align-content: center;
@@ -40,7 +20,7 @@
 	position: relative;
 	z-index: 2;
 
-	&:before {
+	&:after {
 		background: #{map-deep-get($config-global, "color", "foreground", "default")};
 		border-bottom-left-radius: 200px;
 		border-bottom-right-radius: 200px;
@@ -51,6 +31,20 @@
 		margin-left: -100px;
 		position: absolute;
 		bottom: -#{map-deep-get($config-global, "spacing", "vertical") + 5px};
+		width: 200px;
+	}
+
+	&:before {
+		background: #{map-deep-get($config-global, "color", "foreground", "default")};
+		border-top-left-radius: 200px;
+		border-top-right-radius: 200px;
+		content: "";
+		display: block;
+		height: 100px;
+		left: 50%;
+		margin-left: -100px;
+		position: absolute;
+		top: -#{map-deep-get($config-global, "spacing", "vertical") + 5px};
 		width: 200px;
 	}
 

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4005,7 +4005,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	position: absolute;
 	top: -37px;
 	width: 200px;
-	z-index: 1;
+	z-index: 3;
 }
 
 #masthead {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -3989,25 +3989,6 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 /**
  * Extra Child Theme Styles
  */
-#page {
-	position: relative;
-}
-
-#page:before {
-	background: #252E36;
-	border-top-right-radius: 200px;
-	border-top-left-radius: 200px;
-	content: "";
-	display: block;
-	height: 100px;
-	right: 50%;
-	margin-right: -100px;
-	position: absolute;
-	top: -37px;
-	width: 200px;
-	z-index: 3;
-}
-
 #masthead {
 	align-content: center;
 	align-items: center;
@@ -4025,7 +4006,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	z-index: 2;
 }
 
-#masthead:before {
+#masthead:after {
 	background: #252E36;
 	border-bottom-right-radius: 200px;
 	border-bottom-left-radius: 200px;
@@ -4036,6 +4017,20 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-right: -100px;
 	position: absolute;
 	bottom: -37px;
+	width: 200px;
+}
+
+#masthead:before {
+	background: #252E36;
+	border-top-right-radius: 200px;
+	border-top-left-radius: 200px;
+	content: "";
+	display: block;
+	height: 100px;
+	right: 50%;
+	margin-right: -100px;
+	position: absolute;
+	top: -37px;
 	width: 200px;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -4018,25 +4018,6 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 /**
  * Extra Child Theme Styles
  */
-#page {
-	position: relative;
-}
-
-#page:before {
-	background: #252E36;
-	border-top-left-radius: 200px;
-	border-top-right-radius: 200px;
-	content: "";
-	display: block;
-	height: 100px;
-	left: 50%;
-	margin-left: -100px;
-	position: absolute;
-	top: -37px;
-	width: 200px;
-	z-index: 3;
-}
-
 #masthead {
 	align-content: center;
 	align-items: center;
@@ -4054,7 +4035,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	z-index: 2;
 }
 
-#masthead:before {
+#masthead:after {
 	background: #252E36;
 	border-bottom-left-radius: 200px;
 	border-bottom-right-radius: 200px;
@@ -4065,6 +4046,20 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-left: -100px;
 	position: absolute;
 	bottom: -37px;
+	width: 200px;
+}
+
+#masthead:before {
+	background: #252E36;
+	border-top-left-radius: 200px;
+	border-top-right-radius: 200px;
+	content: "";
+	display: block;
+	height: 100px;
+	left: 50%;
+	margin-left: -100px;
+	position: absolute;
+	top: -37px;
 	width: 200px;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4034,7 +4034,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	position: absolute;
 	top: -37px;
 	width: 200px;
-	z-index: 1;
+	z-index: 3;
 }
 
 #masthead {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Just changing z-index of the ::before pseudo-element was causing problems with the semicirle overlapping the site title so I decided to move it from `#page` to `#masthead` since that's where the other semicircle is.

To test this:

* Activate Brompton on your test site. Select to use Brompton's home page.
* Go to edit homepage
* Make sure that the cover image has an overlay active
* Check the frontend, both semi circles should be on top of the red borders of the header and the whole header should be on top of the cover below.

Before | After
--- | ---
<img width="1067" alt="Screenshot 2020-11-12 at 09 41 07" src="https://user-images.githubusercontent.com/3593343/98916368-5f412d00-24cb-11eb-938b-3893048749be.png"> | <img width="1315" alt="Screenshot 2020-11-12 at 09 40 45" src="https://user-images.githubusercontent.com/3593343/98916380-6405e100-24cb-11eb-8e99-f7ce752eeb03.png">


#### Related issue(s):

Closes #2800 
