### PR TITLE
Blank Canvas: Change level of Invitation pattern heading

### DIFF
--- a/blank-canvas/inc/block-patterns.php
+++ b/blank-canvas/inc/block-patterns.php
@@ -114,8 +114,8 @@ if ( ! function_exists( 'blank_canvas_register_block_patterns' ) ) :
 									<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-center is-image-fill has-background" style="background-color:#f5fff4"><figure class="wp-block-media-text__media" style="background-image:url(' . get_stylesheet_directory_uri() . '/assets/pattern-drink.jpg);background-position:50% 50%"><img src="' . get_stylesheet_directory_uri() . '/assets/pattern-drink.jpg" alt="Photo of two drinks." class="wp-image-2207 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":30} -->
 									<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 									<!-- /wp:spacer -->
-									<!-- wp:heading {"style":{"color":{"text":"#c61aa7"}}} -->
-									<h2 class="has-text-color" style="color:#c61aa7"><strong>' . __( 'You&rsquo;re Invited', 'blank-canvas' ) . '</strong></h2>
+									<!-- wp:heading {"level":1,"style":{"color":{"text":"#c61aa7"}}} -->
+									<h1 class="has-text-color" style="color:#c61aa7"><strong>' . __( 'You&rsquo;re Invited', 'blank-canvas' ) . '</strong></h1>
 									<!-- /wp:heading -->
 									<!-- wp:columns -->
 									<div class="wp-block-columns"><!-- wp:column -->


### PR DESCRIPTION
This PR includes a slight change to the Invitation pattern bundled with Blank Canvas: It updates the title from an H2 to an H1. This is more semantic, and also just looks better anyway. 

Before

![Screen Shot 2021-01-21 at 9 08 38 AM](https://user-images.githubusercontent.com/1202812/105362102-78034880-5bc8-11eb-8961-8aed55556aa6.png)

After

![Screen Shot 2021-01-21 at 9 08 10 AM](https://user-images.githubusercontent.com/1202812/105362115-7afe3900-5bc8-11eb-9d36-59e3e6c4e54b.png)
