### PR TITLE
Spearhead: fix themesniffer issues for dotorg submission

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -149,9 +149,9 @@ add_action( 'enqueue_block_assets', 'spearhead_block_extends' );
 /**
  * Add Google webfonts
  *
- * @return string
+ * @return value
  */
-function spearhead_fonts_url() : string {
+function spearhead_fonts_url() {
 	$fonts_url = '';
 
 	$font_families   = array();
@@ -168,7 +168,7 @@ function spearhead_fonts_url() : string {
 /**
  * Load extras
  */
-function seedlet_entry_meta_header() : void {
+function seedlet_entry_meta_header() {
 	// Hide author, post date, category and tag text for pages.
 	if ( 'post' === get_post_type() ) {
 		// Posted on

--- a/spearhead/header.php
+++ b/spearhead/header.php
@@ -26,16 +26,16 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'seedlet' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'spearhead' ); ?></a>
 
 		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 			<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 
 			<?php if ( $has_primary_nav || has_nav_menu( 'social' ) ) : ?>
-				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Main', 'seedlet' ); ?>">
+				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Main', 'spearhead' ); ?>">
 					<button id="primary-close-menu" class="button close">
-						<span class="dropdown-icon close"><?php _e( 'Close', 'seedlet' ); ?> <?php echo seedlet_get_icon_svg( 'close' ); ?></span>
-						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'seedlet' ); ?></span>
+						<span class="dropdown-icon close"><?php _e( 'Close', 'spearhead' ); ?> <?php echo spearhead_get_icon_svg( 'close' ); ?></span>
+						<span class="hide-visually collapsed-text"><?php _e 'collapsed', 'spearhead' ); ?></span>
 					</button>
 					<div class="extra-navigation-wrapper">
 						<?php
@@ -60,7 +60,7 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 								array(
 									'theme_location'  => 'social',
 									'link_before'     => '<span class="screen-reader-text">',
-									'link_after'      => '</span>' . seedlet_get_icon_svg( 'link' ),
+									'link_after'      => '</span>' . spearhead_get_icon_svg( 'link' ),
 									'container_class' => 'social-navigation',
 									'depth'           => 1,
 								)
@@ -74,14 +74,14 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 			<div class="menu-button-container">
 				<?php if ( $has_primary_nav ) : ?>
 					<button id="primary-open-menu" class="button open">
-						<span class="dropdown-icon open"><?php _e( 'Menu', 'seedlet' ); ?> <?php echo seedlet_get_icon_svg( 'menu' ); ?></span>
-						<span class="hide-visually expanded-text"><?php _e( 'expanded', 'seedlet' ); ?></span>
+						<span class="dropdown-icon open"><?php _e( 'Menu', 'spearhead' ); ?> <?php echo seedlet_get_icon_svg( 'menu' ); ?></span>
+						<span class="hide-visually expanded-text"><?php _e( 'expanded', 'spearhead' ); ?></span>
 					</button>
 				<?php endif; ?>
 			</div>
 
 			<?php if ( class_exists( 'WooCommerce' ) ) : ?>
-				<nav class="woo-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Woo Minicart', 'seedlet' ); ?>">
+				<nav class="woo-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Woo Minicart', 'spearhead' ); ?>">
 					<?php
 					echo( sprintf(
 						'<button id="woo-close-menu" class="button close">
@@ -98,14 +98,14 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 									</li>
 								</ul>
 							</li>',
-						esc_html__( 'Close', 'seedlet' ),
-						seedlet_get_icon_svg( 'close' ),
-						esc_html__( 'collapsed', 'seedlet' ),
+						esc_html__( 'Close', 'spearhead' ),
+						spearhead_get_icon_svg( 'close' ),
+						esc_html__( 'collapsed', 'spearhead' ),
 						is_cart() ? 'current-menu-item' : '',
-						esc_attr__( 'View your shopping cart', 'seedlet' ),
-						seedlet_cart_link(),
-						esc_attr__( 'View your shopping list', 'seedlet' ),
-						seedlet_cart_widget()
+						esc_attr__( 'View your shopping cart', 'spearhead' ),
+						spearhead_cart_link(),
+						esc_attr__( 'View your shopping list', 'spearhead' ),
+						spearhead_cart_widget()
 					) );
 					?>
 				</nav><!-- .woo-navigation -->
@@ -114,8 +114,8 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 			<div class="menu-button-container">
 				<?php if ( class_exists( 'WooCommerce' ) ) : ?>
 					<button id="woo-open-menu" class="button open">
-						<span class="dropdown-icon open"><?php echo seedlet_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'seedlet' ); ?></span>
-						<span class="hide-visually expanded-text"><?php esc_html__( 'expanded', 'seedlet' ); ?></span>
+						<span class="dropdown-icon open"><?php echo spearhead_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'seedlet' ); ?></span>
+						<span class="hide-visually expanded-text"><?php esc_html__( 'expanded', 'spearhead' ); ?></span>
 					</button>
 				<?php endif; ?>
 			</div>

--- a/spearhead/header.php
+++ b/spearhead/header.php
@@ -63,7 +63,7 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 									'link_after'     => '</span>' . seedlet_get_icon_svg(
 										'link',
 										'container_class' => 'social-navigation',
-										'depth'           => 1,
+										'depth'           => 1
 									),
 								);
 						endif;

--- a/spearhead/header.php
+++ b/spearhead/header.php
@@ -34,8 +34,8 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 			<?php if ( $has_primary_nav || has_nav_menu( 'social' ) ) : ?>
 				<nav id="site-navigation" class="primary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Main', 'spearhead' ); ?>">
 					<button id="primary-close-menu" class="button close">
-						<span class="dropdown-icon close"><?php _e( 'Close', 'spearhead' ); ?> <?php echo spearhead_get_icon_svg( 'close' ); ?></span>
-						<span class="hide-visually collapsed-text"><?php _e 'collapsed', 'spearhead' ); ?></span>
+						<span class="dropdown-icon close"><?php _e( 'Close', 'spearhead' ); ?> <?php echo seedlet_get_icon_svg( 'close' ); ?></span>
+						<span class="hide-visually collapsed-text"><?php _e( 'collapsed', 'spearhead' ); ?></span>
 					</button>
 					<div class="extra-navigation-wrapper">
 						<?php
@@ -58,13 +58,14 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 						if ( has_nav_menu( 'social' ) ) :
 							wp_nav_menu(
 								array(
-									'theme_location'  => 'social',
-									'link_before'     => '<span class="screen-reader-text">',
-									'link_after'      => '</span>' . spearhead_get_icon_svg( 'link' ),
-									'container_class' => 'social-navigation',
-									'depth'           => 1,
-								)
-							);
+									'theme_location' => 'social',
+									'link_before'    => '<span class="screen-reader-text">',
+									'link_after'     => '</span>' . seedlet_get_icon_svg(
+										'link',
+										'container_class' => 'social-navigation',
+										'depth'           => 1,
+									),
+								);
 						endif;
 						?>
 					</div><!-- .extra-navigation-wrapper -->
@@ -99,7 +100,7 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 								</ul>
 							</li>',
 						esc_html__( 'Close', 'spearhead' ),
-						spearhead_get_icon_svg( 'close' ),
+						seedlet_get_icon_svg( 'close' ),
 						esc_html__( 'collapsed', 'spearhead' ),
 						is_cart() ? 'current-menu-item' : '',
 						esc_attr__( 'View your shopping cart', 'spearhead' ),
@@ -114,7 +115,7 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 			<div class="menu-button-container">
 				<?php if ( class_exists( 'WooCommerce' ) ) : ?>
 					<button id="woo-open-menu" class="button open">
-						<span class="dropdown-icon open"><?php echo spearhead_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'seedlet' ); ?></span>
+						<span class="dropdown-icon open"><?php echo seedlet_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'seedlet' ); ?></span>
 						<span class="hide-visually expanded-text"><?php esc_html__( 'expanded', 'spearhead' ); ?></span>
 					</button>
 				<?php endif; ?>

--- a/spearhead/header.php
+++ b/spearhead/header.php
@@ -115,7 +115,7 @@ $header_classes .= $has_primary_nav ? ' has-menu' : '';
 			<div class="menu-button-container">
 				<?php if ( class_exists( 'WooCommerce' ) ) : ?>
 					<button id="woo-open-menu" class="button open">
-						<span class="dropdown-icon open"><?php echo seedlet_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'seedlet' ); ?></span>
+						<span class="dropdown-icon open"><?php echo seedlet_get_icon_svg( 'shopping_cart' ); ?> <?php _e( 'Cart', 'spearhead' ); ?></span>
 						<span class="hide-visually expanded-text"><?php esc_html__( 'expanded', 'spearhead' ); ?></span>
 					</button>
 				<?php endif; ?>

--- a/spearhead/template-parts/content/content-excerpt.php
+++ b/spearhead/template-parts/content/content-excerpt.php
@@ -14,7 +14,7 @@
 	<header class="entry-header default-max-width">
 		<?php
 		if ( is_sticky() && is_home() && ! is_paged() ) {
-			printf( '<span class="sticky-post">%s</span>', _x( 'Featured', 'post', 'seedlet' ) );
+			printf( '<span class="sticky-post">%s</span>', _x( 'Featured', 'post', 'spearhead' ) );
 		}
 		the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		?>


### PR DESCRIPTION
This PR fixes a handful of issues in Spearhead reported by the themesniffer plugin.

**To test**
- Check out this PR and run `./package-dotorg.sh spearhead`
- Upload and activate the resulting theme zip.
- Install and run the [themesniffer plugin](https://github.com/WPTRT/theme-sniffer/releases/download/1.1.2/theme-sniffer.zip) using `spearhead` as the text domain and php 5.6, and using the WPThemeReview team as your ruleset
- Verify that the only errors are from `inc/block-patterns` and overriding Seedlet parent theme functions in `functions.php` — I believe these errors should be acceptable to the theme review team.