### PR TITLE
GH-2847 Adds AMP meta to compatible themes.

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: alves
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: alves
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style.css
+++ b/alves/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: alves
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: balasana
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.10
+Version: 1.2.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: balasana
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.10
+Version: 1.2.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: balasana
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.10
+Version: 1.2.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: barnsbury
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: barnsbury
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: barnsbury
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: brompton
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: brompton
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: brompton
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: exford
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: exford
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style.css
+++ b/exford/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: exford
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: hever
 Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,12 +6,13 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: hever
 Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,12 +6,13 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: hever
 Tags: full-site-editing, one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: leven
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: leven
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style.css
+++ b/leven/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: leven
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: mayland
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: mayland
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: mayland
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: maywood
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: maywood
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: maywood
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.12
+Version: 1.5.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: morden
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.12
+Version: 1.5.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: morden
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.12
+Version: 1.5.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style.css
+++ b/morden/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: morden
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: redhill
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: redhill
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: redhill
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: rivington
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: rivington
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: rivington
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: shawburn
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: shawburn
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: shawburn
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -11,6 +11,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: stow
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: stow
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style.css
+++ b/stow/style.css
@@ -12,6 +12,7 @@ License URI: LICENSE
 Template: varia
 Text Domain: stow
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, full-site-editing
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -11,6 +11,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/varia/style.css
+++ b/varia/style.css
@@ -11,6 +11,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -10,6 +10,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+AMP: true
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Added `AMP:true` meta in the following themes.

- [x] Varia
- [x] Alves
- [x] Balasana
- [x] Barnsbury
- [x] Brompton
- [x] Exford
- [x] Hever
- [x] Leven
- [x] Mayland
- [x] Maywood
- [x] Morden
- [x] Redhill
- [x] Rivington
- [x] Shawburn
- [x] Stow


#### #2847
