### PR TITLE
Prevented color change on social in cover

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -533,33 +533,33 @@ object {
 .wp-block-cover .wp-block-cover__inner-container,
 .wp-block-cover .wp-block-cover-image-text,
 .wp-block-cover .wp-block-cover-text,
-.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover .block-editor-block-list__block:not(.wp-social-link),
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text,
-.wp-block-cover-image .block-editor-block-list__block {
+.wp-block-cover-image .block-editor-block-list__block:not(.wp-social-link) {
 	color: currentColor;
 }
 
 .wp-block-cover .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
 .wp-block-cover .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
 .wp-block-cover .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
-.wp-block-cover .block-editor-block-list__block a:not(.has-text-color):not(.wp-block-button__link),
+.wp-block-cover .block-editor-block-list__block:not(.wp-social-link) a:not(.has-text-color):not(.wp-block-button__link),
 .wp-block-cover-image .wp-block-cover__inner-container a:not(.has-text-color):not(.wp-block-button__link),
 .wp-block-cover-image .wp-block-cover-image-text a:not(.has-text-color):not(.wp-block-button__link),
 .wp-block-cover-image .wp-block-cover-text a:not(.has-text-color):not(.wp-block-button__link),
-.wp-block-cover-image .block-editor-block-list__block a:not(.has-text-color):not(.wp-block-button__link) {
+.wp-block-cover-image .block-editor-block-list__block:not(.wp-social-link) a:not(.has-text-color):not(.wp-block-button__link) {
 	color: currentColor;
 }
 
 .wp-block-cover .wp-block-cover__inner-container .has-link-color a,
 .wp-block-cover .wp-block-cover-image-text .has-link-color a,
 .wp-block-cover .wp-block-cover-text .has-link-color a,
-.wp-block-cover .block-editor-block-list__block .has-link-color a,
+.wp-block-cover .block-editor-block-list__block:not(.wp-social-link) .has-link-color a,
 .wp-block-cover-image .wp-block-cover__inner-container .has-link-color a,
 .wp-block-cover-image .wp-block-cover-image-text .has-link-color a,
 .wp-block-cover-image .wp-block-cover-text .has-link-color a,
-.wp-block-cover-image .block-editor-block-list__block .has-link-color a {
+.wp-block-cover-image .block-editor-block-list__block:not(.wp-social-link) .has-link-color a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
@@ -907,11 +907,6 @@ li > ol {
 dt {
 	font-family: var(--definition-term--font-family);
 	font-weight: bold;
-}
-
-.wp-block-media-text .block-editor-inner-blocks {
-	padding-right: var(--global--spacing-horizontal);
-	padding-left: var(--global--spacing-horizontal);
 }
 
 .wp-block-navigation .wp-block-navigation__container {

--- a/seedlet/assets/sass/blocks/cover/_editor.scss
+++ b/seedlet/assets/sass/blocks/cover/_editor.scss
@@ -9,7 +9,7 @@
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text,
-	.block-editor-block-list__block {
+	.block-editor-block-list__block:not(.wp-social-link) {
 		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
 
 		a:not(.has-text-color):not(.wp-block-button__link) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The social buttons color setting assigned by Gutenburg default styles
was being clobbered by this color setting.  This change prevents any
wp-social-link elements from being selected.

This was reported against Spearhead but I found that it was caused by something in Seedlet and also is reproduced there.  The fix was tested against both themes.  

![image](https://user-images.githubusercontent.com/146530/106012796-c5c8f680-6089-11eb-9ad6-816ab14afb74.png)

#### Related issue(s):

This fixes #3111 