### PR TITLE
Alto Focus: Update editor styles

### DIFF
--- a/altofocus/assets/stylesheets/editor-blocks.css
+++ b/altofocus/assets/stylesheets/editor-blocks.css
@@ -19,7 +19,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 1.0 General Typography
 --------------------------------------------------------------*/
 
-.edit-post-visual-editor .block-editor-block-list__block,
+.block-editor-block-list__block,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-size: 13.875px;
 	font-family: "Libre Baskerville", "Georgia", Georgia, "Times New Roman", Times, serif;
@@ -27,15 +27,15 @@ Description: Used to style Gutenberg Blocks in the editor.
 	line-height: 1.75em;
 }
 
-.edit-post-visual-editor .block-editor-block-list__block {
+.block-editor-block-list__block {
 	color: #111;
 }
 
-.edit-post-visual-editor .block-editor-block-list__block p {
+.block-editor-block-list__block p {
 	font-size: 13.875px;
 }
 
-.edit-post-visual-editor .block-editor-block-list__block p:not(:last-child) {
+.block-editor-block-list__block p:not(:last-child) {
 	margin-bottom: 1.75em
 }
 
@@ -92,8 +92,8 @@ Description: Used to style Gutenberg Blocks in the editor.
 }
 
 @media screen and (min-width: 37.5em) {
-	.edit-post-visual-editor .block-editor-block-list__block,
-	.edit-post-visual-editor .block-editor-block-list__block p,
+	.block-editor-block-list__block,
+	.block-editor-block-list__block p,
 	.editor-default-block-appender textarea.editor-default-block-appender__content  {
 		font-size: 16.875px;
 	}
@@ -155,7 +155,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 
 /* Link styles */
 
-.edit-post-visual-editor a,
+a,
 .block-editor-block-list__block a,
 .wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #e38900;
@@ -272,32 +272,32 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* List */
 
-.edit-post-visual-editor ul:not(.wp-block-gallery),
+ul:not(.wp-block-gallery),
 .block-editor-block-list__block ul:not(.wp-block-gallery),
 .block-library-list ul {
 	list-style: disc;
 }
 
-.edit-post-visual-editor ol,
+ol,
 .block-editor-block-list__block ol,
 .block-library-list ol.editor-rich-text__tinymce {
 	list-style: decimal;
 }
 
-.edit-post-visual-editor ul:not(.wp-block-gallery) li > ul,
+ul:not(.wp-block-gallery) li > ul,
 .block-editor-block-list__block ul:not(.wp-block-gallery) li > ul,
 .block-library-list li > ul,
-.edit-post-visual-editor li > ol,
+li > ol,
 .block-editor-block-list__block li > ol,
 .block-library-list li > ol {
 	margin-bottom: 0;
 	margin-left: 1.5em;
 }
 
-.rtl .edit-post-visual-editor ul:not(.wp-block-gallery),
+.rtl ul:not(.wp-block-gallery),
 .rtl .block-editor-block-list__block ul:not(.wp-block-gallery),
 .rtl .block-library-list ul,
-.rtl .edit-post-visual-editor ol,
+.rtl ol,
 .rtl .block-editor-block-list__block ol,
 .rtl .block-library-list ol.editor-rich-text__tinymce {
 	margin-left: 0;
@@ -332,7 +332,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Cover */
 
-.edit-post-visual-editor .block-editor-block-list__block p.wp-block-cover-text {
+.block-editor-block-list__block p.wp-block-cover-text {
 	font-size: 24px;
 }
 
@@ -500,9 +500,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 	list-style: disc;
 }
 
-.edit-post-visual-editor [data-align="center"] .wp-block-categories__list,
-.edit-post-visual-editor [data-align="center"] .wp-block-archives,
-.edit-post-visual-editor [data-align="center"] .wp-block-lastest-posts {
+[data-align="center"] .wp-block-categories__list,
+[data-align="center"] .wp-block-archives,
+[data-align="center"] .wp-block-lastest-posts {
 	list-style-position: inside;
 }
 

--- a/altofocus/assets/stylesheets/editor-blocks.css
+++ b/altofocus/assets/stylesheets/editor-blocks.css
@@ -10,9 +10,8 @@ Description: Used to style Gutenberg Blocks in the editor.
 2.0 General Block Styles
 3.0 Blocks - Common Blocks
 4.0 Blocks - Formatting
-5.0 Blocks - Layout Elements
-6.0 Blocks - Widgets
-7.0 Blocks - Animations
+5.0 Blocks - Widgets
+6.0 Blocks - Layout Elements
 --------------------------------------------------------------*/
 
 /*--------------------------------------------------------------
@@ -446,7 +445,34 @@ li > ol,
 }
 
 /*--------------------------------------------------------------
-5.0 Blocks - Layout Elements
+5.0 Blocks - Widgets
+--------------------------------------------------------------*/
+
+.wp-block-archives ul,
+.wp-block-categories ul,
+.wp-block-categories ul ul,
+.wp-block-latest-posts ul {
+	list-style: disc;
+}
+
+[data-align="center"] .wp-block-categories__list,
+[data-align="center"] .wp-block-archives,
+[data-align="center"] .wp-block-lastest-posts {
+	list-style-position: inside;
+}
+
+.wp-block-archives li,
+.wp-block-categories li,
+.wp-block-latest-posts li {
+	margin-bottom: 0;
+}
+
+.wp-block-latest-posts.is-grid {
+	list-style: none;
+}
+
+/*--------------------------------------------------------------
+6.0 Blocks - Layout Elements
 --------------------------------------------------------------*/
 
 /* Button */
@@ -487,96 +513,4 @@ li > ol,
 	background-color: #ccc;
 	border: 0;
 	height: 1px;
-}
-
-/*--------------------------------------------------------------
-6.0 Blocks - Widgets
---------------------------------------------------------------*/
-
-.editor-styles-wrapper .wp-block-archives ul,
-.editor-styles-wrapper .wp-block-categories ul,
-.editor-styles-wrapper .wp-block-categories ul ul,
-.editor-styles-wrapper .wp-block-latest-posts ul {
-	list-style: disc;
-}
-
-[data-align="center"] .wp-block-categories__list,
-[data-align="center"] .wp-block-archives,
-[data-align="center"] .wp-block-lastest-posts {
-	list-style-position: inside;
-}
-
-.editor-styles-wrapper .wp-block-archives li,
-.editor-styles-wrapper .wp-block-categories li,
-.editor-styles-wrapper .wp-block-latest-posts li {
-	margin-bottom: 0;
-}
-
-.editor-styles-wrapper .wp-block-latest-posts.is-grid {
-	list-style: none;
-}
-
-/*--------------------------------------------------------------
-7.0 Blocks - Animations
---------------------------------------------------------------*/
-
-@-webkit-keyframes bounce-reveal {
-	0%,
-	100% {
-		-webkit-transform: scale(1);
-		transform: scale(1);
-	}
-	33% {
-		-webkit-transform: scale(1.1);
-		transform: scale(1.1);
-	}
-	66% {
-		-webkit-transform: scale(0.9);
-		transform: scale(0.9);
-	}
-}
-
-@-moz-keyframes bounce-reveal {
-	0%,
-	100% {
-		-moz-transform: scale(1);
-		transform: scale(1);
-	}
-	33% {
-		-moz-transform: scale(1.1);
-		transform: scale(1.1);
-	}
-	66% {
-		-moz-transform: scale(0.9);
-		transform: scale(0.9);
-	}
-}
-
-@-o-keyframes bounce-reveal {
-	0%,
-	100% {
-		-o-transform: scale(1);
-		transform: scale(1);
-	}
-	33% {
-		-o-transform: scale(1.1);
-		transform: scale(1.1);
-	}
-	66% {
-		-o-transform: scale(0.9);
-		transform: scale(0.9);
-	}
-}
-
-@keyframes bounce-reveal {
-	0%,
-	100% {
-		transform: scale(1);
-	}
-	33% {
-		transform: scale(1.1);
-	}
-	66% {
-		transform: scale(0.9);
-	}
 }

--- a/altofocus/assets/stylesheets/editor-blocks.css
+++ b/altofocus/assets/stylesheets/editor-blocks.css
@@ -19,7 +19,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 1.0 General Typography
 --------------------------------------------------------------*/
 
-.edit-post-visual-editor .editor-block-list__block,
+.edit-post-visual-editor .block-editor-block-list__block,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-size: 13.875px;
 	font-family: "Libre Baskerville", "Georgia", Georgia, "Times New Roman", Times, serif;
@@ -27,15 +27,15 @@ Description: Used to style Gutenberg Blocks in the editor.
 	line-height: 1.75em;
 }
 
-.edit-post-visual-editor .editor-block-list__block {
+.edit-post-visual-editor .block-editor-block-list__block {
 	color: #111;
 }
 
-.edit-post-visual-editor .editor-block-list__block p {
+.edit-post-visual-editor .block-editor-block-list__block p {
 	font-size: 13.875px;
 }
 
-.edit-post-visual-editor .editor-block-list__block p:not(:last-child) {
+.edit-post-visual-editor .block-editor-block-list__block p:not(:last-child) {
 	margin-bottom: 1.75em
 }
 
@@ -92,8 +92,8 @@ Description: Used to style Gutenberg Blocks in the editor.
 }
 
 @media screen and (min-width: 37.5em) {
-	.edit-post-visual-editor .editor-block-list__block,
-	.edit-post-visual-editor .editor-block-list__block p,
+	.edit-post-visual-editor .block-editor-block-list__block,
+	.edit-post-visual-editor .block-editor-block-list__block p,
 	.editor-default-block-appender textarea.editor-default-block-appender__content  {
 		font-size: 16.875px;
 	}
@@ -156,7 +156,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 /* Link styles */
 
 .edit-post-visual-editor a,
-.editor-block-list__block a,
+.block-editor-block-list__block a,
 .wp-block-freeform.block-library-rich-text__tinymce a {
 	color: #e38900;
 	text-decoration: none;
@@ -273,32 +273,32 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* List */
 
 .edit-post-visual-editor ul:not(.wp-block-gallery),
-.editor-block-list__block ul:not(.wp-block-gallery),
+.block-editor-block-list__block ul:not(.wp-block-gallery),
 .block-library-list ul {
 	list-style: disc;
 }
 
 .edit-post-visual-editor ol,
-.editor-block-list__block ol,
+.block-editor-block-list__block ol,
 .block-library-list ol.editor-rich-text__tinymce {
 	list-style: decimal;
 }
 
 .edit-post-visual-editor ul:not(.wp-block-gallery) li > ul,
-.editor-block-list__block ul:not(.wp-block-gallery) li > ul,
+.block-editor-block-list__block ul:not(.wp-block-gallery) li > ul,
 .block-library-list li > ul,
 .edit-post-visual-editor li > ol,
-.editor-block-list__block li > ol,
+.block-editor-block-list__block li > ol,
 .block-library-list li > ol {
 	margin-bottom: 0;
 	margin-left: 1.5em;
 }
 
 .rtl .edit-post-visual-editor ul:not(.wp-block-gallery),
-.rtl .editor-block-list__block ul:not(.wp-block-gallery),
+.rtl .block-editor-block-list__block ul:not(.wp-block-gallery),
 .rtl .block-library-list ul,
 .rtl .edit-post-visual-editor ol,
-.rtl .editor-block-list__block ol,
+.rtl .block-editor-block-list__block ol,
 .rtl .block-library-list ol.editor-rich-text__tinymce {
 	margin-left: 0;
 	margin-right: 1.5em;
@@ -332,7 +332,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Cover */
 
-.edit-post-visual-editor .editor-block-list__block p.wp-block-cover-text {
+.edit-post-visual-editor .block-editor-block-list__block p.wp-block-cover-text {
 	font-size: 24px;
 }
 
@@ -580,4 +580,3 @@ p.has-drop-cap:not(:focus)::first-letter {
 		transform: scale(0.9);
 	}
 }
-

--- a/altofocus/assets/stylesheets/style.scss
+++ b/altofocus/assets/stylesheets/style.scss
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.com/themes/altofocus/
 Author: Automattic, Inc
 Author URI: http://automattic.com
 Description: AltoFocus is a theme for photographers, artists, and other creative types in search of a simple and easy way to display their work.
-Version: 1.0.9-wpcom
+Version: 1.0.11-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: altofocus

--- a/altofocus/functions.php
+++ b/altofocus/functions.php
@@ -117,6 +117,12 @@ function altofocus_setup() {
 		),
 	) );
 
+	add_theme_support( 'editor-styles' );
+	add_editor_style( array(
+		altofocus_libre_baskerville_url(),
+		altofocus_karla_url(),
+		get_template_directory_uri() . '/assets/stylesheets/editor-blocks.css',
+	) );
 }
 endif;
 add_action( 'after_setup_theme', 'altofocus_setup' );
@@ -304,22 +310,6 @@ function altofocus_scripts() {
 	) );
 }
 add_action( 'wp_enqueue_scripts', 'altofocus_scripts' );
-
-/**
- * Enqueue editor styles for Gutenberg
- */
-function altofocus_block_editor_styles() {
-	// Block styles.
-	wp_enqueue_style( 'altofocus-block-editor-style', get_template_directory_uri() . '/assets/stylesheets/editor-blocks.css' );
-
-	// Libre Franklin font
-	wp_enqueue_style( 'altofocus-libre-baskerville', altofocus_libre_baskerville_url(), array(), null );
-
-	// Karla font
-	wp_enqueue_style( 'altofocus-karla', altofocus_karla_url(), array(), null );
-
-}
-add_action( 'enqueue_block_editor_assets', 'altofocus_block_editor_styles' );
 
 /**
  * Check whether the browser supports JavaScript

--- a/altofocus/functions.php
+++ b/altofocus/functions.php
@@ -119,9 +119,9 @@ function altofocus_setup() {
 
 	add_theme_support( 'editor-styles' );
 	add_editor_style( array(
+		get_template_directory_uri() . '/assets/stylesheets/editor-blocks.css',
 		altofocus_libre_baskerville_url(),
 		altofocus_karla_url(),
-		get_template_directory_uri() . '/assets/stylesheets/editor-blocks.css',
 	) );
 }
 endif;

--- a/altofocus/functions.php
+++ b/altofocus/functions.php
@@ -8,122 +8,143 @@
  */
 
 if ( ! function_exists( 'altofocus_setup' ) ) :
-/**
- * Sets up theme defaults and registers support for various WordPress features.
- *
- * Note that this function is hooked into the aftercomponentsetup_theme hook, which
- * runs before the init hook. The init hook is too late for some features, such
- * as indicating support for post thumbnails.
- */
-function altofocus_setup() {
-
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed in the /languages/ directory.
-	 * If you're building a theme based on components, use a find and replace
-	 * to change 'altofocus' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'altofocus', get_template_directory() . '/languages' );
-
-	// Add default posts and comments RSS feed links to head.
-	add_theme_support( 'automatic-feed-links' );
-
-	/*
-	 * Let WordPress manage the document title.
-	 * By adding theme support, we declare that this theme does not use a
-	 * hard-coded <title> tag in the document head, and expect WordPress to
-	 * provide it for us.
-	 */
-	add_theme_support( 'title-tag' );
-
-	/*
-	 * Enable support for Post Thumbnails on posts and pages.
-	 *
-	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-	 */
-	add_theme_support( 'post-thumbnails' );
-
-	add_image_size( 'altofocus-thumb-image', 640, 9999, false );
-	add_image_size( 'altofocus-post-featured-image', 1200, 800, false );
-
-	// This theme uses wp_nav_menu() in one location.
-	register_nav_menus( array(
-		'menu-1' => esc_html__( 'Top', 'altofocus' ),
-	) );
-
 	/**
-	 * Add support for core custom logo.
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the aftercomponentsetup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
 	 */
-	add_theme_support( 'custom-logo', array(
-		'height'      => 200,
-		'width'       => 200,
-		'flex-width'  => true,
-		'flex-height' => true,
-	) );
+	function altofocus_setup() {
 
-	/*
-	 * Switch default core markup for search form, comment form, and comments
-	 * to output valid HTML5.
-	 */
-	add_theme_support( 'html5', array(
-		'search-form',
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'caption',
-	) );
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed in the /languages/ directory.
+		 * If you're building a theme based on components, use a find and replace
+		 * to change 'altofocus' to the name of your theme in all the template files.
+		 */
+		load_theme_textdomain( 'altofocus', get_template_directory() . '/languages' );
 
-	// Set up the WordPress core custom background feature.
-	add_theme_support( 'custom-background', apply_filters( 'altofocus_custom_background_args', array(
-		'default-color'      => 'ffffff',
-		'default-image'      => '',
-		'default-position-x' => 'center',
-		'default-position-y' => 'center',
-		'default-repeat'     => 'no-repeat',
-		'default-attachment' => 'fixed',
-		'default-size'       => 'cover',
-		'wp-head-callback'   => 'altofocus_custom_background_cb'
-	) ) );
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
 
-	// Add support for responsive embeds.
-	add_theme_support( 'responsive-embeds' );
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
 
-	// Add support for custom color scheme.
-	add_theme_support( 'editor-color-palette', array(
-		array(
-			'name'  => esc_html__( 'Orange', 'altofocus' ),
-			'slug'  => 'orange',
-			'color' => '#e38900',
-		),
-		array(
-			'name'  => esc_html__( 'Dark Gray', 'altofocus' ),
-			'slug'  => 'dark-gray',
-			'color' => '#111',
-		),
-		array(
-			'name'  => esc_html__( 'Medium Gray', 'altofocus' ),
-			'slug'  => 'medium-gray',
-			'color' => '#888',
-		),
-		array(
-			'name'  => esc_html__( 'Light Gray', 'altofocus' ),
-			'slug'  => 'light-gray',
-			'color' => '#ccc',
-		),
-		array(
-			'name'  => esc_html__( 'White', 'altofocus' ),
-			'slug'  => 'white',
-			'color' => '#fff',
-		),
-	) );
+		/*
+		 * Enable support for Post Thumbnails on posts and pages.
+		 *
+		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+		 */
+		add_theme_support( 'post-thumbnails' );
 
-	add_theme_support( 'editor-styles' );
-	add_editor_style( array(
-		get_template_directory_uri() . '/assets/stylesheets/editor-blocks.css',
-		altofocus_libre_baskerville_url(),
-		altofocus_karla_url(),
-	) );
-}
+		add_image_size( 'altofocus-thumb-image', 640, 9999, false );
+		add_image_size( 'altofocus-post-featured-image', 1200, 800, false );
+
+		// This theme uses wp_nav_menu() in one location.
+		register_nav_menus(
+			array(
+				'menu-1' => esc_html__( 'Top', 'altofocus' ),
+			)
+		);
+
+		/**
+		 * Add support for core custom logo.
+		 */
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 200,
+				'width'       => 200,
+				'flex-width'  => true,
+				'flex-height' => true,
+			)
+		);
+
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support(
+			'html5',
+			array(
+				'search-form',
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'caption',
+			)
+		);
+
+		// Set up the WordPress core custom background feature.
+		add_theme_support(
+			'custom-background',
+			apply_filters(
+				'altofocus_custom_background_args',
+				array(
+					'default-color'      => 'ffffff',
+					'default-image'      => '',
+					'default-position-x' => 'center',
+					'default-position-y' => 'center',
+					'default-repeat'     => 'no-repeat',
+					'default-attachment' => 'fixed',
+					'default-size'       => 'cover',
+					'wp-head-callback'   => 'altofocus_custom_background_cb',
+				)
+			)
+		);
+
+		// Add support for responsive embeds.
+		add_theme_support( 'responsive-embeds' );
+
+		// Add support for custom color scheme.
+		add_theme_support(
+			'editor-color-palette',
+			array(
+				array(
+					'name'  => esc_html__( 'Orange', 'altofocus' ),
+					'slug'  => 'orange',
+					'color' => '#e38900',
+				),
+				array(
+					'name'  => esc_html__( 'Dark Gray', 'altofocus' ),
+					'slug'  => 'dark-gray',
+					'color' => '#111',
+				),
+				array(
+					'name'  => esc_html__( 'Medium Gray', 'altofocus' ),
+					'slug'  => 'medium-gray',
+					'color' => '#888',
+				),
+				array(
+					'name'  => esc_html__( 'Light Gray', 'altofocus' ),
+					'slug'  => 'light-gray',
+					'color' => '#ccc',
+				),
+				array(
+					'name'  => esc_html__( 'White', 'altofocus' ),
+					'slug'  => 'white',
+					'color' => '#fff',
+				),
+			)
+		);
+
+		add_theme_support( 'editor-styles' );
+		add_editor_style(
+			array(
+				'style.css',
+				'/assets/stylesheets/blocks.css',
+				'/assets/stylesheets/editor-blocks.css',
+				altofocus_libre_baskerville_url(),
+				altofocus_karla_url(),
+			)
+		);
+	}
 endif;
 add_action( 'after_setup_theme', 'altofocus_setup' );
 
@@ -136,7 +157,7 @@ add_action( 'after_setup_theme', 'altofocus_setup' );
  */
 function altofocus_content_width() {
 
-	$GLOBALS[ 'content_width' ] = apply_filters( 'altofocus_content_width', '770' );
+	$GLOBALS['content_width'] = apply_filters( 'altofocus_content_width', '770' );
 }
 add_action( 'after_setup_theme', 'altofocus_content_width', 0 );
 
@@ -147,15 +168,17 @@ add_action( 'after_setup_theme', 'altofocus_content_width', 0 );
  */
 function altofocus_widgets_init() {
 
-	register_sidebar( array(
-		'name'          => esc_html__( 'Footer', 'altofocus' ),
-		'id'            => 'sidebar-1',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
+	register_sidebar(
+		array(
+			'name'          => esc_html__( 'Footer', 'altofocus' ),
+			'id'            => 'sidebar-1',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		)
+	);
 }
 add_action( 'widgets_init', 'altofocus_widgets_init' );
 
@@ -298,16 +321,24 @@ function altofocus_scripts() {
 	}
 
 	// Screenreader text
-	wp_localize_script( 'altofocus-navigation', 'altoFocusScreenReaderText', array(
-		'expand'   => esc_html__( 'expand child menu', 'altofocus' ),
-		'collapse' => esc_html__( 'collapse child menu', 'altofocus' ),
-	) );
+	wp_localize_script(
+		'altofocus-navigation',
+		'altoFocusScreenReaderText',
+		array(
+			'expand'   => esc_html__( 'expand child menu', 'altofocus' ),
+			'collapse' => esc_html__( 'collapse child menu', 'altofocus' ),
+		)
+	);
 
 	// Flexslider text
-	wp_localize_script( 'altofocus-flexslider', 'altoFocusFlexSliderText', array(
-		'next'     => esc_html__( 'Next', 'altofocus' ),
-		'previous' => esc_html__( 'Previous', 'altofocus' ),
-	) );
+	wp_localize_script(
+		'altofocus-flexslider',
+		'altoFocusFlexSliderText',
+		array(
+			'next'     => esc_html__( 'Next', 'altofocus' ),
+			'previous' => esc_html__( 'Previous', 'altofocus' ),
+		)
+	);
 }
 add_action( 'wp_enqueue_scripts', 'altofocus_scripts' );
 
@@ -315,7 +346,7 @@ add_action( 'wp_enqueue_scripts', 'altofocus_scripts' );
  * Check whether the browser supports JavaScript
  */
 function altofocus_html_js_class() {
-	echo '<script>document.documentElement.className = document.documentElement.className.replace("no-js","js");</script>'. "\n";
+	echo '<script>document.documentElement.className = document.documentElement.className.replace("no-js","js");</script>' . "\n";
 }
 add_action( 'wp_head', 'altofocus_html_js_class', 1 );
 

--- a/altofocus/style.css
+++ b/altofocus/style.css
@@ -5,7 +5,7 @@ Theme URI: https://wordpress.com/themes/altofocus/
 Author: Automattic, Inc
 Author URI: http://automattic.com
 Description: AltoFocus is a theme for photographers, artists, and other creative types in search of a simple and easy way to display their work.
-Version: 1.0.10-wpcom
+Version: 1.0.11-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: altofocus
@@ -3024,7 +3024,6 @@ body {
   float: left;
   top: 100%;
 }
-
 #infinite-handle span {
   background: transparent;
   display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds theme support for editor styles and updates the editor styles so that the frontend and the editor match. Ideally we wouldn't need editor styles at all, but there's no consistent way to target editor content at the moment.

#### Related issue(s):
Part of #3280