### PR TITLE
Stratford: Remove CSS to control link visibility

### DIFF
--- a/stratford/sass/_extra-child-theme.scss
+++ b/stratford/sass/_extra-child-theme.scss
@@ -72,12 +72,6 @@ a {
 	}
 }
 
-.has-background {
-	a {
-		color: currentColor;
-	}
-}
-
 /**
  * 2. Header
  */

--- a/stratford/sass/style-child-theme-editor.scss
+++ b/stratford/sass/style-child-theme-editor.scss
@@ -86,12 +86,6 @@ $font_size_widget_title: #{map-deep-get($config-heading, "font", "size", "h3")};
 	}
 }
 
-.has-background {
-	a {
-		color: currentColor;
-	}
-}
-
 .editor-post-title__block .editor-post-title__input {
 	text-align: left;
 	color: $color_primary;

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1327,10 +1327,6 @@ p:not(.site-title) a:hover {
 	text-decoration: none;
 }
 
-.has-background a {
-	color: currentColor;
-}
-
 .editor-post-title__block .editor-post-title__input {
 	text-align: left;
 	color: #2c313f;

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -4041,10 +4041,6 @@ p:not(.site-title) a:hover {
 	text-decoration: none;
 }
 
-.has-background a {
-	color: currentColor;
-}
-
 /**
  * 2. Header
  */

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4070,10 +4070,6 @@ p:not(.site-title) a:hover {
 	text-decoration: none;
 }
 
-.has-background a {
-	color: currentColor;
-}
-
 /**
  * 2. Header
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes CSS added in https://github.com/Automattic/themes/pull/2961/commits/2e52a5e49102fad23b245e8f0f074e493c39fb12. I think this should be handled by Gutenberg, so we don't need this.

You can test by setting the theme to Stratford and then adding a post using this markup:

```
<!-- wp:group {"backgroundColor":"background-light"} -->
<div class="wp-block-group has-background-light-background-color has-background"><div class="wp-block-group__inner-container"><!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link">test button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div></div>
<!-- /wp:group -->
```

In trunk it looks like this:
<img width="976" alt="Screenshot 2021-01-19 at 11 22 39" src="https://user-images.githubusercontent.com/275961/105028334-ce497d80-5a48-11eb-8f42-401512f41c6d.png">

With the fix:
<img width="953" alt="Screenshot 2021-01-19 at 11 23 23" src="https://user-images.githubusercontent.com/275961/105028327-cd185080-5a48-11eb-9006-06cc6fb7c2a3.png">


#### Related issue(s):
Fixes #2996 