### PR TITLE
Varia: Remove color definitions from background settings

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #3E7D98;
-	color: #ffffff;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #9B6A36;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #394d55;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #4d6974;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #253136;
-	color: #ffffff;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #fafafa;
-	color: #394d55;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #d9d9d9;
-	color: #394d55;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #ffffff;
-	color: #394d55;
 }
 
 .is-small-text,

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #3E7D98;
-	color: #ffffff;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #9B6A36;
-	color: #ffffff;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #394d55;
-	color: #ffffff;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #4d6974;
-	color: #ffffff;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #253136;
-	color: #ffffff;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #fafafa;
-	color: #394d55;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #d9d9d9;
-	color: #394d55;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #394d55;
 }
 
 .is-small-text,

--- a/alves/style.css
+++ b/alves/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #3E7D98;
-	color: #ffffff;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #9B6A36;
-	color: #ffffff;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #394d55;
-	color: #ffffff;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #4d6974;
-	color: #ffffff;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #253136;
-	color: #ffffff;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #fafafa;
-	color: #394d55;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #d9d9d9;
-	color: #394d55;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #394d55;
 }
 
 .is-small-text,

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #19744C;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #BC2213;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #303030;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #505050;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #101010;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #F0F0F0;
-	color: #303030;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #D0D0D0;
-	color: #303030;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #303030;
 }
 
 .is-small-text,

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #19744C;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #BC2213;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #303030;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #505050;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #101010;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F0F0F0;
-	color: #303030;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #D0D0D0;
-	color: #303030;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #303030;
 }
 
 .is-small-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #19744C;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #BC2213;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #303030;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #505050;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #101010;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F0F0F0;
-	color: #303030;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #D0D0D0;
-	color: #303030;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #303030;
 }
 
 .is-small-text,

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #20603C;
-	color: #FFFDF6;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #655441;
-	color: #FFFDF6;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #3C2323;
-	color: #FFFDF6;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #844d4d;
-	color: #FFFDF6;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #0D1B24;
-	color: #FFFDF6;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FDF9EC;
-	color: #3C2323;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #3C2323;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFDF6;
-	color: #3C2323;
 }
 
 .is-small-text,

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #20603C;
-	color: #FFFDF6;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #655441;
-	color: #FFFDF6;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #3C2323;
-	color: #FFFDF6;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #844d4d;
-	color: #FFFDF6;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #0D1B24;
-	color: #FFFDF6;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FDF9EC;
-	color: #3C2323;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #3C2323;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
-	color: #3C2323;
 }
 
 .is-small-text,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #20603C;
-	color: #FFFDF6;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #655441;
-	color: #FFFDF6;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #3C2323;
-	color: #FFFDF6;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #844d4d;
-	color: #FFFDF6;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #0D1B24;
-	color: #FFFDF6;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FDF9EC;
-	color: #3C2323;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #3C2323;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
-	color: #3C2323;
 }
 
 .is-small-text,

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #C04239;
-	color: #E8E4DD;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #FFFFFF;
-	color: #E8E4DD;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #252E36;
-	color: #E8E4DD;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #666666;
-	color: #E8E4DD;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #474747;
-	color: #E8E4DD;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #CFCDC7;
-	color: #252E36;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #B9B6B2;
-	color: #252E36;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #E8E4DD;
-	color: #252E36;
 }
 
 .is-small-text,

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #C04239;
-	color: #E8E4DD;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #E8E4DD;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #252E36;
-	color: #E8E4DD;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #E8E4DD;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #474747;
-	color: #E8E4DD;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #CFCDC7;
-	color: #252E36;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #B9B6B2;
-	color: #252E36;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
-	color: #252E36;
 }
 
 .is-small-text,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #C04239;
-	color: #E8E4DD;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #E8E4DD;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #252E36;
-	color: #E8E4DD;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #E8E4DD;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #474747;
-	color: #E8E4DD;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #CFCDC7;
-	color: #252E36;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #B9B6B2;
-	color: #252E36;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
-	color: #252E36;
 }
 
 .is-small-text,

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1067,49 +1067,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #FF7A5C;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .is-small-text,

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2469,50 +2469,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #FF7A5C;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .is-small-text,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2476,50 +2476,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #FF7A5C;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .is-small-text,

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #0073AA;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #0d1b24;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #1e1e1e;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FAFAFA;
-	color: #1e1e1e;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #1e1e1e;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #1e1e1e;
 }
 
 .is-small-text,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2471,50 +2471,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #0073AA;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #0d1b24;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #1e1e1e;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #1e1e1e;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #1e1e1e;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #1e1e1e;
 }
 
 .is-small-text,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2478,50 +2478,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #0073AA;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #0d1b24;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #1e1e1e;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #000000;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #1e1e1e;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #1e1e1e;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #1e1e1e;
 }
 
 .is-small-text,

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #23883D;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #0963C4;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #6E6E6E;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #F7F7F7;
-	color: #111111;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #CCCCCC;
-	color: #111111;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #111111;
 }
 
 .is-small-text,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #23883D;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #0963C4;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #6E6E6E;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F7F7F7;
-	color: #111111;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #CCCCCC;
-	color: #111111;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #111111;
 }
 
 .is-small-text,

--- a/exford/style.css
+++ b/exford/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #23883D;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #0963C4;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #6E6E6E;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F7F7F7;
-	color: #111111;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #CCCCCC;
-	color: #111111;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #111111;
 }
 
 .is-small-text,

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1097,49 +1097,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: var(--wp--preset--color--primary);
-	color: var(--wp--preset--color--background);
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: var(--wp--preset--color--secondary);
-	color: var(--wp--preset--color--background);
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: var(--wp--preset--color--foreground);
-	color: var(--wp--preset--color--background);
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: var(--wp--preset--color--foreground-low-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: var(--wp--preset--color--foreground-high-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: var(--wp--preset--color--background-high-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: var(--wp--preset--color--background-low-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2499,50 +2499,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
-	color: var(--wp--preset--color--background);
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--secondary);
-	color: var(--wp--preset--color--background);
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground);
-	color: var(--wp--preset--color--background);
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground-low-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground-high-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background-high-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background-low-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/hever/style.css
+++ b/hever/style.css
@@ -2506,50 +2506,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
-	color: var(--wp--preset--color--background);
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--secondary);
-	color: var(--wp--preset--color--background);
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground);
-	color: var(--wp--preset--color--background);
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground-low-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--foreground-high-contrast);
-	color: var(--wp--preset--color--background);
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background-high-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background-low-contrast);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #ff302c;
-	color: #f7f7f6;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #1285ce;
-	color: #f7f7f6;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: #f7f7f6;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: #f7f7f6;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: #f7f7f6;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #f7f7f6;
-	color: #444444;
 }
 
 .is-small-text,

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #ff302c;
-	color: #f7f7f6;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #1285ce;
-	color: #f7f7f6;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: #f7f7f6;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #f7f7f6;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #f7f7f6;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
-	color: #444444;
 }
 
 .is-small-text,

--- a/leven/style.css
+++ b/leven/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #ff302c;
-	color: #f7f7f6;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #1285ce;
-	color: #f7f7f6;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: #f7f7f6;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: #f7f7f6;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #f7f7f6;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
-	color: #444444;
 }
 
 .is-small-text,

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -1069,49 +1069,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #000000;
-	color: #ffffff;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #1a1a1a;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #010101;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #666666;
-	color: #ffffff;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #333333;
-	color: #ffffff;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #f2f2f2;
-	color: #010101;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #d9d9d9;
-	color: #010101;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #ffffff;
-	color: #010101;
 }
 
 .is-small-text,

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2471,50 +2471,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
-	color: #ffffff;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #1a1a1a;
-	color: #ffffff;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #010101;
-	color: #ffffff;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #ffffff;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #333333;
-	color: #ffffff;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #f2f2f2;
-	color: #010101;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #d9d9d9;
-	color: #010101;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #010101;
 }
 
 .is-small-text,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2478,50 +2478,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
-	color: #ffffff;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #1a1a1a;
-	color: #ffffff;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #010101;
-	color: #ffffff;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #ffffff;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #333333;
-	color: #ffffff;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #f2f2f2;
-	color: #010101;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #d9d9d9;
-	color: #010101;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #010101;
 }
 
 .is-small-text,

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1085,49 +1085,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #897248;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #c4493f;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #181818;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #686868;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #F7F7F7;
-	color: #181818;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #CCCCCC;
-	color: #181818;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #181818;
 }
 
 .is-small-text,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #897248;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #c4493f;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #181818;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #686868;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F7F7F7;
-	color: #181818;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #CCCCCC;
-	color: #181818;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #181818;
 }
 
 .is-small-text,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #897248;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #c4493f;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #181818;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #686868;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #020202;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F7F7F7;
-	color: #181818;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #CCCCCC;
-	color: #181818;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #181818;
 }
 
 .is-small-text,

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #CD2220;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #007AB7;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #303030;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #757575;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #101010;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #F8F8F8;
-	color: #303030;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #E1DFDF;
-	color: #303030;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #303030;
 }
 
 .is-small-text,

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CD2220;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #007AB7;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #303030;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #757575;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #101010;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F8F8F8;
-	color: #303030;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #E1DFDF;
-	color: #303030;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #303030;
 }
 
 .is-small-text,

--- a/morden/style.css
+++ b/morden/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CD2220;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #007AB7;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #303030;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #757575;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #101010;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F8F8F8;
-	color: #303030;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #E1DFDF;
-	color: #303030;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #303030;
 }
 
 .is-small-text,

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -1082,49 +1082,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #CA2017;
-	color: #FFFFFF;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #007FDB;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #222222;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #666666;
-	color: #FFFFFF;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FAFAFA;
-	color: #222222;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #222222;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #FFFFFF;
-	color: #222222;
 }
 
 .is-small-text,

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CA2017;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #007FDB;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #222222;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #222222;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #222222;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #222222;
 }
 
 .is-small-text,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CA2017;
-	color: #FFFFFF;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #007FDB;
-	color: #FFFFFF;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #222222;
-	color: #FFFFFF;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #666666;
-	color: #FFFFFF;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: #FFFFFF;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #222222;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #222222;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #222222;
 }
 
 .is-small-text,

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #CAAB57;
-	color: #060f29;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #EE4266;
-	color: #060f29;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #f2f2f2;
-	color: #060f29;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: white;
-	color: #060f29;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #8F8F8F;
-	color: #060f29;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #0d1f55;
-	color: #f2f2f2;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #030713;
-	color: #f2f2f2;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #060f29;
-	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CAAB57;
-	color: #060f29;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #EE4266;
-	color: #060f29;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #f2f2f2;
-	color: #060f29;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: white;
-	color: #060f29;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #8F8F8F;
-	color: #060f29;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #0d1f55;
-	color: #f2f2f2;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #030713;
-	color: #f2f2f2;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
-	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CAAB57;
-	color: #060f29;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #EE4266;
-	color: #060f29;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #f2f2f2;
-	color: #060f29;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: white;
-	color: #060f29;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #8F8F8F;
-	color: #060f29;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #0d1f55;
-	color: #f2f2f2;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #030713;
-	color: #f2f2f2;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
-	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #222222;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #116821;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #757575;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #F0F0F0;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #E0E0E0;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2471,50 +2471,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #222222;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #116821;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #757575;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F0F0F0;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #E0E0E0;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2478,50 +2478,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #222222;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #116821;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #757575;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #F0F0F0;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #E0E0E0;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #0C80A1;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #D4401C;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #222222;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #EAEAEA;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #0C80A1;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #D4401C;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #222222;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #EAEAEA;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #0C80A1;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #D4401C;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #222222;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #EAEAEA;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #404040;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #f25f70;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -2472,50 +2472,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #404040;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #f25f70;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/stow/style.css
+++ b/stow/style.css
@@ -2479,50 +2479,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #404040;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #f25f70;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #2c313f;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #3e69dc;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #74767e;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #f3f3f3;
-	color: #74767e;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #74767e;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #74767e;
 }
 
 .is-small-text,

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2471,50 +2471,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #2c313f;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #3e69dc;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #74767e;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #f3f3f3;
-	color: #74767e;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #74767e;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #74767e;
 }
 
 .is-small-text,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2478,50 +2478,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #2c313f;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #3e69dc;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #74767e;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #f3f3f3;
-	color: #74767e;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #74767e;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #74767e;
 }
 
 .is-small-text,

--- a/varia/sass/blocks/utilities/_editor.scss
+++ b/varia/sass/blocks/utilities/_editor.scss
@@ -72,49 +72,41 @@
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: #{map-deep-get($config-global, "color", "primary", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: #{map-deep-get($config-global, "color", "secondary", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "light")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "dark")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #{map-deep-get($config-global, "color", "background", "light")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #{map-deep-get($config-global, "color", "background", "dark")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 // Gutenberg Font-size utility classes

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -164,50 +164,42 @@
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "primary", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "secondary", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "light")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "dark")};
-	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "light")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "dark")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 // Gutenberg Font-size options

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1070,49 +1070,41 @@ pre.wp-block-verse {
 .wp-block .has-primary-background-color,
 .has-primary-background-color {
 	background-color: blue;
-	color: white;
 }
 
 .wp-block .has-secondary-background-color,
 .has-secondary-background-color {
 	background-color: red;
-	color: white;
 }
 
 .wp-block .has-foreground-background-color,
 .has-foreground-background-color {
 	background-color: #444444;
-	color: white;
 }
 
 .wp-block .has-foreground-light-background-color,
 .has-foreground-light-background-color {
 	background-color: #767676;
-	color: white;
 }
 
 .wp-block .has-foreground-dark-background-color,
 .has-foreground-dark-background-color {
 	background-color: #111111;
-	color: white;
 }
 
 .wp-block .has-background-light-background-color,
 .has-background-light-background-color {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .wp-block .has-background-dark-background-color,
 .has-background-dark-background-color {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .wp-block .has-background-background-color,
 .has-background-background-color {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2505,50 +2505,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: blue;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: red;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,

--- a/varia/style.css
+++ b/varia/style.css
@@ -2512,50 +2512,42 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: blue;
-	color: white;
 }
 
 .has-secondary-background-color,
 .has-secondary-background-color.has-background-dim {
 	background-color: red;
-	color: white;
 }
 
 .has-background-dim,
 .has-foreground-background-color,
 .has-foreground-background-color.has-background-dim {
 	background-color: #444444;
-	color: white;
 }
 
 .has-foreground-light-background-color,
 .has-foreground-light-background-color.has-background-dim {
 	background-color: #767676;
-	color: white;
 }
 
 .has-foreground-dark-background-color,
 .has-foreground-dark-background-color.has-background-dim {
 	background-color: #111111;
-	color: white;
 }
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
 	background-color: #FAFAFA;
-	color: #444444;
 }
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
 	background-color: #DDDDDD;
-	color: #444444;
 }
 
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .is-small-text,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the color definitions from the background definitions for custom colors. This now means that if someone sets text and background colors without good contrast they will be hard to read, but I guess we have to give the user control :)

#### Related issue(s):
Fixes #3150
Fixes #2844
Fixes #1763