### PR TITLE
Varia + children: Fix new mobile menu to work with wpcom colors

### DIFF
--- a/alves/inc/wpcom-colors.php
+++ b/alves/inc/wpcom-colors.php
@@ -13,7 +13,10 @@ add_color_rule( 'bg', '#ffffff', array(
 			body .widget_eu_cookie_law_widget #eu-cookie-law,
 			body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept,
 			.main-navigation > div > ul > li > .sub-menu,
-			.site-header .main-navigation > div > ul > li .sub-menu a', 'background-color' ),
+			.site-header .main-navigation > div > ul > li .sub-menu a,
+			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.mobile-nav-side .site-header #site-navigation.main-navigation .woocommerce-menu-container, 
+			.mobile-nav-side .site-header #site-navigation.main-navigation > div', 'background-color' ),
 
 	// Text-color
 	array( '.a8c-posts-list-item__featured span,
@@ -312,7 +315,11 @@ add_color_rule( 'fg1', '#9B6A36', array(
 			button:hover,
 			input.has-focus[type="submit"],
 			input:focus[type="submit"],
-			input:hover[type="submit"]', 'background-color' ),
+			input:hover[type="submit"],
+			.main-navigation .button:focus,
+			.main-navigation .button:hover,
+			.main-navigation #toggle:focus + #toggle-menu,
+			.has-secondary-background-color', 'background-color' ),
 
 	// Border-color
 	array( 'input[type="color"]:focus,

--- a/barnsbury/inc/wpcom-colors.php
+++ b/barnsbury/inc/wpcom-colors.php
@@ -24,7 +24,10 @@ add_color_rule( 'bg', '#FFFDF6', array(
 			.main-navigation > div > ul > li.focus li.current-menu-item > a,
 			.main-navigation > div > ul > li.current-menu-item li:hover > a,
 			.main-navigation > div > ul > li.current-menu-item li.focus > a,
-			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a', 'background-color' ),
+			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.mobile-nav-side .site-header #site-navigation.main-navigation .woocommerce-menu-container, 
+			.mobile-nav-side .site-header #site-navigation.main-navigation > div', 
+			'background-color' ),
 
 	// Text-color
 	array( '.a8c-posts-list-item__featured span,
@@ -294,7 +297,11 @@ add_color_rule( 'fg1', '#655441', array(
 	array( '.has-secondary-color', 'color' ),
 
 	// Background-color
-	array( '.has-secondary-background-color,
+	array( '	
+			.main-navigation .button:focus,
+			.main-navigation .button:hover,
+			.main-navigation #toggle:focus + #toggle-menu,
+			.has-secondary-background-color,
 			.has-secondary-background-color.has-background-dim', 'background-color' ),
 
 ), __( 'Secondary Color' ) );

--- a/dalston/inc/wpcom-colors.php
+++ b/dalston/inc/wpcom-colors.php
@@ -19,7 +19,11 @@ add_color_rule( 'bg', '#FFFFFF', array(
 			.site-header .main-navigation > div > ul > li.focus li:hover > a, .site-header .main-navigation > div > ul > li.focus li.focus > a, 
 			.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a, .site-header .main-navigation > div > ul > li.current-menu-item li:hover > a, 
 			.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a, 
-			.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a', 'background-color' ),
+			.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.site-header .main-navigation > div > ul > li .sub-menu a,
+			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.mobile-nav-side .site-header #site-navigation.main-navigation .woocommerce-menu-container, 
+			.mobile-nav-side .site-header #site-navigation.main-navigation > div', 'background-color' ),
 
 	// Text-color
 	array( '.a8c-posts-list-item__featured span,
@@ -400,7 +404,12 @@ add_color_rule( 'fg1', '#0d1b24', array(
 	array( '.has-secondary-color[class]', 'color' ),
 
 	// Background-color
-	array( '.has-secondary-background-color[class]', 'background-color' ),
+	array( '.has-secondary-background-color[class],
+			input:hover[type="submit"],
+			.main-navigation .button:focus,
+			.main-navigation .button:hover,
+			.main-navigation #toggle:focus + #toggle-menu,
+			.has-secondary-background-color', 'background-color' ),
 
 ), __( 'Secondary Color' ) );
 

--- a/mayland/inc/wpcom-colors.php
+++ b/mayland/inc/wpcom-colors.php
@@ -10,7 +10,11 @@ add_color_rule( 'bg', '#ffffff', array(
 			body,
 			body .widget_eu_cookie_law_widget #eu-cookie-law,
 			body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept,
-			.main-navigation > div > ul > li > .sub-menu', 'background-color' ),
+			.main-navigation > div > ul > li > .sub-menu,
+			.site-header .main-navigation > div > ul > li .sub-menu a,
+			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.mobile-nav-side .site-header #site-navigation.main-navigation .woocommerce-menu-container, 
+			.mobile-nav-side .site-header #site-navigation.main-navigation > div', 'background-color' ),
 
 	// Text-color
 	array( '.a8c-posts-list-item__featured span,
@@ -363,7 +367,12 @@ add_color_rule( 'fg1', '#1a1a1a', array(
 
 	// Background-color
 	array( '.has-secondary-background-color[class],
-			.has-secondary-background-color.has-background-dim[class]', 'background-color' ),
+			.has-secondary-background-color.has-background-dim[class],
+			input:hover[type="submit"],
+			.main-navigation .button:focus,
+			.main-navigation .button:hover,
+			.main-navigation #toggle:focus + #toggle-menu,
+			.has-secondary-background-color', 'background-color' ),
 
 ), __( 'Secondary Color' ) );
 

--- a/mayland/inc/wpcom-colors.php
+++ b/mayland/inc/wpcom-colors.php
@@ -21,6 +21,7 @@ add_color_rule( 'bg', '#ffffff', array(
 			.sticky-post,
 			.wp-block-pullquote.is-style-solid-color,
 			body .widget_eu_cookie_law_widget #eu-cookie-law.negative,
+			.main-navigation .button,
 			.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color)', 'color' ),
 
 	// Background-color Lightened

--- a/rivington/inc/wpcom-colors.php
+++ b/rivington/inc/wpcom-colors.php
@@ -22,7 +22,11 @@ add_color_rule( 'bg', '#060f29', array(
 			.site-header .main-navigation > div > ul > li.focus li:hover > a,
 			.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
 			.site-header .main-navigation > div > ul > li:hover li.focus > a,
-			.site-header .main-navigation > div > ul > li:hover li:hover > a', 'background-color' ),
+			.site-header .main-navigation > div > ul > li:hover li:hover > a,
+			.site-header .main-navigation > div > ul > li .sub-menu a,
+			.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a,
+			.mobile-nav-side .site-header #site-navigation.main-navigation .woocommerce-menu-container, 
+			.mobile-nav-side .site-header #site-navigation.main-navigation > div', 'background-color' ),
 
 	// Text-color
 	array( '.a8c-posts-list-item__featured span,
@@ -385,7 +389,12 @@ add_color_rule( 'fg1', '#EE4266', array(
 	array( '.has-secondary-color[class]', 'color' ),
 
 	// Background-color
-	array( '.has-secondary-background-color[class]', 'background-color' ),
+	array( '.has-secondary-background-color[class],
+			input:hover[type="submit"],
+			.main-navigation .button:focus,
+			.main-navigation .button:hover,
+			.main-navigation #toggle:focus + #toggle-menu,
+			.has-secondary-background-color', 'background-color' ),
 
 ), __( 'Secondary Color' ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

**This is a WIP**

This PR fixes the colors of the new mobile menu when we change them through the customizer.

To test:

1. On your sandbox, with this PR loaded, select one of the themes this PR affects.
2. Go to the customizer, change the palette
3. View the site on mobile mode
4. Check that the colors for the menu correspond to the palette selected.
5. Check on the frontend too 
6. Check that everything looks fine when the "old" menu design is applied (uncheck "Display mobile menu on the side" on Customizer / Menu / Mobile settings)


**Alves:**

<img width="415" alt="Screenshot 2020-12-22 at 14 46 35" src="https://user-images.githubusercontent.com/3593343/102895189-8ee93a80-4464-11eb-8381-e90d1582669b.png">


**Barnsbury:**

<img width="427" alt="Screenshot 2020-12-21 at 12 48 00" src="https://user-images.githubusercontent.com/3593343/102774218-dd2a0b00-438a-11eb-82ab-166cbb87c46d.png">


**Dalston:**

<img width="446" alt="Screenshot 2020-12-22 at 15 12 07" src="https://user-images.githubusercontent.com/3593343/102897332-200de080-4468-11eb-99a2-b909b4231d78.png">

Hever doesn't have custom colors. 

**Mayland:**

<img width="411" alt="Screenshot 2020-12-22 at 15 47 18" src="https://user-images.githubusercontent.com/3593343/102900772-120e8e80-446d-11eb-8542-7ad2d47dafd7.png">

Morden doesn't have custom colors. 

**Rivington:**

<img width="385" alt="Screenshot 2020-12-22 at 15 51 44" src="https://user-images.githubusercontent.com/3593343/102901201-a1b43d00-446d-11eb-9548-b059bcf30116.png">



#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/2929