### PR TITLE
Multiple themes: fix right/left arrows in RTL mode

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.15
+Version: 1.3.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.15
+Version: 1.3.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.15
+Version: 1.3.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/calm-business/package.json
+++ b/calm-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calm-business",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/calm-business/print.css
+++ b/calm-business/print.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*
 Theme Name: Calm (Twenty Nineteen)
 
@@ -18,16 +17,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Margins */
   @page {
     margin: 2cm;
-}
-
+  }
   .entry {
     margin-top: 1em;
   }
-
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }
-
   /* Fonts */
   body {
     font: 13pt Georgia, "Times New Roman", Times, serif;
@@ -35,11 +31,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     background: #fff !important;
     color: #000;
   }
-
   h1 {
     font-size: 24pt;
   }
-
   h2,
   h3,
   h4,
@@ -51,16 +45,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     font-size: 14pt;
     margin-top: 25px;
   }
-
   /* Page breaks */
   a {
     page-break-inside: avoid;
   }
-
   blockquote {
     page-break-inside: avoid;
   }
-
   h1,
   h2,
   h3,
@@ -70,20 +61,16 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     page-break-after: avoid;
     page-break-inside: avoid;
   }
-
   img {
     page-break-inside: avoid;
     page-break-after: avoid;
   }
-
   table, pre {
     page-break-inside: avoid;
   }
-
   ul, ol, dl {
     page-break-before: avoid;
   }
-
   /* Links */
   a:link, a:visited, a {
     background: transparent;
@@ -91,27 +78,21 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     text-decoration: underline;
     text-align: left;
   }
-
   a {
     page-break-inside: avoid;
   }
-
   a[href^=http]:after {
     content: " < " attr(href) "> ";
   }
-
   a:after > img {
     content: "";
   }
-
   article a[href^="#"]:after {
     content: "";
   }
-
   a:not(:local-link):after {
     content: " < " attr(href) "> ";
   }
-
   /* Visibility */
   .main-navigation,
   .site-title + .main-navigation,
@@ -127,13 +108,11 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .comment .comment-metadata .edit-link {
     display: none;
   }
-
   .entry .entry-content .wp-block-button .wp-block-button__link,
   .entry .entry-content .button {
     color: #000;
     background: none;
   }
-
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;
@@ -150,7 +129,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }
@@ -163,13 +143,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     position: relative;
     height: initial;
     width: initial;
-    object-fit: none;
+    -o-object-fit: none;
+       object-fit: none;
     min-width: 0;
     min-height: 0;
     max-width: 100%;
     margin-top: 1rem;
   }
-
   /* Remove image filters from featured image */
   .image-filters-enabled *:after {
     display: none !important;

--- a/calm-business/sass/site/primary/_posts-and-pages.scss
+++ b/calm-business/sass/site/primary/_posts-and-pages.scss
@@ -215,7 +215,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/calm-business/sass/site/primary/_posts-and-pages.scss
+++ b/calm-business/sass/site/primary/_posts-and-pages.scss
@@ -215,7 +215,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/calm-business/sass/site/primary/_posts-and-pages.scss
+++ b/calm-business/sass/site/primary/_posts-and-pages.scss
@@ -215,7 +215,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/calm-business/sass/site/primary/_posts-and-pages.scss
+++ b/calm-business/sass/site/primary/_posts-and-pages.scss
@@ -215,7 +215,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/calm-business/style-editor-customizer.css
+++ b/calm-business/style-editor-customizer.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*!
 Twenty Nineteen Customizer Styles & Non-latin Font Fallbacks
 

--- a/calm-business/style-editor.css
+++ b/calm-business/style-editor.css
@@ -297,7 +297,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     width: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
   }
@@ -404,7 +403,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -424,7 +422,6 @@ body.page .main-navigation {
     left: auto;
     display: block;
     width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
   }
 }
@@ -458,7 +455,7 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
   font-family: "Poppins", sans-serif;
   font-weight: normal;
-  content: "– " counters(submenu, "– ", none);
+  content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
@@ -489,7 +486,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -513,7 +509,6 @@ body.page .main-navigation {
     left: auto;
     display: table;
     width: -webkit-max-content;
-    width: -moz-max-content;
     width: max-content;
   }
 }
@@ -556,7 +551,7 @@ body.page .main-navigation {
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
   font-family: "Poppins", sans-serif;
   font-weight: normal;
-  content: "– " counters(submenu, "– ", none);
+  content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
@@ -1642,7 +1637,7 @@ ul.wp-block-archives li ul,
   font-size: 0.88889em;
   font-weight: 600;
   line-height: 1.2;
-  content: "– " counters(submenu, "– ", none);
+  content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 

--- a/calm-business/style-jetpack.css
+++ b/calm-business/style-jetpack.css
@@ -1,5 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /* Reset font-family styles for Jetpack
  *
  * See: https://github.com/Automattic/jetpack/blob/master/modules/theme-tools/compat/twentynineteen.css

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -2620,7 +2620,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02190";
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -2620,7 +2620,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -2620,7 +2620,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content:  ←;
+  content: "←";
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/calm-business/style-rtl.css
+++ b/calm-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.com
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your stylish rooms and quality products! With its bold typography and peaceful color scheme, Calm Business exudes a calm, inviting atmosphere as a bed and breakfast, time share, or brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.6.1
+Version: 1.6.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: calm-business
@@ -2620,7 +2620,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02190";
+  content: 02190;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -2626,7 +2626,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -2626,7 +2626,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -2626,7 +2626,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl: ←*/;
+  content: "→" /*rtl:"←"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.com
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your stylish rooms and quality products! With its bold typography and peaceful color scheme, Calm Business exudes a calm, inviting atmosphere as a bed and breakfast, time share, or brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.6.1
+Version: 1.6.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: calm-business
@@ -2626,7 +2626,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/calm-business/style.scss
+++ b/calm-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.com
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your stylish rooms and quality products! With its bold typography and peaceful color scheme, Calm Business exudes a calm, inviting atmosphere as a bed and breakfast, time share, or brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.6.1
+Version: 1.6.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: calm-business

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3149,7 +3149,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3149,7 +3149,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3149,7 +3149,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3149,7 +3149,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -3168,7 +3168,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -3168,7 +3168,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3168,7 +3168,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -3168,7 +3168,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/package-lock.json
+++ b/dalston/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/sass/style-child-theme.scss
+++ b/dalston/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.11
+Version: 1.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/dara/rtl.css
+++ b/dara/rtl.css
@@ -287,6 +287,17 @@ body:not(.search):not(.single-jetpack-testimonial) .jetpack-testimonial:nth-chil
 	margin-right: auto;
 }
 
+[class*="navigation"] .nav-previous .meta-nav:before {
+	content: "\2192";
+}
+[class*="navigation"] .nav-next .meta-nav:after {
+	content: "\2190";
+}
+.comment-reply-link:after {
+	content: "\00A0\2190";
+}
+
+
 /*--------------------------------------------------------------
 13 Media Queries
 --------------------------------------------------------------*/

--- a/dara/style.css
+++ b/dara/style.css
@@ -723,11 +723,11 @@ textarea {
 	width: 100%;
 }
 [class*="navigation"] .nav-previous .meta-nav:before {
-	content: "\2190";
+	content: "\2190" /*rtl:"\2192"*/;
 	margin-right: 5px;
 }
 [class*="navigation"] .nav-next .meta-nav:after {
-	content: "\2192";
+	content: "\2192" /*rtl:"\2190"*/;
 	margin-left: 5px;
 }
 .post-navigation a,

--- a/dara/style.css
+++ b/dara/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wordpress.com/themes/dara/
 Author: Automattic
 Author URI: http://wordpress.com/themes/
 Description: With bold featured images and bright, cheerful colors, Dara is ready to get to work for your business.
-Version: 1.2.7-wpcom
+Version: 1.2.8-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: dara

--- a/elegant-business/package-lock.json
+++ b/elegant-business/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elegant-business",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/elegant-business/package.json
+++ b/elegant-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elegant-business",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/elegant-business/print.css
+++ b/elegant-business/print.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*
 Theme Name: Twenty Nineteen
 
@@ -18,16 +17,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Margins */
   @page {
     margin: 2cm;
-}
-
+  }
   .entry {
     margin-top: 1em;
   }
-
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }
-
   /* Fonts */
   body {
     font: 13pt Georgia, "Times New Roman", Times, serif;
@@ -35,11 +31,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     background: #fff !important;
     color: #000;
   }
-
   h1 {
     font-size: 24pt;
   }
-
   h2,
   h3,
   h4,
@@ -51,16 +45,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     font-size: 14pt;
     margin-top: 25px;
   }
-
   /* Page breaks */
   a {
     page-break-inside: avoid;
   }
-
   blockquote {
     page-break-inside: avoid;
   }
-
   h1,
   h2,
   h3,
@@ -70,20 +61,16 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     page-break-after: avoid;
     page-break-inside: avoid;
   }
-
   img {
     page-break-inside: avoid;
     page-break-after: avoid;
   }
-
   table, pre {
     page-break-inside: avoid;
   }
-
   ul, ol, dl {
     page-break-before: avoid;
   }
-
   /* Links */
   a:link, a:visited, a {
     background: transparent;
@@ -91,27 +78,21 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     text-decoration: underline;
     text-align: left;
   }
-
   a {
     page-break-inside: avoid;
   }
-
   a[href^=http]:after {
     content: " < " attr(href) "> ";
   }
-
   a:after > img {
     content: "";
   }
-
   article a[href^="#"]:after {
     content: "";
   }
-
   a:not(:local-link):after {
     content: " < " attr(href) "> ";
   }
-
   /* Visibility */
   .main-navigation,
   .site-title + .main-navigation,
@@ -127,13 +108,11 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .comment .comment-metadata .edit-link {
     display: none;
   }
-
   .entry .entry-content .wp-block-button .wp-block-button__link,
   .entry .entry-content .button {
     color: #000;
     background: none;
   }
-
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;
@@ -150,7 +129,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }
@@ -163,13 +143,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     position: relative;
     height: initial;
     width: initial;
-    object-fit: none;
+    -o-object-fit: none;
+       object-fit: none;
     min-width: 0;
     min-height: 0;
     max-width: 100%;
     margin-top: 1rem;
   }
-
   /* Remove image filters from featured image */
   .image-filters-enabled *:after {
     display: none !important;

--- a/elegant-business/sass/site/primary/_posts-and-pages.scss
+++ b/elegant-business/sass/site/primary/_posts-and-pages.scss
@@ -196,7 +196,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				margin-left: 0.5em;
 			}
 

--- a/elegant-business/sass/site/primary/_posts-and-pages.scss
+++ b/elegant-business/sass/site/primary/_posts-and-pages.scss
@@ -196,7 +196,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				margin-left: 0.5em;
 			}
 

--- a/elegant-business/sass/site/primary/_posts-and-pages.scss
+++ b/elegant-business/sass/site/primary/_posts-and-pages.scss
@@ -196,7 +196,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				margin-left: 0.5em;
 			}
 

--- a/elegant-business/sass/site/primary/_posts-and-pages.scss
+++ b/elegant-business/sass/site/primary/_posts-and-pages.scss
@@ -196,7 +196,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				margin-left: 0.5em;
 			}
 

--- a/elegant-business/style-editor-customizer.css
+++ b/elegant-business/style-editor-customizer.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*!
 Twenty Nineteen Customizer Styles & Non-latin Font Fallbacks
 

--- a/elegant-business/style-jetpack.css
+++ b/elegant-business/style-jetpack.css
@@ -1,5 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /* Reset font-family styles for Jetpack
  *
  * See: https://github.com/Automattic/jetpack/blob/master/modules/theme-tools/compat/twentynineteen.css

--- a/elegant-business/style-rtl.css
+++ b/elegant-business/style-rtl.css
@@ -2540,7 +2540,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   margin-right: 0.5em;
 }
 

--- a/elegant-business/style-rtl.css
+++ b/elegant-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, beautiful typography, Elegant Business conveys quality and integrity, which makes it especially good fit for coffee shops, pop-up shops, and brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: elegant-business

--- a/elegant-business/style-rtl.css
+++ b/elegant-business/style-rtl.css
@@ -2540,7 +2540,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02190";
   margin-right: 0.5em;
 }
 

--- a/elegant-business/style-rtl.css
+++ b/elegant-business/style-rtl.css
@@ -2540,7 +2540,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02190";
+  content: 02190;
   margin-right: 0.5em;
 }
 

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   margin-left: 0.5em;
 }
 

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl: ←*/;
+  content: "→" /*rtl:"←"*/;
   margin-left: 0.5em;
 }
 

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, beautiful typography, Elegant Business conveys quality and integrity, which makes it especially good fit for coffee shops, pop-up shops, and brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: elegant-business
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   margin-left: 0.5em;
 }
 

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   margin-left: 0.5em;
 }
 

--- a/elegant-business/style.scss
+++ b/elegant-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, beautiful typography, Elegant Business conveys quality and integrity, which makes it especially good fit for coffee shops, pop-up shops, and brick & mortar store fronts.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: elegant-business

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/friendly-business/package.json
+++ b/friendly-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendly-business",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/friendly-business/sass/site/primary/_posts-and-pages.scss
+++ b/friendly-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/friendly-business/sass/site/primary/_posts-and-pages.scss
+++ b/friendly-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/friendly-business/sass/site/primary/_posts-and-pages.scss
+++ b/friendly-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/friendly-business/sass/site/primary/_posts-and-pages.scss
+++ b/friendly-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/friendly-business/style-rtl.css
+++ b/friendly-business/style-rtl.css
@@ -2564,7 +2564,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02190";
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/friendly-business/style-rtl.css
+++ b/friendly-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, approachable, with bold, handsome typography, Friendly Business conveys quality and sustainability, which makes it especially good fit for education, agriculture and family-run businesses.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: friendly-business
@@ -138,8 +138,7 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -632,18 +631,14 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    -webkit-hyphens: none;
-        -ms-hyphens: none;
-            hyphens: none;
+    hyphens: none;
   }
 }
 
@@ -793,6 +788,10 @@ html[lang="vi"] .site * {
 /* Elements */
 html {
   box-sizing: border-box;
+}
+
+::-moz-selection {
+  background-color: #c7d6c8;
 }
 
 ::selection {
@@ -1212,6 +1211,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     width: auto;
+    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
   }
@@ -1316,6 +1316,7 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
+    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -1334,7 +1335,6 @@ body.page .main-navigation {
     left: 0;
     right: auto;
     display: block;
-    width: -webkit-max-content;
     width: max-content;
   }
 }
@@ -1398,6 +1398,7 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
+    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -1420,7 +1421,6 @@ body.page .main-navigation {
     left: 0;
     right: auto;
     display: table;
-    width: -webkit-max-content;
     width: max-content;
   }
 }
@@ -1676,10 +1676,7 @@ body.page .main-navigation {
 
 .post-navigation .nav-links a .meta-nav {
   color: #0d1b24;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
@@ -1691,9 +1688,7 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .post-title {
-  -webkit-hyphens: auto;
-      -ms-hyphens: auto;
-          hyphens: auto;
+  hyphens: auto;
 }
 
 .post-navigation .nav-links a:hover {
@@ -1819,8 +1814,7 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(50%);
-          clip-path: inset(50%);
+  clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1836,8 +1830,7 @@ body.page .main-navigation {
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  -webkit-clip-path: none;
-          clip-path: none;
+  clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -2134,6 +2127,7 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
+  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
@@ -2155,12 +2149,11 @@ body.page .main-navigation {
   /* When image filters are active, make it grayscale to colorize it blue. */
 }
 
-@supports ((-o-object-fit: cover) or (object-fit: cover)) {
+@supports (object-fit: cover) {
   .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
     right: 0;
-    -o-object-fit: cover;
-       object-fit: cover;
+    object-fit: cover;
     top: 0;
     transform: none;
     width: 100%;
@@ -2328,6 +2321,10 @@ body.page .main-navigation {
   .image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
+}
+
+.site-header.featured-image ::-moz-selection {
+  background: rgba(255, 253, 246, 0.17);
 }
 
 .site-header.featured-image ::selection {
@@ -2564,7 +2561,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02190";
+  content: 02190;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/friendly-business/style-rtl.css
+++ b/friendly-business/style-rtl.css
@@ -138,7 +138,8 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
   /* 2 */
 }
 
@@ -631,14 +632,18 @@ h6 {
 .error-404 .page-title,
 .comments-title,
 blockquote {
-  hyphens: auto;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
   word-break: break-word;
 }
 
 /* Do not hyphenate entry title on tablet view and bigger. */
 @media only screen and (min-width: 768px) {
   .entry-title {
-    hyphens: none;
+    -webkit-hyphens: none;
+        -ms-hyphens: none;
+            hyphens: none;
   }
 }
 
@@ -788,10 +793,6 @@ html[lang="vi"] .site * {
 /* Elements */
 html {
   box-sizing: border-box;
-}
-
-::-moz-selection {
-  background-color: #c7d6c8;
 }
 
 ::selection {
@@ -1211,7 +1212,6 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     width: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
   }
@@ -1316,7 +1316,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -1335,6 +1334,7 @@ body.page .main-navigation {
     left: 0;
     right: auto;
     display: block;
+    width: -webkit-max-content;
     width: max-content;
   }
 }
@@ -1398,7 +1398,6 @@ body.page .main-navigation {
     top: auto;
     bottom: auto;
     height: auto;
-    min-width: -moz-max-content;
     min-width: -webkit-max-content;
     min-width: max-content;
     transform: none;
@@ -1421,6 +1420,7 @@ body.page .main-navigation {
     left: 0;
     right: auto;
     display: table;
+    width: -webkit-max-content;
     width: max-content;
   }
 }
@@ -1676,7 +1676,10 @@ body.page .main-navigation {
 
 .post-navigation .nav-links a .meta-nav {
   color: #0d1b24;
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
@@ -1688,7 +1691,9 @@ body.page .main-navigation {
 }
 
 .post-navigation .nav-links a .post-title {
-  hyphens: auto;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
 }
 
 .post-navigation .nav-links a:hover {
@@ -1814,7 +1819,8 @@ body.page .main-navigation {
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
+  -webkit-clip-path: inset(50%);
+          clip-path: inset(50%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -1830,7 +1836,8 @@ body.page .main-navigation {
   border-radius: 3px;
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
   clip: auto !important;
-  clip-path: none;
+  -webkit-clip-path: none;
+          clip-path: none;
   color: #21759b;
   display: block;
   font-size: 14px;
@@ -2127,7 +2134,6 @@ body.page .main-navigation {
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
-  -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
 
@@ -2149,11 +2155,12 @@ body.page .main-navigation {
   /* When image filters are active, make it grayscale to colorize it blue. */
 }
 
-@supports (object-fit: cover) {
+@supports ((-o-object-fit: cover) or (object-fit: cover)) {
   .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
     right: 0;
-    object-fit: cover;
+    -o-object-fit: cover;
+       object-fit: cover;
     top: 0;
     transform: none;
     width: 100%;
@@ -2321,10 +2328,6 @@ body.page .main-navigation {
   .image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
-}
-
-.site-header.featured-image ::-moz-selection {
-  background: rgba(255, 253, 246, 0.17);
 }
 
 .site-header.featured-image ::selection {
@@ -2561,7 +2564,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/friendly-business/style.css
+++ b/friendly-business/style.css
@@ -2570,7 +2570,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/friendly-business/style.css
+++ b/friendly-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, approachable, with bold, handsome typography, Friendly Business conveys quality and sustainability, which makes it especially good fit for education, agriculture and family-run businesses.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: friendly-business
@@ -2570,7 +2570,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/friendly-business/style.css
+++ b/friendly-business/style.css
@@ -2570,7 +2570,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/friendly-business/style.scss
+++ b/friendly-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Template: twentynineteen
 Description: Simple, approachable, with bold, handsome typography, Friendly Business conveys quality and sustainability, which makes it especially good fit for education, agriculture and family-run businesses.
 Requires at least: WordPress 4.9.6
-Version: 1.4.1
+Version: 1.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: friendly-business

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Independent Publisher 2
 Theme URI: http://wordpress.com/themes/independent-publisher-2
-Version: 2.1.8-wpcom
+Version: 2.1.9-wpcom
 Description: Independent Publisher 2 is a clean and polished theme with a light color scheme, bold typography, and full-width images.
 Author: Raam Dev
 Author URI: http://raamdev.com/

--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -897,12 +897,12 @@ input::-moz-focus-inner {
 
 .posts-navigation .nav-links .nav-previous a:before {
 	margin-right: .4375em;
-	content: "\2190";
+	content: "\2190" /*rtl:"\2192"*/;
 }
 
 .posts-navigation .nav-links .nav-next a:after {
 	margin-left: .4375em;
-	content: "\2192";
+	content: "\2192" /*rtl:"\2190"*/;
 }
 
 /*--------------------------------------------------------------

--- a/intergalactic-2/rtl.css
+++ b/intergalactic-2/rtl.css
@@ -115,6 +115,11 @@ a.more-link:after {
 	margin-right: 5px;
 	margin-left: auto;
 }
+#infinite-handle span:after {
+	margin-left: auto;
+	margin-right:5px;
+	content: "\2190";
+}
 .singular .edit-link {
 	float: left;
 	text-align: left;

--- a/intergalactic-2/style.css
+++ b/intergalactic-2/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/intergalactic-2/
 Author: Automattic
 Author URI: https://wordpress.com/themes/
 Description: Intergalactic 2 is a stunning specimen for your personal blog. Bold featured images act as the backdrop to your text, giving you a high-contrast, readable theme that's perfect for making your content pop. The one-column layout provides a distraction-free environment for reading, while the slide-out menu keeps your navigation and secondary content readily accessible.
-Version: 2.0.4-wpcom
+Version: 2.0.5-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: intergalactic

--- a/intergalactic-2/style.css
+++ b/intergalactic-2/style.css
@@ -1513,7 +1513,7 @@ a.more-link:after {
 
 	margin-left: 5px;
 
-	content: '\2192';
+	content: "\2192" /*rtl:"\2190"*/;
 }
 a.more-link:hover,
 a.more-link:active,
@@ -1882,7 +1882,7 @@ a.more-link:focus {
 
 	margin-left: 5px;
 
-	content: '\2192';
+	content: "\2192" /*rtl:"\2190"*/;
 }
 
 .infinite-loader {

--- a/ixion/style.css
+++ b/ixion/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wordpress.com/themes/ixion/
 Author: Automattic
 Author URI: http://wordpress.com/themes/
 Description: A theme for non-profits, organizations, and schools.
-Version: 1.1.5-wpcom
+Version: 1.1.6-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: ixion

--- a/ixion/style.css
+++ b/ixion/style.css
@@ -609,7 +609,7 @@ input[type="submit"]:focus,
 }
 #infinite-handle span:after {
 	display: inline;
-	content: '\2192';
+	content: "\2192" /*rtl:"\2190"*/;
 	margin-left: 6px;
 }
 
@@ -846,7 +846,7 @@ table {
 .comment-navigation .nav-previous a:before,
 .posts-navigation .nav-previous a:before,
 .post-navigation .nav-previous a:before {
-	content: '\2190';
+	content: "\2190" /*rtl:"\2192"*/;
 	margin-right: 6px;
 }
 .comment-navigation .nav-next a,
@@ -857,7 +857,7 @@ table {
 .comment-navigation .nav-next a:after,
 .posts-navigation .nav-next a:after,
 .post-navigation .nav-next a:after {
-	content: '\2192';
+	content: "\2192" /*rtl:"\2190"*/;
 	margin-left: 6px;
 }
 

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.15
+Version: 1.4.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -397,7 +397,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -397,7 +397,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -397,7 +397,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -397,7 +397,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.15
+Version: 1.4.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.15
+Version: 1.4.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/modern-business/package.json
+++ b/modern-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-business",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/modern-business/sass/site/primary/_posts-and-pages.scss
+++ b/modern-business/sass/site/primary/_posts-and-pages.scss
@@ -205,7 +205,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/modern-business/sass/site/primary/_posts-and-pages.scss
+++ b/modern-business/sass/site/primary/_posts-and-pages.scss
@@ -205,7 +205,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/modern-business/sass/site/primary/_posts-and-pages.scss
+++ b/modern-business/sass/site/primary/_posts-and-pages.scss
@@ -205,7 +205,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/modern-business/sass/site/primary/_posts-and-pages.scss
+++ b/modern-business/sass/site/primary/_posts-and-pages.scss
@@ -205,7 +205,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6
 Template: twentynineteen
-Version: 1.7.1
+Version: 1.7.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02190";
+  content: 02190;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -2546,7 +2546,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02190";
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -2552,7 +2552,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6
 Template: twentynineteen
-Version: 1.7.1
+Version: 1.7.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen
@@ -2552,7 +2552,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -2552,7 +2552,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl: ←*/;
+  content: "→" /*rtl:"←"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -2552,7 +2552,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/modern-business/style.scss
+++ b/modern-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6
 Template: twentynineteen
-Version: 1.7.1
+Version: 1.7.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.15
+Version: 1.5.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02190";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.15
+Version: 1.5.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02190";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.15
+Version: 1.5.16
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/pique/rtl.css
+++ b/pique/rtl.css
@@ -30,6 +30,16 @@ body {
 	right: 0;
 }
 
+.comment-navigation .nav-previous span::before,
+.posts-navigation .nav-previous span::before,
+.post-navigation .nav-previous span::before {
+	content: "\2192";
+}
+.comment-navigation .nav-next span::after,
+.posts-navigation .nav-next span::after,
+.post-navigation .nav-next span::after {
+	content: "\2190";
+}
 /* Adjust teeny menu */
 @media (max-width: 767px) {
 	.main-navigation a {

--- a/pique/style.css
+++ b/pique/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/pique/
 Author: Automattic
 Author URI: http://wordpress.com/themes/
 Description: A one-page scrolling theme for small businesses.
-Version: 1.4.9-wpcom
+Version: 1.4.10-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: pique

--- a/pique/style.css
+++ b/pique/style.css
@@ -1247,7 +1247,7 @@ a:active {
 .comment-navigation .nav-previous span::before,
 .posts-navigation .nav-previous span::before,
 .post-navigation .nav-previous span::before {
-	content: '\2190';
+	content: "\2190" /*rtl:"\2192"*/;
 	display: inline-block;
 	display: inline-block;
 	font-family: FontAwesome;
@@ -1271,7 +1271,7 @@ a:active {
 .comment-navigation .nav-next span::after,
 .posts-navigation .nav-next span::after,
 .post-navigation .nav-next span::after {
-	content: '\2192';
+	content: "\2192" /*rtl:"\2190"*/;
 	display: inline-block;
 	display: inline-block;
 	font-family: FontAwesome;
@@ -3739,7 +3739,7 @@ div.sharedaddy .sd-title.widget-title {
 .infinite-scroll #infinite-handle
     .search-results .read-more a::before,
 .search-results .read-more .infinite-scroll #infinite-handle a::before {
-	content: '\2190';
+	content: "\2190" /*rtl:"\2192"*/;
 	display: inline-block;
 	display: inline-block;
 	font-family: FontAwesome;

--- a/professional-business/package.json
+++ b/professional-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "professional-business",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/professional-business/print.css
+++ b/professional-business/print.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*
 Theme Name: Professional Business
 
@@ -18,16 +17,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Margins */
   @page {
     margin: 2cm;
-}
-
+  }
   .entry {
     margin-top: 1em;
   }
-
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }
-
   /* Fonts */
   body {
     font: 13pt Georgia, "Times New Roman", Times, serif;
@@ -35,11 +31,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     background: #fff !important;
     color: #000;
   }
-
   h1 {
     font-size: 24pt;
   }
-
   h2,
   h3,
   h4,
@@ -51,16 +45,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     font-size: 14pt;
     margin-top: 25px;
   }
-
   /* Page breaks */
   a {
     page-break-inside: avoid;
   }
-
   blockquote {
     page-break-inside: avoid;
   }
-
   h1,
   h2,
   h3,
@@ -70,20 +61,16 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     page-break-after: avoid;
     page-break-inside: avoid;
   }
-
   img {
     page-break-inside: avoid;
     page-break-after: avoid;
   }
-
   table, pre {
     page-break-inside: avoid;
   }
-
   ul, ol, dl {
     page-break-before: avoid;
   }
-
   /* Links */
   a:link, a:visited, a {
     background: transparent;
@@ -91,27 +78,21 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     text-decoration: underline;
     text-align: left;
   }
-
   a {
     page-break-inside: avoid;
   }
-
   a[href^=http]:after {
     content: " < " attr(href) "> ";
   }
-
   a:after > img {
     content: "";
   }
-
   article a[href^="#"]:after {
     content: "";
   }
-
   a:not(:local-link):after {
     content: " < " attr(href) "> ";
   }
-
   /* Visibility */
   .main-navigation,
   .site-title + .main-navigation,
@@ -127,13 +108,11 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .comment .comment-metadata .edit-link {
     display: none;
   }
-
   .entry .entry-content .wp-block-button .wp-block-button__link,
   .entry .entry-content .button {
     color: #000;
     background: none;
   }
-
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;
@@ -150,7 +129,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }
@@ -163,13 +143,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     position: relative;
     height: initial;
     width: initial;
-    object-fit: none;
+    -o-object-fit: none;
+       object-fit: none;
     min-width: 0;
     min-height: 0;
     max-width: 100%;
     margin-top: 1rem;
   }
-
   /* Remove image filters from featured image */
   .image-filters-enabled *:after {
     display: none !important;

--- a/professional-business/sass/site/primary/_posts-and-pages.scss
+++ b/professional-business/sass/site/primary/_posts-and-pages.scss
@@ -201,7 +201,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				margin-left: 0.5em;
 			}
 

--- a/professional-business/sass/site/primary/_posts-and-pages.scss
+++ b/professional-business/sass/site/primary/_posts-and-pages.scss
@@ -201,7 +201,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				margin-left: 0.5em;
 			}
 

--- a/professional-business/sass/site/primary/_posts-and-pages.scss
+++ b/professional-business/sass/site/primary/_posts-and-pages.scss
@@ -201,7 +201,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				margin-left: 0.5em;
 			}
 

--- a/professional-business/sass/site/primary/_posts-and-pages.scss
+++ b/professional-business/sass/site/primary/_posts-and-pages.scss
@@ -201,7 +201,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				margin-left: 0.5em;
 			}
 

--- a/professional-business/style-editor-customizer.css
+++ b/professional-business/style-editor-customizer.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*!
 Professional Business Customizer Styles & Non-latin Font Fallbacks
 

--- a/professional-business/style-jetpack.css
+++ b/professional-business/style-jetpack.css
@@ -1,5 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /* Reset font-family styles for Jetpack
  *
  * See: https://github.com/Automattic/jetpack/blob/master/modules/theme-tools/compat/twentynineteen.css

--- a/professional-business/style-rtl.css
+++ b/professional-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.com/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, elegant typography, Professional Business conveys quality and integrity, which makes it especially good fit for accounting, law, and consultancy firms.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: professional-business

--- a/professional-business/style-rtl.css
+++ b/professional-business/style-rtl.css
@@ -2593,7 +2593,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: 02190;
   margin-right: 0.5em;
 }
 

--- a/professional-business/style-rtl.css
+++ b/professional-business/style-rtl.css
@@ -2593,7 +2593,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   margin-right: 0.5em;
 }
 

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://wordpress.com/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, elegant typography, Professional Business conveys quality and integrity, which makes it especially good fit for accounting, law, and consultancy firms.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: professional-business
@@ -2599,7 +2599,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   margin-left: 0.5em;
 }
 

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -2599,7 +2599,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   margin-left: 0.5em;
 }
 

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -2599,7 +2599,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   margin-left: 0.5em;
 }
 

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -2599,7 +2599,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl: ←*/;
+  content: "→" /*rtl:"←"*/;
   margin-left: 0.5em;
 }
 

--- a/professional-business/style.scss
+++ b/professional-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://wordpress.com/
 Template: twentynineteen
 Description: Simple, yet sophisticated, with subtle, elegant typography, Professional Business conveys quality and integrity, which makes it especially good fit for accounting, law, and consultancy firms.
 Requires at least: WordPress 4.9.6
-Version: 1.5.1
+Version: 1.5.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: professional-business

--- a/radcliffe-2/inc/style-wpcom.css
+++ b/radcliffe-2/inc/style-wpcom.css
@@ -123,7 +123,7 @@ div[class^="gr_custom_book_container"] {
 	padding: 24px 0 0;
 }
 .widget_flickr #flickr_badge_uber_wrapper td a:last-child:after {
-	content: "\2192";
+	content: "\2192" /*rtl:"\2190"*/;
 	margin-left: 6px;
 }
 

--- a/radcliffe-2/style.css
+++ b/radcliffe-2/style.css
@@ -4,7 +4,7 @@ Theme URI: http://wordpress.com/themes/radcliffe-2
 Author: Anders Norén
 Author URI: http://www.andersnoren.se
 Description: A theme for bloggers who want their content to take center stage.
-Version: 2.0.8-wpcom
+Version: 2.0.9-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: radcliffe-2

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -394,7 +394,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -394,7 +394,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -394,7 +394,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -394,7 +394,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.12
+Version: 1.4.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * These styles should be loaded by the Block Editor only
  */
@@ -1642,7 +1643,7 @@ pre.wp-block-verse {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }
@@ -1877,7 +1878,7 @@ pre.wp-block-verse {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1643,7 +1643,7 @@ pre.wp-block-verse {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }
@@ -1878,7 +1878,7 @@ pre.wp-block-verse {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -1642,7 +1642,7 @@ pre.wp-block-verse {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }
@@ -1877,7 +1877,7 @@ pre.wp-block-verse {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/assets/sass/components/entry/_content.scss
+++ b/seedlet/assets/sass/components/entry/_content.scss
@@ -22,7 +22,7 @@
 		}
 
 		&:after {
-			content: "\02192";
+			content: "\02192" /*rtl:"\02190"*/;
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/assets/sass/components/entry/_content.scss
+++ b/seedlet/assets/sass/components/entry/_content.scss
@@ -22,7 +22,7 @@
 		}
 
 		&:after {
-			content: "\02192" /*rtl:"\02190"*/;
+			content: "\02192" #{"/*rtl:02190*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/assets/sass/components/entry/_content.scss
+++ b/seedlet/assets/sass/components/entry/_content.scss
@@ -22,7 +22,7 @@
 		}
 
 		&:after {
-			content: "\02192" #{"/*rtl:02190*/"};
+			content: "\02192" #{"/*rtl:\"\02190\"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.5-wpcom
+Version: 1.1.6-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
@@ -92,7 +92,7 @@
 		margin-top: var(--global--spacing-unit);
 
 		&:after {
-			content: "\02192";
+			content: "\02192" /*rtl:"\02190"*/;
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
@@ -92,7 +92,7 @@
 		margin-top: var(--global--spacing-unit);
 
 		&:after {
-			content: "\02192" /*rtl:"\02190"*/;
+			content: "\02192" #{"/*rtl:02190*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
+++ b/seedlet/assets/sass/vendors/jetpack/blocks/blog-posts/_editor.scss
@@ -92,7 +92,7 @@
 		margin-top: var(--global--spacing-unit);
 
 		&:after {
-			content: "\02192" #{"/*rtl:02190*/"};
+			content: "\02192" #{"/*rtl:\"\02190\"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/seedlet/package.json
+++ b/seedlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.5-wpcom",
+  "version": "1.1.6-wpcom",
   "description": "Seedlet",
   "bugs": {
     "url": "https://github.com/Automattic/seedlet/issues"

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -3172,7 +3172,7 @@ nav a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
 Theme Name: Seedlet
 Theme URI: https://wordpress.com/theme/seedlet
@@ -7,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.5-wpcom
+Version: 1.1.6-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
@@ -3171,7 +3172,7 @@ nav a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
 Theme Name: Seedlet
 Theme URI: https://wordpress.com/theme/seedlet
@@ -7,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.5-wpcom
+Version: 1.1.6-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
@@ -3192,7 +3193,7 @@ nav a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3193,7 +3193,7 @@ nav a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -3192,7 +3192,7 @@ nav a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/sophisticated-business/package.json
+++ b/sophisticated-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophisticated-business",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/sophisticated-business/print.css
+++ b/sophisticated-business/print.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*
 Theme Name: Sophisticated Business
 
@@ -18,16 +17,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   /* Margins */
   @page {
     margin: 2cm;
-}
-
+  }
   .entry {
     margin-top: 1em;
   }
-
   .entry .entry-header, .site-footer .site-info {
     margin: 0;
   }
-
   /* Fonts */
   body {
     font: 13pt Georgia, "Times New Roman", Times, serif;
@@ -35,11 +31,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     background: #fff !important;
     color: #000;
   }
-
   h1 {
     font-size: 24pt;
   }
-
   h2,
   h3,
   h4,
@@ -51,16 +45,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     font-size: 14pt;
     margin-top: 25px;
   }
-
   /* Page breaks */
   a {
     page-break-inside: avoid;
   }
-
   blockquote {
     page-break-inside: avoid;
   }
-
   h1,
   h2,
   h3,
@@ -70,20 +61,16 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     page-break-after: avoid;
     page-break-inside: avoid;
   }
-
   img {
     page-break-inside: avoid;
     page-break-after: avoid;
   }
-
   table, pre {
     page-break-inside: avoid;
   }
-
   ul, ol, dl {
     page-break-before: avoid;
   }
-
   /* Links */
   a:link, a:visited, a {
     background: transparent;
@@ -91,27 +78,21 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     text-decoration: underline;
     text-align: left;
   }
-
   a {
     page-break-inside: avoid;
   }
-
   a[href^=http]:after {
     content: " < " attr(href) "> ";
   }
-
   a:after > img {
     content: "";
   }
-
   article a[href^="#"]:after {
     content: "";
   }
-
   a:not(:local-link):after {
     content: " < " attr(href) "> ";
   }
-
   /* Visibility */
   .main-navigation,
   .site-title + .main-navigation,
@@ -127,13 +108,11 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .comment .comment-metadata .edit-link {
     display: none;
   }
-
   .entry .entry-content .wp-block-button .wp-block-button__link,
   .entry .entry-content .button {
     color: #000;
     background: none;
   }
-
   /* Site Header (With Featured Image) */
   .site-header.featured-image {
     min-height: 0;
@@ -150,7 +129,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }
@@ -163,13 +143,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     position: relative;
     height: initial;
     width: initial;
-    object-fit: none;
+    -o-object-fit: none;
+       object-fit: none;
     min-width: 0;
     min-height: 0;
     max-width: 100%;
     margin-top: 1rem;
   }
-
   /* Remove image filters from featured image */
   .image-filters-enabled *:after {
     display: none !important;

--- a/sophisticated-business/sass/site/primary/_posts-and-pages.scss
+++ b/sophisticated-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:"\02190"*/"};
+				content: "\02192" #{"/*rtl:\"\02190\"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/sophisticated-business/sass/site/primary/_posts-and-pages.scss
+++ b/sophisticated-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" #{"/*rtl:02190*/"};
+				content: "\02192" #{"/*rtl:"\02190"*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/sophisticated-business/sass/site/primary/_posts-and-pages.scss
+++ b/sophisticated-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192";
+				content: "\02192" /*rtl:"\02190"*/;
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/sophisticated-business/sass/site/primary/_posts-and-pages.scss
+++ b/sophisticated-business/sass/site/primary/_posts-and-pages.scss
@@ -198,7 +198,7 @@
 			color: inherit;
 
 			&:after {
-				content: "\02192" /*rtl:"\02190"*/;
+				content: "\02192" #{"/*rtl:02190*/"};
 				display: inline-block;
 				margin-left: 0.5em;
 			}

--- a/sophisticated-business/style-editor-customizer.css
+++ b/sophisticated-business/style-editor-customizer.css
@@ -1,4 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /*!
 Sophisticated Business Customizer Styles & Non-latin Font Fallbacks
 
@@ -107,7 +106,7 @@ html[lang="vi"] .wp-block * {
 .is-dark-theme .editor-block-list__layout .editor-block-list__layout .editor-block-mover__control:hover {
   background: #fff;
   color: #191e23;
-  box-shadow: inset 0 0 0 1px #e2e4e7, inset 0 0 0 2px white, 0 1px 1px rgba(25, 30, 35, 0.2);
+  box-shadow: inset 0 0 0 1px #e2e4e7, inset 0 0 0 2px #fff, 0 1px 1px rgba(25, 30, 35, 0.2);
 }
 
 .is-dark-theme .editor-block-list__layout .editor-block-list__layout .editor-block-mover__control[aria-disabled=true] {

--- a/sophisticated-business/style-jetpack.css
+++ b/sophisticated-business/style-jetpack.css
@@ -1,5 +1,3 @@
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
-/*THIS FILE IS COMPILED FROM AN .SCSS FILE - DO NOT EDIT DIRECTLY*/
 /* Reset font-family styles for Jetpack
  *
  * See: https://github.com/Automattic/jetpack/blob/master/modules/theme-tools/compat/twentynineteen.css

--- a/sophisticated-business/style-rtl.css
+++ b/sophisticated-business/style-rtl.css
@@ -7,7 +7,7 @@ Author URI: https://automattic.com/
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your delicious food and special concoctions! With its bold typography and chic color scheme, Sophisticated Business exudes the same cool, intimate atmosphere as an upscale bar, lounge, or pub.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.3
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: sophisticated-business

--- a/sophisticated-business/style-rtl.css
+++ b/sophisticated-business/style-rtl.css
@@ -2503,7 +2503,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: 02190;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/sophisticated-business/style-rtl.css
+++ b/sophisticated-business/style-rtl.css
@@ -2503,7 +2503,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: 02190;
+  content:  ←;
   display: inline-block;
   margin-right: 0.5em;
 }

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -2509,7 +2509,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl:02190*/;
+  content: "→" /*rtl: ←*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -2509,7 +2509,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "→" /*rtl: ←*/;
+  content: "→" /*rtl:"←"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -7,7 +7,7 @@ Author URI: https://automattic.com/
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your delicious food and special concoctions! With its bold typography and chic color scheme, Sophisticated Business exudes the same cool, intimate atmosphere as an upscale bar, lounge, or pub.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.3
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: sophisticated-business
@@ -2509,7 +2509,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192" /*rtl:"\02190"*/;
+  content: "→" /*rtl:02190*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -2509,7 +2509,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "\02192" /*rtl:"\02190"*/;
   display: inline-block;
   margin-left: 0.5em;
 }

--- a/sophisticated-business/style.scss
+++ b/sophisticated-business/style.scss
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Template: twentynineteen
 Description: Your classy establishment needs an equally classy website to showcase your delicious food and special concoctions! With its bold typography and chic color scheme, Sophisticated Business exudes the same cool, intimate atmosphere as an upscale bar, lounge, or pub.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.3
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: sophisticated-business

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -3152,7 +3152,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3171,7 +3171,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -382,7 +382,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: 02190;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: 02190;
+	content:  ←;
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -3151,7 +3151,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content:  ←;
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl:02190*/;
+	content: "→" /*rtl: ←*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "→" /*rtl: ←*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.11
+Version: 1.3.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3170,7 +3170,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:02190*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/varia/package.json
+++ b/varia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "A variable-based design system for WordPress sites built with Gutenberg.",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues?q=is%3Aopen+is%3Aissue+label%3Avaria"

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -5,6 +5,8 @@ declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "da
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}
 	echo 'Rebulding '${child}
+	perl -pi -e 's/Version: ((\d+\.)*)(\d+)(.*)$/"Version: ".$1.($3+1).$4/ge' sass/style-child-theme.scss
+	perl -pi -e 's/\"version\": \"((\d+\.)*)(\d+)\"(.*)$/"\"version\": \"".$1.($3+1)."\"".$4/ge' package.json
 	npm install
 	npm run build
 done

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -5,8 +5,6 @@ declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "da
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}
 	echo 'Rebulding '${child}
-	perl -pi -e 's/Version: ((\d+\.)*)(\d+)(.*)$/"Version: ".$1.($3+1).$4/ge' sass/style-child-theme.scss
-	perl -pi -e 's/\"version\": \"((\d+\.)*)(\d+)\"(.*)$/"\"version\": \"".$1.($3+1)."\"".$4/ge' package.json
 	npm install
 	npm run build
 done

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -96,7 +96,7 @@
 		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
 
 		&:after {
-			content: "\02192" #{"/*rtl:02190*/"};
+			content: "\02192" #{"/*rtl:"\02190"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -96,7 +96,7 @@
 		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
 
 		&:after {
-			content: "\02192";
+			content: "\02192" /*rtl:"\02190"*/;
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -96,7 +96,7 @@
 		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
 
 		&:after {
-			content: "\02192" #{"/*rtl:"\02190"*/"};
+			content: "\02192" #{"/*rtl:\"\02190\"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/blocks/blog-posts/_editor.scss
+++ b/varia/sass/blocks/blog-posts/_editor.scss
@@ -96,7 +96,7 @@
 		margin-top: #{map-deep-get($config-global, "spacing", "unit")};
 
 		&:after {
-			content: "\02192" /*rtl:"\02190"*/;
+			content: "\02192" #{"/*rtl:02190*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:after {
-			content: "\02192" #{"/*rtl:"\02190"*/"};
+			content: "\02192" #{"/*rtl:\"\02190\"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:after {
-			content: "\02192" /*rtl:"\02190"*/;
+			content: "\02192" #{"/*rtl:02190*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:after {
-			content: "\02192";
+			content: "\02192" /*rtl:"\02190"*/;
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:after {
-			content: "\02192" #{"/*rtl:02190*/"};
+			content: "\02192" #{"/*rtl:"\02190"*/"};
 			display: inline-block;
 			margin-left: 0.5em;
 		}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -388,7 +388,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -388,7 +388,7 @@ object {
 }
 
 .wp-block-a8c-blog-posts .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.10
+Version: 1.5.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -3185,7 +3185,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "←";
 	display: inline-block;
 	margin-right: 0.5em;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -3204,7 +3204,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192";
+	content: "\02192" /*rtl:"\02190"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.10
+Version: 1.5.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -3204,7 +3204,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: "\02192" /*rtl:"\02190"*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.5.10
+Version: 1.5.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia


### PR DESCRIPTION
We use hardcoded numerical values for left-right arrows in CSS. 
Those need to be mirrored in RTL mode. 

Example issue (hever in this case) - the arrow is pointing the wrong way:
<img width="324" alt="Screen Shot 2021-01-07 at 15 10 58" src="https://user-images.githubusercontent.com/844866/103896400-93675180-50fa-11eb-94f7-cfa1b8713c5e.png">

#### Changes proposed in this Pull Request:
- The first commit replaces the right arrow css (\2192 or \02192) with left arrow ( \2190 or \02190) and vice versa, using a directive for RTLCSS.
- The 2nd commit adds the result of running `npm run build:rtl` in all supported directories
- The next few commits address specific themes that use the manually built rtl.css file

