### PR TITLE
Add experimental theme.json to seedlet

### DIFF
--- a/seedlet/experimental-theme.json
+++ b/seedlet/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"global": {
+		"styles": {
+			"color": {
+				"link": "var( --global--color-primary )"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This change adds the experimental-theme.json to seedlet so that it can
properly style a link color in the Block Editor.

This JSON structure is correct for Gutenberg < 9.9 and will need to be
updated.

An un-styled link color:
![image](https://user-images.githubusercontent.com/146530/107971701-cc5bd700-6f80-11eb-8db0-396bd7ea08fc.png)

A styled link color:
![image](https://user-images.githubusercontent.com/146530/107971761-e1d10100-6f80-11eb-8a13-7ed57fed1374.png)

Fixes #3243 