### PR TITLE
Varia: use the_content() for Testimonials archives

### DIFF
--- a/varia/archive-jetpack-testimonial.php
+++ b/varia/archive-jetpack-testimonial.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The template for displaying Jetpack Testomonial archive pages
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Varia
+ * @since 1.0.0
+ */
+
+get_header();
+?>
+
+	<section id="primary" class="content-area">
+		<main id="main" class="site-main">
+
+		<?php if ( have_posts() ) : ?>
+
+			<header class="page-header responsive-max-width">
+				<?php
+					the_archive_title( '<h1 class="page-title">', '</h1>' );
+				?>
+			</header><!-- .page-header -->
+
+			<?php
+			// Start the Loop.
+			while ( have_posts() ) :
+				the_post();
+
+				/*
+				 * Include the Post-Format-specific template for the content.
+				 * If you want to override this in a child theme, then include a file
+				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
+				 */
+				get_template_part( 'template-parts/content/content-testimonial', 'excerpt' );
+
+				// End the loop.
+			endwhile;
+
+			// Previous/next page navigation.
+			varia_the_posts_navigation();
+
+			// If no content, include the "No posts found" template.
+		else :
+			get_template_part( 'template-parts/content/content', 'none' );
+
+		endif;
+		?>
+		</main><!-- #main -->
+	</section><!-- #primary -->
+
+<?php
+get_footer();

--- a/varia/template-parts/content/content-testimonial-excerpt.php
+++ b/varia/template-parts/content/content-testimonial-excerpt.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Template part for displaying Jetpack Tesimonial archives excerpt
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Varia
+ * @since 1.0.0
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header responsive-max-width">
+		<?php
+		if ( is_sticky() && is_home() && ! is_paged() ) {
+			printf( '<span class="sticky-post">%s</span>', _x( 'Featured', 'post', 'varia' ) );
+		}
+		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
+		?>
+	</header><!-- .entry-header -->
+
+	<?php varia_post_thumbnail(); ?>
+
+	<div class="entry-content">
+		<?php the_content(); ?>
+	</div><!-- .entry-content -->
+
+	<footer class="entry-footer responsive-max-width">
+		<?php varia_entry_footer(); ?>
+	</footer><!-- .entry-footer -->
+</article><!-- #post-${ID} -->


### PR DESCRIPTION
Currently Varia themes user the_excerpt() for in the archives for all posts. This strips out any styling from the content.

This seems appropriate for many instances. With Jetpack-Testimonials it is *much* more likely that the full content of the post is likely to be designed to be shown in the archive view as well. 

#### Changes proposed in this Pull Request:

This Pull Request adds templates for the Jetpack-Testimonials archive in order to use the_content() instead - retaining any styling.

#### Screenshots

![](https://user-images.githubusercontent.com/1842363/75648363-fcdd2f00-5ca3-11ea-8a7a-971f074fdc8a.png)
[link to image](https://user-images.githubusercontent.com/1842363/75648363-fcdd2f00-5ca3-11ea-8a7a-971f074fdc8a.png)

#### Related issue(s):

#1832 
