### PR TITLE
Barnsbury: updated position of logo when no tagline or title are enabled

### DIFF
--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/_extra-child-theme.scss
+++ b/barnsbury/sass/_extra-child-theme.scss
@@ -72,6 +72,13 @@ a {
 			margin-top: 0;
 			margin-bottom: 0;
 		}
+
+		&.has-logo:not(.has-title-and-tagline) {
+			grid-template-areas:
+				"site-logo main-navigation"
+				"site-logo social-navigation";
+		}
+
 	}
 
 	.site-logo {

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4045,6 +4045,9 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-logo {
 		grid-area: site-logo;

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.9
+Version: 1.2.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4074,6 +4074,9 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	.site-header > * {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+	.site-header.has-logo:not(.has-title-and-tagline) {
+		grid-template-areas: "site-logo main-navigation" "site-logo social-navigation";
 	}
 	.site-logo {
 		grid-area: site-logo;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->


Solves https://github.com/Automattic/themes/issues/1467 for Barnsbury theme following the solution applied to other Varia themes: on https://github.com/Automattic/themes/pull/2782

<img width="1364" alt="Screenshot 2020-11-23 at 13 32 22" src="https://user-images.githubusercontent.com/3593343/99962378-5e907c80-2d90-11eb-885d-c4de0ea26989.png">

<img width="1376" alt="Screenshot 2020-11-23 at 13 32 15" src="https://user-images.githubusercontent.com/3593343/99962382-5fc1a980-2d90-11eb-8c3e-d20aca24538e.png">

