### PR TITLE
Varia: re-order Gutenberg color utilities rules

### DIFF
--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2424,39 +2424,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	background-attachment: fixed;
 }
 
-.has-primary-color {
-	color: #000000;
-}
-
-.has-secondary-color {
-	color: #1a1a1a;
-}
-
-.has-foreground-color {
-	color: #010101;
-}
-
-.has-foreground-light-color {
-	color: #666666;
-}
-
-.has-foreground-dark-color {
-	color: #333333;
-}
-
-.has-background-light-color {
-	color: #f2f2f2;
-}
-
-.has-background-dark-color {
-	color: #d9d9d9;
-}
-
-.has-background-dim,
-.has-background-color {
-	color: #ffffff;
-}
-
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
@@ -2515,6 +2482,39 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
 	color: #010101;
+}
+
+.has-primary-color {
+	color: #000000;
+}
+
+.has-secondary-color {
+	color: #1a1a1a;
+}
+
+.has-foreground-color {
+	color: #010101;
+}
+
+.has-foreground-light-color {
+	color: #666666;
+}
+
+.has-foreground-dark-color {
+	color: #333333;
+}
+
+.has-background-light-color {
+	color: #f2f2f2;
+}
+
+.has-background-dark-color {
+	color: #d9d9d9;
+}
+
+.has-background-dim,
+.has-background-color {
+	color: #ffffff;
 }
 
 .is-small-text,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2431,39 +2431,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	background-attachment: fixed;
 }
 
-.has-primary-color {
-	color: #000000;
-}
-
-.has-secondary-color {
-	color: #1a1a1a;
-}
-
-.has-foreground-color {
-	color: #010101;
-}
-
-.has-foreground-light-color {
-	color: #666666;
-}
-
-.has-foreground-dark-color {
-	color: #333333;
-}
-
-.has-background-light-color {
-	color: #f2f2f2;
-}
-
-.has-background-dark-color {
-	color: #d9d9d9;
-}
-
-.has-background-dim,
-.has-background-color {
-	color: #ffffff;
-}
-
 .has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
@@ -2522,6 +2489,39 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
 	color: #010101;
+}
+
+.has-primary-color {
+	color: #000000;
+}
+
+.has-secondary-color {
+	color: #1a1a1a;
+}
+
+.has-foreground-color {
+	color: #010101;
+}
+
+.has-foreground-light-color {
+	color: #666666;
+}
+
+.has-foreground-dark-color {
+	color: #333333;
+}
+
+.has-background-light-color {
+	color: #f2f2f2;
+}
+
+.has-background-dark-color {
+	color: #d9d9d9;
+}
+
+.has-background-dim,
+.has-background-color {
+	color: #ffffff;
 }
 
 .is-small-text,

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -111,42 +111,6 @@
 	background-attachment: fixed;
 }
 
-// Gutenberg text color options
-.has-text-color {}
-
-.has-primary-color {
-	color: #{map-deep-get($config-global, "color", "primary", "default")};
-}
-
-.has-secondary-color {
-	color: #{map-deep-get($config-global, "color", "secondary", "default")};
-}
-
-.has-foreground-color {
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
-}
-
-.has-foreground-light-color {
-	color: #{map-deep-get($config-global, "color", "foreground", "light")};
-}
-
-.has-foreground-dark-color {
-	color: #{map-deep-get($config-global, "color", "foreground", "dark")};
-}
-
-.has-background-light-color {
-	color: #{map-deep-get($config-global, "color", "background", "light")};
-}
-
-.has-background-dark-color {
-	color: #{map-deep-get($config-global, "color", "background", "dark")};
-}
-
-.has-background-dim,
-.has-background-color {
-	color: #{map-deep-get($config-global, "color", "background", "default")};
-}
-
 // Gutenberg background-color options
 .has-background {
 	&:not(.has-background-background-color) a:not(.wp-block-button__link),
@@ -208,6 +172,42 @@
 .has-background-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
 	color: #{map-deep-get($config-global, "color", "foreground", "default")};
+}
+
+// Gutenberg text color options
+.has-text-color {}
+
+.has-primary-color {
+	color: #{map-deep-get($config-global, "color", "primary", "default")};
+}
+
+.has-secondary-color {
+	color: #{map-deep-get($config-global, "color", "secondary", "default")};
+}
+
+.has-foreground-color {
+	color: #{map-deep-get($config-global, "color", "foreground", "default")};
+}
+
+.has-foreground-light-color {
+	color: #{map-deep-get($config-global, "color", "foreground", "light")};
+}
+
+.has-foreground-dark-color {
+	color: #{map-deep-get($config-global, "color", "foreground", "dark")};
+}
+
+.has-background-light-color {
+	color: #{map-deep-get($config-global, "color", "background", "light")};
+}
+
+.has-background-dark-color {
+	color: #{map-deep-get($config-global, "color", "background", "dark")};
+}
+
+.has-background-dim,
+.has-background-color {
+	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 // Gutenberg Font-size options


### PR DESCRIPTION
This PR addresses #2548.

Previously, if a block had both a preset color and background color set, the cascade would cause the color to be overridden by the background color utility class:

<img width="426" alt="Screen Shot 2021-02-04 at 12 18 34 PM" src="https://user-images.githubusercontent.com/5375500/106930103-2b009580-66e3-11eb-829a-49b2fd379d58.png">

This PR re-orders them so that if a preset color is selected, it will take precedence — without increasing the specificity.

**To test**
- Activate this PR + Mayland
- Add a button with a preset color + preset background
- Verify the front-end and editor match and appear as expected

Note that this should probably be compiled into all the child themes if we like the change.