### PR TITLE
Blank Canvas: Even out footer spacing

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -176,3 +176,27 @@ add_action( 'customize_controls_enqueue_scripts', 'blank_canvas_customizer_enque
  * Customizer additions.
  */
 require get_stylesheet_directory() . '/inc/customizer.php';
+
+/**
+ * Adds custom classes to the array of body classes.
+ *
+ * @param array $classes Classes for the body element.
+ * @return array
+ */
+function blank_canvas_body_classes( $classes ) {
+
+	if ( false === get_theme_mod( 'show_post_and_page_titles', false ) ) {
+		$classes[] = 'hide-post-and-page-titles';
+	}
+
+	if ( false === get_theme_mod( 'show_site_footer', false ) ) {
+		$classes[] = 'hide-site-footer';
+	}
+
+	if ( false === get_theme_mod( 'show_comments', false ) ) {
+		$classes[] = 'hide-comments';
+	}
+
+	return $classes;
+}
+add_filter( 'body_class', 'blank_canvas_body_classes' );

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -58,29 +58,6 @@ Used as block pattern image.
 
 /* Remove some top padding if the first block on the page is a full-width image, cover, media & text, or group block. */
 
-.single .entry-content.hide-post-and-page-titles > .wp-block-image.alignfull:first-child,
-.page .entry-content.hide-post-and-page-titles > .wp-block-image.alignfull:first-child,
-.single .entry-content.hide-post-and-page-titles > .wp-block-cover.alignfull:first-child,
-.page .entry-content.hide-post-and-page-titles > .wp-block-cover.alignfull:first-child,
-.single .entry-content.hide-post-and-page-titles > .wp-block-media-text.alignfull:first-child,
-.page .entry-content.hide-post-and-page-titles > .wp-block-media-text.alignfull:first-child,
-.single .entry-content.hide-post-and-page-titles > .wp-block-group.has-background.alignfull:first-child,
-.page .entry-content.hide-post-and-page-titles > .wp-block-group.has-background.alignfull:first-child {
-	margin-top: calc(-1 * var(--global--spacing-vertical));
-}
-
-/* Center-align headers and footers. */
-
-.entry-header,
-.page-title,
-.entry-footer,
-.site-info,
-.footer-menu {
-	text-align: center;
-}
-
-/* Remove some top padding if the first block on the page is a full-width image, cover, media & text, or group block. */
-
 .single.hide-post-and-page-titles .entry-content > .wp-block-image.alignfull:first-child,
 .page.hide-post-and-page-titles .entry-content > .wp-block-image.alignfull:first-child,
 .single.hide-post-and-page-titles .entry-content > .wp-block-cover.alignfull:first-child,
@@ -103,4 +80,14 @@ Used as block pattern image.
 .single.hide-site-footer.hide-comments .entry-content > .wp-block-media-text.alignfull:last-child,
 .single.hide-site-footer.hide-comments .entry-content > .wp-block-group.has-background.alignfull:last-child {
 	margin-bottom: calc(-1 * var(--global--spacing-vertical));
+}
+
+/* Center-align headers and footers. */
+
+.entry-header,
+.page-title,
+.entry-footer,
+.site-info,
+.footer-menu {
+	text-align: center;
 }

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -78,3 +78,29 @@ Used as block pattern image.
 .footer-menu {
 	text-align: center;
 }
+
+/* Remove some top padding if the first block on the page is a full-width image, cover, media & text, or group block. */
+
+.single.hide-post-and-page-titles .entry-content > .wp-block-image.alignfull:first-child,
+.page.hide-post-and-page-titles .entry-content > .wp-block-image.alignfull:first-child,
+.single.hide-post-and-page-titles .entry-content > .wp-block-cover.alignfull:first-child,
+.page.hide-post-and-page-titles .entry-content > .wp-block-cover.alignfull:first-child,
+.single.hide-post-and-page-titles .entry-content > .wp-block-media-text.alignfull:first-child,
+.page.hide-post-and-page-titles .entry-content > .wp-block-media-text.alignfull:first-child,
+.single.hide-post-and-page-titles .entry-content > .wp-block-group.has-background.alignfull:first-child,
+.page.hide-post-and-page-titles .entry-content > .wp-block-group.has-background.alignfull:first-child {
+	margin-top: calc(-1 * var(--global--spacing-vertical));
+}
+
+/* Remove some bottom padding if the last block on the page is a full-width image, cover, media & text, or group block. */
+
+.page.hide-site-footer .entry-content > .wp-block-image.alignfull:last-child,
+.page.hide-site-footer .entry-content > .wp-block-cover.alignfull:last-child,
+.page.hide-site-footer .entry-content > .wp-block-media-text.alignfull:last-child,
+.single.hide-site-footer.hide-site-footer .entry-content > .wp-block-group.has-background.alignfull:last-child,
+.single.hide-site-footer.hide-comments .entry-content > .wp-block-image.alignfull:last-child,
+.single.hide-site-footer.hide-comments .entry-content > .wp-block-cover.alignfull:last-child,
+.single.hide-site-footer.hide-comments .entry-content > .wp-block-media-text.alignfull:last-child,
+.single.hide-site-footer.hide-comments .entry-content > .wp-block-group.has-background.alignfull:last-child {
+	margin-bottom: calc(-1 * var(--global--spacing-vertical));
+}

--- a/blank-canvas/template-parts/content/content-singular.php
+++ b/blank-canvas/template-parts/content/content-singular.php
@@ -26,11 +26,7 @@ $show_post_and_page_titles = get_theme_mod( 'show_post_and_page_titles', false )
 
 	<?php seedlet_post_thumbnail(); ?>
 
-	<div class="entry-content
-	<?php
-	if ( ! $show_post_and_page_titles ) :
-		?>
-		hide-post-and-page-titles<?php endif; ?>">
+	<div class="entry-content">
 		<?php
 		the_content(
 			sprintf(


### PR DESCRIPTION
Blank canvas adjusts the top padding when certain full-width blocks are at the top of the page. This PR adjusts the bottom spacing for those instances too so it's more even. This is especially useful for some of the new patterns we're adding in #3151.

We only want this to happen if the comments and footer options are disabled, so this adds a couple body classes to hook the styles onto. Since we're adding body classes anyway, it migrates the existing `hide-post-and-page-titles` class from `entry-content` to the body instead.

Before|After
---|---
<img width="1140" alt="Screen Shot 2021-02-02 at 2 55 16 PM" src="https://user-images.githubusercontent.com/1202812/106654943-bdc7f580-6566-11eb-8774-a5c4c3eb5327.png">|<img width="1148" alt="Screen Shot 2021-02-02 at 2 55 38 PM" src="https://user-images.githubusercontent.com/1202812/106654945-be608c00-6566-11eb-9343-17353c123dd4.png">
