### PR TITLE
Seedlet: Only hide site header/footer if the homepage is set to a static page

### DIFF
--- a/seedlet/template-parts/footer/footer-content.php
+++ b/seedlet/template-parts/footer/footer-content.php
@@ -1,4 +1,4 @@
-<?php if ( ! ( true === get_theme_mod( 'hide_site_footer', false ) && is_front_page() ) ) : ?>
+<?php if ( ! ( true === get_theme_mod( 'hide_site_footer', false ) && is_front_page() && is_page() ) ) : ?>
 	<?php get_template_part( 'template-parts/footer/footer-widgets' ); ?>
 	<?php get_template_part( 'template-parts/footer/footer-menu' ); ?>
 <?php endif; ?>

--- a/seedlet/template-parts/header/header-content.php
+++ b/seedlet/template-parts/header/header-content.php
@@ -6,7 +6,7 @@ $header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ?
 $header_classes .= $has_primary_nav ? ' has-menu' : '';
 ?>
 
-<?php if ( ! ( true === get_theme_mod( 'hide_site_header', false ) && is_front_page() ) ) : ?>
+<?php if ( ! ( true === get_theme_mod( 'hide_site_header', false ) && is_front_page() && is_page() ) ) : ?>
 	<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 		<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 		<?php get_template_part( 'template-parts/header/navigation' ); ?>


### PR DESCRIPTION
As per the checkbox labels, the options added in #2985 should only apply if the homepage is set to display a static page: 

![Screen Shot 2021-01-12 at 9 15 25 AM](https://user-images.githubusercontent.com/1202812/104325515-b60cb800-54b6-11eb-9323-7ad395b26dee.png)

This mirrors wpcom's "Hide Homepage Title" functionality. Currently, the options hide the title even when an index is set to the homepage. This PR corrects that.

## Screenshots

Before

![Kapture 2021-01-12 at 09 13 28](https://user-images.githubusercontent.com/1202812/104325876-17cd2200-54b7-11eb-9b4f-a3070166ee14.gif)

After

![Kapture 2021-01-12 at 09 14 13](https://user-images.githubusercontent.com/1202812/104325905-1f8cc680-54b7-11eb-95b5-049fb8c8b4a3.gif)
