### PR TITLE
Remove 'dark-editor-style' theme support

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -21,7 +21,6 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 
 		// Add support for editor styles.
 		add_theme_support( 'editor-styles' );
-		add_theme_support( 'dark-editor-style' );
 
 		// Enqueue editor styles.
 		add_editor_style(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This fixes the issue where some styles (such as the image caption) have
"dark mode" support added to them.  This is fine if a user has "dark
mode" enabled for their system.  But in the default mode it isn't a
"dark" style and therefore those stylistic behaviors introduce problems.

I did not notice any negative behavior due to this being removed.

This behavior seems to have been introduced due to recent changes in
Gutenberg that introduce additional editor styles for themes that
express support for 'dark-editor-style'.

#### Testing

This bug only happens when your local system is NOT configured to use DARK MODE.
This bug requires an up-to-date version of Gutenberg.  (Due to the recent change introducing additional dark-mode editor styles noted above).  I wasn't able to determine exactly which version that change was introduced in.

#### Related issue(s):

https://github.com/Automattic/themes/issues/2905