### PR TITLE
Remove unnecessary h-padding styles

### DIFF
--- a/varia/sass/blocks/media-text/_editor.scss
+++ b/varia/sass/blocks/media-text/_editor.scss
@@ -1,14 +1,4 @@
 .wp-block-media-text {
-	.block-editor-inner-blocks {
-		padding-right: #{map-deep-get($config-global, "spacing", "horizontal")};
-		padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
-
-		@include media(tablet) {
-			padding-right: #{map-deep-get($config-global, "spacing", "vertical")};
-			padding-left: #{map-deep-get($config-global, "spacing", "vertical")};
-		}
-	}
-
 	&[style*="background-color"]:not(.has-background-background-color) {
 		a {
 			color: currentColor;


### PR DESCRIPTION
Changes proposed in this Pull Request:
The editor-only horizontal padding for the block element doesn't appear
to be helpful. Removing these styles allows all elements (including
those blocks that add .block-editor-inner-blocks when in the editor) to
lay out as expected.

Note: this is the parent change only, child themes still need to be recompiled but this was not done in this change expecting that it would be compiled in a larger deployment.

Related issue(s):
This will fix the Varia portion of #2618. A [separate PR was be opened for Seedlet](https://github.com/Automattic/themes/pull/3099).
