### PR TITLE
Update/3243 seedlet link color (refactor theme.json)

### DIFF
--- a/seedlet/experimental-theme.json
+++ b/seedlet/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"global": {
+		"styles": {
+			"color": {
+				"link": "var( --global--color-primary )"
+			}
+		}
+	}
+}

--- a/seedlet/experimental-theme.json
+++ b/seedlet/experimental-theme.json
@@ -1,6 +1,6 @@
 {
-	"global": {
-		"styles": {
+	"styles": {
+		"root": {
 			"color": {
 				"link": "var( --global--color-primary )"
 			}


### PR DESCRIPTION
Refactored the experimental-theme.json introduced in #3271 to fix #3243 to fit the structure for the
change as of Gutenberg 9.9