### PR TITLE
Maywood: Remove code which targets Gutenberg UI

### DIFF
--- a/maywood/inc/wpcom-editor-colors.php
+++ b/maywood/inc/wpcom-editor-colors.php
@@ -5,36 +5,54 @@
 
 // Background Color
 // $config-global--color-background-default
-add_editor_color_rule( 'bg', '#FFFFFF', array(
+add_editor_color_rule(
+	'bg',
+	'#FFFFFF',
+	array(
 
-	// Text-color
-	array( '#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color,
-			#editor .editor-styles-wrapper .wp-block-cover.has-background-dim, 
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color,
+			#editor .editor-styles-wrapper .wp-block-cover.has-background-dim,
 			#editor .editor-styles-wrapper .wp-block-cover-image.has-background-dim,
-			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .block-editor-block-list__block', 'color' ),
-	// Background-color
-	array( '#editor .editor-styles-wrapper,
-			#editor .editor-styles-wrapper .fse-template-part .main-navigation > div > ul > li > .sub-menu', 'background-color' ),
+			#editor .editor-styles-wrapper .wp-block-cover:not([class*="background-color"]) .block-editor-block-list__block',
+			'color',
+		),
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper,
+			#editor .editor-styles-wrapper .fse-template-part .main-navigation > div > ul > li > .sub-menu',
+			'background-color',
+		),
 
-	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .wp-block-separator.is-style-dots', 'color', '-1' ),
-	// Border-color darkened
-	array( '#editor .editor-styles-wrapper .wp-block-code', 'border-color', '-1' ),
-	// Border-top-color darkened
-	array( '#editor .editor-styles-wrapper .wp-block-pullquote', 'border-top-color', '-1' ),
-	// Border-bottom-color darkened
-	array( '#editor .editor-styles-wrapper .wp-block-pullquote,
-			#editor .editor-styles-wrapper .wp-block-separator', 'border-bottom-color', '-1' ),
+		// Text-color darkened
+		array( '#editor .editor-styles-wrapper .wp-block-separator.is-style-dots', 'color', '-1' ),
+		// Border-color darkened
+		array( '#editor .editor-styles-wrapper .wp-block-code', 'border-color', '-1' ),
+		// Border-top-color darkened
+		array( '#editor .editor-styles-wrapper .wp-block-pullquote', 'border-top-color', '-1' ),
+		// Border-bottom-color darkened
+		array(
+			'#editor .editor-styles-wrapper .wp-block-pullquote,
+			#editor .editor-styles-wrapper .wp-block-separator',
+			'border-bottom-color',
+			'-1',
+		),
 
-	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .wp-block-table.is-style-stripes tbody tr:nth-child(odd),
-			#editor .editor-styles-wrapper table.is-style-stripes tbody tr:nth-child(odd)', 'color', '-1' ),
+		// Background-color darkened
+		array(
+			'#editor .editor-styles-wrapper .wp-block-table.is-style-stripes tbody tr:nth-child(odd),
+			#editor .editor-styles-wrapper table.is-style-stripes tbody tr:nth-child(odd)',
+			'color',
+			'-1',
+		),
 
-	/**
-	 * Utility Classes
-	 */
-	// Text-color
-	array( '#editor .editor-styles-wrapper .has-primary-background-color[class],
+		/**
+		 * Utility Classes
+		 */
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .has-primary-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-primary-background-color[class],
 			#editor .editor-styles-wrapper .has-secondary-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-secondary-background-color[class],
@@ -45,55 +63,91 @@ add_editor_color_rule( 'bg', '#FFFFFF', array(
 			#editor .editor-styles-wrapper .has-foreground-light-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-foreground-light-background-color[class],
 			#editor .editor-styles-wrapper .has-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-color[class]', 'color' ),
-	// Background-color
-	array( '#editor .editor-styles-wrapper .has-background-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-background-color[class]', 'background-color' ),
+			#editor .editor-styles-wrapper .wp-block .has-background-color[class]',
+			'color',
+		),
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .has-background-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-background-background-color[class]',
+			'background-color',
+		),
 
-	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .has-background-dark-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-dark-color[class]', 'color', '-1'  ),
-	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .has-background-dark-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-dark-background-color[class]', 'background-color', '-1' ),
+		// Text-color darkened
+		array(
+			'#editor .editor-styles-wrapper .has-background-dark-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-background-dark-color[class]',
+			'color',
+			'-1',
+		),
+		// Background-color darkened
+		array(
+			'#editor .editor-styles-wrapper .has-background-dark-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-background-dark-background-color[class]',
+			'background-color',
+			'-1',
+		),
 
-	// Text-color lightened
-	array( '#editor .editor-styles-wrapper .has-background-light-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-light-color[class]', 'color', '+1'  ),
-	// Background-color lightened
-	array( '#editor .editor-styles-wrapper .has-background-light-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-background-light-background-color[class]', 'background-color', '+1' ),
+		// Text-color lightened
+		array(
+			'#editor .editor-styles-wrapper .has-background-light-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-background-light-color[class]',
+			'color',
+			'+1',
+		),
+		// Background-color lightened
+		array(
+			'#editor .editor-styles-wrapper .has-background-light-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-background-light-background-color[class]',
+			'background-color',
+			'+1',
+		),
 
-), __( 'Background Color' ) );
+	),
+	__( 'Background Color' )
+);
 
 // Link Color
 // $config-global--color-primary-default
-add_editor_color_rule( 'link', '#897248', array(
+add_editor_color_rule(
+	'link',
+	'#897248',
+	array(
 
-	// Text-color
-	array( '#editor .editor-styles-wrapper .fse-template-part .main-navigation a:hover,
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .fse-template-part .main-navigation a:hover,
 			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .entry-title a,
 			#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link,
 			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline,
-			#editor .editor-styles-wrapper a', 'color' ),
+			#editor .editor-styles-wrapper a',
+			'color',
+		),
 
-	// Background-color
-	array( '#editor .editor-styles-wrapper .button,
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .button,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation #toggle:focus + #toggle-menu,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation .button,
 			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .button,
 			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-			#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color', 'background-color' ),
+			#editor .editor-styles-wrapper .wp-block-pullquote.is-style-solid-color',
+			'background-color',
+		),
 
-	// Border color left
-	array( '#editor .editor-styles-wrapper .wp-block-quote', 'border-left-color' ),
+		// Border color left
+		array( '#editor .editor-styles-wrapper .wp-block-quote', 'border-left-color' ),
 
-	// Border color right
-	array( '#editor .editor-styles-wrapper .wp-block-quote[style*="text-align: right"],
-			#editor .editor-styles-wrapper .wp-block-quote[style*="text-align:right"]', 'border-right-color' ),
+		// Border color right
+		array(
+			'#editor .editor-styles-wrapper .wp-block-quote[style*="text-align: right"],
+			#editor .editor-styles-wrapper .wp-block-quote[style*="text-align:right"]',
+			'border-right-color',
+		),
 
-	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link.has-focus,
+		// Text-color darkened
+		array(
+			'#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link.has-focus,
 			#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link:focus,
 			#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link:hover,
 			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts .cat-links a:active,
@@ -106,10 +160,14 @@ add_editor_color_rule( 'link', '#897248', array(
 			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline.has-focus,
 			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline:focus,
 			#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline:hover,
-			#editor .editor-styles-wrapper a:hover', 'color', '-1' ),
+			#editor .editor-styles-wrapper a:hover',
+			'color',
+			'-1',
+		),
 
-	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .button.has-focus,
+		// Background-color darkened
+		array(
+			'#editor .editor-styles-wrapper .button.has-focus,
 			#editor .editor-styles-wrapper .button:focus,
 			#editor .editor-styles-wrapper .button:hover,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation .button:focus,
@@ -120,26 +178,41 @@ add_editor_color_rule( 'link', '#897248', array(
 			#editor .editor-styles-wrapper .wp-block-a8c-blog-posts + .has-focus.button,
 			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link.has-focus,
 			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover', 'background-color', '-1' ),
+			#editor .editor-styles-wrapper .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover',
+			'background-color',
+			'-1',
+		),
 
-	/**
-	 * Utility Classes
-	 */
-	// Text-color
-	array( '#editor .editor-styles-wrapper .has-primary-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-primary-color[class]', 'color' ),
-	// Background-color
-	array( '#editor .editor-styles-wrapper .has-primary-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-primary-background-color[class]', 'background-color' ),
+		/**
+		 * Utility Classes
+		 */
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .has-primary-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-primary-color[class]',
+			'color',
+		),
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .has-primary-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-primary-background-color[class]',
+			'background-color',
+		),
 
-), __( 'Link Color' ) );
+	),
+	__( 'Link Color' )
+);
 
 // Text Color
 // $config-global--color-foreground-default
-add_editor_color_rule( 'txt', '#181818', array(
+add_editor_color_rule(
+	'txt',
+	'#181818',
+	array(
 
-	// Text-color
-	array( '#editor .editor-styles-wrapper,
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper,
 			#editor .editor-styles-wrapper .a8c-posts-list__item .a8c-posts-list-item__meta,
 			#editor .editor-styles-wrapper .wp-block-image figcaption,
 			#editor .editor-styles-wrapper .wp-block-latest-comments .wp-block-latest-comments__comment-date,
@@ -164,75 +237,114 @@ add_editor_color_rule( 'txt', '#181818', array(
 			#editor .editor-styles-wrapper .wp-block-pullquote,
 			#editor .editor-styles-wrapper .wp-block-code > code,
 			#editor .editor-styles-wrapper .wp-block-verse,
-			#editor .editor-styles-wrapper .components-button,
 			#editor .editor-styles-wrapper .wp-block-table.is-style-stripes tbody tr:nth-child(odd),
 			#editor .editor-styles-wrapper table.is-style-stripes tbody tr:nth-child(odd),
 			#editor .editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation a,
 			#editor .editor-styles-wrapper .fse-template-part .main-navigation a:link,
-			#editor .editor-styles-wrapper .fse-template-part .main-navigation a:visited', 'color' ),
-			
-	// Background-color
-	array( '#editor .editor-styles-wrapper .wp-block-cover.has-background-dim, 
-			#editor .editor-styles-wrapper .wp-block-cover-image.has-background-dim', 'background-color' ),
-			
-	/**
-	 * Utility Classes
-	 */
-	// Text-color
-	array( '#editor .editor-styles-wrapper .has-background-background-color[class],
+			#editor .editor-styles-wrapper .fse-template-part .main-navigation a:visited',
+			'color',
+		),
+
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .wp-block-cover.has-background-dim,
+			#editor .editor-styles-wrapper .wp-block-cover-image.has-background-dim',
+			'background-color',
+		),
+
+		/**
+		 * Utility Classes
+		 */
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .has-background-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-background-background-color[class],
 			#editor .editor-styles-wrapper .has-background-dark-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-background-dark-background-color[class],
 			#editor .editor-styles-wrapper .has-background-light-background-color[class],
 			#editor .editor-styles-wrapper .wp-block .has-background-light-background-color[class],
 			#editor .editor-styles-wrapper .has-foreground-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-color[class]', 'color' ),
-	// Background-color
-	array( '#editor .editor-styles-wrapper .has-foreground-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-background-color[class]', 'background-color' ),
+			#editor .editor-styles-wrapper .wp-block .has-foreground-color[class]',
+			'color',
+		),
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .has-foreground-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-foreground-background-color[class]',
+			'background-color',
+		),
 
-	// Text-color darkened
-	array( '#editor .editor-styles-wrapper .has-foreground-dark-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-dark-color[class]', 'color', '-1' ),
-	// Background-color darkened
-	array( '#editor .editor-styles-wrapper .has-foreground-dark-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-dark-background-color[class]', 'background-color', '-1' ),
+		// Text-color darkened
+		array(
+			'#editor .editor-styles-wrapper .has-foreground-dark-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-foreground-dark-color[class]',
+			'color',
+			'-1',
+		),
+		// Background-color darkened
+		array(
+			'#editor .editor-styles-wrapper .has-foreground-dark-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-foreground-dark-background-color[class]',
+			'background-color',
+			'-1',
+		),
 
-	// Text-color brightened
-	array( '#editor .editor-styles-wrapper .has-foreground-light-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-light-color[class]', 'color', '+2' ),
-	// Background-color brightened
-	array( '#editor .editor-styles-wrapper .has-foreground-light-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-foreground-light-background-color[class]', 'background-color', '+2' ),
+		// Text-color brightened
+		array(
+			'#editor .editor-styles-wrapper .has-foreground-light-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-foreground-light-color[class]',
+			'color',
+			'+2',
+		),
+		// Background-color brightened
+		array(
+			'#editor .editor-styles-wrapper .has-foreground-light-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-foreground-light-background-color[class]',
+			'background-color',
+			'+2',
+		),
 
-), __( 'Text Color' ) );
+	),
+	__( 'Text Color' )
+);
 
 // Accent Color (Red)
 // $config-global--color-secondary-default
-add_editor_color_rule( 'fg1', '#c4493f', array(
+add_editor_color_rule(
+	'fg1',
+	'#c4493f',
+	array(
 
-	/**
-	 * Utility Classes
-	 */
+		/**
+		* Utility Classes
+		*/
 
-	// Text-color
-	array( '#editor .editor-styles-wrapper .has-secondary-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-secondary-color[class]', 'color' ),
-	// Background-color
-	array( '#editor .editor-styles-wrapper .has-secondary-background-color[class],
-			#editor .editor-styles-wrapper .wp-block .has-secondary-background-color[class]', 'background-color' ),
+		// Text-color
+		array(
+			'#editor .editor-styles-wrapper .has-secondary-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-secondary-color[class]',
+			'color',
+		),
+		// Background-color
+		array(
+			'#editor .editor-styles-wrapper .has-secondary-background-color[class],
+			#editor .editor-styles-wrapper .wp-block .has-secondary-background-color[class]',
+			'background-color',
+		),
 
-), __( 'Secondary Color' ) );
+	),
+	__( 'Secondary Color' )
+);
 
 /**
  * Custom CSS
  */
 function maywood_custom_editor_colors_extra_css() {
 	$colors_array = get_theme_mod( 'colors_manager' );
-	$txt           = $colors_array['colors']['txt'];
-?>
+	$txt          = $colors_array['colors']['txt'];
+	?>
 
 	#editor .editor-styles-wrapper .block-editor-default-block-appender textarea.block-editor-default-block-appender__content,
 	#editor .editor-styles-wrapper .wp-block .editor-post-title__input::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
@@ -250,7 +362,7 @@ function maywood_custom_editor_colors_extra_css() {
 		opacity: 0.66;
 	}
 
-	#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline.has-background[class], 
+	#editor .editor-styles-wrapper .wp-block-button__link.is-style-outline.has-background[class],
 	#editor .editor-styles-wrapper .is-style-outline .wp-block-button__link.has-background[class] {
 		background: transparent !important;
 	}
@@ -261,11 +373,11 @@ function maywood_custom_editor_colors_extra_css() {
 		color: currentColor;
 	}
 
-	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h1, 
-	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h2, 
-	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h3, 
-	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h4, 
-	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h5, 
+	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h1,
+	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h2,
+	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h3,
+	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h4,
+	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h5,
 	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] h6,
 	#editor .editor-styles-wrapper .wp-block-cover video + .wp-block-cover__inner-container h1,
 	#editor .editor-styles-wrapper .wp-block-cover video + .wp-block-cover__inner-container h2,
@@ -287,12 +399,13 @@ function maywood_custom_editor_colors_extra_css() {
 	#editor .editor-styles-wrapper .wp-block-cover-image video + .wp-block-cover__inner-container h6 {
 		text-shadow: none;
 	}
-	
+
 	#editor .editor-styles-wrapper .wp-block-cover[style*="background-image"] p,
 	#editor .editor-styles-wrapper .wp-block-cover video + .wp-block-cover__inner-container p,
 	#editor .editor-styles-wrapper .wp-block-cover-image[style*="background-image"] p,
 	#editor .editor-styles-wrapper .wp-block-cover-image video + .wp-block-cover__inner-container p {
 		text-shadow: none;
 	}
-<?php }
+	<?php
+}
 add_theme_support( 'custom_colors_extra_css', 'maywood_custom_editor_colors_extra_css' );


### PR DESCRIPTION
This was added here: https://github.com/Automattic/themes/commit/69ca43eca44cc88a0495a2f903be03335e73c974

But it causes this issue: https://github.com/Automattic/themes/issues/2855

So I think we should remove it.

Fixes https://github.com/Automattic/wp-calypso/issues/47117