### PR TITLE
Change CSS variable assignment order

### DIFF
--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -262,8 +262,9 @@ class Seedlet_Custom_Colors {
 	 * Customizer & frontend custom color variables.
 	 */
 	function seedlet_custom_color_variables() {
+		wp_enqueue_style( 'seedlet-custom-color-overrides', get_template_directory_uri() . '/assets/css/custom-color-overrides.css', array(), wp_get_theme()->get( 'Version' ) );
 		if ( 'default' !== get_theme_mod( 'custom_colors_active' ) ) {
-			wp_add_inline_style( 'seedlet-style', $this->seedlet_generate_custom_color_variables() );
+			wp_add_inline_style( 'seedlet-custom-color-overrides', $this->seedlet_generate_custom_color_variables() );
 		}
 	}
 

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -120,7 +120,9 @@ function spearhead_scripts() {
 	wp_enqueue_style( 'spearhead-fonts', spearhead_fonts_url(), array(), null );
 
 	// Child theme variables
+	wp_dequeue_style( 'seedlet-custom-color-overrides' );
 	wp_enqueue_style( 'spearhead-variables-style', get_stylesheet_directory_uri() . '/variables.css', array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'seedlet-custom-color-overrides' );
 
 	// enqueue child styles
 	wp_enqueue_style( 'spearhead-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

First Seedlet was changed so that all custom CSS variables for color
definitions are associated with the 'seedlet-custom-color-overrides'
stylesheed.  (Previously only editor override styles were associated
with that stylesheet.

Next Spearhead was changed to first dequeue that stylesheet, THEN assign
the spearhead-specific style variables THEN re-enqueue that
seedlet-custom-color-overrides stylesheet.

This puts the customizer color variable assignments AFTER the Spearhead
variable assignments so that those are the values that are used.

NOTE: [This Pull Request](https://github.com/Automattic/themes/pull/2776) also seems to be addressing this issue.  However there were quite a few more changes in that PR.  If those additional changes are necessary I don't yet grasp all of the reasons.  That work should be reviewed against this proposed change and perhaps that's a better fix. My 'druthers is that since that large amount of changes appears to address an edge-case that it instead be tagged as a new issue and instead play golf with this tiny change.

#### Testing

This has been tested by using the Customizer to change the colors to something recognizable and observing that those colors are shown correctly in: 

The Customizer
![image](https://user-images.githubusercontent.com/146530/104612012-bb533980-5653-11eb-9967-25a9b76a0429.png)

The Editor
![image](https://user-images.githubusercontent.com/146530/104611940-a8406980-5653-11eb-9bba-ecbfc06b3c6d.png)

The View
![image](https://user-images.githubusercontent.com/146530/104612066-c908bf00-5653-11eb-9901-e45448153290.png)


It was confirmed that this change doesn't effect the WP-COM behavior which utilizes another color customizer utility.

![image](https://user-images.githubusercontent.com/146530/104611852-919a1280-5653-11eb-9a0a-d7ade98e90b1.png)

It was confirmed that this change doesn't change the behavior of Spearhead which was already working as expected.

#### Related issue(s):
Closes #2701 