### PR TITLE
Stricter check for colors

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -159,11 +159,11 @@ if ( ! function_exists( 'varia_setup' ) ) :
 		 */
 		$colors_array   = get_theme_mod( 'colors_manager' ); // color annotations array()
 		$default_colors = varia_default_colors();
-		$primary        = ! empty( $colors_array ) ? $colors_array['colors']['link'] : $default_colors['primary']; // $config-global--color-primary-default;
-		$secondary      = ! empty( $colors_array ) ? $colors_array['colors']['fg1'] : $default_colors['secondary'];  // $config-global--color-secondary-default;
-		$tertiary       = ! empty( $colors_array ) ? $colors_array['colors']['fg2'] : $default_colors['tertiary'];   // $config-global--color-tertiary-default;
-		$foreground     = ! empty( $colors_array ) ? $colors_array['colors']['txt'] : $default_colors['foreground'];  // $config-global--color-foreground-default;
-		$background     = ! empty( $colors_array ) ? $colors_array['colors']['bg'] : $default_colors['background'];   // $config-global--color-background-default;
+		$primary        = ! empty( $colors_array ) && $colors_array['colors'] ? $colors_array['colors']['link'] : $default_colors['primary']; // $config-global--color-primary-default;
+		$secondary      = ! empty( $colors_array ) && $colors_array['colors'] ? $colors_array['colors']['fg1'] : $default_colors['secondary'];  // $config-global--color-secondary-default;
+		$tertiary       = ! empty( $colors_array ) && $colors_array['colors'] ? $colors_array['colors']['fg2'] : $default_colors['tertiary'];   // $config-global--color-tertiary-default;
+		$foreground     = ! empty( $colors_array ) && $colors_array['colors'] ? $colors_array['colors']['txt'] : $default_colors['foreground'];  // $config-global--color-foreground-default;
+		$background     = ! empty( $colors_array ) && $colors_array['colors'] ? $colors_array['colors']['bg'] : $default_colors['background'];   // $config-global--color-background-default;
 
 		$editor_colors_array = array(
 			array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change imposes a stricter check for using values provided in the
$colors_array.  This was causing empty values from being used instead of
the provided defaults.

This can be reproduced on any Varia-based theme on .com that hasn't made modifications for that theme.  Once modifications are made the issue cannot be reproduced.

#### Related issue(s):

This fixes #3231