### PR TITLE
Add category description to archive page

### DIFF
--- a/seedlet/archive.php
+++ b/seedlet/archive.php
@@ -17,9 +17,8 @@ get_header();
 		<?php if ( have_posts() ) : ?>
 
 			<header class="page-header default-max-width">
-				<?php
-					the_archive_title();
-				?>
+				<?php the_archive_title(); ?>
+				<?php the_archive_description('<div class="archive-description">', '</div>'); ?>
 			</header><!-- .page-header -->
 
 			<?php

--- a/seedlet/assets/sass/pages/_archives.scss
+++ b/seedlet/assets/sass/pages/_archives.scss
@@ -1,3 +1,8 @@
 .page-title {
 	font-size: var(--heading--font-size-h4);
 }
+
+.archive-description p {
+    font-size: var(--global--font-size-sm);
+    margin-top: calc(0.5 * var(--global--spacing-vertical));
+}

--- a/seedlet/package-lock.json
+++ b/seedlet/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3810,6 +3810,11 @@ img#wpstats {
 	font-size: var(--heading--font-size-h4);
 }
 
+.archive-description p {
+	font-size: var(--global--font-size-sm);
+	margin-top: calc(0.5 * var(--global--spacing-vertical));
+}
+
 /**
  * Jetpack styles
  */


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Per the discussion in #2809 and #2793 this adds the description to the Seedlet `archive.php` and applies the styling to the SCSS. Changes were compiled and the version bumped.

#### Screenshots
*Spearhead*
with description
[![Screenshot](https://d.pr/i/5pJ58h+)](https://d.pr/i/5pJ58h)

without description
[![Screenshot](https://d.pr/i/9loNoE+)](https://d.pr/i/9loNoE)

*Seedlet*
with description
[![Screenshot](https://d.pr/i/Y4NOv5+)](https://d.pr/i/Y4NOv5)

without description
[![Screenshot](https://d.pr/i/iKqv7O+)](https://d.pr/i/iKqv7O)

## Related issue(s):
Fixes #2809 
Fixes #2793 