### PR TITLE
Spearhead: Use the Seedlet scripts for IE11 fixes

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -385,10 +385,10 @@ function seedlet_scripts() {
 	global $is_IE;
 	if ( $is_IE ) {
 		// If IE 11 or below, use a ponyfill to add CSS Variable support
-		wp_register_script( 'css-vars-ponyfill', get_stylesheet_directory_uri() . '/assets/js/css-vars-ponyfill2.js' );
+		wp_register_script( 'css-vars-ponyfill', get_template_directory_uri() . '/assets/js/css-vars-ponyfill2.js' );
 		wp_enqueue_script(
 			'ie11-fix',
-			get_stylesheet_directory_uri() . '/assets/js/ie11-fix.js',
+			get_template_directory_uri() . '/assets/js/ie11-fix.js',
 			array( 'css-vars-ponyfill' ),
 			'1.0'
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Queues the IE11 fixes from the parent not the child.

To test, open spearheaddemo.wordpress.com in IE11 and check you can see something.

#### Related issue(s):
#3043 