### PR TITLE
Seedlet: Fix Pullquote default alignment in the editor

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -955,8 +955,6 @@ p.has-background {
 
 .wp-block-pullquote {
 	padding: calc( 2 * var(--global--spacing-unit)) 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: left;
 	border-top-color: var(--pullquote--border-color);
 	border-top-width: var(--pullquote--border-width);

--- a/seedlet/assets/sass/blocks/pullquote/_editor.scss
+++ b/seedlet/assets/sass/blocks/pullquote/_editor.scss
@@ -1,7 +1,5 @@
 .wp-block-pullquote {
 	padding: calc( 2 * var(--global--spacing-unit) ) 0;
-	margin-left: 0;
-	margin-right: 0;
 	text-align: left;
 	// Theme?
 	border-top-color: var(--pullquote--border-color);


### PR DESCRIPTION
Closes: #2552 

Before:
<img width="1510" alt="104951093-30ab6b00-59c2-11eb-9591-cd11b25d4681" src="https://user-images.githubusercontent.com/905781/104967787-81cc5680-59e4-11eb-90d8-358d5da471fa.png">

After:
![pullquote_editor](https://user-images.githubusercontent.com/905781/104967835-a32d4280-59e4-11eb-9022-99101dfbbc13.png)
