### PR TITLE
Change layout direction of Seedlet Submenu

### DIFF
--- a/spearhead/assets/sass/navigation.scss
+++ b/spearhead/assets/sass/navigation.scss
@@ -29,6 +29,9 @@ $navigation-max-break-point: 'laptop-only';
 		@include media( $navigation-min-break-point ) {
 			padding: calc(0.5 * var(--primary-nav--padding)) calc( 2 * var(--primary-nav--padding) );
 			transition: all 0.15s ease;
+			text-align: right;
+			left: unset;
+			right: 0;
 
 			> .menu-item.menu-item-has-children {
 				padding: calc(0.5 * var(--primary-nav--padding)) calc( 2 * var(--primary-nav--padding) ) 0 0;

--- a/spearhead/navigation-rtl.css
+++ b/spearhead/navigation-rtl.css
@@ -545,6 +545,9 @@
 	.woo-navigation div ul > li > .sub-menu {
 		padding: calc(0.5 * var(--primary-nav--padding)) calc( 2 * var(--primary-nav--padding));
 		transition: all 0.15s ease;
+		text-align: left;
+		right: unset;
+		left: 0;
 	}
 	.primary-navigation div ul > li > .sub-menu > .menu-item.menu-item-has-children,
 	.woo-navigation div ul > li > .sub-menu > .menu-item.menu-item-has-children {

--- a/spearhead/navigation.css
+++ b/spearhead/navigation.css
@@ -545,6 +545,9 @@
 	.woo-navigation div ul > li > .sub-menu {
 		padding: calc(0.5 * var(--primary-nav--padding)) calc( 2 * var(--primary-nav--padding));
 		transition: all 0.15s ease;
+		text-align: right;
+		left: unset;
+		right: 0;
 	}
 	.primary-navigation div ul > li > .sub-menu > .menu-item.menu-item-has-children,
 	.woo-navigation div ul > li > .sub-menu > .menu-item.menu-item-has-children {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This changes the alignment of submenus.  It will align the container to
the RIGHT of the parent (rather than the left as it was doing) and RIGHT
ALIGN the sub-menu items (whereas previously they were left aligned).

This is to address #2790.

Before:
![image](https://user-images.githubusercontent.com/146530/104367175-6e068900-54e8-11eb-965e-1a9f2fb79c04.png)
![image](https://user-images.githubusercontent.com/146530/104378381-e7f13f00-54f5-11eb-9322-58aca2ae24bf.png)

After:
![image](https://user-images.githubusercontent.com/146530/104367122-5c24e600-54e8-11eb-8d10-f1eca83f3c7d.png)
![image](https://user-images.githubusercontent.com/146530/104378328-d27c1500-54f5-11eb-910b-ee71456c10a3.png)

RTL:
![image](https://user-images.githubusercontent.com/146530/104378801-8ed5db00-54f6-11eb-82ab-3b182a98dd65.png)


#### Related issue(s):
https://github.com/Automattic/themes/issues/2790
