### PR TITLE
Blank Canvas: Add auto-loading-homepage tag

### DIFF
--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: blank-canvas
-Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready
+Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready, auto-loading-homepage
 
 Blank Canvas WordPress Theme, (C) 2021 Automattic, Inc.
 Blank Canvas is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Add the `auto-loading-homepage` tag to Blank Canvas theme.

This theme is presented as having auto-loading-homepage functionality and has the corresponding options on theme switching.  However the theme switching homepage options don't work as expected due to the lack of this tag.

#### Related issue(s):
related https://github.com/Automattic/wp-calypso/issues/49317