### PR TITLE
Blank Canvas: Update theme description

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -140,7 +140,7 @@ if ( ! function_exists( 'seedlet_entry_meta_footer' ) ) :
 			sprintf(
 				wp_kses(
 					/* translators: %s: Name of current post. Only visible to screen readers. */
-					__( 'Edit <span class="screen-reader-text">%s</span>', 'seedlet' ),
+					__( 'Edit <span class="screen-reader-text">%s</span>', 'blank-canvas' ),
 					array(
 						'span' => array(
 							'class' => array(),

--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -10,11 +10,13 @@ A blank starting point for building your site.
 
 == Description ==
 
-Blank Canvas is a blank starting point for building your site. 
+Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets, so the page you design in the WordPress editor is the same page you’ll see on the front end.
+
+The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 
 == Changelog ==
 
-= 1.0 =
+= 1.1 =
 * Initial release 
 
 == Copyright ==

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -3,7 +3,7 @@ Theme Name: Blank Canvas
 Theme URI: https://github.com/Automattic/themes/blank-canvas
 Author: Automattic
 Author URI: https://automattic.com/
-Description: A blank starting point for building your site.
+Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 Requires at least: 4.9.6
 Tested up to: 5.6
 Requires PHP: 5.6.2


### PR DESCRIPTION
Updates the theme description to match what we have on [the WordPress.com theme landing page](https://wordpress.com/theme/blank-canvas).

Also updates a textdomain while I was in there. Though that function comes from Seedlet, themes should _technically_ only have one textdomain in use (as per the Theme Check plugin).