### PR TITLE
Spearhead: Fix link color

### DIFF
--- a/spearhead/experimental-theme.json
+++ b/spearhead/experimental-theme.json
@@ -1,6 +1,11 @@
 
 {
 	"global": {
+        "styles": {
+            "color": {
+                "link": "var( --global--color-primary )"
+            }
+        },
 		"settings": {
 			"border": {
         		"customRadius": true


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We need to specify the link color in theme.json.

Before:
<img width="423" alt="Screenshot 2021-01-27 at 17 15 58" src="https://user-images.githubusercontent.com/275961/106028068-68519b80-60c3-11eb-8ef5-45b77c345159.png">

After:
<img width="375" alt="Screenshot 2021-01-27 at 17 15 47" src="https://user-images.githubusercontent.com/275961/106028088-6daee600-60c3-11eb-8717-6b6009294818.png">
