### PR TITLE
Stow: Restore Social Navigation

### DIFF
--- a/stow/template-parts/header/header-content.php
+++ b/stow/template-parts/header/header-content.php
@@ -1,4 +1,5 @@
 <header id="masthead" class="site-header">
 	<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 	<?php get_template_part( 'template-parts/header/site', 'navigation' ); ?>
+	<?php get_template_part( 'template-parts/header/social', 'navigation' ); ?>
 </header><!-- #masthead -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR restores the social navigation that was missing from Stow after our latest changes to the Varia children header and footer visibility options.

#### Related issue(s):

Closes #3090