### PR TITLE
Added zip files and package-lock to sync ignore

### DIFF
--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -3,6 +3,8 @@
 .gitignore
 .sandbox-config
 .sandbox-ignore
+package-lock.json
 sandbox.sh
 vendor
 node_modules
+**/*.zip


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Added zip files and package-lock to sync ignore so that they would be excluded from sandbox syncing scripts.

The remaining files yet to be synced due to this change can be synced here: D53109-code

#### Related issue(s):

no related issues