### PR TITLE
Varia: fix customizer on wpcom

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -351,10 +351,25 @@ function varia_mobile_nav_on_side_setup() {
 	add_action( 'after_switch_theme', 'varia_enable_mobile_nav_on_side' );
 
 	// Enable the customizer control toggle for the mobile nav on the side.
-	add_action( 'customize_register' , 'varia_register_mobile_nav_on_side_customizer_control' );
+	add_action( 'customize_register', 'varia_register_mobile_nav_on_side_customizer_control' );
 
 	// Adds the script that help toggle the mobile nav.
 	add_action( 'wp_enqueue_scripts', 'varia_add_mobile_nav_on_side_scripts' );
+}
+
+/**
+* Sanitize the checkbox.
+*
+* @param boolean $input.
+*
+* @return boolean true if is 1 or '1', false if anything else
+*/
+function varia_sanitize_checkbox( $input ) {
+	if ( 1 == $input ) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 /**
@@ -363,45 +378,52 @@ function varia_mobile_nav_on_side_setup() {
 function varia_customize_header_footer( $wp_customize ) {
 
 	// Add setting to hide the site header on the homepage.
-	$wp_customize->add_setting( 'hide_site_header', array(
-		'default'              => false,
-		'type'                 => 'theme_mod',
-		'transport'            => 'refresh',
-		'sanitize_callback'    => 'varia_sanitize_checkbox',
-	) );
+	$wp_customize->add_setting(
+		'hide_site_header',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
 
 	// Add control to hide the site header on the homepage.
-	$wp_customize->add_control( 'hide_site_header', array(
-		'label'		  => esc_html__( 'Hide the Site Header', 'seedlet' ),
-		'description' => esc_html__( 'Check to hide the site header, if your homepage is set to display a static page.', 'seedlet' ),
-		'section'	  => 'static_front_page',
-		'priority'	  => 10,
-		'type'		  => 'checkbox',
-		'settings'	  => 'hide_site_header',
-	) );
+	$wp_customize->add_control(
+		'hide_site_header',
+		array(
+			'label'       => esc_html__( 'Hide the Site Header', 'seedlet' ),
+			'description' => esc_html__( 'Check to hide the site header, if your homepage is set to display a static page.', 'seedlet' ),
+			'section'     => 'static_front_page',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'hide_site_header',
+		)
+	);
 
 	// Add setting to hide footer elements on the homepage.
-	$wp_customize->add_setting( 'hide_site_footer', array(
-		'default'              => false,
-		'type'                 => 'theme_mod',
-		'transport'            => 'refresh',
-		'sanitize_callback'    => 'varia_sanitize_checkbox',
-	) );
+	$wp_customize->add_setting(
+		'hide_site_footer',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
 
 	// Add control to hide footer elements on the homepage.
-	$wp_customize->add_control( 'hide_site_footer', array(
-		'label'		  => esc_html__( 'Hide the Site Footer Menu & Widgets', 'seedlet' ),
-		'description' => esc_html__( 'Check to hide the site menu & widgets in the footer, if your homepage is set to display a static page.', 'seedlet' ),
-		'section'	  => 'static_front_page',
-		'priority'	  => 10,
-		'type'		  => 'checkbox',
-		'settings'	  => 'hide_site_footer',
-	) );
-
-	// Sanitize checkboxes.
-	function varia_sanitize_checkbox( $checked = null ) {
-		return (bool) isset( $checked ) && true === $checked;
-	}
+	$wp_customize->add_control(
+		'hide_site_footer',
+		array(
+			'label'       => esc_html__( 'Hide the Site Footer Menu & Widgets', 'seedlet' ),
+			'description' => esc_html__( 'Check to hide the site menu & widgets in the footer, if your homepage is set to display a static page.', 'seedlet' ),
+			'section'     => 'static_front_page',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'hide_site_footer',
+		)
+	);
 }
 add_action( 'customize_register', 'varia_customize_header_footer' );
 

--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -16,9 +16,12 @@ function varia_wpcom_setup() {
 	global $themecolors;
 
 	// Disable automatically generated color palettes.
-	add_theme_support( 'wpcom-colors', array(
-	        'only-featured-palettes' => true,
-	) );
+	add_theme_support(
+		'wpcom-colors',
+		array(
+			'only-featured-palettes' => true,
+		)
+	);
 
 	// Set theme colors for third party services.
 	if ( ! isset( $themecolors ) ) {
@@ -37,52 +40,46 @@ add_action( 'after_setup_theme', 'varia_wpcom_setup' );
  * Add setting for hiding page title on the homepage.
  */
 function varia_wpcom_customize_update( $wp_customize ) {
-	$wp_customize->add_setting( 'hide_front_page_title', array(
-		'default'              => false,
-		'type'                 => 'theme_mod',
-		'transport'            => 'postMessage',
-		'sanitize_callback'    => 'varia_sanitize_checkbox',
-	) );
+	$wp_customize->add_setting(
+		'hide_front_page_title',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
 
-	$wp_customize->add_control( 'hide_front_page_title', array(
-		'label'		  => esc_html__( 'Hide Homepage Title', 'varia' ),
-		'description' => esc_html__( 'Check to hide the page title, if your homepage is set to display a static page.', 'varia' ),
-		'section'	  => 'static_front_page',
-		'priority'	  => 10,
-		'type'		  => 'checkbox',
-		'settings'	  => 'hide_front_page_title',
-	) );
+	$wp_customize->add_control(
+		'hide_front_page_title',
+		array(
+			'label'       => esc_html__( 'Hide Homepage Title', 'varia' ),
+			'description' => esc_html__( 'Check to hide the page title, if your homepage is set to display a static page.', 'varia' ),
+			'section'     => 'static_front_page',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'hide_front_page_title',
+		)
+	);
 
-    $wp_customize->add_setting( 'color_a11y_warning' );
-    $wp_customize->add_control( 'color_a11y_warning', array(
-        'id'          => 'id',
-        'label'       => esc_html__( 'Color Accessibility Warning', 'varia' ),
-		'description' => sprintf(
-							__( 'In order to ensure people can read your site, try to maintain a strong contrast ratio between the colors you choose here. <a href="%s" target="_blank">Learn more about color contrast</a>.', 'varia' ),
-							esc_url( 'https://a11yproject.com/posts/what-is-color-contrast/' )
-						 ),
-        'section'     => 'colors_manager_tool',
-		'priority'	  => 10,
-		'type'		  => 'hidden',
-    ) );
+	$wp_customize->add_setting( 'color_a11y_warning' );
+	$wp_customize->add_control(
+		'color_a11y_warning',
+		array(
+			'id'          => 'id',
+			'label'       => esc_html__( 'Color Accessibility Warning', 'varia' ),
+			'description' => sprintf(
+				__( 'In order to ensure people can read your site, try to maintain a strong contrast ratio between the colors you choose here. <a href="%s" target="_blank">Learn more about color contrast</a>.', 'varia' ),
+				esc_url( 'https://a11yproject.com/posts/what-is-color-contrast/' )
+			),
+			'section'     => 'colors_manager_tool',
+			'priority'    => 10,
+			'type'        => 'hidden',
+		)
+	);
 
 }
 add_action( 'customize_register', 'varia_wpcom_customize_update' );
-
-/**
-* Sanitize the checkbox.
-*
-* @param boolean $input.
-*
-* @return boolean true if is 1 or '1', false if anything else
-*/
-function varia_sanitize_checkbox( $input ) {
-	if ( 1 == $input ) {
-		return true;
-	} else {
-		return false;
-	}
-}
 
 /**
  * Bind JS handlers to instantly live-preview changes.
@@ -146,8 +143,8 @@ add_filter( 'body_class', 'varia_wpcom_body_classes' );
 function varia_wpcom_admin_body_classes( $classes ) {
 	global $post;
 	$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
-	$hide = get_theme_mod( 'hide_front_page_title', false );
-	$front_page = (int) get_option( 'page_on_front' );
+	$hide                   = get_theme_mod( 'hide_front_page_title', false );
+	$front_page             = (int) get_option( 'page_on_front' );
 
 	if ( $is_block_editor_screen && $front_page === $post->ID && true === $hide ) {
 		$classes .= ' hide-homepage-title';
@@ -168,7 +165,7 @@ add_action( 'enqueue_block_editor_assets', 'varia_wpcom_editor_scripts' );
 /**
  * Enqueue CSS for customizer a11y warning.
  */
-function varia_enqueue_message_scripts() {
+function varia_wpcom_enqueue_message_scripts() {
 	wp_enqueue_style( 'varia-customize-message-wpcom-style', get_template_directory_uri() . '/inc/customize-message-wpcom.css', array(), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'customize_controls_enqueue_scripts', 'varia_enqueue_message_scripts' );
+add_action( 'customize_controls_enqueue_scripts', 'varia_wpcom_enqueue_message_scripts' );


### PR DESCRIPTION
This PR fixes the customizer fatals on Varia themes on wpcom.

It removes the duplicate sanitization function definition and pulls it out so the wpcom function can use it also.

Side note — php linting and auto-formatting ran on these files.