### PR TITLE
Seedlet: remove 2016 reference

### DIFF
--- a/seedlet/image.php
+++ b/seedlet/image.php
@@ -37,7 +37,7 @@ get_header();
 							/**
 							 * Filter the default seedlet image attachment size.
 							 *
-							 * @since Twenty Sixteen 1.0
+							 * @since Seedlet 1.0
 							 *
 							 * @param string $image_size Image size. Default 'large'.
 							 */


### PR DESCRIPTION
This PR addresses #2424.

I don't think we need to add attribution for 2016 since it's just a filter function which is a part of core, but rather just change the name space. 