### PR TITLE
Require theme files without assuming the theme is installed

### DIFF
--- a/spearhead/inc/wpcom-colors.php
+++ b/spearhead/inc/wpcom-colors.php
@@ -1,6 +1,7 @@
 <?php
 
-require_once get_template_directory() . '/inc/wpcom-colors-utils.php';
+// We can't assume that the theme is activated when this is called, so we can't rely on get_template_directory().
+require_once get_theme_root() . '/pub/seedlet/inc/wpcom-colors-utils.php';
 
 seedlet_define_color_annotations(
 	array(


### PR DESCRIPTION
Spearhead was assuming that it was activated when including this file, but there are some cases where this is loaded without the theme being active. This change will load the correct files regardless of the current active theme.