### PR TITLE
Blank Canvas: Remove option to hide page title on the homepage.

### DIFF
--- a/blank-canvas/inc/wpcom.php
+++ b/blank-canvas/inc/wpcom.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * WordPress.com-specific functions and definitions.
+ *
+ * This file is centrally included from `wp-content/mu-plugins/wpcom-theme-compat.php`.
+ *
+ * @package Blank Canvas
+ */
+
+/**
+ * Remove setting for hiding page title on the homepage.
+ */
+function blank_canvas_wpcom_customize_update( $wp_customize ) {
+	$wp_customize->remove_control( 'hide_front_page_title');
+}
+add_action( 'customize_register', 'blank_canvas_wpcom_customize_update', 11 );


### PR DESCRIPTION
Fixes #2979

Seedlet includes this wpcom option to hide the homepage title. The Blank Canvas theme doesn't display a post title on any page, so this option is irrelevant. This PR removes the control from the customizer for the theme. 

---

Before: 
![Screen Shot 2021-01-07 at 12 25 12](https://user-images.githubusercontent.com/1202812/103924125-a0c51180-50e3-11eb-9867-d397f88881c1.png)

After:
![Screen Shot 2021-01-07 at 12 24 50](https://user-images.githubusercontent.com/1202812/103924169-ade20080-50e3-11eb-9bf2-08a6fbed872d.png)
