### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ By contributing code to our free themes, you grant its use under the [GNU Genera
 
 Themes code should adhere to the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). This repo contains a pre-commit hook which enables you to detect and fix code that doesn't follow the standards.
 
-To set this uo follow these instructions:
+To set this up follow these instructions:
 1. Run `npm i` in the root of the repo.
 2. Run `composer install`
 


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Minor typo in README.md, line 49: 'uo'->'up'

#### Related issue(s):
