### PR TITLE
Filter colors for Seedlet child themes

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -67,6 +67,20 @@ endif;
 add_action( 'after_setup_theme', 'blank_canvas_setup', 11 );
 
 /**
+ * Filter the colors for Blank Canvas
+ */
+function blank_canvas_colors() {
+	return array(
+		array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
+		array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
+		array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
+		array( '--global--color-secondary', '#007cba', __( 'Secondary Color', 'seedlet' ) ),
+		array( '--global--color-tertiary', '#FAFAFA', __( 'Tertiary Color', 'seedlet' ) ),
+	);
+}
+add_filter( 'seedlet_colors', 'blank_canvas_colors' );
+
+/**
  * Remove Seedlet theme features.
  */
 function blank_canvas_remove_parent_theme_features() {

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -20,7 +20,7 @@ class Seedlet_Custom_Colors {
 		/**
 		 * Define color variables
 		 */
-		$this->seedlet_custom_color_variables = array(
+		$seedlet_colors                       = array(
 			array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
 			array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
 			array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
@@ -28,6 +28,7 @@ class Seedlet_Custom_Colors {
 			array( '--global--color-tertiary', '#FAFBF6', __( 'Tertiary Color', 'seedlet' ) ),
 			array( '--global--color-border', '#EFEFEF', __( 'Borders Color', 'seedlet' ) ),
 		);
+		$this->seedlet_custom_color_variables = apply_filters( 'seedlet_colors', $seedlet_colors );
 
 		/**
 		 * Register Customizer actions

--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -95,11 +95,24 @@ if ( ! function_exists( 'spearhead_setup' ) ) :
 				),
 			)
 		);
+
 		remove_filter( 'excerpt_more', 'seedlet_continue_reading_link' );
 		remove_filter( 'the_content_more_link', 'seedlet_continue_reading_link' );
 	}
 endif;
 add_action( 'after_setup_theme', 'spearhead_setup', 12 );
+
+/**
+ * Filter the colors for Speahead
+ */
+function spearhead_colors() {
+	return array(
+		array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
+		array( '--global--color-foreground', '#000000', __( 'Foreground Color', 'seedlet' ) ),
+		array( '--global--color-primary', '#DB0042', __( 'Primary Color', 'seedlet' ) ),
+	);
+}
+add_filter( 'seedlet_colors', 'spearhead_colors' );
 
 /**
  * Filter the content_width in pixels, based on the child-theme's design and stylesheet.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds a filter to the colors for Seedlet colors customizations, so that child themes can hook into them and modify them.

To test look at Spearhead and Blank Canvas in the customizer in a .org install and confirm that you can see the correct colors.

#### Related issue(s):
Fixes #3016