### PR TITLE
Blank Canvas: Clarify comments setting title & description

### DIFF
--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 				'show_comments',
 				array(
 					'label'       => esc_html__( 'Make comments visible', 'blank-canvas' ),
-					'description' => esc_html__( 'Check to show comments underneath posts. Comments can be configured in "Settings > Discussion".', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show comments underneath posts. Comments can be configured in your site’s Discussion settings screen.', 'blank-canvas' ),
 					'section'     => 'jetpack_content_options',
 					'priority'    => 10,
 					'type'        => 'checkbox',

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 				'show_comments',
 				array(
 					'label'       => esc_html__( 'Make comments visible', 'blank-canvas' ),
-					'description' => esc_html__( 'Check to show comments underneath posts. Comments can be configured in your site’s Discussion settings screen.', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show comments underneath posts and pages. Comments can be configured in your site’s Discussion settings screen.', 'blank-canvas' ),
 					'section'     => 'jetpack_content_options',
 					'priority'    => 10,
 					'type'        => 'checkbox',

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -134,8 +134,8 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 			$wp_customize->add_control(
 				'show_comments',
 				array(
-					'label'       => esc_html__( 'Enable comments', 'blank-canvas' ),
-					'description' => esc_html__( "Check to show comments underneath each post.", 'blank-canvas' ),
+					'label'       => esc_html__( 'Make comments visible', 'blank-canvas' ),
+					'description' => esc_html__( 'Check to show comments underneath posts. Comments can be configured in "Settings > Discussion".', 'blank-canvas' ),
 					'section'     => 'jetpack_content_options',
 					'priority'    => 10,
 					'type'        => 'checkbox',


### PR DESCRIPTION
Another followup from the .org theme review. It was suggested that we [clarify the wording](https://themes.trac.wordpress.org/ticket/94482#comment:9) of our comments option so it doesn't clash with the default comments settings. 

Before|After
---|---
![Screen Shot 2021-02-19 at 10 45 13 AM](https://user-images.githubusercontent.com/1202812/108526808-929c1080-729f-11eb-8660-0f7675332cce.png)|![Screen Shot 2021-02-19 at 10 51 00 AM](https://user-images.githubusercontent.com/1202812/108527530-60d77980-72a0-11eb-9153-02451b683e85.png)
