### PR TITLE
Seedlet Blocks: Remove theme attributes from block templates

### DIFF
--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","align":"full","tagName":"header"} /-->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
 <div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
@@ -18,4 +18,4 @@
 <!-- /wp:query --></div></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","align":"full","tagName":"footer"} /-->

--- a/seedlet-blocks/block-templates/singular.html
+++ b/seedlet-blocks/block-templates/singular.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"seedlet-blocks","align":"full","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","align":"full","tagName":"header"} /-->
 
 <!-- wp:group {"align":"full","className":"site-content","tagName":"main"} -->
 <div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
@@ -6,4 +6,4 @@
 <!-- wp:post-content {"align":"full"} /--></div></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"seedlet-blocks","align":"full","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","align":"full","tagName":"footer"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove theme attributes from seedlet blocks block templates

#### Context:
This PR was created as a follow-up to WordPress/gutenberg#28088. See the aforementioned PR description and code changes for more context.

#### Discussion:

1. What this means for theme designers is that, when creating block templates, the theme attribute can be omitted from serialized wp_template_part blocks (like we've done in this PR). The logic for the Gutenberg full site editor will automatically add a theme attribute that matches the current, activated theme's stylesheet.
2. New sites created for full site editing will _not_ load template parts correctly until https://github.com/WordPress/gutenberg/pull/28088 and https://github.com/WordPress/gutenberg/pull/27910 are added to a release, but to be fair, template parts are already broken on new FSE sites https://github.com/Automattic/wp-calypso/issues/48145.

#### Testing:
- Apply this PR
- Run Gutenberg locally (see instructions [here](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md#using-wp-env-to-install-a-local-environment))
- Install the seedlet-blocks theme by referencing it in `.wp-env.override.json`
    ```javascript 
      // .wp-env.override.json

      // Replace ~/work/theme-experiments/seedlet-blocks with 
      // the path to your locally installed seedlet-blocks theme
      {
           "mappings": {
               "wp-content/themes/seedlet-blocks": "~/work/themes/seedlet-blocks",
           }
      }```
- `npx wp-env start --update`
- Activate the seedlet-blocks theme
- Open the front end and the site editor. FSE templates and template parts should load without issue.
- Reinstall the seedlet-blocks theme in a subdirectory by modifying `.wp-env.override.json`
   ```javascript 
      // .wp-env.override.json
     
      // Add a test subdirectory in the mapping
      {
           "mappings": {
               "wp-content/themes/test/seedlet-blocks": "~/work/themes/seedlet-blocks",
           }
      }```
- `npx wp-env start --update`
- Activate seedlet-blocks.
- Open the front end and the site editor. FSE templates and template parts should _still_ load without issue.

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/48145