### PR TITLE
Varia themes: fix cover block + layout grid bug

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.14
+Version: 1.2.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.14
+Version: 1.2.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3970,6 +3970,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.14
+Version: 1.2.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3999,6 +3999,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.16
+Version: 1.3.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.16
+Version: 1.3.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.3.16
+Version: 1.3.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3961,6 +3961,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3990,6 +3990,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/dalston/package-lock.json
+++ b/dalston/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/sass/style-child-theme.scss
+++ b/dalston/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3963,6 +3963,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.12
+Version: 1.2.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3992,6 +3992,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3974,6 +3974,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4003,6 +4003,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.3.13
+Version: 1.3.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3963,6 +3963,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3992,6 +3992,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.16
+Version: 1.4.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.16
+Version: 1.4.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.16
+Version: 1.4.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.16
+Version: 1.5.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.16
+Version: 1.5.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.5.16
+Version: 1.5.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.4.13
+Version: 1.4.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.2.13
+Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3963,6 +3963,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3992,6 +3992,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3963,6 +3963,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.3.14
+Version: 1.3.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3992,6 +3992,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3964,6 +3964,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.14
+Version: 1.4.15
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3993,6 +3993,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3963,6 +3963,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.12
+Version: 1.3.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -3992,6 +3992,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/varia/sass/vendors/jetpack/_style.scss
+++ b/varia/sass/vendors/jetpack/_style.scss
@@ -155,6 +155,7 @@ body {
 	.wp-block-jetpack-layout-grid-column {
 
 		& > * {
+			height: auto; // In case a child block has a height set to 100%;
 			margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
 			margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
 

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3997,6 +3997,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -4026,6 +4026,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
  * Layout Grid
  */
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > * {
+	height: auto;
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
 }


### PR DESCRIPTION
This PR addresses #2976. 

To describe what's going on in more detail: 

- The cover block's default CSS contains `height: 100%;`
- When you place a cover block inside a layout grid column, the cover takes up 100% of the calculated height of the layout grid column, pushing whatever else inside that same column _beyond_ the height the column takes up in the document flow. This is why the footer credit appears in the middle as reported in 2976. 
- It happens to be that the Doyle layout uses this pattern, but any theme that implements the pattern would experience this issue.

This PR targets all direct descendants of layout grid columns to set their `height: auto`. It feels like a bandaid, and I'm not attached to this solution but wanted to put it out there to get a fix in place.

**To test**
- Follow the steps to recreate the pattern described in #2976. You can use any varia theme on a free plan.
- Verify that any elements that are placed after the group block appear to overlap the layout grid
- Apply this patch (D55158), and verify that the issue is resolved