### PR TITLE
Varia: Remove overflow:scroll on pre element

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/alves/style.css
+++ b/alves/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -321,7 +321,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -321,7 +321,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/hever/style.css
+++ b/hever/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.10
+Version: 1.3.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/morden/style.css
+++ b/morden/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.11
+Version: 1.4.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -323,7 +323,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -322,7 +322,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/varia/sass/base/_normalize.scss
+++ b/varia/sass/base/_normalize.scss
@@ -64,7 +64,6 @@ hr {
 pre {
   font-family: monospace, monospace; /* 1 */
   font-size: 1em; /* 2 */
-  overflow: scroll;
 }
 
 /* Text-level semantics

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -356,7 +356,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics

--- a/varia/style.css
+++ b/varia/style.css
@@ -356,7 +356,6 @@ pre {
 	/* 1 */
 	font-size: 1em;
 	/* 2 */
-	overflow: scroll;
 }
 
 /* Text-level semantics


### PR DESCRIPTION
`overflow: scroll` is applied to `pre` elements in our normalize file.
This creates unsightly scrollbars on Verse blocks and others. The latest
version of `normalize.css` doesn't include this particular style.

Let's try removing it, and assuming everything is ok we'll remove it
from Seedlet-based themes too.

Fixes #2842