### PR TITLE
Spearhead: fix more filter

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -222,7 +222,7 @@ function spearhead_more_link() {
 /**
  * Use this instead of the default WordPress ellipsis which is […].
  */
-function spearhead_excerpt_more() {
+function spearhead_excerpt_more( $more ) {
 	if ( is_admin() ) {
 		return $more;
 	}


### PR DESCRIPTION
This PR addresses a bug in Spearhead in the function that filters the more link. See https://themes.trac.wordpress.org/ticket/91317#comment:11