### PR TITLE
Add filter to change bundled google fonts in assorted themes.

### DIFF
--- a/affinity/functions.php
+++ b/affinity/functions.php
@@ -248,6 +248,13 @@ function affinity_fonts_url() {
 			$font_families[] = 'Lora:400,400italic,700,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/alves/functions.php
+++ b/alves/functions.php
@@ -186,6 +186,13 @@ function alves_fonts_url() {
 			$font_families[] = 'Karla:400,700,400italic,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/apostrophe-2/functions.php
+++ b/apostrophe-2/functions.php
@@ -246,6 +246,13 @@ function apostrophe_2_fonts_url() {
 			$font_families[] = 'Open Sans:300,300italic,400,400italic,600,600italic,700,700italic,800,800italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext,cyrillic' ),

--- a/balasana/functions.php
+++ b/balasana/functions.php
@@ -157,6 +157,13 @@ function balasana_fonts_url() {
 			$font_families[] = 'Roboto:400,400i,700,700i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/barnsbury/functions.php
+++ b/barnsbury/functions.php
@@ -140,6 +140,13 @@ function barnsbury_fonts_url() {
 			$font_families[] = 'Rubik:400,700,400italic,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/brompton/functions.php
+++ b/brompton/functions.php
@@ -161,6 +161,13 @@ function brompton_fonts_url() {
 			$font_families[] = 'Nunito Sans:400,400i,700,700i,900,900i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/button-2/functions.php
+++ b/button-2/functions.php
@@ -232,6 +232,13 @@ function button_2_fonts_url() {
 			$font_families[] = 'Lora:400italic,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/calm-business/functions.php
+++ b/calm-business/functions.php
@@ -84,6 +84,13 @@ function calm_business_fonts_url() {
 			$font_families[] = 'Poppins:400,400i,600,600i,700,700i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/coutoire/functions.php
+++ b/coutoire/functions.php
@@ -145,6 +145,13 @@ function coutoire_fonts_url() {
 			$font_families[] = 'EB Garamond:400,400i,600';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -157,6 +157,13 @@ function dalston_fonts_url() {
 			$font_families[] = 'Crimson Text:400,600,700,400italic,600italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/dara/functions.php
+++ b/dara/functions.php
@@ -220,6 +220,14 @@ function dara_fonts_url() {
 		if ( 'off' !== $yrsa ) {
 			$font_families[] = 'Yrsa:300,400,700';
 		}
+
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/dyad-2/functions.php
+++ b/dyad-2/functions.php
@@ -287,6 +287,13 @@ function dyad_2_fonts_url() {
 			$font_families[] = 'Noto Serif:400,400italic,700,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/elegant-business/functions.php
+++ b/elegant-business/functions.php
@@ -115,6 +115,13 @@ function elegant_business_fonts_url() {
 			$font_families[] = 'Source Serif Pro:400,700,400italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/exford/functions.php
+++ b/exford/functions.php
@@ -148,6 +148,13 @@ function exford_fonts_url() {
 			$font_families[] = 'Source Sans Pro:400,700,400i,700i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/friendly-business/functions.php
+++ b/friendly-business/functions.php
@@ -85,6 +85,13 @@ function friendly_business_fonts_url() {
 			$font_families[] = 'Rubik:400,700,400italic,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/hever/functions.php
+++ b/hever/functions.php
@@ -108,6 +108,13 @@ function hever_fonts_url() {
 
 		$font_families[] = 'PT Sans:400,400i,700,700i';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family'  => urlencode( implode( '|', $font_families ) ),
 			'subset'  => urlencode( 'latin,latin-ext' ),

--- a/ibis/functions.php
+++ b/ibis/functions.php
@@ -47,6 +47,13 @@ function ibis_fonts_url() {
 
 		$font_families[] = 'Lora:400,400i,600,600i,700,700i';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/intergalactic-2/functions.php
+++ b/intergalactic-2/functions.php
@@ -255,6 +255,13 @@ function intergalactic_2_fonts_url() {
 		$font_families   = array();
 		$font_families[] = 'Lato:300,400,700,300italic,400italic,700italic&subset=latin,latin-ext';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/karuna/functions.php
+++ b/karuna/functions.php
@@ -299,6 +299,13 @@ function karuna_fonts_url() {
 		$font_families   = array();
 		$font_families[] = 'Karla:400,400italic,700,700italic';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/leven/functions.php
+++ b/leven/functions.php
@@ -142,6 +142,13 @@ function leven_fonts_url() {
 			$font_families[] = 'Crimson Text:400,400i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/libre-2/functions.php
+++ b/libre-2/functions.php
@@ -201,6 +201,13 @@ function libre_2_fonts_url() {
 		$font_families   = array();
 		$font_families[] = 'Libre Baskerville:400,400italic,700';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/libretto/functions.php
+++ b/libretto/functions.php
@@ -259,6 +259,13 @@ function libretto_fonts_url() {
 			$font_families[] = 'Droid Sans Mono:400';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/lodestar/functions.php
+++ b/lodestar/functions.php
@@ -172,6 +172,13 @@ function lodestar_fonts_url() {
 			$font_families[] = 'Karla:400,400italic,700,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/mayland/functions.php
+++ b/mayland/functions.php
@@ -138,6 +138,13 @@ function mayland_fonts_url() {
 
 		$font_families[] = 'Poppins:400,400i,600,600i';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/maywood/functions.php
+++ b/maywood/functions.php
@@ -137,6 +137,13 @@ function maywood_fonts_url() {
 
 		$font_families[] = 'IBM Plex Sans:300,300i,500,500i,700';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/modern-business/functions.php
+++ b/modern-business/functions.php
@@ -79,6 +79,14 @@ function modern_business_fonts_url() {
 		if ( 'off' !== $font ) {
 			$font_families[] = 'IBM Plex Sans:300,300i,500,700';
 		}
+
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/morden/functions.php
+++ b/morden/functions.php
@@ -107,6 +107,13 @@ function morden_fonts_url() {
 
 		$font_families[] = 'Noto Sans:400,400i,700,700i';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/penscratch-2/functions.php
+++ b/penscratch-2/functions.php
@@ -250,6 +250,13 @@ function penscratch_2_fonts_url() {
 		$font_families   = array();
 		$font_families[] = 'Roboto Slab:300,400,700';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/pique/functions.php
+++ b/pique/functions.php
@@ -259,6 +259,13 @@ function pique_fonts_url() {
 			$font_families[] = 'Karla:400,700,400italic,700italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/professional-business/functions.php
+++ b/professional-business/functions.php
@@ -84,6 +84,13 @@ function professional_business_fonts_url() {
 			$font_families[] = 'Crimson Text:400,600,700,400italic,600italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/rebalance/functions.php
+++ b/rebalance/functions.php
@@ -226,6 +226,13 @@ function rebalance_fonts_url() {
 			$font_families[] = 'Libre Baskerville:700,900,400italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/rivington/functions.php
+++ b/rivington/functions.php
@@ -146,6 +146,13 @@ function rivington_fonts_url() {
 
 		$font_families[] = 'Poppins:400,400i,600,600i';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/rockfield/functions.php
+++ b/rockfield/functions.php
@@ -108,6 +108,13 @@ function rockfield_fonts_url() {
 			$font_families[] = 'Lora:400,400i,700,700i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/scratchpad/functions.php
+++ b/scratchpad/functions.php
@@ -303,6 +303,13 @@ function scratchpad_fonts_url() {
 			$font_families[] = 'Kalam:400,700';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -305,6 +305,13 @@ function seedlet_fonts_url() {
 			$font_families[] = 'Playfair Display:ital,wght@0,400;0,700;1,400';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/shawburn/functions.php
+++ b/shawburn/functions.php
@@ -108,6 +108,13 @@ function shawburn_fonts_url() {
 			$font_families[] = 'PT Serif:400,400i,700,700i';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/sketch/functions.php
+++ b/sketch/functions.php
@@ -241,6 +241,13 @@ function sketch_fonts_url() {
 		$font_families   = array();
 		$font_families[] = 'Lato:300,400,700,300italic,400italic,700italic';
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/sophisticated-business/functions.php
+++ b/sophisticated-business/functions.php
@@ -87,6 +87,13 @@ function sophisticated_business_fonts_url() {
 			$font_families[] = 'Poppins:400,600,700,400italic,600italic';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/stow/functions.php
+++ b/stow/functions.php
@@ -119,6 +119,14 @@ function stow_fonts_url() {
 		if ( 'off' !== $oswald ) {
 			$font_families[] = 'Oswald:300,400';
 		}
+
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/stratford/functions.php
+++ b/stratford/functions.php
@@ -120,6 +120,13 @@ function stratford_fonts_url() {
 			$font_families[] = 'Inconsolata:400,700';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),

--- a/toujours/functions.php
+++ b/toujours/functions.php
@@ -312,6 +312,13 @@ function toujours_fonts_url() {
 			$font_families[] = 'Merriweather:700italic,400,400italic,700,600';
 		}
 
+		/**
+		 * A filter to enable child themes to add/change/omit font families.
+		 * 
+		 * @param array $font_families An array of font families to be imploded for the Google Font API
+		 */
+		$font_families = apply_filters( 'included_google_font_families', $font_families );
+
 		$query_args = array(
 			'family' => urlencode( implode( '|', $font_families ) ),
 			'subset' => urlencode( 'latin,latin-ext' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Initially intended as a part-fix for #3134 to enable child themes to swap typefaces that get included more easily, this also extends that change across to many themes using the common patterns.

#### It explicitly does not change the following themes:

* spearhead (uses different endpoint and method and is already a child theme)

And the following themes that have multiple functions that generate typeface includes so as to avoid confusion:

* canard
* gazette
* illustratr
* publication


#### Related issue(s): #3134
