### PR TITLE
Coutoire: Apply editor colors for Coutoire after Varia ones

### DIFF
--- a/coutoire/functions.php
+++ b/coutoire/functions.php
@@ -104,7 +104,7 @@ if ( ! function_exists( 'coutoire_setup' ) ) :
 		);
 	}
 endif;
-add_action( 'after_setup_theme', 'coutoire_setup' );
+add_action( 'after_setup_theme', 'coutoire_setup', 12 );
 
 /**
  * Filter the content_width in pixels, based on the child-theme's design and stylesheet.
@@ -169,7 +169,7 @@ function coutoire_scripts() {
 	wp_dequeue_style( 'varia-style' );
 
 	// enqueue child styles
-	wp_enqueue_style('coutoire-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ));
+	wp_enqueue_style( 'coutoire-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 
 	// enqueue child RTL styles
 	wp_style_add_data( 'coutoire-style', 'rtl', 'replace' );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds the action to apply editor colors after the Varia ones so that the correct ones show in the editor.

Before:
<img width="800" alt="Screenshot 2021-01-27 at 15 29 42" src="https://user-images.githubusercontent.com/275961/106013580-7d72fe00-60b4-11eb-933e-b2923a249e68.png">

After:
<img width="802" alt="Screenshot 2021-01-27 at 15 26 28" src="https://user-images.githubusercontent.com/275961/106013603-82d04880-60b4-11eb-946a-4c8bba887f1c.png">


#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/3121