### PR TITLE
Multiple Themes: Clean up top margin when header & homepage title are hidden

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -3171,6 +3171,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -3190,6 +3190,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -3173,6 +3173,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -3192,6 +3192,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -3168,6 +3168,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -3187,6 +3187,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/morden/sass/_extra-child-theme.scss
+++ b/morden/sass/_extra-child-theme.scss
@@ -480,6 +480,18 @@ article .entry-header .entry-title,
 	}
 }
 
+@include media(mobile) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content {
+
+			> .wp-block-image.alignfull:first-child,
+			> .wp-block-cover.alignfull:first-child,
+			> .wp-block-media-text.alignfull:first-child,
+			> .wp-block-group.has-background.alignfull:first-child {
+				margin-top: -#{4 * map-deep-get($config-global, "spacing", "unit")};
+			}
+	}
+}
+
 /**
  * Comments
  */

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -4421,6 +4437,15 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -64px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
 		margin-top: -64px;
 	}
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -4450,6 +4466,15 @@ article .entry-header .entry-title a:active, article .entry-header .entry-title 
 
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -64px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
 		margin-top: -64px;
 	}
 }

--- a/redhill/sass/_extra-child-theme.scss
+++ b/redhill/sass/_extra-child-theme.scss
@@ -216,6 +216,16 @@ a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content {
+
+		> .wp-block-image.alignfull:first-child,
+		> .wp-block-cover.alignfull:first-child,
+		> .wp-block-media-text.alignfull:first-child,
+		> .wp-block-group.has-background.alignfull:first-child {
+			margin-top: 0;
+		}
+}
+
 // Cover & Hero block
 .wp-block-cover .wp-block-cover__inner-container,
 .wp-block-coblocks-hero .wp-block-coblocks-hero__box {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -4193,6 +4209,13 @@ p:not(.site-title) a:hover {
 
 .home.page.hide-homepage-title .site-main {
 	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: 0;
 }
 
 .wp-block-cover .wp-block-cover__inner-container > *,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -4222,6 +4238,13 @@ p:not(.site-title) a:hover {
 
 .home.page.hide-homepage-title .site-main {
 	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: 0;
 }
 
 .wp-block-cover .wp-block-cover__inner-container > *,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -308,6 +308,19 @@ a {
 	}
 }
 
+// Remove margin if alignfull is first element and header is hidden.
+@include media(mobile) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content {
+
+			> .wp-block-image.alignfull:first-child,
+			> .wp-block-cover.alignfull:first-child,
+			> .wp-block-media-text.alignfull:first-child,
+			> .wp-block-group.has-background.alignfull:first-child {
+				margin-top: -#{2.75 * map-deep-get($config-global, "spacing", "unit")};
+			}
+	}
+}
+
 // Remove margin if alignfull is last element
 .page:not(.logged-in) {
 	.hentry .entry-content {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -3173,6 +3173,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
@@ -4297,6 +4301,15 @@ p:not(.site-title) a:hover {
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
 		margin-top: -64px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
+		margin-top: -44px;
 	}
 }
 

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -3192,6 +3192,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
@@ -4326,6 +4330,15 @@ p:not(.site-title) a:hover {
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
 		margin-top: -64px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
+		margin-top: -44px;
 	}
 }
 

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -22,6 +22,18 @@ body {
 	}
 }
 
+@include media(mobile) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content {
+
+			> .wp-block-image.alignfull:first-child,
+			> .wp-block-cover.alignfull:first-child,
+			> .wp-block-media-text.alignfull:first-child,
+			> .wp-block-group.has-background.alignfull:first-child {
+				margin-top: -#{3 * map-deep-get($config-global, "spacing", "unit")};
+			}
+	}
+}
+
 a {
 	text-decoration: none;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -3168,6 +3168,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -3997,6 +4013,15 @@ body {
 
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -48px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
 		margin-top: -48px;
 	}
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -3187,6 +3187,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }
@@ -4026,6 +4042,15 @@ body {
 
 @media only screen and (min-width: 560px) {
 	.home.hide-homepage-title .hentry .entry-content > *:first-child.alignfull {
+		margin-top: -48px;
+	}
+}
+
+@media only screen and (min-width: 560px) {
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-image.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-cover.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-media-text.alignfull:first-child,
+	.home.page.hide-homepage-header.hide-homepage-title .hentry .entry-content > .wp-block-group.has-background.alignfull:first-child {
 		margin-top: -48px;
 	}
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -3169,6 +3169,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -3188,6 +3188,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -3168,6 +3168,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -3187,6 +3187,22 @@ body:not(.fse-enabled) .footer-menu a {
 	overflow: scroll;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: -32px;
+}
+
 .entry-attachment {
 	text-align: center;
 }

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -237,6 +237,9 @@ function varia_scripts() {
 	// Theme styles
 	wp_enqueue_style( 'varia-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 
+	// Theme styles
+	wp_enqueue_style( 'varia-wpcom-style', get_template_directory_uri() . '/inc/style-wpcom.css', array(), wp_get_theme()->get( 'Version' ) );
+
 	// RTL styles
 	wp_style_add_data( 'varia-style', 'rtl', 'replace' );
 

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -237,9 +237,6 @@ function varia_scripts() {
 	// Theme styles
 	wp_enqueue_style( 'varia-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 
-	// Theme styles
-	wp_enqueue_style( 'varia-wpcom-style', get_template_directory_uri() . '/inc/style-wpcom.css', array(), wp_get_theme()->get( 'Version' ) );
-
 	// RTL styles
 	wp_style_add_data( 'varia-style', 'rtl', 'replace' );
 

--- a/varia/inc/template-functions.php
+++ b/varia/inc/template-functions.php
@@ -54,6 +54,8 @@ function varia_body_classes( $classes ) {
 		$classes[] = 'hide-homepage-footer';
 	}
 
+	$classes[] = 'hide-homepage-title';
+
 	return $classes;
 }
 add_filter( 'body_class', 'varia_body_classes' );

--- a/varia/inc/template-functions.php
+++ b/varia/inc/template-functions.php
@@ -54,8 +54,6 @@ function varia_body_classes( $classes ) {
 		$classes[] = 'hide-homepage-footer';
 	}
 
-	$classes[] = 'hide-homepage-title';
-
 	return $classes;
 }
 add_filter( 'body_class', 'varia_body_classes' );

--- a/varia/sass/components/content/_entry-content.scss
+++ b/varia/sass/components/content/_entry-content.scss
@@ -62,6 +62,11 @@
 		margin-top: 0;
 		padding-top: 0;
 
+		// First children should usually have top margin.
+		> *:first-child {
+			margin-top: map-deep-get($config-global, "spacing", "vertical");
+		}
+
 		// Move some full-width blocks up to the top of the screen.
 		> .wp-block-image.alignfull:first-child,
 		> .wp-block-cover.alignfull:first-child,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3207,6 +3207,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,

--- a/varia/style.css
+++ b/varia/style.css
@@ -3226,6 +3226,10 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
+	margin-top: 32px;
+}
+
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
 .home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,


### PR DESCRIPTION
Followup from #2961. 

When both the "Hide Header" and "Hide Homepage Title" settings are activated, many of Varia's child themes needed some slight adjustments to ensure: 

- That the first child block of `entry-content` had top margin, and didn't bump up against the top of the screen. 
- That certain full-width blocks _do_ properly bump up against the top of the screen. 

The fix was generally just to:

- Add a rule to Varia to ensure that the top margin is present by default. 
- Recompile CSS for all of the child themes.
- Add special case margins for themes that use non-standard margins (Shawburn, Rockfield, Morden, Redhill).

## Screenshots

Generally, this is what things looked like before, using Barnsbury (on the left) and Stow (on the right) as examples: 

### Before

Full-width Media/Text Block|Paragraph
---|---
![Screen Shot 2021-01-20 at 11 44 53 AM](https://user-images.githubusercontent.com/1202812/105206989-facacb80-5b14-11eb-8304-142dd8fd6d65.png)|![Screen Shot 2021-01-20 at 11 48 02 AM](https://user-images.githubusercontent.com/1202812/105207408-7dec2180-5b15-11eb-8fcd-0183f2c750ab.png)


### After

Full-width Media/Text Block|Paragraph
---|---
![Screen Shot 2021-01-20 at 11 39 52 AM](https://user-images.githubusercontent.com/1202812/105206607-90199000-5b14-11eb-9409-f25c289f75be.png)|![Screen Shot 2021-01-20 at 11 48 25 AM](https://user-images.githubusercontent.com/1202812/105207410-80e71200-5b15-11eb-971f-fb8c1fa830cb.png)



