### PR TITLE
Seedlet: Fix wrapping cart headers

### DIFF
--- a/seedlet/assets/css/style-woocommerce-rtl.css
+++ b/seedlet/assets/css/style-woocommerce-rtl.css
@@ -1409,6 +1409,11 @@ body[class*="woocommerce"] #page .woocommerce-customer-details > *:empty {
 /**
  * Cart page
  */
+body[class*="woocommerce"] #page table.shop_table th,
+body[class*="woocommerce"] #page table.shop_table td {
+	word-break: unset;
+}
+
 body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }

--- a/seedlet/assets/css/style-woocommerce.css
+++ b/seedlet/assets/css/style-woocommerce.css
@@ -1409,6 +1409,11 @@ body[class*="woocommerce"] #page .woocommerce-customer-details > *:empty {
 /**
  * Cart page
  */
+body[class*="woocommerce"] #page table.shop_table th,
+body[class*="woocommerce"] #page table.shop_table td {
+	word-break: unset;
+}
+
 body[class*="woocommerce"] #page table.shop_table td.product-remove {
 	border-width: 0;
 }

--- a/seedlet/assets/sass/vendors/woocommerce/pages/_cart.scss
+++ b/seedlet/assets/sass/vendors/woocommerce/pages/_cart.scss
@@ -2,6 +2,10 @@
  * Cart page
  */
 body[class*="woocommerce"] #page { // adding #page here to override default wc styles without !important
+	table.shop_table th,
+	table.shop_table td {
+		word-break: unset;
+	}
 
 	table.shop_table td.product-remove {
 		border-width: 0;


### PR DESCRIPTION
This fixes #2794 but turn off word-break for the cart headers:

#### Changes proposed in this Pull Request:
Before:
<img width="816" alt="Screenshot 2021-01-13 at 10 09 32" src="https://user-images.githubusercontent.com/275961/104438130-8d082800-5587-11eb-94da-c5597132cb0f.png">

After:
<img width="851" alt="Screenshot 2021-01-13 at 10 08 52" src="https://user-images.githubusercontent.com/275961/104438136-8f6a8200-5587-11eb-95c4-4ba17e3ae753.png">



#### Related issue(s): #2794
