### PR TITLE
Blank Canvas: Only load the header if there's content in it

### DIFF
--- a/blank-canvas/header.php
+++ b/blank-canvas/header.php
@@ -28,7 +28,7 @@ $header_class = $show_title ? 'site-title' : 'screen-reader-text';
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'blank-canvas' ); ?></a>
 
-	<?php if ( ! is_singular() ) { ?>
+	<?php if ( ! is_singular() ) : ?>
 		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 			<?php if ( has_custom_logo() && $show_title ) : ?>
 				<div class="site-logo"><?php the_custom_logo(); ?></div>

--- a/blank-canvas/header.php
+++ b/blank-canvas/header.php
@@ -28,26 +28,28 @@ $header_class = $show_title ? 'site-title' : 'screen-reader-text';
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'blank-canvas' ); ?></a>
 
-	<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
-		<?php if ( has_custom_logo() && $show_title && ! is_singular() ) : ?>
-			<div class="site-logo"><?php the_custom_logo(); ?></div>
-		<?php endif; ?>
+	<?php if ( ! is_singular() ) { ?>
+		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
+			<?php if ( has_custom_logo() && $show_title ) : ?>
+				<div class="site-logo"><?php the_custom_logo(); ?></div>
+			<?php endif; ?>
 
-		<div class="site-branding">
-			<?php if ( ! empty( $blog_info ) && $show_title && ! is_singular() ) : ?>
-				<?php if ( is_front_page() && is_home() ) : ?>
-					<h1 class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></h1>
-				<?php else : ?>
-					<p class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></p>
+			<div class="site-branding">
+				<?php if ( ! empty( $blog_info ) && $show_title ) : ?>
+					<?php if ( is_front_page() && is_home() ) : ?>
+						<h1 class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></h1>
+					<?php else : ?>
+						<p class="<?php echo esc_attr( $header_class ); ?>"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php echo $blog_info; ?></a></p>
+					<?php endif; ?>
 				<?php endif; ?>
-			<?php endif; ?>
 
-			<?php if ( ( $description || is_customize_preview() ) && $show_title && ! is_singular() ) : ?>
-				<p class="site-description">
-					<?php echo $description; ?>
-				</p>
-			<?php endif; ?>
-		</div><!-- .site-branding -->
-	</header><!-- #masthead -->
+				<?php if ( ( $description || is_customize_preview() ) && $show_title ) : ?>
+					<p class="site-description">
+						<?php echo $description; ?>
+					</p>
+				<?php endif; ?>
+			</div><!-- .site-branding -->
+		</header><!-- #masthead -->
+	<?php endif; ?>
 
 	<div id="content" class="site-content">


### PR DESCRIPTION
Changes the conditionals a bit in the `header.php` file so that it doesn't load in a bunch of empty HTML elements like this:

![image](https://user-images.githubusercontent.com/1202812/103815774-dd383500-5031-11eb-92a8-8e0290666363.png)

Instead, it'll only load the whole `<header>` element if the page is not `singular`.