### PR TITLE
Varia: Remove word-break style in tables

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/alves/style.css
+++ b/alves/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2318,7 +2318,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2318,7 +2318,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/exford/style.css
+++ b/exford/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/hever/style.css
+++ b/hever/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/leven/style.css
+++ b/leven/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/morden/style.css
+++ b/morden/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/stow/style.css
+++ b/stow/style.css
@@ -2321,7 +2321,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2320,7 +2320,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/varia/sass/blocks/table/_style.scss
+++ b/varia/sass/blocks/table/_style.scss
@@ -12,7 +12,6 @@ table,
 	th {
 		padding: calc( 0.5 * #{map-deep-get($config-global, "spacing", "unit")} );
 		border: 1px solid;
-		word-break: break-all;
 	}
 
 	&.is-style-stripes tbody tr:nth-child(odd) {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2354,7 +2354,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),

--- a/varia/style.css
+++ b/varia/style.css
@@ -2354,7 +2354,6 @@ table th,
 .wp-block-table th {
 	padding: calc( 0.5 * 16px);
 	border: 1px solid;
-	word-break: break-all;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),


### PR DESCRIPTION
Related to #3056.

The `word-break: break-all` style creates unwanted and unexpected breaks in text in tables. Let's remove it.

Fixes #2375, fixes #2120.