### PR TITLE
Varia: remove extra specificity of background color classes

### DIFF
--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1082,9 +1082,9 @@ pre.wp-block-verse {
 	color: #FFFFFF;
 }
 
-.has-background-dim:not(.has-text-color),
-.has-foreground-background-color:not(.has-text-color),
-.has-foreground-background-color.has-background-dim:not(.has-text-color) {
+.has-background-dim,
+.has-foreground-background-color,
+.has-foreground-background-color.has-background-dim {
 	background-color: #444444;
 }
 

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2485,9 +2485,9 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background-dim:not(.has-text-color),
-.has-foreground-background-color:not(.has-text-color),
-.has-foreground-background-color.has-background-dim:not(.has-text-color) {
+.has-background-dim,
+.has-foreground-background-color,
+.has-foreground-background-color.has-background-dim {
 	background-color: #444444;
 }
 

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2492,9 +2492,9 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	color: #FFFFFF;
 }
 
-.has-background-dim:not(.has-text-color),
-.has-foreground-background-color:not(.has-text-color),
-.has-foreground-background-color.has-background-dim:not(.has-text-color) {
+.has-background-dim,
+.has-foreground-background-color,
+.has-foreground-background-color.has-background-dim {
 	background-color: #444444;
 }
 

--- a/varia/sass/blocks/utilities/_editor.scss
+++ b/varia/sass/blocks/utilities/_editor.scss
@@ -87,9 +87,9 @@
 	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
-.has-background-dim:not(.has-text-color),
-.has-foreground-background-color:not(.has-text-color),
-.has-foreground-background-color.has-background-dim:not(.has-text-color) {
+.has-background-dim,
+.has-foreground-background-color,
+.has-foreground-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -179,9 +179,9 @@
 	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
-.has-background-dim:not(.has-text-color),
-.has-foreground-background-color:not(.has-text-color),
-.has-foreground-background-color.has-background-dim:not(.has-text-color) {
+.has-background-dim,
+.has-foreground-background-color,
+.has-foreground-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 


### PR DESCRIPTION
I don't think we should use the extra level of specificity `not:has-text-color` to target classes that are meant to apply a background color. It causes unexpected behavior like #2994. This PR removes them.

If we are comfortable with this, the changes would need to be recompiled for all Varia themes.