### PR TITLE
Blank Canvas: Improve top margin CSS rules

### DIFF
--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -30,14 +30,6 @@ GNU General Public License for more details.
 
 @import "variables.css";
 
-/* Remove outside padding on single post pages. */
-
-.single .site-main,
-.page .site-main {
-	padding-top: 0;
-	padding-bottom: 0;
-}
-
 /* Remove extra margin from articles on single post pages. */
 
 .single .site-main > article,
@@ -47,9 +39,15 @@ GNU General Public License for more details.
 
 /* Add some top padding if the first block on the page is not full-width or a spacer. */
 
-.single .entry-content > *:first-child:not(.alignfull):not(.wp-block-spacer),
-.page .entry-content > *:first-child:not(.alignfull):not(.wp-block-spacer) {
-	padding-top: var(--global--spacing-vertical);
+.single .entry-content > .wp-block-image.alignfull:first-child,
+.page .entry-content > .wp-block-image.alignfull:first-child,
+.single .entry-content > .wp-block-cover.alignfull:first-child,
+.page .entry-content > .wp-block-cover.alignfull:first-child,
+.single .entry-content > .wp-block-media-text.alignfull:first-child,
+.page .entry-content > .wp-block-media-text.alignfull:first-child
+.single .entry-content > .wp-block-group.has-background.alignfull:first-child,
+.page .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: calc(-1 * var(--global--spacing-vertical));
 }
 
 /* Add some top padding for archive pages. */

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -37,7 +37,7 @@ GNU General Public License for more details.
 	margin-bottom: 0;
 }
 
-/* Add some top padding if the first block on the page is not full-width or a spacer. */
+/* Add some top padding if the first block on the page is a full-width image, cover, media & text, or group block. */
 
 .single .entry-content > .wp-block-image.alignfull:first-child,
 .page .entry-content > .wp-block-image.alignfull:first-child,


### PR DESCRIPTION
There are just a handful of instances where we want Blank Canvas to remove margins from the first block used in the post/page. In these cases, we want the block to appear full-bleed, right to the top edge of the page.

- Full-width Images
- Full-width Cover Blocks
- Full-width Media & Text Blocks
- Full-width Group Blocks (When they have a background color, and thus supply their own padding).

The theme previously used a faulty approach to determine when and when not to apply these margins: It removed the margin by default, and only added it back in for certain blocks. It led to some cases when top margins were removed unnecessarily. 

This PR takes the opposite approach: it includes the top padding by default all the time, and removes it only in the use cases listed out above. If/when we find other use cases we can 


## Screenshots

Here how the theme previously displayed a post that starts out with a standard-width cover block: 

![Screen Shot 2021-01-08 at 10 53 52 AM](https://user-images.githubusercontent.com/1202812/104035254-ea733200-519f-11eb-8bca-e9e4bc428659.png)

This PR corrects that and adds top margin: 

![Screen Shot 2021-01-08 at 10 54 08 AM](https://user-images.githubusercontent.com/1202812/104035417-18f10d00-51a0-11eb-89ee-65885a54dbe5.png)

It also retains the zero'd out top margin if that cover block were set to full-width: 

![Screen Shot 2021-01-08 at 10 58 53 AM](https://user-images.githubusercontent.com/1202812/104035753-800ec180-51a0-11eb-8c38-ef4898eb6c13.png)

