### PR TITLE
Varia: fix to add logic to prevent empty menu button

### DIFF
--- a/varia/header.php
+++ b/varia/header.php
@@ -11,6 +11,12 @@
  * @since 1.0.0
  */
 $has_primary_nav = has_nav_menu( 'menu-1' );
+$has_menu_items = wp_nav_menu(
+	array(
+		'theme_location' => 'menu-1',
+		'fallback_cb' => false,
+		'echo' => false 
+	));
 $header_classes  = 'site-header responsive-max-width';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';
 $header_classes .= 1 === get_theme_mod( 'header_text', 1 ) ? ' has-title-and-tagline' : '';
@@ -48,7 +54,7 @@ if ( function_exists( 'wp_body_open' ) ) {
 		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 			<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-			<?php if ( $has_primary_nav ) : ?>
+			<?php if ( $has_primary_nav && $has_menu_items ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varia' ); ?>">
 
 					<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">

--- a/varia/header.php
+++ b/varia/header.php
@@ -10,17 +10,18 @@
  * @subpackage Varia
  * @since 1.0.0
  */
-$has_primary_nav = has_nav_menu( 'menu-1' );
-$has_menu_items = wp_nav_menu(
+$has_primary_nav       = has_nav_menu( 'menu-1' );
+$has_primary_nav_items = wp_nav_menu(
 	array(
 		'theme_location' => 'menu-1',
-		'fallback_cb' 	 => false,
-		'echo' 			 => false 
-	));
-$header_classes  = 'site-header responsive-max-width';
-$header_classes .= has_custom_logo() ? ' has-logo' : '';
-$header_classes .= 1 === get_theme_mod( 'header_text', 1 ) ? ' has-title-and-tagline' : '';
-$header_classes .= $has_primary_nav ? ' has-menu' : '';
+		'fallback_cb'    => false,
+		'echo'           => false,
+	)
+);
+$header_classes        = 'site-header responsive-max-width';
+$header_classes       .= has_custom_logo() ? ' has-logo' : '';
+$header_classes       .= 1 === get_theme_mod( 'header_text', 1 ) ? ' has-title-and-tagline' : '';
+$header_classes       .= $has_primary_nav ? ' has-menu' : '';
 ?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -54,7 +55,7 @@ if ( function_exists( 'wp_body_open' ) ) {
 		<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 			<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-			<?php if ( $has_primary_nav && $has_menu_items ) : ?>
+			<?php if ( $has_primary_nav && $has_primary_nav_items ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'varia' ); ?>">
 
 					<input type="checkbox" role="button" aria-haspopup="true" id="toggle" class="hide-visually">
@@ -68,9 +69,9 @@ if ( function_exists( 'wp_body_open' ) ) {
 
 					<?php
 					$main_nav_args = array(
-						'theme_location'  => 'menu-1',
-						'menu_class'      => 'main-menu',
-						'items_wrap'      => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
+						'theme_location' => 'menu-1',
+						'menu_class'     => 'main-menu',
+						'items_wrap'     => '<ul id="%1$s" class="%2$s" aria-label="submenu">%3$s</ul>',
 					);
 					if ( get_theme_mod( 'enable_side_menu' ) === 1 ) {
 						$main_nav_args['container_class'] = 'main-menu-container';

--- a/varia/header.php
+++ b/varia/header.php
@@ -14,8 +14,8 @@ $has_primary_nav = has_nav_menu( 'menu-1' );
 $has_menu_items = wp_nav_menu(
 	array(
 		'theme_location' => 'menu-1',
-		'fallback_cb' => false,
-		'echo' => false 
+		'fallback_cb' 	 => false,
+		'echo' 			 => false 
 	));
 $header_classes  = 'site-header responsive-max-width';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Currently the menu logic checks if the primary menu is set using `has_nav_menu( 'menu-1' )`. This does not check to make sure the menu has links in it. I added another check to the logic.

```
$has_menu_items = wp_nav_menu(
	array(
		'theme_location'    => 'menu-1',
		'fallback_cb' 	    => false,
		'echo' 	            => false 
	)
);
```

This returns `false` if the menu is empty preventing the button from being added.

#### Screenshots
[![Screenshot](https://d.pr/i/Qwureb+)](https://d.pr/i/Qwureb)

## Related issue(s):
Fixes #2918 