### PR TITLE
Remove unnecessary h-padding styles

### DIFF
--- a/seedlet/assets/sass/blocks/_editor.scss
+++ b/seedlet/assets/sass/blocks/_editor.scss
@@ -17,7 +17,6 @@
 @import "latest-posts/editor";
 @import "legacy/editor"; // "Blocks" from the legacy WP editor, ie: galleries, .button class, etc.
 @import "list/editor";
-@import "media-text/editor";
 @import "navigation/editor";
 @import "paragraph/editor";
 @import "posts-list/editor";

--- a/seedlet/assets/sass/blocks/media-text/_editor.scss
+++ b/seedlet/assets/sass/blocks/media-text/_editor.scss
@@ -1,6 +1,0 @@
-.wp-block-media-text {
-	.block-editor-inner-blocks {
-		padding-right: var(--global--spacing-horizontal);
-		padding-left: var(--global--spacing-horizontal);
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The editor-only horizontal padding for the block element doesn't appear
to be helpful. Removing these styles allows all elements (including
those blocks that add .block-editor-inner-blocks when in the editor) to
lay out as expected.

Note that neither Spearhead or Blank Canvas suffer from the same.

#### Related issue(s):

This will fix the seedlet portion of #2618. A separate PR was opened for [Varia (and children)](https://github.com/Automattic/themes/pull/3100) for the same.