### PR TITLE
Migrate Palette definitions from PHP to JSON

### DIFF
--- a/spearhead/experimental-theme.json
+++ b/spearhead/experimental-theme.json
@@ -9,6 +9,25 @@
 		"settings": {
 			"border": {
         		"customRadius": true
+			},
+			"color": {
+				"palette": [
+					{
+						"slug": "primary",
+						"color": "#DB0042",
+						"name": "Primary"
+					},
+					{
+						"slug": "foreground",
+						"color": "#000000",
+						"name": "Foreground"
+					},
+					{
+						"slug": "background",
+						"color": "#FFFFFF",
+						"name": "Background"
+					}
+				]
 			}
 		}
 	}

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -75,26 +75,6 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 		);
 
 		// Add child theme editor color pallete to match Sass-map variables in `_config-child-theme-deep.scss`.
-		add_theme_support(
-			'editor-color-palette',
-			array(
-				array(
-					'name'  => __( 'Primary', 'spearhead' ),
-					'slug'  => 'primary',
-					'color' => '#DB0042',
-				),
-				array(
-					'name'  => __( 'Foreground', 'spearhead' ),
-					'slug'  => 'foreground',
-					'color' => '#000000',
-				),
-				array(
-					'name'  => __( 'Background', 'spearhead' ),
-					'slug'  => 'background',
-					'color' => '#FFFFFF',
-				),
-			)
-		);
 		remove_filter( 'excerpt_more', 'seedlet_continue_reading_link' );
 		remove_filter( 'the_content_more_link', 'seedlet_continue_reading_link' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change moves the palette definitions from the functions.php and into the theme.json file.

The CSS variables that are generated and their availability is not expected to change (either to the block editor or in the view) only how that information is expressed by the theme.

The exception to the above are the Global CSS variables generated and inlined by Gutenberg for both the Block Editor:
![image](https://user-images.githubusercontent.com/146530/106186708-a1951480-6172-11eb-8245-4218e3eae627.png)
and in the view:
![image](https://user-images.githubusercontent.com/146530/106186851-d6a16700-6172-11eb-9f34-ecba0cea4192.png)

#### Related issue(s):

This MAY be the beginning of a fix for https://github.com/Automattic/themes/issues/2644

With Spearhead generating palette information via theme.json we might be able to use THAT as the "flag" to NOT style elements with inline styles in the block editor if the color definitions come from theme.json (since in that situation it is guaranteed that the classes will exist).  This check could be done as an alternative to an additional theme supports.