### PR TITLE
Try/monticello block menu patterns

### DIFF
--- a/monticello/block-template-parts/menu-list-item.html
+++ b/monticello/block-template-parts/menu-list-item.html
@@ -1,0 +1,23 @@
+<!-- wp:columns {"className":"theme-menu-item"} -->
+<div class="wp-block-columns theme-menu-item">
+    <!-- wp:column {"width":"80%"} -->
+    <div class="wp-block-column" style="flex-basis:80%">
+        <!-- wp:paragraph {"className":"theme-menu-item-name"} -->
+        <p class="theme-menu-item-name">Menu Item Name</p>
+        <!-- /wp:paragraph -->
+    
+        <!-- wp:paragraph {"className":"theme-menu-item-description"} -->
+        <p class="theme-menu-item-description">Menu Item Description</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column {"width":"20%"} -->
+    <div class="wp-block-column" style="flex-basis:20%">
+        <!-- wp:paragraph {"align":"right","className":"theme-menu-item-price"} -->
+        <p class="has-text-align-right theme-menu-item-price">$0.00</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->

--- a/monticello/functions.php
+++ b/monticello/functions.php
@@ -63,3 +63,6 @@ function monticello_fonts_url() {
 
 // Block Patterns.
 require get_template_directory() . '/inc/block-patterns.php';
+
+// Block Styles.
+require get_template_directory() . '/inc/block-styles.php';

--- a/monticello/inc/block-patterns.php
+++ b/monticello/inc/block-patterns.php
@@ -56,33 +56,41 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'      => esc_html__( 'Menu Item', 'monticello' ),
 			'categories' => array( 'monticello' ),
 			'content'    => '
-			<!-- wp:group {"className":"is-style-menu-list-item"} -->
-			<div class="wp-block-group is-style-menu-list-item"><div class="wp-block-group__inner-container">
-<!-- wp:columns -->
-<div class="wp-block-columns">
-    <!-- wp:column {"width":"80%"} -->
-    <div class="wp-block-column" style="flex-basis:80%">
-        <!-- wp:paragraph {"className":"menu-list-item-name"} -->
-        <p class="menu-list-item-name">Menu Item Name</p>
-        <!-- /wp:paragraph -->
+				<!-- wp:group {"className":"is-style-menu-list-item"} -->
+				<div class="wp-block-group is-style-menu-list-item"><div class="wp-block-group__inner-container">
+
+				<!-- wp:columns -->
+				<div class="wp-block-columns">
+
+    			<!-- wp:column {"width":"80%"} -->
+				<div class="wp-block-column" style="flex-basis:80%">
+
+        		<!-- wp:paragraph {"className":"menu-list-item-name"} -->
+        		<p class="menu-list-item-name">Menu Item Name</p>
+        		<!-- /wp:paragraph -->
     
-        <!-- wp:paragraph {"className":"menu-list-item-description"} -->
-        <p class="menu-list-item-description">Menu Item Description</p>
-        <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
+        		<!-- wp:paragraph {"className":"menu-list-item-description"} -->
+        		<p class="menu-list-item-description">Menu Item Description</p>
+				<!-- /wp:paragraph -->
+
+    			</div>
+    			<!-- /wp:column -->
     
-    <!-- wp:column {"width":"20%"} -->
-    <div class="wp-block-column" style="flex-basis:20%">
-        <!-- wp:paragraph {"align":"right","className":"menu-list-item-price"} -->
-        <p class="has-text-align-right menu-list-item-price">$0.00</p>
-        <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
-</div></div>
-<!-- /wp:group -->
+    			<!-- wp:column {"width":"20%"} -->
+				<div class="wp-block-column" style="flex-basis:20%">
+
+        		<!-- wp:paragraph {"align":"right","className":"menu-list-item-price"} -->
+        		<p class="has-text-align-right menu-list-item-price">$0.00</p>
+				<!-- /wp:paragraph -->
+
+    			</div>
+				<!-- /wp:column -->
+
+				</div>
+				<!-- /wp:columns -->
+
+				</div></div>
+				<!-- /wp:group -->
 			',
 
 		)

--- a/monticello/inc/block-patterns.php
+++ b/monticello/inc/block-patterns.php
@@ -48,4 +48,43 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			<!-- /wp:group -->',
 		)
 	);
+
+	// Menu List Item
+	register_block_pattern(
+		'monticello/menu-list-item',
+		array(
+			'title'      => esc_html__( 'Menu Item', 'monticello' ),
+			'categories' => array( 'monticello' ),
+			'content'    => '
+			<!-- wp:group {"className":"is-style-menu-list-item"} -->
+			<div class="wp-block-group is-style-menu-list-item"><div class="wp-block-group__inner-container">
+<!-- wp:columns -->
+<div class="wp-block-columns">
+    <!-- wp:column {"width":"80%"} -->
+    <div class="wp-block-column" style="flex-basis:80%">
+        <!-- wp:paragraph {"className":"menu-list-item-name"} -->
+        <p class="menu-list-item-name">Menu Item Name</p>
+        <!-- /wp:paragraph -->
+    
+        <!-- wp:paragraph {"className":"menu-list-item-description"} -->
+        <p class="menu-list-item-description">Menu Item Description</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column {"width":"20%"} -->
+    <div class="wp-block-column" style="flex-basis:20%">
+        <!-- wp:paragraph {"align":"right","className":"menu-list-item-price"} -->
+        <p class="has-text-align-right menu-list-item-price">$0.00</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+</div></div>
+<!-- /wp:group -->
+			',
+
+		)
+	);
 }

--- a/monticello/inc/block-patterns.php
+++ b/monticello/inc/block-patterns.php
@@ -56,8 +56,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'      => esc_html__( 'Menu Item', 'monticello' ),
 			'categories' => array( 'monticello' ),
 			'content'    => '
-				<!-- wp:group {"className":"is-style-menu-list-item"} -->
-				<div class="wp-block-group is-style-menu-list-item"><div class="wp-block-group__inner-container">
+				<!-- wp:group {"className":"menu-list-item"} -->
+				<div class="wp-block-group menu-list-item"><div class="wp-block-group__inner-container">
 
 				<!-- wp:columns -->
 				<div class="wp-block-columns">

--- a/monticello/inc/block-styles.css
+++ b/monticello/inc/block-styles.css
@@ -1,0 +1,27 @@
+.is-style-menu-list-item {
+	font-family: var(--wp--custom--font-family--secondary);
+	font-weight: 700;
+    margin: 0 0 12px;
+}
+
+.is-style-menu-list-item p,
+.is-style-menu-list-item .wp-block-columns {
+	margin: 0;
+}
+
+.is-style-menu-list-item .menu-list-item-description,
+.is-style-menu-list-item .menu-list-item-price {
+	font-weight: 400;
+}
+
+/*
+These styles are specific to the editor and mostly added so that I knew what I was working with while I was working in the editor.
+I don't expect the border is something that would remain.
+The margins being forced on the elements in the editor seem over-zealous though.
+*/
+.block-editor .is-style-menu-list-item {
+    border: 2px grey dotted;
+}
+.block-editor .editor-styles-wrapper .is-style-menu-list-item p {
+ 	margin: 0;
+}

--- a/monticello/inc/block-styles.css
+++ b/monticello/inc/block-styles.css
@@ -1,27 +1,17 @@
-.is-style-menu-list-item {
-	font-family: var(--wp--custom--font-family--secondary);
-	font-weight: 700;
-    margin: 0 0 12px;
+.is-style-highlighted-group {
+    background-color: var(--wp--preset--color--orange);
+    color: var(--wp--preset--color--light-beige-3);
+    padding: 50px 80px;
+    font-weight: 400;
 }
 
-.is-style-menu-list-item p,
-.is-style-menu-list-item .wp-block-columns {
-	margin: 0;
-}
-
-.is-style-menu-list-item .menu-list-item-description,
-.is-style-menu-list-item .menu-list-item-price {
-	font-weight: 400;
-}
-
-/*
-These styles are specific to the editor and mostly added so that I knew what I was working with while I was working in the editor.
-I don't expect the border is something that would remain.
-The margins being forced on the elements in the editor seem over-zealous though.
-*/
-.block-editor .is-style-menu-list-item {
-    border: 2px grey dotted;
-}
-.block-editor .editor-styles-wrapper .is-style-menu-list-item p {
- 	margin: 0;
+.is-style-highlighted-group h1,
+.is-style-highlighted-group h2,
+.is-style-highlighted-group h3,
+.is-style-highlighted-group h4,
+.is-style-highlighted-group h5,
+.is-style-highlighted-group h6
+{
+    font-family: var(--wp--custom--font-family--primary);
+    font-weight: 600;
 }

--- a/monticello/inc/block-styles.php
+++ b/monticello/inc/block-styles.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Block Styles
+ *
+ * @link https://developer.wordpress.org/block-editor/developers/filters/block-filters/#server-side-registration-helper
+ *
+ * @package WordPress
+ * @subpackage Monticello
+ * @since 1.0.0
+ */
+
+ /**
+ * Register Custom Block Styles
+ */
+if ( function_exists( 'register_block_style' ) ) {
+	function block_styles_register_block_styles() {
+
+		/**
+		 * Register stylesheet
+		 */
+		wp_register_style(
+			'monticello-block-style',
+			get_template_directory_uri() . '/inc/block-styles.css',
+			array(),
+			wp_get_theme()->get( 'Version' )
+		);
+
+		/**
+		 * Register block style
+		 */
+		register_block_style(
+			'core/group',
+			array(
+				'name'         => 'menu-list-item',
+				'label'        => 'Menu List Item',
+				'style_handle' => 'monticello-block-style',
+			)
+		);
+	}
+
+	add_action( 'init', 'block_styles_register_block_styles' );
+}

--- a/monticello/inc/block-styles.php
+++ b/monticello/inc/block-styles.php
@@ -31,8 +31,8 @@ if ( function_exists( 'register_block_style' ) ) {
 		register_block_style(
 			'core/group',
 			array(
-				'name'         => 'menu-list-item',
-				'label'        => 'Menu List Item',
+				'name'         => 'highlighted-group',
+				'label'        => 'Highlighted Group',
 				'style_handle' => 'monticello-block-style',
 			)
 		);

--- a/monticello/style.css
+++ b/monticello/style.css
@@ -82,18 +82,23 @@ represented in .json
 }
 
 /* END BUTTON STYLES */
+
 /*
-.theme-menu-item {
+These are styles for the 'menu-list-item' block pattern.
+I'm not sure that these style should live here but I don't have a better place for them yet.
+*/
+.menu-list-item {
 	font-family: var(--wp--custom--font-family--secondary);
 	font-weight: 700;
+    margin: 0 0 12px;
+}
+
+.menu-list-item p,
+.menu-list-item .wp-block-columns {
 	margin: 0;
 }
 
-.theme-menu-item p {
-	margin: 0;
-}
-
-.theme-menu-item .theme-menu-item-description {
+.menu-list-item .menu-list-item-description,
+.menu-list-item .menu-list-item-price {
 	font-weight: 400;
 }
-*/

--- a/monticello/style.css
+++ b/monticello/style.css
@@ -82,3 +82,18 @@ represented in .json
 }
 
 /* END BUTTON STYLES */
+/*
+.theme-menu-item {
+	font-family: var(--wp--custom--font-family--secondary);
+	font-weight: 700;
+	margin: 0;
+}
+
+.theme-menu-item p {
+	margin: 0;
+}
+
+.theme-menu-item .theme-menu-item-description {
+	font-weight: 400;
+}
+*/


### PR DESCRIPTION
A first pass a creating re-usable elements that can be used to build menus for Monticello block-based theme.

In block-patterns.php I registered a NEW pattern called 'Menu Item'.  
This was mostly gutenberg markup I coped out of a page editor and tweaked by hand a little bit as I worked through it.  It's essentially a GROUP at the top-level wrapping a COLUMNS container with three pieces of content (name, description, price).  The top-level GROUP has the `is-style-menu-list-item` class applied out-of-the-gate so that the block style (outlined later) is picked up as soon as it's dropped in.  The other P elements all have helpful custom classes assigned for further styling.

In block-styles.php (added and called from functions.php) the custom block styles are initialized and pulled in from block-styles.css and the `menu-list-item` block style is defined.

block-styles.css provides the custom CSS that the `menu-list-item` needs to lay out properly in this theme.

The above registers everything and allows me to drop reusable elements into my page that I can pretty easily change to suit the needs outlined in the comp.  The result, after some work, looks something like this:

![image](https://user-images.githubusercontent.com/146530/99586892-54e4ce80-29b6-11eb-8157-4082ce88c363.png)

![image](https://user-images.githubusercontent.com/146530/99586243-71343b80-29b5-11eb-9654-af962b32048b.png)

I noticed a couple of limitations while leveraging these elements to build out a page:

* While it's simple to add these elements onto a PAGE it's not possible to easily add them into a CONTAINER.  When attempting to add menu items to my two-column section I was NOT offered the options of choosing one of the patterns.
![image](https://user-images.githubusercontent.com/146530/99586425-b9ebf480-29b5-11eb-9ce3-69d40a57b34d.png)

* Using the Gutenberg editor to edit a POST I was able to leverage this Block Pattern.  However, using the Full Site Editor I had no option to choose to insert a Block Pattern.
![image](https://user-images.githubusercontent.com/146530/99586720-1818d780-29b6-11eb-8d01-4fd09cee3a35.png)
