### PR TITLE
Seedlet: Fix button colors

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -541,14 +541,14 @@ object {
 	color: currentColor;
 }
 
-.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
-.wp-block-cover .block-editor-block-list__block a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color),
-.wp-block-cover-image .block-editor-block-list__block a:not(.has-text-color) {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .block-editor-block-list__block a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .block-editor-block-list__block a:not(.has-text-color):not(.wp-block-button__link) {
 	color: currentColor;
 }
 

--- a/seedlet/assets/sass/blocks/button/_style.scss
+++ b/seedlet/assets/sass/blocks/button/_style.scss
@@ -39,6 +39,10 @@ input[type="submit"],
 			&.has-focus {
 				color: var(--button--color-background-hover);
 			}
+
+			&.has-text-color {
+				color: inherit;
+			}
 		}
 	}
 

--- a/seedlet/assets/sass/blocks/button/_style.scss
+++ b/seedlet/assets/sass/blocks/button/_style.scss
@@ -25,10 +25,13 @@ input[type="submit"],
 
 		&.wp-block-button__link,
 		.wp-block-button__link {
-			color: var(--button--color-background);
 			background: transparent;
 			border: var(--button--border-width) solid currentcolor;
 			padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+
+			&:not(.has-text-color) {
+				color: var(--button--color-background);
+			}
 
 			&:active {
 				color: var(--button--color-background);
@@ -38,10 +41,6 @@ input[type="submit"],
 			&:focus,
 			&.has-focus {
 				color: var(--button--color-background-hover);
-			}
-
-			&.has-text-color {
-				color: inherit;
 			}
 		}
 	}

--- a/seedlet/assets/sass/blocks/cover/_editor.scss
+++ b/seedlet/assets/sass/blocks/cover/_editor.scss
@@ -12,7 +12,7 @@
 	.block-editor-block-list__block {
 		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
 
-		a:not(.has-text-color) {
+		a:not(.has-text-color):not(.wp-block-button__link) {
 			color: currentColor;
 		}
 		.has-link-color a {

--- a/seedlet/assets/sass/blocks/cover/_style.scss
+++ b/seedlet/assets/sass/blocks/cover/_style.scss
@@ -13,7 +13,7 @@
 		margin-top: var(--global--spacing-vertical);
 		margin-bottom: var(--global--spacing-vertical);
 
-		a:not(.has-text-color) {
+		a:not(.has-text-color):not(.wp-block-button__link) {
 			color: currentColor;
 		}
 		.has-link-color a {

--- a/seedlet/assets/sass/blocks/utilities/_style.scss
+++ b/seedlet/assets/sass/blocks/utilities/_style.scss
@@ -180,7 +180,7 @@
 
 // Gutenberg background-color options
 .has-background {
-	&:not(.has-background-background-color) a:not(.has-text-color),
+	&:not(.has-background-background-color) a:not(.has-text-color):not(.wp-block-button__link),
 	p, h1, h2, h3, h4, h5, h6 {
 		color: currentColor;
 	}

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1265,6 +1265,11 @@ object {
 	color: var(--button--color-background-hover);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link.has-text-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
+	color: inherit;
+}
+
 .wp-block-button.is-style-squared .wp-block-button__link {
 	border-radius: 0;
 }
@@ -2606,7 +2611,7 @@ pre.wp-block-verse {
 	color: var(--global--color-black);
 }
 
-.has-background:not(.has-background-background-color) a:not(.has-text-color),
+.has-background:not(.has-background-background-color) a:not(.has-text-color):not(.wp-block-button__link),
 .has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1247,10 +1247,14 @@ object {
 
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: var(--button--color-background);
 	background: transparent;
 	border: var(--button--border-width) solid currentcolor;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-text-color),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: var(--button--color-background);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:active,
@@ -1263,11 +1267,6 @@ object {
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: var(--button--color-background-hover);
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link.has-text-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
-	color: inherit;
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -1370,12 +1370,12 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color) {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link) {
 	color: currentColor;
 }
 

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1265,6 +1265,11 @@ object {
 	color: var(--button--color-background-hover);
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link.has-text-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
+	color: inherit;
+}
+
 .wp-block-button.is-style-squared .wp-block-button__link {
 	border-radius: 0;
 }
@@ -2615,7 +2620,7 @@ pre.wp-block-verse {
 	color: var(--global--color-black);
 }
 
-.has-background:not(.has-background-background-color) a:not(.has-text-color),
+.has-background:not(.has-background-background-color) a:not(.has-text-color):not(.wp-block-button__link),
 .has-background p, .has-background h1, .has-background h2, .has-background h3, .has-background h4, .has-background h5, .has-background h6 {
 	color: currentColor;
 }

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1247,10 +1247,14 @@ object {
 
 .wp-block-button.is-style-outline.wp-block-button__link,
 .wp-block-button.is-style-outline .wp-block-button__link {
-	color: var(--button--color-background);
 	background: transparent;
 	border: var(--button--border-width) solid currentcolor;
 	padding: var(--button--padding-vertical) var(--button--padding-horizontal);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-text-color),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+	color: var(--button--color-background);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:active,
@@ -1263,11 +1267,6 @@ object {
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: var(--button--color-background-hover);
-}
-
-.wp-block-button.is-style-outline.wp-block-button__link.has-text-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-text-color {
-	color: inherit;
 }
 
 .wp-block-button.is-style-squared .wp-block-button__link {

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -1370,12 +1370,12 @@ object {
 	margin-bottom: var(--global--spacing-vertical);
 }
 
-.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover .wp-block-cover-text a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color),
-.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color) {
+.wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover-image .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link) {
 	color: currentColor;
 }
 


### PR DESCRIPTION
This fixes a couple button color issues I saw in Seedlet: 

1. Outlined buttons with a custom text color were not appearing correctly in the front-end. 
2. When inside of a block that contained a background color (Cover, Group), all buttons were using the `currentColor` for the text color. This often led to unreadable buttons. 

Before|After
---|---
![Screen Shot 2021-01-22 at 3 07 27 PM](https://user-images.githubusercontent.com/1202812/105540184-ca755f80-5cc3-11eb-9bc7-1fcc6f448374.png)|![Screen Shot 2021-01-22 at 3 06 33 PM](https://user-images.githubusercontent.com/1202812/105540187-cba68c80-5cc3-11eb-9d40-c1a1d76d6219.png)
