### PR TITLE
Blank Canvas: Customizer Fixes

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -91,6 +91,19 @@ function blank_canvas_dequeue_parent_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_dequeue_parent_scripts', 11 );
 
+function blank_canvas_remove_customizer_settings( $wp_customize ) {
+
+	// Remove the navigation menus Customizer panel.
+	$wp_customize->get_panel( 'nav_menus' )->active_callback = '__return_false';
+
+	// Remove Jetpack's Author Bio setting.
+	if ( function_exists( 'jetpack_author_bio' ) ) {
+		$wp_customize->remove_control( 'jetpack_content_author_bio_title' );
+		$wp_customize->remove_control( 'jetpack_content_author_bio' );
+	}
+}
+add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
+
 /**
  * Remove Meta Footer Items.
  */

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -83,6 +83,9 @@ function blank_canvas_remove_parent_theme_features() {
 }
 add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 11 );
 
+/**
+ * Dequeue Seedlet scripts.
+ */
 function blank_canvas_dequeue_parent_scripts() {
 
 	// Naviation assets.
@@ -91,6 +94,17 @@ function blank_canvas_dequeue_parent_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_dequeue_parent_scripts', 11 );
 
+/**
+ * Remove Seedlet's widget area.
+ */
+function blank_canvas_remove_widgets_area() {
+	unregister_sidebar( 'sidebar-1' );
+}
+add_action( 'widgets_init', 'blank_canvas_remove_widgets_area', 11 );
+
+/**
+ * Remove unused custmizer settings.
+ */
 function blank_canvas_remove_customizer_settings( $wp_customize ) {
 
 	// Remove the navigation menus Customizer panel.

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -116,7 +116,7 @@ function blank_canvas_remove_customizer_settings( $wp_customize ) {
 	}
 
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'title_tagline' )->description = __( 'This theme is designed to hide the site title and tagline on all single posts and pages.', 'blank-canvas' );
+	$wp_customize->get_section( 'title_tagline' )->description = __( 'This theme is designed to hide the site logo, site title, and tagline on all single posts and pages.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -117,7 +117,7 @@ function blank_canvas_remove_customizer_settings( $wp_customize ) {
 	}
 
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'title_tagline' )->description = 'This theme is designed to hide the site title and tagline on all single posts and pages.';
+	$wp_customize->get_section( 'title_tagline' )->description = __( 'This theme is designed to hide the site title and tagline on all single posts and pages.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -115,6 +115,9 @@ function blank_canvas_remove_customizer_settings( $wp_customize ) {
 		$wp_customize->remove_control( 'jetpack_content_author_bio_title' );
 		$wp_customize->remove_control( 'jetpack_content_author_bio' );
 	}
+
+	// Add a Customizer message about the site title & tagline options.
+	$wp_customize->get_section( 'title_tagline' )->description = 'This theme is designed to hide the site title and tagline on all single posts and pages.';
 }
 add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -71,20 +71,21 @@ add_action( 'after_setup_theme', 'blank_canvas_setup', 11 );
  */
 function blank_canvas_remove_parent_theme_features() {
 
-	// Theme Support
+	// Theme Support.
 	remove_theme_support( 'custom-header' );
 	remove_theme_support( 'custom-logo' );
 	remove_theme_support( 'customize-selective-refresh-widgets' );
 
-	// Navigation Areas
+	// Navigation Areas.
 	unregister_nav_menu( 'primary' );
 	unregister_nav_menu( 'footer' );
 	unregister_nav_menu( 'social' );
 }
-add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 10 );
+add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 11 );
 
 function blank_canvas_dequeue_parent_scripts() {
-	// Naviation assets
+
+	// Naviation assets.
 	wp_dequeue_script( 'seedlet-primary-navigation-script' );
 	wp_dequeue_style( 'seedlet-style-navigation' );
 }

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -73,7 +73,6 @@ function blank_canvas_remove_parent_theme_features() {
 
 	// Theme Support.
 	remove_theme_support( 'custom-header' );
-	remove_theme_support( 'custom-logo' );
 	remove_theme_support( 'customize-selective-refresh-widgets' );
 
 	// Navigation Areas.

--- a/seedlet/inc/wpcom.php
+++ b/seedlet/inc/wpcom.php
@@ -146,11 +146,25 @@ function seedlet_wpcom_customize_update( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( 'hide_front_page_title', array(
+		'label'		  => esc_html__( 'Hide Homepage Title', 'seedlet' ),
 		'description' => esc_html__( 'Check to hide the page title, if your homepage is set to display a static page.', 'seedlet' ),
 		'section'	  => 'static_front_page',
 		'priority'	  => 10,
 		'type'		  => 'checkbox',
 		'settings'	  => 'hide_front_page_title',
+	) );
+
+	$wp_customize->add_setting( 'color_a11y_warning' );
+    $wp_customize->add_control( 'color_a11y_warning', array(
+        'id'          => 'id',
+        'label'       => esc_html__( 'Color Accessibility Warning', 'seedlet' ),
+		'description' => sprintf(
+							__( 'In order to ensure people can read your site, try to maintain a strong contrast ratio between the colors you choose here. <a href="%s" target="_blank">Learn more about color contrast</a>.', 'seedlet' ),
+							esc_url( 'https://a11yproject.com/posts/what-is-color-contrast/' )
+						 ),
+        'section'     => 'colors_manager_tool',
+		'priority'	  => 10,
+		'type'		  => 'hidden',
 	) );
 }
 add_action( 'customize_register', 'seedlet_wpcom_customize_update' );

--- a/seedlet/inc/wpcom.php
+++ b/seedlet/inc/wpcom.php
@@ -146,25 +146,11 @@ function seedlet_wpcom_customize_update( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( 'hide_front_page_title', array(
-		'label'		  => esc_html__( 'Hide Homepage Title', 'seedlet' ),
 		'description' => esc_html__( 'Check to hide the page title, if your homepage is set to display a static page.', 'seedlet' ),
 		'section'	  => 'static_front_page',
 		'priority'	  => 10,
 		'type'		  => 'checkbox',
 		'settings'	  => 'hide_front_page_title',
-	) );
-
-	$wp_customize->add_setting( 'color_a11y_warning' );
-    $wp_customize->add_control( 'color_a11y_warning', array(
-        'id'          => 'id',
-        'label'       => esc_html__( 'Color Accessibility Warning', 'seedlet' ),
-		'description' => sprintf(
-							__( 'In order to ensure people can read your site, try to maintain a strong contrast ratio between the colors you choose here. <a href="%s" target="_blank">Learn more about color contrast</a>.', 'seedlet' ),
-							esc_url( 'https://a11yproject.com/posts/what-is-color-contrast/' )
-						 ),
-        'section'     => 'colors_manager_tool',
-		'priority'	  => 10,
-		'type'		  => 'hidden',
 	) );
 }
 add_action( 'customize_register', 'seedlet_wpcom_customize_update' );


### PR DESCRIPTION
This PR tidies up customizer options for the Blank Canvas theme: 

- It increases the priority of the `blank_canvas_remove_parent_theme_features` function, to ensure that the nav menu areas are actually removed (Fixes #2980)
- It removes the "Navigation" panel from the customizer entirely, since no menu areas are present in this theme. (I guess this doesn't disappear automatically?)  
- It removes Seedlet's widget area, so the Widgets panel should no longer appear.
- It adds a message to the top of the "Site Identity" panel, to clarify that the title and tagline will never appear on single posts and pages. 

---

## Screenshots

Before|After
---|---
<img width="299" alt="Screen Shot 2021-01-07 at 2 07 51 PM" src="https://user-images.githubusercontent.com/1202812/103933799-f56f8900-50f1-11eb-9cd5-51b95a901721.png">|<img width="301" alt="Screen Shot 2021-01-07 at 2 06 50 PM" src="https://user-images.githubusercontent.com/1202812/103933801-f6a0b600-50f1-11eb-8c28-7f0e7a3c7879.png">

Before|After
---|---
<img width="300" alt="Screen Shot 2021-01-07 at 2 09 10 PM" src="https://user-images.githubusercontent.com/1202812/103933823-fbfe0080-50f1-11eb-9f97-2a3e47368e92.png">|<img width="300" alt="Screen Shot 2021-01-07 at 2 10 54 PM" src="https://user-images.githubusercontent.com/1202812/103933971-336cad00-50f2-11eb-8516-4841ac4186d4.png">


