### PR TITLE
Improved sandbox script to delete appropriately

### DIFF
--- a/sandbox.sh
+++ b/sandbox.sh
@@ -82,11 +82,11 @@ How do you wish to proceed? [1]"
 
       # These are the files changed in THIS branch since it diverged
       # EVEN IF they changed in trunk we STILL want to include them in our sync
-      comitted_files_to_include=$(git diff ${hash2} ${current_branch} --name-only)
-      comitted_files_to_include=($comitted_files_to_include)
+      committed_files_to_include=$(git diff ${hash2} ${current_branch} --name-only)
+      committed_files_to_include=($committed_files_to_include)
 
-      # Remove from the files_to_ignore collection anything found in comitted_files_to_include
-      for target in "${comitted_files_to_include[@]}"; do
+      # Remove from the files_to_ignore collection anything found in committed_files_to_include
+      for target in "${committed_files_to_include[@]}"; do
         for i in "${!files_to_ignore[@]}"; do
           if [[ ${files_to_ignore[i]} = $target ]]; then
             unset 'files_to_ignore[i]'
@@ -96,11 +96,11 @@ How do you wish to proceed? [1]"
 
       # These are the changes we have made but haven't committed yet
       # EVEN IF they changed in trunk we STILL want to include them in our sync
-      uncomitted_files_to_include=$(git diff HEAD --name-only)
-      uncomitted_files_to_include=($uncomitted_files_to_include)
+      uncommitted_files_to_include=$(git diff HEAD --name-only)
+      uncommitted_files_to_include=($uncommitted_files_to_include)
 
-      # Remove from the files_to_ignore collection anything found in the uncomitted_files_to_include
-      for target in "${uncomitted_files_to_include[@]}"; do
+      # Remove from the files_to_ignore collection anything found in the uncommitted_files_to_include
+      for target in "${uncommitted_files_to_include[@]}"; do
         for i in "${!files_to_ignore[@]}"; do
           if [[ ${files_to_ignore[i]} = $target ]]; then
             unset 'files_to_ignore[i]'
@@ -131,11 +131,11 @@ How do you wish to proceed? [1]"
   # Determine which files have been removed from the repository (or renamed) as of this head, within the past three months, according to git
   files_to_delete=$(git log --format=format:"" --name-only --since="last three months" -M100% --diff-filter=D HEAD)
 
-  # Determine which files have been removed locally but not comitted as a change
-  uncomitted_files_to_delete=$(git diff HEAD --name-only --diff-filter=D)
+  # Determine which files have been removed locally but not committed as a change
+  uncommitted_files_to_delete=$(git diff HEAD --name-only --diff-filter=D)
 
   # Remove all of those files from the destination.  (Note, if a file has since been re-added to the repo it will be uploaded in the next step)
-  remove_command="ssh $SANDBOX_USER@$SANDBOX_LOCATION 'cd $SANDBOX_PUBLIC_THEMES_FOLDER && rm -f $files_to_delete $uncomitted_files_to_delete'"
+  remove_command="ssh $SANDBOX_USER@$SANDBOX_LOCATION 'cd $SANDBOX_PUBLIC_THEMES_FOLDER && rm -f $files_to_delete $uncommitted_files_to_delete'"
   eval $remove_command;
 
   cmd="rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude=$ignore_string ./ $SANDBOX_USER@$SANDBOX_LOCATION:$SANDBOX_PUBLIC_THEMES_FOLDER/"

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -82,10 +82,11 @@ How do you wish to proceed? [1]"
 
       # These are the files changed in THIS branch since it diverged
       # EVEN IF they changed in trunk we STILL want to include them in our sync
-      files_to_include=$(git diff ${hash2} ${current_branch} --name-only)
-      files_to_include=($files_to_include)
+      comitted_files_to_include=$(git diff ${hash2} ${current_branch} --name-only)
+      comitted_files_to_include=($comitted_files_to_include)
 
-      for target in "${files_to_include[@]}"; do
+      # Remove from the files_to_ignore collection anything found in comitted_files_to_include
+      for target in "${comitted_files_to_include[@]}"; do
         for i in "${!files_to_ignore[@]}"; do
           if [[ ${files_to_ignore[i]} = $target ]]; then
             unset 'files_to_ignore[i]'
@@ -95,10 +96,11 @@ How do you wish to proceed? [1]"
 
       # These are the changes we have made but haven't committed yet
       # EVEN IF they changed in trunk we STILL want to include them in our sync
-      files_to_include=$(git diff HEAD --name-only)
-      files_to_include=($files_to_include)
+      uncomitted_files_to_include=$(git diff HEAD --name-only)
+      uncomitted_files_to_include=($uncomitted_files_to_include)
 
-      for target in "${files_to_include[@]}"; do
+      # Remove from the files_to_ignore collection anything found in the uncomitted_files_to_include
+      for target in "${uncomitted_files_to_include[@]}"; do
         for i in "${!files_to_ignore[@]}"; do
           if [[ ${files_to_ignore[i]} = $target ]]; then
             unset 'files_to_ignore[i]'
@@ -106,8 +108,9 @@ How do you wish to proceed? [1]"
         done
       done
 
-      ignore_string=""
 
+      # Build a string based on files_to_ignore to pass to rsync
+      ignore_string=""
       for target in "${files_to_ignore[@]}"; do
         ignore_string="${ignore_string}${target}','"
       done
@@ -125,12 +128,15 @@ How do you wish to proceed? [1]"
 
   fi
 
-  # Determine which files have been removed from the repository (as of this head, within the past month) according to git
-  files_to_delete=$(git log --format=format:"" --name-only --since="last month" --diff-filter=D HEAD)
+  # Determine which files have been removed from the repository (as of this head, within the past three months) according to git
+  files_to_delete=$(git log --format=format:"" --name-only --since="last three months" --diff-filter=D HEAD)
+
+  # Determine which files have been removed locally but not comitted as a change
+  uncomitted_files_to_delete=$(git diff HEAD --name-only --diff-filter=D)
 
   # Remove all of those files from the destination.  (Note, if a file has since been re-added to the repo it will be uploaded in the next step)
-  rmcmd="ssh $SANDBOX_USER@$SANDBOX_LOCATION 'cd $SANDBOX_PUBLIC_THEMES_FOLDER && rm -f $files_to_delete'"
-  eval $rmcmd;
+  remove_command="ssh $SANDBOX_USER@$SANDBOX_LOCATION 'cd $SANDBOX_PUBLIC_THEMES_FOLDER && rm -f $files_to_delete $uncomitted_files_to_delete'"
+  eval $remove_command;
 
   cmd="rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude=$ignore_string ./ $SANDBOX_USER@$SANDBOX_LOCATION:$SANDBOX_PUBLIC_THEMES_FOLDER/"
   eval $cmd

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -125,6 +125,13 @@ How do you wish to proceed? [1]"
 
   fi
 
+  # Determine which files have been removed from the repository (as of this head, within the past month) according to git
+  files_to_delete=$(git log --format=format:"" --name-only --since="last month" --diff-filter=D HEAD)
+
+  # Remove all of those files from the destination.  (Note, if a file has since been re-added to the repo it will be uploaded in the next step)
+  rmcmd="ssh $SANDBOX_USER@$SANDBOX_LOCATION 'cd $SANDBOX_PUBLIC_THEMES_FOLDER && rm -f $files_to_delete'"
+  eval $rmcmd;
+
   cmd="rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude=$ignore_string ./ $SANDBOX_USER@$SANDBOX_LOCATION:$SANDBOX_PUBLIC_THEMES_FOLDER/"
   eval $cmd
 

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -128,8 +128,8 @@ How do you wish to proceed? [1]"
 
   fi
 
-  # Determine which files have been removed from the repository (as of this head, within the past three months) according to git
-  files_to_delete=$(git log --format=format:"" --name-only --since="last three months" --diff-filter=D HEAD)
+  # Determine which files have been removed from the repository (or renamed) as of this head, within the past three months, according to git
+  files_to_delete=$(git log --format=format:"" --name-only --since="last three months" -M100% --diff-filter=D HEAD)
 
   # Determine which files have been removed locally but not comitted as a change
   uncomitted_files_to_delete=$(git diff HEAD --name-only --diff-filter=D)


### PR DESCRIPTION
This change collects a list of what files have been deleted in the
repository and removes them from the sandbox via rm.

If those files have since returned (deleted but returned) they will
still be deleted but, since those files will be in your local copy will
be synced to the sandbox.

Also this change is determining which files that have been deleted locally but NOT as a committed change to the repository and removing those files from the sandbox.
