### PR TITLE
Seedlet: Remove word-break style in tables

### DIFF
--- a/seedlet/assets/sass/blocks/table/_style.scss
+++ b/seedlet/assets/sass/blocks/table/_style.scss
@@ -12,6 +12,5 @@ table,
 	th {
 		padding: calc( 0.5 * var(--global--spacing-unit) );
 		border: 1px solid;
-		word-break: break-all;
 	}
 }


### PR DESCRIPTION
The `word-break: break-all` style creates unwanted and unexpected breaks in text in tables. Let's remove it.

Fixes #2410.