### PR TITLE
Use custom background color for high-contrast

### DIFF
--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -245,6 +245,10 @@ class Seedlet_Custom_Colors {
 				if ( $theme_mod_variable_name === '--global--color-foreground' && $theme_mod_default_color !== $theme_mod_custom_color ) {
 					$theme_css .= '--global--color-foreground-low-contrast: ' . $adjusted_color . ';';
 				}
+
+				if ( $theme_mod_variable_name === '--global--color-background' && $theme_mod_default_color !== $theme_mod_custom_color ) {
+					$theme_css .= '--global--color-background-high-contrast:' . $theme_mod_custom_color . ';';
+				}
 			}
 		}
 


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Continuing #3105 but ensuring that the background color is used as the
high contrast background color when set in the .org color customizer.

Prior to the change the 'sticky post' background (and anything else that used the --global--color-background-high-contrast CSS variable) wouldn't pick up changes made via the .org color customizer.   (Due to changes in #3105 those portions were working fine using .com color customizer).

#### Related issue(s):

This may be the issue that caused #3016 to be reopened.