### PR TITLE
Varia: Remove color overrides for media and text

### DIFF
--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2013,10 +2013,6 @@ dd {
 	margin-bottom: 0;
 }
 
-.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
-	color: currentColor;
-}
-
 @media only screen and (min-width: 560px) {
 	.wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
 		padding-top: 32px;

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2013,10 +2013,6 @@ dd {
 	margin-bottom: 0;
 }
 
-.wp-block-media-text[class*="background-color"]:not(.has-background-background-color) .wp-block-media-text__content a, .wp-block-media-text[style*="background-color"] .wp-block-media-text__content a {
-	color: currentColor;
-}
-
 @media only screen and (min-width: 560px) {
 	.wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__content {
 		padding-top: 32px;

--- a/varia/sass/blocks/media-text/_style.scss
+++ b/varia/sass/blocks/media-text/_style.scss
@@ -26,15 +26,6 @@
 		}
 	}
 
-	&[class*="background-color"]:not(.has-background-background-color),
-	&[style*="background-color"] {
-		.wp-block-media-text__content {
-			a {
-				color: currentColor;
-			}
-		}
-	}
-
 	/**
 	 * Block Options
 	 */


### PR DESCRIPTION
Noticed on this site: https://bluprohomeinspections.com/

You can reproduce with this content:

```
<!-- wp:columns {"align":"full"} -->
<div class="wp-block-columns alignfull"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:media-text {"align":"full","mediaPosition":"right","mediaId":25,"mediaType":"image","mediaWidth":44,"imageFill":true,"backgroundColor":"primary","textColor":"background"} -->
<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile is-image-fill has-background-color has-primary-background-color has-text-color has-background" style="grid-template-columns:auto 44%"><figure class="wp-block-media-text__media" style="background-image:url(https://bluprohomeinspections.com/wp-content/uploads/2021/01/architecture-1867187_1920-1024x698.jpg);background-position:50% 50%"><img src="https://bluprohomeinspections.com/wp-content/uploads/2021/01/architecture-1867187_1920-1024x698.jpg" alt="Home" class="wp-image-25 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:heading {"textAlign":"left","placeholder":"Add hero heading…"} -->
<h2 class="has-text-align-left">Looking out for you before and after you buy</h2>
<!-- /wp:heading -->

<!-- wp:buttons {"contentJustification":"left","align":"left"} -->
<div class="wp-block-buttons is-content-justification-left"><!-- wp:button {"placeholder":"Primary button…","borderRadius":5,"style":{"color":{"background":"#d9d5a9"}},"textColor":"primary","className":"is-style-shadow"} -->
<div class="wp-block-button is-style-shadow"><a class="wp-block-button__link has-primary-color has-text-color has-background" href="#contact" style="border-radius:5px;background-color:#d9d5a9" rel="">Contact Us Today</a></div>
<!-- /wp:button -->

<!-- wp:button {"borderRadius":5,"style":{"color":{"text":"#d9d5a9"}},"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color" href="https://www.spectora.com/home-inspectors/blupro-inspections/schedule" style="border-radius:5px;color:#d9d5a9" target="_blank" rel="noreferrer noopener">Schedule an Inspection</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer --></div></div>
<!-- /wp:media-text --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:heading {"textColor":"secondary"} -->
<h2 class="has-secondary-color has-text-color" id="about">About Us</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>With BluPro Home Inspections, you are getting decades of experience helping clients better their homes. We use the best inspection software that is easy to navigate, with great features that clients and agents love.</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"textColor":"secondary"} -->
<h2 class="has-secondary-color has-text-color" id="contact">Contact Us</h2>
<!-- /wp:heading -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center"} -->
<div class="wp-block-column is-vertically-aligned-center"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"75%"} -->
<div class="wp-block-column" style="flex-basis:75%"><!-- wp:jetpack/contact-info -->
<div class="wp-block-jetpack-contact-info">
<!-- wp:jetpack/email {"email":"Email: gbarney@bluprohomeinspections.com"} -->
<div class="wp-block-jetpack-email">Email: <a href="mailto:gbarney@bluprohomeinspections.com">gbarney@bluprohomeinspections.com</a></div>
<!-- /wp:jetpack/email -->
<!-- wp:jetpack/phone {"phone":"Phone: 401-757-1215"} -->
<div class="wp-block-jetpack-phone"><span class="phone-prefix">Phone: </span><a href="tel:4017571215">401-757-1215</a></div>
<!-- /wp:jetpack/phone -->
<!-- wp:jetpack/address {"address":"152A Stone Dam Rd","city":"N. Scituate","region":"RI","postal":"02857","linkToGoogleMaps":true} -->
<div class="wp-block-jetpack-address"><a href="https://www.google.com/maps/search/152A+Stone Dam Rd,+N. Scituate,+RI,+02857" target="_blank" rel="noopener noreferrer" title="Open address in Google Maps"><div class="jetpack-address__address jetpack-address__address1">152A Stone Dam Rd</div><div><span class="jetpack-address__city">N. Scituate</span>, <span class="jetpack-address__region">RI</span> <span class="jetpack-address__postal">02857</span></div></a></div>
<!-- /wp:jetpack/address -->
<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
</div>
<!-- /wp:jetpack/contact-info --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p><strong>Email, call, text us, or fill out the form below to get in touch.</strong></p>
<!-- /wp:paragraph -->

<!-- wp:jetpack/contact-form {"subject":"[] Welcome","to":"gtbarney10@gmail.com"} -->
<!-- wp:jetpack/field-name {"required":true} /-->
<!-- wp:jetpack/field-email {"required":true} /-->
<!-- wp:jetpack/field-textarea /-->
<!-- wp:jetpack/button {"element":"button","text":"Submit","textColor":"background","backgroundColor":"secondary","borderRadius":5,"align":"center","className":"is-style-fill"} /-->
<!-- /wp:jetpack/contact-form -->

<!-- wp:themify-builder/canvas /-->
```

#### Changes proposed in this Pull Request:
I have just removed these lines from Varia. I think Gutenberg should be able to handle these cases without fixes in the theme.

#### Related issue(s):
