### PR TITLE
Varia: Fix gap that appears below the header

### DIFF
--- a/varia/inc/style-wpcom.css
+++ b/varia/inc/style-wpcom.css
@@ -9,6 +9,10 @@
 	display: none;
 }
 
+.home.page.hide-homepage-title .site-main > article > .entry-content {
+	margin-top: 0;
+}
+
 /**
  * Fix Direct Manipulation icons in the Customizer
  */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR reverts the change done in this commit https://github.com/Automattic/themes/commit/c6ff72af3e6938aadce5aa971c7ff0c24ccb1435 that is causing a gap below the header on multiple varia children. Sometimes it's more noticeable like on Rockfield because it separates the fixed header from the cover block, in other themes it simply adds a larger separation. 

#### Related issue(s):

https://github.com/Automattic/wp-calypso/issues/49190#event-4238742550
