### PR TITLE
Blank Canvas: Remove site-title class from header

### DIFF
--- a/blank-canvas/template-parts/header/header-content.php
+++ b/blank-canvas/template-parts/header/header-content.php
@@ -5,7 +5,7 @@ $header_classes  = 'site-header header_classes';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';
 $header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
 $header_classes .= $has_primary_nav ? ' has-menu' : '';
-$header_classes .= $show_title ? ' site-title' : ' screen-reader-text';
+$header_classes .= !$show_title ? ' screen-reader-text' : '';
 ?>
 
 <?php if ( true === get_theme_mod( 'show_site_header', false ) ) : ?>

--- a/blank-canvas/template-parts/header/header-content.php
+++ b/blank-canvas/template-parts/header/header-content.php
@@ -3,7 +3,7 @@ $show_title = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
 $has_primary_nav = has_nav_menu( 'primary' );
 $header_classes  = 'site-header header_classes';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';
-$header_classes .= $show_title ? ' has-title-and-tagline' : ' screen-reader-text';
+$header_classes .= $show_title ? ' has-title-and-tagline' : '';
 $header_classes .= $has_primary_nav ? ' has-menu' : '';
 ?>
 

--- a/blank-canvas/template-parts/header/header-content.php
+++ b/blank-canvas/template-parts/header/header-content.php
@@ -3,9 +3,8 @@ $show_title = ( true === get_theme_mod( 'display_title_and_tagline', true ) );
 $has_primary_nav = has_nav_menu( 'primary' );
 $header_classes  = 'site-header header_classes';
 $header_classes .= has_custom_logo() ? ' has-logo' : '';
-$header_classes .= true === get_theme_mod( 'display_title_and_tagline', true ) ? ' has-title-and-tagline' : '';
+$header_classes .= $show_title ? ' has-title-and-tagline' : ' screen-reader-text';
 $header_classes .= $has_primary_nav ? ' has-menu' : '';
-$header_classes .= !$show_title ? ' screen-reader-text' : '';
 ?>
 
 <?php if ( true === get_theme_mod( 'show_site_header', false ) ) : ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
It looks like the `$header_classes` variable picked up a couple of generic classes often used for the site title and screen reader text. This may have been accidental? ~I combined this with the first check for the site title/tagline. The `else` was empty.~

The `site-title` class added all the styling from the site title to the entire header content and the `screen-reader-text` class caused the logo to be bumped off the screen when `display_title_and_tagline` was *false*. I am not sure if we wanted to replace these with something else. It didn't appear these were relevant to other code or styling, I could have missed something though?

#### Screenshots
Before:

[![Screenshot](https://d.pr/i/ONOqc8+)](https://d.pr/i/ONOqc8)

[![Screenshot](https://d.pr/i/Ci3M3W+)](https://d.pr/i/Ci3M3W)

After:

[![Screenshot](https://d.pr/i/nCbWgT+)](https://d.pr/i/nCbWgT)

[![Screenshot](https://d.pr/i/1cKrXy+)](https://d.pr/i/1cKrXy)

#### Related issue(s):
Fixes #3166 