### PR TITLE
Blank Canvas: Update customizer message styles

### DIFF
--- a/blank-canvas/assets/customizer.css
+++ b/blank-canvas/assets/customizer.css
@@ -1,0 +1,16 @@
+/**
+ * Customizer CSS
+ *
+ * Adjusts the theme's message about the site branding display to appear like a notice.
+ */
+
+#sub-accordion-section-title_tagline .customize-section-description {
+	background: #FFF;
+	border: 1px solid #ccd0d4;
+	border-left: 4px solid #00a0d2;
+	box-shadow: 0 1px 1px rgba( 0, 0, 0, .04 );
+	margin: 15px 0 6px 0;
+	padding: 9px 14px;
+	overflow: hidden;
+	width: auto;
+}

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -162,3 +162,11 @@ function blank_canvas_enqueue() {
 	wp_enqueue_style( 'blank-canvas-styles', get_stylesheet_uri() );
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_enqueue', 11 );
+
+/**
+ * Enqueue CSS for Customizer message.
+ */
+function blank_canvas_customizer_enqueue() {
+	wp_enqueue_style( 'blank-canvas-customizer-style', get_stylesheet_directory_uri() . '/assets/customizer.css', array(), wp_get_theme()->get( 'Version' ) );
+}
+add_action( 'customize_controls_enqueue_scripts', 'blank_canvas_customizer_enqueue' );


### PR DESCRIPTION
Fixes #3034. 

This PR styles the theme's customizer message to appear like a notice. This shows up in the "Site Identity" section. It borrows Varia's approach (and code) for enqueuing and [styling a customizer-specific stylesheet](https://github.com/Automattic/themes/blob/3992b5c9988d17ec64a3849ca225bbc315a505e4/varia/inc/customize-message-wpcom.css) to accomplish this.  

Before|After
---|---
![Screen Shot 2021-01-18 at 4 09 52 PM](https://user-images.githubusercontent.com/1202812/104963082-c1288200-59a7-11eb-96b6-87bc78798a6e.png)|![Screen Shot 2021-01-18 at 4 08 52 PM](https://user-images.githubusercontent.com/1202812/104963084-c2f24580-59a7-11eb-94b0-076c41e16a82.png)
