### PR TITLE
Varia: Remove colors from the cover block

### DIFF
--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -607,28 +607,6 @@ object {
 	color: white;
 }
 
-.wp-block-cover .wp-block-cover__inner-container,
-.wp-block-cover .wp-block-cover-image-text,
-.wp-block-cover .wp-block-cover-text,
-.wp-block-cover .block-editor-block-list__block,
-.wp-block-cover-image .wp-block-cover__inner-container,
-.wp-block-cover-image .wp-block-cover-image-text,
-.wp-block-cover-image .wp-block-cover-text,
-.wp-block-cover-image .block-editor-block-list__block {
-	color: currentColor;
-}
-
-.wp-block-cover .wp-block-cover__inner-container a,
-.wp-block-cover .wp-block-cover-image-text a,
-.wp-block-cover .wp-block-cover-text a,
-.wp-block-cover .block-editor-block-list__block a,
-.wp-block-cover-image .wp-block-cover__inner-container a,
-.wp-block-cover-image .wp-block-cover-image-text a,
-.wp-block-cover-image .wp-block-cover-text a,
-.wp-block-cover-image .block-editor-block-list__block a {
-	color: currentColor;
-}
-
 .wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
 .wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
 .wp-block-cover:not([class*='background-color']) .wp-block-cover-text,

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1554,24 +1554,8 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text {
-	color: currentColor;
 	margin-top: 32px;
 	margin-bottom: 32px;
-}
-
-.wp-block-cover .wp-block-cover__inner-container a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover__inner-container a.wp-block-button__link:hover,
-.wp-block-cover .wp-block-cover-image-text a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover-image-text a.wp-block-button__link:hover,
-.wp-block-cover .wp-block-cover-text a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover-text a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover__inner-container a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover__inner-container a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover-image-text a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover-image-text a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover-text a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover-text a.wp-block-button__link:hover {
-	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1554,24 +1554,8 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover__inner-container,
 .wp-block-cover-image .wp-block-cover-image-text,
 .wp-block-cover-image .wp-block-cover-text {
-	color: currentColor;
 	margin-top: 32px;
 	margin-bottom: 32px;
-}
-
-.wp-block-cover .wp-block-cover__inner-container a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover__inner-container a.wp-block-button__link:hover,
-.wp-block-cover .wp-block-cover-image-text a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover-image-text a.wp-block-button__link:hover,
-.wp-block-cover .wp-block-cover-text a:not(.wp-block-button__link),
-.wp-block-cover .wp-block-cover-text a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover__inner-container a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover__inner-container a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover-image-text a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover-image-text a.wp-block-button__link:hover,
-.wp-block-cover-image .wp-block-cover-text a:not(.wp-block-button__link),
-.wp-block-cover-image .wp-block-cover-text a.wp-block-button__link:hover {
-	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -12,17 +12,6 @@
 		color: #{map-deep-get($config-cover, "color", "foreground")};
 	}
 
-	.wp-block-cover__inner-container,
-	.wp-block-cover-image-text,
-	.wp-block-cover-text,
-	.block-editor-block-list__block {
-		color: currentColor; // uses text color specified with background-color options in /blocks/utilities/_style.scss
-
-		a {
-			color: currentColor;
-		}
-	}
-
 	/* default & custom background-color */
 	&:not([class*='background-color']){
 		.wp-block-cover__inner-container,

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -14,14 +14,8 @@
 	.wp-block-cover__inner-container,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {
-		color: currentColor;
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
-
-		a:not(.wp-block-button__link),
-		a.wp-block-button__link:hover {
-			color: currentColor;
-		}
 	}
 
 	/* Treating H2 separately to account for legacy /core styles */


### PR DESCRIPTION
I think we can just remove these color resets and let Gutenberg handle them.

Fixes #2971
