### PR TITLE
Varia: Remove overrides for links in elements with background color set

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #FFFDF6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFDF6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFDF6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #E8E4DD;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #E8E4DD;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #E8E4DD;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1052,7 +1052,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2455,7 +2455,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2462,7 +2462,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2457,7 +2457,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2464,7 +2464,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1082,7 +1082,6 @@ pre.wp-block-verse {
 	color: var(--wp--preset--color--background);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2485,7 +2485,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: var(--wp--preset--color--background);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2492,7 +2492,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: var(--wp--preset--color--background);
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #f7f7f6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #f7f7f6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #f7f7f6;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -1054,7 +1054,6 @@ pre.wp-block-verse {
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2457,7 +2457,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2464,7 +2464,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #ffffff;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1070,7 +1070,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.2
+Version: 1.6.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.2
+Version: 1.6.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -1067,7 +1067,6 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: #060f29;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #060f29;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.2
+Version: 1.3.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #060f29;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2457,7 +2457,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2464,7 +2464,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2458,7 +2458,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.2
+Version: 1.5.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2465,7 +2465,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1055,7 +1055,6 @@ pre.wp-block-verse {
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2457,7 +2457,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.2
+Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2464,7 +2464,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: white;
 }
 
-.has-background:not(.has-background-background-color) a:not(.wp-block-button__link),
 .has-background p:not(.has-text-color),
 .has-background h1:not(.has-text-color),
 .has-background h2:not(.has-text-color),

--- a/varia/sass/blocks/utilities/_editor.scss
+++ b/varia/sass/blocks/utilities/_editor.scss
@@ -57,7 +57,6 @@
 
 // Gutenberg background-color options
 .has-background {
-	&:not(.has-background-background-color) a:not(.wp-block-button__link),
 	p:not(.has-text-color),
 	h1:not(.has-text-color),
 	h2:not(.has-text-color),

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -149,7 +149,6 @@
 
 // Gutenberg background-color options
 .has-background {
-	&:not(.has-background-background-color) a:not(.wp-block-button__link),
 	p:not(.has-text-color),
 	h1:not(.has-text-color),
 	h2:not(.has-text-color),


### PR DESCRIPTION
This removes special overrides for links inside elements with background colors. I don't think we need these fallbacks, but is we do Gutenberg should be able to handle them.

I have only rebuilt hever to make this easier to review, but we should really rebuild all. I can do that once the review is done.

Fixes: #2667 