### PR TITLE
Blank Canvas: Bump version to 1.2

### DIFF
--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -10,11 +10,14 @@ A blank starting point for building your site.
 
 == Description ==
 
-Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets, so the page you design in the WordPress editor is the same page you’ll see on the front end.
+Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets by default, so the page you design in the WordPress editor is the same page you’ll see on the front end.
 
 The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 
 == Changelog ==
+
+= 1.2 =
+* Adds Customizer options for showing a global header, menu, and widgets. 
 
 = 1.1 =
 * Initial release 

--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -17,7 +17,7 @@ The theme’s default styles are conservative, relying on simple sans-serif font
 == Changelog ==
 
 = 1.2 =
-* Adds Customizer options for showing a global header, menu, and widgets. 
+* Adds Customizer options for showing page titles, a global header, menu, and widgets. 
 
 = 1.1 =
 * Initial release 

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -3,11 +3,11 @@ Theme Name: Blank Canvas
 Theme URI: https://github.com/Automattic/themes/blank-canvas
 Author: Automattic
 Author URI: https://automattic.com/
-Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
+Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets by default, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 Requires at least: 4.9.6
 Tested up to: 5.6
 Requires PHP: 5.6.2
-Version: 1.1
+Version: 1.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet


### PR DESCRIPTION
This PR updates Blank Canvas to v1.2 — the changes in https://github.com/Automattic/themes/pull/3115 seem impactful enough to merit a full point update. 