### PR TITLE
Blank Canvas: Add customizer options to enable header and footer areas and page titles.

### DIFF
--- a/blank-canvas/assets/customizer.css
+++ b/blank-canvas/assets/customizer.css
@@ -4,12 +4,23 @@
  * Adjusts the theme's message about the site branding display to appear like a notice.
  */
 
-#sub-accordion-section-menu_locations .customize-section-description {
+#sub-accordion-section-menu_locations .customize-section-description,
+#sub-accordion-section-sidebar-widgets-sidebar-1 .customize-section-description {
 	background: #FFF;
 	border: 1px solid #ccd0d4;
 	border-left: 4px solid #00a0d2;
 	box-shadow: 0 1px 1px rgba( 0, 0, 0, .04 );
 	margin: 15px 0 6px 0;
+	padding: 9px 14px;
+	overflow: hidden;
+	width: auto;
+}
+
+#sub-accordion-panel-nav_menus .customize-info .customize-panel-description {
+	background: #FFF;
+	border-top: 1px solid #ccd0d4;
+	border-left: 4px solid #00a0d2;
+	display: block;
 	padding: 9px 14px;
 	overflow: hidden;
 	width: auto;

--- a/blank-canvas/assets/customizer.css
+++ b/blank-canvas/assets/customizer.css
@@ -4,8 +4,7 @@
  * Adjusts the theme's message about the site branding display to appear like a notice.
  */
 
-#sub-accordion-section-menu_locations .customize-section-description,
-#sub-accordion-section-sidebar-widgets-sidebar-1 .customize-section-description {
+#sub-accordion-section-menu_locations .customize-section-description {
 	background: #FFF;
 	border: 1px solid #ccd0d4;
 	border-left: 4px solid #00a0d2;
@@ -16,6 +15,7 @@
 	width: auto;
 }
 
+#sub-accordion-panel-widgets .customize-info .customize-panel-description,
 #sub-accordion-panel-nav_menus .customize-info .customize-panel-description {
 	background: #FFF;
 	border-top: 1px solid #ccd0d4;

--- a/blank-canvas/assets/customizer.css
+++ b/blank-canvas/assets/customizer.css
@@ -4,7 +4,7 @@
  * Adjusts the theme's message about the site branding display to appear like a notice.
  */
 
-#sub-accordion-section-title_tagline .customize-section-description {
+#sub-accordion-section-menu_locations .customize-section-description {
 	background: #FFF;
 	border: 1px solid #ccd0d4;
 	border-left: 4px solid #00a0d2;

--- a/blank-canvas/assets/customizer.css
+++ b/blank-canvas/assets/customizer.css
@@ -4,6 +4,7 @@
  * Adjusts the theme's message about the site branding display to appear like a notice.
  */
 
+ #sub-accordion-section-title_tagline .customize-section-description,
 #sub-accordion-section-menu_locations .customize-section-description {
 	background: #FFF;
 	border: 1px solid #ccd0d4;

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -112,7 +112,9 @@ add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 
 function blank_canvas_add_customizer_settings( $wp_customize ) {
 
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_section( 'menu_locations' )->description            = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_panel( 'nav_menus' )->description                   = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_section( 'sidebar-widgets-sidebar-1' )->description = __( 'Widgets will only be displayed on this theme if the footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_add_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -70,15 +70,9 @@ add_action( 'after_setup_theme', 'blank_canvas_setup', 11 );
  * Remove Seedlet theme features.
  */
 function blank_canvas_remove_parent_theme_features() {
-
 	// Theme Support.
 	remove_theme_support( 'custom-header' );
 	remove_theme_support( 'customize-selective-refresh-widgets' );
-
-	// Navigation Areas.
-	unregister_nav_menu( 'primary' );
-	unregister_nav_menu( 'footer' );
-	unregister_nav_menu( 'social' );
 }
 add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 11 );
 
@@ -86,28 +80,18 @@ add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 11
  * Dequeue Seedlet scripts.
  */
 function blank_canvas_dequeue_parent_scripts() {
-
-	// Naviation assets.
-	wp_dequeue_script( 'seedlet-primary-navigation-script' );
-	wp_dequeue_style( 'seedlet-style-navigation' );
+	if ( false === get_theme_mod( 'show_site_header', false ) ) {
+		// Naviation assets.
+		wp_dequeue_script( 'seedlet-primary-navigation-script' );
+		wp_dequeue_style( 'seedlet-style-navigation' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_dequeue_parent_scripts', 11 );
-
-/**
- * Remove Seedlet's widget area.
- */
-function blank_canvas_remove_widgets_area() {
-	unregister_sidebar( 'sidebar-1' );
-}
-add_action( 'widgets_init', 'blank_canvas_remove_widgets_area', 11 );
 
 /**
  * Remove unused custmizer settings.
  */
 function blank_canvas_remove_customizer_settings( $wp_customize ) {
-
-	// Remove the navigation menus Customizer panel.
-	$wp_customize->get_panel( 'nav_menus' )->active_callback = '__return_false';
 
 	// Remove Jetpack's Author Bio setting.
 	if ( function_exists( 'jetpack_author_bio' ) ) {
@@ -120,9 +104,8 @@ function blank_canvas_remove_customizer_settings( $wp_customize ) {
 	$wp_customize->remove_control( 'hide_site_header' );
 	$wp_customize->remove_control( 'hide_site_footer' );
 
-
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'title_tagline' )->description = __( 'This theme is designed to hide the site logo, site title, and tagline on all single posts and pages.', 'blank-canvas' );
+	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
 
@@ -175,3 +158,8 @@ function blank_canvas_customizer_enqueue() {
 	wp_enqueue_style( 'blank-canvas-customizer-style', get_stylesheet_directory_uri() . '/assets/customizer.css', array(), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'customize_controls_enqueue_scripts', 'blank_canvas_customizer_enqueue' );
+
+/**
+ * Customizer additions.
+ */
+require get_stylesheet_directory() . '/inc/customizer.php';

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -103,11 +103,18 @@ function blank_canvas_remove_customizer_settings( $wp_customize ) {
 	// since they're already hidden by default.
 	$wp_customize->remove_control( 'hide_site_header' );
 	$wp_customize->remove_control( 'hide_site_footer' );
+}
+add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
+
+/**
+ * Add custmizer settings.
+ */
+function blank_canvas_add_customizer_settings( $wp_customize ) {
 
 	// Add a Customizer message about the site title & tagline options.
 	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 }
-add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 );
+add_action( 'customize_register', 'blank_canvas_add_customizer_settings', 11 );
 
 /**
  * Remove Meta Footer Items.

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -112,9 +112,9 @@ add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 
 function blank_canvas_add_customizer_settings( $wp_customize ) {
 
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'menu_locations' )->description            = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_panel( 'nav_menus' )->description                   = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_section( 'sidebar-widgets-sidebar-1' )->description = __( 'Widgets will only be displayed on this theme if the footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_panel( 'widgets' )->description          = __( 'Widgets will only be displayed on this theme if the footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_add_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -112,10 +112,10 @@ add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 
 function blank_canvas_add_customizer_settings( $wp_customize ) {
 
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'title_tagline' )->description  = __( 'This theme will not show the site logo, site title, and tagline on all single posts and pages unless the site header is enabled in the the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_panel( 'widgets' )->description          = __( 'Widgets will only be displayed on this theme if the footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_section( 'title_tagline' )->description  = __( 'The site logo, title, and tagline will only appear on single posts and pages if the “Site header and top menu" option is enabled in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_section( 'menu_locations' )->description = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
+	$wp_customize->get_panel( 'widgets' )->description          = __( 'This theme will only display Widgets if they are enabled in the Content Options section.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_add_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -111,11 +111,14 @@ add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 
  */
 function blank_canvas_add_customizer_settings( $wp_customize ) {
 
+	// Cast the widgets panel as an object.
+	$customizer_widgets_panel = (object) $wp_customize->get_panel( 'widgets' );
+
 	// Add a Customizer message about the site title & tagline options.
 	$wp_customize->get_section( 'title_tagline' )->description  = __( 'The site logo, title, and tagline will only appear on single posts and pages if the “Site header and top menu" option is enabled in the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_section( 'menu_locations' )->description = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
-	$wp_customize->get_panel( 'widgets' )->description          = __( 'This theme will only display Widgets if they are enabled in the Content Options section.', 'blank-canvas' );
+	$customizer_widgets_panel->description                      = __( 'This theme will only display Widgets if they are enabled in the Content Options section.', 'blank-canvas' );
 }
 add_action( 'customize_register', 'blank_canvas_add_customizer_settings', 11 );
 

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -112,6 +112,7 @@ add_action( 'customize_register', 'blank_canvas_remove_customizer_settings', 11 
 function blank_canvas_add_customizer_settings( $wp_customize ) {
 
 	// Add a Customizer message about the site title & tagline options.
+	$wp_customize->get_section( 'title_tagline' )->description  = __( 'This theme will not show the site logo, site title, and tagline on all single posts and pages unless the site header is enabled in the the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_section( 'menu_locations' )->description = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'Menus will only be displayed on this theme if the header or footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_panel( 'widgets' )->description          = __( 'Widgets will only be displayed on this theme if the footer is enabled. This can be done in the Content Options section.', 'blank-canvas' );

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Blank Canvas Theme: Customizer
+ *
+ * @package Blank Canvas
+ * @since 1.0.0
+ */
+
+if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
+	/**
+	 * Customizer Settings.
+	 *
+	 * @since 1.0.0
+	 */
+	class Blank_Canvas_Customize {
+
+		/**
+		 * Constructor. Instantiate the object.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 */
+		public function __construct() {
+			add_action( 'customize_register', array( $this, 'register' ) );
+		}
+
+		/**
+		 * Register customizer options.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+		 *
+		 * @return void
+		 */
+		public function register( $wp_customize ) {
+
+			// Add Content section.
+			$wp_customize->add_section(
+				'jetpack_content_options',
+				array(
+					'title'    => esc_html__( 'Content Options', 'blank-canvas' ),
+					'priority' => 100,
+				)
+			);
+
+			// Add setting to show post and page titles.
+			$wp_customize->add_setting(
+				'show_post_and_page_titles',
+				array(
+					'default'           => false,
+					'type'              => 'theme_mod',
+					'transport'         => 'refresh',
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
+				)
+			);
+
+			// Add control to show the site header on the homepage.
+			$wp_customize->add_control(
+				'show_post_and_page_titles',
+				array(
+					'label'       => esc_html__( 'Show post and page titles', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show titles at the top of single posts and pages.', 'blank-canvas' ),
+					'section'     => 'jetpack_content_options',
+					'priority'    => 10,
+					'type'        => 'checkbox',
+					'settings'    => 'show_post_and_page_titles',
+				)
+			);
+
+			// Add setting to show the site header.
+			$wp_customize->add_setting(
+				'show_site_header',
+				array(
+					'default'           => false,
+					'type'              => 'theme_mod',
+					'transport'         => 'refresh',
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
+				)
+			);
+
+			// Add control to show the site header.
+			$wp_customize->add_control(
+				'show_site_header',
+				array(
+					'label'       => esc_html__( 'Enable site header and navigation', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show a standard site header, navigation menu and social links menu on the top of every page.', 'blank-canvas' ),
+					'section'     => 'jetpack_content_options',
+					'priority'    => 10,
+					'type'        => 'checkbox',
+					'settings'    => 'show_site_header',
+				)
+			);
+
+			// Add setting to show the site footer.
+			$wp_customize->add_setting(
+				'show_site_footer',
+				array(
+					'default'           => false,
+					'type'              => 'theme_mod',
+					'transport'         => 'refresh',
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
+				)
+			);
+
+			// Add control to show the site footer.
+			$wp_customize->add_control(
+				'show_site_footer',
+				array(
+					'label'       => esc_html__( 'Enable footer menu and widgets', 'blank-canvas' ),
+					'description' => esc_html__( "Check to show a navigation menu and widgets in your site's footer area.", 'blank-canvas' ),
+					'section'     => 'jetpack_content_options',
+					'priority'    => 10,
+					'type'        => 'checkbox',
+					'settings'    => 'show_site_footer',
+				)
+			);
+		}
+
+		/**
+		 * Sanitize boolean for checkbox.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $checked Whether or not a box is checked.
+		 *
+		 * @return bool
+		 */
+		public static function sanitize_checkbox( $checked = null ) {
+			return (bool) isset( $checked ) && true === $checked;
+		}
+	}
+
+	new Blank_Canvas_Customize();
+}

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -47,30 +47,6 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 				)
 			);
 
-			// Add setting to show post and page titles.
-			$wp_customize->add_setting(
-				'show_post_and_page_titles',
-				array(
-					'default'           => false,
-					'type'              => 'theme_mod',
-					'transport'         => 'refresh',
-					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
-				)
-			);
-
-			// Add control to show the site header on the homepage.
-			$wp_customize->add_control(
-				'show_post_and_page_titles',
-				array(
-					'label'       => esc_html__( 'Show post and page titles', 'blank-canvas' ),
-					'description' => esc_html__( 'Check to show titles at the top of single posts and pages.', 'blank-canvas' ),
-					'section'     => 'jetpack_content_options',
-					'priority'    => 10,
-					'type'        => 'checkbox',
-					'settings'    => 'show_post_and_page_titles',
-				)
-			);
-
 			// Add setting to show the site header.
 			$wp_customize->add_setting(
 				'show_site_header',
@@ -86,7 +62,7 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 			$wp_customize->add_control(
 				'show_site_header',
 				array(
-					'label'       => esc_html__( 'Enable site header and navigation', 'blank-canvas' ),
+					'label'       => esc_html__( 'Enable site header and top menu', 'blank-canvas' ),
 					'description' => esc_html__( 'Check to show a standard site header, navigation menu and social links menu on the top of every page.', 'blank-canvas' ),
 					'section'     => 'jetpack_content_options',
 					'priority'    => 10,
@@ -110,12 +86,36 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 			$wp_customize->add_control(
 				'show_site_footer',
 				array(
-					'label'       => esc_html__( 'Enable footer menu and widgets', 'blank-canvas' ),
+					'label'       => esc_html__( 'Enable widgets and footer menu', 'blank-canvas' ),
 					'description' => esc_html__( "Check to show a navigation menu and widgets in your site's footer area.", 'blank-canvas' ),
 					'section'     => 'jetpack_content_options',
 					'priority'    => 10,
 					'type'        => 'checkbox',
 					'settings'    => 'show_site_footer',
+				)
+			);
+
+			// Add setting to show post and page titles.
+			$wp_customize->add_setting(
+				'show_post_and_page_titles',
+				array(
+					'default'           => false,
+					'type'              => 'theme_mod',
+					'transport'         => 'refresh',
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
+				)
+			);
+
+			// Add control to show post and page titles.
+			$wp_customize->add_control(
+				'show_post_and_page_titles',
+				array(
+					'label'       => esc_html__( 'Show post and page titles', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show titles at the top of single posts and pages.', 'blank-canvas' ),
+					'section'     => 'jetpack_content_options',
+					'priority'    => 10,
+					'type'        => 'checkbox',
+					'settings'    => 'show_post_and_page_titles',
 				)
 			);
 			

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -118,6 +118,30 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 					'settings'    => 'show_site_footer',
 				)
 			);
+			
+			// Add setting to show the comments
+			$wp_customize->add_setting(
+				'show_comments',
+				array(
+					'default'           => false,
+					'type'              => 'theme_mod',
+					'transport'         => 'refresh',
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ),
+				)
+			);
+
+			// Add control to show the comments.
+			$wp_customize->add_control(
+				'show_comments',
+				array(
+					'label'       => esc_html__( 'Enable comments', 'blank-canvas' ),
+					'description' => esc_html__( "Check to show comments underneath each post.", 'blank-canvas' ),
+					'section'     => 'jetpack_content_options',
+					'priority'    => 10,
+					'type'        => 'checkbox',
+					'settings'    => 'show_comments',
+				)
+			);
 		}
 
 		/**

--- a/blank-canvas/single.php
+++ b/blank-canvas/single.php
@@ -20,6 +20,13 @@ get_header();
 				the_post();
 
 				get_template_part( 'template-parts/content/content-singular' );
+				
+				if ( true === get_theme_mod( 'show_comments', false ) ) :
+					// If comments are open or we have at least one comment, load up the comment template.
+					if ( comments_open() || get_comments_number() ) {
+						comments_template();
+					}
+				endif; 
 
 			endwhile; // End of the loop.
 			?>

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -58,14 +58,14 @@ Used as block pattern image.
 
 /* Remove some top padding if the first block on the page is a full-width image, cover, media & text, or group block. */
 
-.single .entry-content > .wp-block-image.alignfull:first-child,
-.page .entry-content > .wp-block-image.alignfull:first-child,
-.single .entry-content > .wp-block-cover.alignfull:first-child,
-.page .entry-content > .wp-block-cover.alignfull:first-child,
-.single .entry-content > .wp-block-media-text.alignfull:first-child,
-.page .entry-content > .wp-block-media-text.alignfull:first-child,
-.single .entry-content > .wp-block-group.has-background.alignfull:first-child,
-.page .entry-content > .wp-block-group.has-background.alignfull:first-child {
+.single .entry-content.hide-post-and-page-titles > .wp-block-image.alignfull:first-child,
+.page .entry-content.hide-post-and-page-titles > .wp-block-image.alignfull:first-child,
+.single .entry-content.hide-post-and-page-titles > .wp-block-cover.alignfull:first-child,
+.page .entry-content.hide-post-and-page-titles > .wp-block-cover.alignfull:first-child,
+.single .entry-content.hide-post-and-page-titles > .wp-block-media-text.alignfull:first-child,
+.page .entry-content.hide-post-and-page-titles > .wp-block-media-text.alignfull:first-child,
+.single .entry-content.hide-post-and-page-titles > .wp-block-group.has-background.alignfull:first-child,
+.page .entry-content.hide-post-and-page-titles > .wp-block-group.has-background.alignfull:first-child {
 	margin-top: calc(-1 * var(--global--spacing-vertical));
 }
 

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -69,17 +69,15 @@ Used as block pattern image.
 	margin-top: calc(-1 * var(--global--spacing-vertical));
 }
 
-/* Add some top padding for archive pages. */
+/* Add some top padding */
 
-body:not(.single):not(.page),
-body:not(.single):not(.page) .site-content {
+body .site-content {
 	padding-top: var(--global--spacing-vertical);
 }
 
 @media screen and (min-width: 580px) {
 
-	body:not(.single):not(.page),
-	body:not(.single):not(.page) .site-content {
+	body .site-content {
 		padding-top: calc(3 * var(--global--spacing-vertical));
 	}
 }

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -69,25 +69,6 @@ Used as block pattern image.
 	margin-top: calc(-1 * var(--global--spacing-vertical));
 }
 
-/* Add some top padding */
-
-body .site-content {
-	padding-top: var(--global--spacing-vertical);
-}
-
-@media screen and (min-width: 580px) {
-
-	body .site-content {
-		padding-top: calc(3 * var(--global--spacing-vertical));
-	}
-}
-
-/* Remove the top border from the entry-footer. */
-
-.site-main > article > .entry-footer {
-	border-top-width: 0
-}
-
 /* Center-align headers and footers. */
 
 .entry-header,

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -74,6 +74,7 @@ Used as block pattern image.
 .entry-header,
 .page-title,
 .entry-footer,
-.site-info {
+.site-info,
+.footer-menu {
 	text-align: center;
 }

--- a/blank-canvas/template-parts/content/content-singular.php
+++ b/blank-canvas/template-parts/content/content-singular.php
@@ -11,6 +11,17 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php if ( true === get_theme_mod( 'show_post_and_page_titles', false ) ) : ?>
+		<header class="entry-header default-max-width">
+			<?php
+			if ( is_singular() ) :
+				the_title( '<h1 class="entry-title">', '</h1>' );
+			else :
+				the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
+			endif;
+			?>
+		</header><!-- .entry-header -->
+	<?php endif; ?>
 
 	<?php seedlet_post_thumbnail(); ?>
 

--- a/blank-canvas/template-parts/content/content-singular.php
+++ b/blank-canvas/template-parts/content/content-singular.php
@@ -8,10 +8,11 @@
  * @since 1.0
  */
 
+$show_post_and_page_titles = get_theme_mod( 'show_post_and_page_titles', false );
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php if ( true === get_theme_mod( 'show_post_and_page_titles', false ) ) : ?>
+	<?php if ( $show_post_and_page_titles ) : ?>
 		<header class="entry-header default-max-width">
 			<?php
 			if ( is_singular() ) :
@@ -25,7 +26,11 @@
 
 	<?php seedlet_post_thumbnail(); ?>
 
-	<div class="entry-content">
+	<div class="entry-content
+	<?php
+	if ( ! $show_post_and_page_titles ) :
+		?>
+		hide-post-and-page-titles<?php endif; ?>">
 		<?php
 		the_content(
 			sprintf(

--- a/blank-canvas/template-parts/footer/footer-content.php
+++ b/blank-canvas/template-parts/footer/footer-content.php
@@ -1,1 +1,7 @@
-<?php get_template_part( 'template-parts/footer/footer-info' );
+<?php if ( true === get_theme_mod( 'show_site_footer', false ) ) : ?>
+	<?php get_template_part( 'template-parts/footer/footer-widgets' ); ?>
+	<?php get_template_part( 'template-parts/footer/footer-menu' ); ?>
+<?php endif; ?>
+
+<?php
+get_template_part( 'template-parts/footer/footer-info' );

--- a/blank-canvas/template-parts/header/header-content.php
+++ b/blank-canvas/template-parts/header/header-content.php
@@ -3,7 +3,12 @@
 	$header_class = $show_title ? 'site-title' : 'screen-reader-text';
 ?>
 
-<?php if ( ! is_singular() ) : ?>
+<?php if ( true === get_theme_mod( 'show_site_header', false ) ) : ?>
+	<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
+		<?php get_template_part( 'template-parts/header/site-branding' ); ?>
+		<?php get_template_part( 'template-parts/header/navigation' ); ?>
+	</header><!-- #masthead -->
+<?php elseif ( ! is_singular() ) : ?>
 	<header id="masthead" class="<?php echo $header_classes; ?>" role="banner">
 		<?php get_template_part( 'template-parts/header/site-branding' ); ?>
 	</header><!-- #masthead -->

--- a/blank-canvas/template-parts/header/header-content.php
+++ b/blank-canvas/template-parts/header/header-content.php
@@ -1,6 +1,11 @@
 <?php
-	$show_title   = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
-	$header_class = $show_title ? 'site-title' : 'screen-reader-text';
+$show_title = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
+$has_primary_nav = has_nav_menu( 'primary' );
+$header_classes  = 'site-header header_classes';
+$header_classes .= has_custom_logo() ? ' has-logo' : '';
+$header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
+$header_classes .= $has_primary_nav ? ' has-menu' : '';
+$header_classes .= $show_title ? ' site-title' : ' screen-reader-text';
 ?>
 
 <?php if ( true === get_theme_mod( 'show_site_header', false ) ) : ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add options to:
- Show site header
- Show site footer
- Show post/page titles

#### Screenshots

<img width="293" alt="Screenshot 2021-01-27 at 13 15 45" src="https://user-images.githubusercontent.com/275961/105996118-d4230c80-60a1-11eb-8839-6311d9927466.png">
<img width="299" alt="Screenshot 2021-01-27 at 13 15 56" src="https://user-images.githubusercontent.com/275961/105996113-d2f1df80-60a1-11eb-8941-a545d3f1c8d9.png">


#### Related issue(s):
Fixes #3033