### PR TITLE
Seedlet: Fix full width Video block

### DIFF
--- a/seedlet/inc/jetpack.php
+++ b/seedlet/inc/jetpack.php
@@ -14,9 +14,6 @@
  * See: https://jetpack.com/support/responsive-videos/
  */
 function seedlet_jetpack_setup() {
-	// Add theme support for Responsive Videos.
-	add_theme_support( 'jetpack-responsive-videos' );
-
 	// Add theme support for Content Options.
 	add_theme_support( 'jetpack-content-options', array(
 		'author-bio' => true,


### PR DESCRIPTION
Closes #2553 

Before:
<img width="1515" alt="video" src="https://user-images.githubusercontent.com/905781/104915544-173dfb00-5991-11eb-9bab-9b1c4c9122a0.png">
After:
<img width="1507" alt="video_after" src="https://user-images.githubusercontent.com/905781/104915685-4ce2e400-5991-11eb-8137-1c2942b802ea.png">
