### PR TITLE
Varia: Don't force outlined buttons to be transparent

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
 	background-color: #2f5f74;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1696,7 +1695,7 @@ p:not(.site-title) a:hover {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
 	background-color: #2f5f74;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 48px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/alves/style-woocommerce-rtl.css
+++ b/alves/style-woocommerce-rtl.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/alves/style-woocommerce.css
+++ b/alves/style-woocommerce.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/alves/style.css
+++ b/alves/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 48px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #FFFFFF;
 	background-color: #145f3e;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/balasana/style-woocommerce-rtl.css
+++ b/balasana/style-woocommerce-rtl.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/balasana/style-woocommerce.css
+++ b/balasana/style-woocommerce.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
 	background-color: #133a24;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 16px 18px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/barnsbury/style-woocommerce-rtl.css
+++ b/barnsbury/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/barnsbury/style-woocommerce.css
+++ b/barnsbury/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 16px 18px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #E8E4DD;
 	background-color: #C04239;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/brompton/style-woocommerce-rtl.css
+++ b/brompton/style-woocommerce-rtl.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/brompton/style-woocommerce.css
+++ b/brompton/style-woocommerce.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -499,7 +499,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #FFFFFF;
 	background-color: #FF7A5C;
 }
@@ -548,7 +548,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -244,10 +244,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1383,10 +1383,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1430,8 +1430,8 @@ button[data-load-more-btn], .button {
 	padding: 9.6px 11.6px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/coutoire/style-woocommerce-rtl.css
+++ b/coutoire/style-woocommerce-rtl.css
@@ -287,14 +287,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/coutoire/style-woocommerce.css
+++ b/coutoire/style-woocommerce.css
@@ -287,14 +287,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -244,10 +244,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1383,10 +1383,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1430,8 +1430,8 @@ button[data-load-more-btn], .button {
 	padding: 9.6px 11.6px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #FFFFFF;
 	background-color: #005177;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/dalston/style-woocommerce-rtl.css
+++ b/dalston/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/dalston/style-woocommerce.css
+++ b/dalston/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #195f2b;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1697,7 +1696,7 @@ pre.wp-block-verse {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #195f2b;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/exford/style-woocommerce-rtl.css
+++ b/exford/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/exford/style-woocommerce.css
+++ b/exford/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/exford/style.css
+++ b/exford/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -527,7 +527,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);
 }
@@ -577,7 +577,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1684,7 +1683,7 @@ pre.wp-block-verse {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -273,10 +273,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1413,10 +1413,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1460,8 +1460,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/hever/style-woocommerce-rtl.css
+++ b/hever/style-woocommerce-rtl.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/hever/style-woocommerce.css
+++ b/hever/style-woocommerce.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/hever/style.css
+++ b/hever/style.css
@@ -273,10 +273,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1413,10 +1413,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1460,8 +1460,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #1285ce;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/leven/style-woocommerce-rtl.css
+++ b/leven/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/leven/style-woocommerce.css
+++ b/leven/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/leven/style.css
+++ b/leven/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #666666;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/mayland/style-woocommerce-rtl.css
+++ b/mayland/style-woocommerce-rtl.css
@@ -306,14 +306,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/mayland/style-woocommerce.css
+++ b/mayland/style-woocommerce.css
@@ -306,14 +306,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -515,7 +515,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #685636;
 }
@@ -565,7 +565,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1747,7 +1746,7 @@ b, strong {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #685636;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/maywood/style-woocommerce-rtl.css
+++ b/maywood/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/maywood/style-woocommerce.css
+++ b/maywood/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #303030;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1660,7 +1659,7 @@ pre.wp-block-verse {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #303030;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/morden/style-woocommerce-rtl.css
+++ b/morden/style-woocommerce-rtl.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/morden/style-woocommerce.css
+++ b/morden/style-woocommerce.css
@@ -342,14 +342,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/morden/style.css
+++ b/morden/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -512,7 +512,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #FFFFFF;
 	background-color: #222222;
 }
@@ -562,7 +562,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/redhill/style-woocommerce-rtl.css
+++ b/redhill/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/redhill/style-woocommerce.css
+++ b/redhill/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.185em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: #060f29;
 	background-color: #b59439;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.185em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.185em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/rivington/style-woocommerce-rtl.css
+++ b/rivington/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.185em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/rivington/style-woocommerce.css
+++ b/rivington/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.185em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.185em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.185em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #444444;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 20px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/rockfield/style-woocommerce-rtl.css
+++ b/rockfield/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/rockfield/style-woocommerce.css
+++ b/rockfield/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 20px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #085a72;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1659,7 +1658,7 @@ pre.wp-block-verse {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #085a72;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 16px-2px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/shawburn/style-woocommerce-rtl.css
+++ b/shawburn/style-woocommerce-rtl.css
@@ -260,14 +260,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/shawburn/style-woocommerce.css
+++ b/shawburn/style-woocommerce.css
@@ -260,14 +260,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 16px-2px 24px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #4f4f4f;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1793,7 +1792,7 @@ a {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #4f4f4f;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/stow/style-woocommerce-rtl.css
+++ b/stow/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/stow/style-woocommerce.css
+++ b/stow/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/stow/style.css
+++ b/stow/style.css
@@ -246,10 +246,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1386,10 +1386,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1433,8 +1433,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.33em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-a8c-blog-posts + .has-focus.button {
 	color: white;
 	background-color: #2c313f;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.33em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.33em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/stratford/style-woocommerce-rtl.css
+++ b/stratford/style-woocommerce-rtl.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.33em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/stratford/style-woocommerce.css
+++ b/stratford/style-woocommerce.css
@@ -288,14 +288,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.33em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -245,10 +245,10 @@ input[type="submit"]:after,
 	margin-top: -0.33em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1385,10 +1385,10 @@ input[type="submit"]:after,
 	margin-top: -0.33em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1432,8 +1432,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/varia/rebuild-child-themes.sh
+++ b/varia/rebuild-child-themes.sh
@@ -5,8 +5,6 @@ declare -a ChildThemes=("alves" "balasana" "barnsbury" "brompton" "coutoire" "da
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}
 	echo 'Rebulding '${child}
-	perl -pi -e 's/Version: ((\d+\.)*)(\d+)(.*)$/"Version: ".$1.($3+1).$4/ge' sass/style-child-theme.scss
-	perl -pi -e 's/\"version\": \"((\d+\.)*)(\d+)\"(.*)$/"\"version\": \"".$1.($3+1)."\"".$4/ge' package.json
 	npm install
 	npm run build
 done

--- a/varia/sass/base/_extends.scss
+++ b/varia/sass/base/_extends.scss
@@ -17,7 +17,7 @@
 	text-decoration: none;
 	padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 
-	&:hover,
+	&:not(.has-background):hover,
 	&:focus,
 	&.has-focus {
 		color: #{map-deep-get($config-button, "color", "text-hover")};

--- a/varia/sass/blocks/button/_editor.scss
+++ b/varia/sass/blocks/button/_editor.scss
@@ -20,7 +20,6 @@
 	&.is-style-outline,
 	.is-style-outline & {
 
-		background: transparent;
 		border: 2px solid currentcolor;
 
 		&:hover,

--- a/varia/sass/blocks/button/_style.scss
+++ b/varia/sass/blocks/button/_style.scss
@@ -23,7 +23,7 @@ input[type="submit"],
 		border: #{map-deep-get($config-button, "border-width")} solid currentcolor;
 		padding: #{map-deep-get($config-button, "padding", "vertical") - map-deep-get($config-button, "border-width")} #{map-deep-get($config-button, "padding", "horizontal")};
 
-		&:not(.has-background-color) {
+		&:not(.has-background) {
 			background: transparent;
 		}
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -155,7 +155,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }
@@ -500,7 +500,7 @@ object {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:hover, .fse-template-part .main-navigation .button:hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }
@@ -550,7 +550,6 @@ object {
 
 .wp-block-button__link.is-style-outline,
 .is-style-outline .wp-block-button__link {
-	background: transparent;
 	border: 2px solid currentcolor;
 }
 
@@ -1599,7 +1598,7 @@ pre.wp-block-verse {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation .button:hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
+.fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: indigo;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -200,10 +200,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -279,10 +279,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1419,10 +1419,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1466,8 +1466,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 

--- a/varia/style-woocommerce-rtl.css
+++ b/varia/style-woocommerce-rtl.css
@@ -248,14 +248,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/varia/style-woocommerce.css
+++ b/varia/style-woocommerce.css
@@ -248,14 +248,14 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:af
 	margin-top: -0.11em;
 }
 
-body[class*="woocommerce"] #page #respond input#submit:hover,
-body[class*="woocommerce"] #page a.button:hover,
-body[class*="woocommerce"] #page button.button:hover,
-body[class*="woocommerce"] #page input.button:hover,
-body[class*="woocommerce"] #page .cart .button:hover,
-body[class*="woocommerce"] #page a.added_to_cart:hover,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:hover,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:hover, body[class*="woocommerce"] #page #respond input#submit:focus,
+body[class*="woocommerce"] #page #respond input#submit:not(.has-background):hover,
+body[class*="woocommerce"] #page a.button:not(.has-background):hover,
+body[class*="woocommerce"] #page button.button:not(.has-background):hover,
+body[class*="woocommerce"] #page input.button:not(.has-background):hover,
+body[class*="woocommerce"] #page .cart .button:not(.has-background):hover,
+body[class*="woocommerce"] #page a.added_to_cart:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:not(.has-background):hover,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:not(.has-background):hover, body[class*="woocommerce"] #page #respond input#submit:focus,
 body[class*="woocommerce"] #page a.button:focus,
 body[class*="woocommerce"] #page button.button:focus,
 body[class*="woocommerce"] #page input.button:focus,

--- a/varia/style.css
+++ b/varia/style.css
@@ -200,10 +200,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -279,10 +279,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1419,10 +1419,10 @@ input[type="submit"]:after,
 	margin-top: -0.11em;
 }
 
-.button:hover, button:hover,
-input:hover[type="submit"],
-.wp-block-button__link:hover,
-.wp-block-file__button:hover, .a8c-posts-list__view-all:hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:hover, .button:focus, button:focus,
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
+.wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover, .button:focus, button:focus,
 input:focus[type="submit"],
 .wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus, .has-focus.button, button.has-focus,
@@ -1466,8 +1466,8 @@ button[data-load-more-btn], .button {
 	padding: 14px 16px;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background-color),
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background),
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background) {
 	background: transparent;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the transparency from outlined buttons in Varia, and then turns off the background hover color if the background color is set.

#### Related issue(s):
Fixes #2568