### PR TITLE
Moved nav hover color annotations to 'primary' to match original SCSS intention

### DIFF
--- a/exford/inc/wpcom-colors.php
+++ b/exford/inc/wpcom-colors.php
@@ -143,6 +143,9 @@ add_color_rule( 'link', '#23883D', array(
 			.wp-block-newspack-blocks-homepage-articles article .entry-title a:focus,
 			.wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
 			a', 'color' ),
+
+	// Hover colors
+	array( '.main-navigation a:hover', 'color' , '-1' ),
 			
 	// Border color left
 	array( '.wp-block-quote', 'border-left-color' ),
@@ -307,7 +310,6 @@ add_color_rule( 'fg1', '#0963C4', array(
 			.entry-meta a:active,
 			.entry-meta a:hover,
 			.footer-navigation .footer-menu a:hover,
-			.main-navigation a:hover,
 			.site-info a:hover,
 			.wp-block-button.is-style-outline .wp-block-button__link.has-focus,
 			.wp-block-button.is-style-outline .wp-block-button__link:focus,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change was started to address #2862.  However after going down a rabbit hole I see that:

$config-header.main-nav.color.link-color is [set to the value](https://github.com/Automattic/themes/blob/trunk/varia/sass/child-theme/_config-child-theme-deep.scss#L351) of $config-global.color.primary.hover which Exford defaults to [a riff on the primary color](https://github.com/Automattic/themes/blob/trunk/exford/sass/_config-child-theme-deep.scss#L74) rather than being based on the secondary.

However, in the[ Exford Color Annotations code ](https://github.com/Automattic/themes/blob/trunk/exford/inc/wpcom-colors.php#L311)there are selectors that group this (and likely other elements) with the styling of the Secondary Color instead.

As soon as ANY (just one) color is changed in the Color Annotations (doesn't have to be the secondary as seemed to be indicated by the original ticket) the color annotations CSS is complied overriding the original intentions.

TL;DR there is a discrepancy between the "default" styles and styles generated by the color annotations.

This fix is ONE option to take care of this discrepancy.  If we do then we'll need to comb the styles to determine which bits are incorrect and should be re-styled in the same vein as this initial change.  This option assumes that the original intent was correct and with this change people with any changes to Exford colors will experience some changes: things previously styled with the "Secondary" color will instead follow the theme's original design basing those hover colors on the Primary (link) color instead.

Another option could assume that the existing Color Annotations are correct.  With a minor adjustment the color annotations could be generated ALWAYS (even if there are no customizations) which would eliminate the differences between "Customized" and "Not Customize" color values.  This would effect anybody who is using Exford who has NOT made any color customizations (the original intent of the hover of certain elements would now be controlled by the "Secondary Color".  This solution would address the original ask of the bug report.  This option is the least amount of effort.

#### Related issue(s):
Fixes: #2862 