### PR TITLE
Varia: fix button styles leaking into editor

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: #ffffff;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 48px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
 	background-color: #2f5f74;
@@ -1694,7 +1686,6 @@ p:not(.site-title) a:hover {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1711,10 +1702,8 @@ p:not(.site-title) a:hover {
 	padding: 16px 48px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1722,24 +1711,19 @@ p:not(.site-title) a:hover {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
 	background-color: #2f5f74;

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 48px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1710,7 +1710,7 @@ p:not(.site-title) a:hover {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1728,10 +1728,10 @@ p:not(.site-title) a:hover {
 	padding: 16px 48px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1741,27 +1741,27 @@ p:not(.site-title) a:hover {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 48px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;
@@ -1710,7 +1694,6 @@ p:not(.site-title) a:hover {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1728,11 +1711,9 @@ p:not(.site-title) a:hover {
 	padding: 16px 48px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1741,28 +1722,23 @@ p:not(.site-title) a:hover {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: #ffffff;

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #FFFFFF;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;
 	background-color: #145f3e;

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 18px 18px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #FFFDF6;
@@ -481,10 +480,8 @@ object {
 	padding: 18px 18px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
 	background-color: #133a24;

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 18px 18px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #E8E4DD;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #E8E4DD;
 	background-color: #C04239;

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #E8E4DD;

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -482,12 +482,12 @@ input[type="submit"],
 	padding: 11.6px 11.6px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -497,32 +497,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #FFFFFF;
@@ -480,10 +479,8 @@ object {
 	padding: 11.6px 11.6px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -491,24 +488,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;
 	background-color: #FF7A5C;

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -482,13 +480,9 @@ input[type="submit"],
 	padding: 11.6px 11.6px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -497,33 +491,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/package-lock.json
+++ b/dalston/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/sass/style-child-theme.scss
+++ b/dalston/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #FFFFFF;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;
 	background-color: #005177;

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #195f2b;
@@ -1695,7 +1687,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1712,10 +1703,8 @@ pre.wp-block-verse {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1723,24 +1712,19 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #195f2b;

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
@@ -1711,7 +1695,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1729,11 +1712,9 @@ pre.wp-block-verse {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1742,28 +1723,23 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1711,7 +1711,7 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1729,10 +1729,10 @@ pre.wp-block-verse {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1742,27 +1742,27 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -491,8 +491,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -510,12 +510,12 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -525,32 +525,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1698,7 +1698,7 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1716,10 +1716,10 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1729,27 +1729,27 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -491,9 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -510,13 +508,9 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -525,33 +519,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
@@ -1698,7 +1682,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1716,11 +1699,9 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1729,28 +1710,23 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -491,8 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -508,10 +507,8 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -519,24 +516,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);
@@ -1682,7 +1674,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1699,10 +1690,8 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1710,24 +1699,19 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: white;

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: white;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: white;
 	background-color: #1285ce;

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: white;

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: white;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: white;
 	background-color: #666666;

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -479,8 +479,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: white;
@@ -496,10 +495,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -507,24 +504,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #685636;
@@ -1745,7 +1737,6 @@ b, strong {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1762,10 +1753,8 @@ b, strong {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1773,24 +1762,19 @@ b, strong {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
 	background-color: #685636;

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -479,9 +479,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -498,13 +496,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -513,33 +507,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
@@ -1761,7 +1745,6 @@ b, strong {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1779,11 +1762,9 @@ b, strong {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1792,28 +1773,23 @@ b, strong {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -479,8 +479,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -498,12 +498,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -513,32 +513,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1761,7 +1761,7 @@ b, strong {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1779,10 +1779,10 @@ b, strong {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1792,27 +1792,27 @@ b, strong {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -491,8 +491,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -510,12 +510,12 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -525,32 +525,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1701,7 +1701,7 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1719,10 +1719,10 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1732,27 +1732,27 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -491,9 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -510,13 +508,9 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -525,33 +519,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
@@ -1701,7 +1685,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1719,11 +1702,9 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1732,28 +1713,23 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -491,8 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -508,10 +507,8 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -519,24 +516,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);
@@ -1685,7 +1677,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1702,10 +1693,8 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1713,24 +1702,19 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -476,8 +476,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: #FFFFFF;
@@ -493,10 +492,8 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -504,24 +501,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;
 	background-color: #222222;

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -476,9 +476,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -495,13 +493,9 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -510,33 +504,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #FFFFFF;

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -476,8 +476,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -495,12 +495,12 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -510,32 +510,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -464,8 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1.15;
 	color: #060f29;
@@ -481,10 +480,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -492,24 +489,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.195em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.185em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #060f29;
 	background-color: #b59439;

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -464,9 +464,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1.15;
@@ -483,13 +481,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -498,33 +492,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.195em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.185em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: #060f29;

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -464,8 +464,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -483,12 +483,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -498,32 +498,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.195em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.185em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.5
+Version: 1.3.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -488,9 +488,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
@@ -507,13 +505,9 @@ input[type="submit"],
 	padding: 16px 20px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -522,33 +516,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: var(--wp--preset--color--background);

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -488,8 +488,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -507,12 +507,12 @@ input[type="submit"],
 	padding: 16px 20px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -522,32 +522,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -488,8 +488,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -505,10 +504,8 @@ object {
 	padding: 16px 20px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -516,24 +513,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -492,9 +492,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -511,13 +509,9 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -526,33 +520,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
@@ -1701,7 +1685,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1719,11 +1702,9 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1732,28 +1713,23 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -492,8 +492,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -511,12 +511,12 @@ input[type="submit"],
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -526,32 +526,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1701,7 +1701,7 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1719,10 +1719,10 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1732,27 +1732,27 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -492,8 +492,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -509,10 +508,8 @@ object {
 	padding: 16px 24px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -520,24 +517,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);
@@ -1685,7 +1677,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1702,10 +1693,8 @@ pre.wp-block-verse {
 	padding: 16px 24px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1713,24 +1702,19 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -491,8 +491,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -510,12 +510,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -525,32 +525,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1834,7 +1834,7 @@ a {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1852,10 +1852,10 @@ a {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1865,27 +1865,27 @@ a {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -491,9 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -510,13 +508,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -525,33 +519,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
@@ -1834,7 +1818,6 @@ a {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1852,11 +1835,9 @@ a {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1865,28 +1846,23 @@ a {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -491,8 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -508,10 +507,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -519,24 +516,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--secondary-hover);
@@ -1818,7 +1810,6 @@ a {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -1835,10 +1826,8 @@ a {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
-.fse-template-part .main-navigation .wp-block-button__link:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
 	display: block;
@@ -1846,24 +1835,19 @@ a {
 	width: 0;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
-.fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
-.fse-template-part .main-navigation .has-focus.wp-block-button__link,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation .wp-block-button__link:focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--secondary-hover);

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.5
+Version: 1.5.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -491,8 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, input[type="submit"],
-.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button, .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1.44;
 	color: var(--wp--preset--color--background);
@@ -508,10 +507,8 @@ object {
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
 	display: block;
@@ -519,24 +516,19 @@ object {
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
-.wp-block-button__link:before,
+.wp-block-a8c-blog-posts + .button:before, .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.34em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
-.wp-block-button__link:after,
+.wp-block-a8c-blog-posts + .button:after, .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.33em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
-.wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, .wp-block-button__link:not(.has-background):hover,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, .wp-block-button__link:focus,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary);

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -491,8 +491,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
@@ -510,12 +510,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
@@ -525,32 +525,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.34em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.33em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -491,9 +491,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	line-height: 1.44;
@@ -510,13 +508,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	content: '';
@@ -525,33 +519,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before {
 	margin-bottom: -0.34em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after {
 	margin-top: -0.33em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button {
 	color: var(--wp--preset--color--background);

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.5
+Version: 1.4.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/varia/package-lock.json
+++ b/varia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.5.13",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/varia/sass/blocks/button/_editor.scss
+++ b/varia/sass/blocks/button/_editor.scss
@@ -1,7 +1,6 @@
 /**
  * Button
  */
-input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button {
 	// Extend button style

--- a/varia/sass/blocks/button/_editor.scss
+++ b/varia/sass/blocks/button/_editor.scss
@@ -1,14 +1,12 @@
 /**
  * Button
  */
-button:not(.components-button),
-.button:not(.components-button),
- input[type="submit"],
- .wp-block-button__link,
- .wp-block-file__button {
-	 // Extend button style
-	 @extend %button-style;
- }
+input[type="submit"],
+.wp-block-button__link,
+.wp-block-file__button {
+	// Extend button style
+	@extend %button-style;
+}
 
 /* Default Style */
 .wp-block-button__link {

--- a/varia/sass/blocks/button/_editor.scss
+++ b/varia/sass/blocks/button/_editor.scss
@@ -1,8 +1,8 @@
 /**
  * Button
  */
- button,
- .button,
+button:not(.components-button),
+.button:not(.components-button),
  input[type="submit"],
  .wp-block-button__link,
  .wp-block-file__button {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -125,8 +125,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -144,12 +144,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -159,32 +159,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -502,8 +502,8 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button,
-.button,
+.wp-block-a8c-blog-posts + .button, button:not(.components-button),
+.button:not(.components-button),
 input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -521,12 +521,12 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -536,32 +536,32 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:before,
-.button:before,
+.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
+.button:not(.components-button):before,
 input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:after,
-.button:after,
+.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
+.button:not(.components-button):after,
 input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-button:not(.has-background):hover,
-.button:not(.has-background):hover,
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
+.button:not(.has-background):hover:not(.components-button),
 input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, button:focus,
-.button:focus,
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
+.button:focus:not(.components-button),
 input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, button.has-focus,
-.has-focus.button,
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
+.has-focus.button:not(.components-button),
 input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
@@ -1651,7 +1651,7 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button,
+.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1669,10 +1669,10 @@ pre.wp-block-verse {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
@@ -1682,27 +1682,27 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:before,
+.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:after,
+.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover,
+.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus,
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
 .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus,
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
 .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -125,9 +125,7 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -144,13 +142,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -159,33 +153,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
@@ -502,9 +486,7 @@ object {
  *   let’s use a placeholder to keep them all
  *   in-sync
  */
-.wp-block-a8c-blog-posts + .button, button:not(.components-button),
-.button:not(.components-button),
-input[type="submit"],
+.wp-block-a8c-blog-posts + .button, input[type="submit"],
 .wp-block-button__link,
 .wp-block-file__button, .fse-template-part .main-navigation .button {
 	line-height: 1;
@@ -521,13 +503,9 @@ input[type="submit"],
 	padding: 16px 16px;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -536,33 +514,23 @@ input[type="submit"]:after,
 	width: 0;
 }
 
-.wp-block-a8c-blog-posts + .button:before, button:not(.components-button):before,
-.button:not(.components-button):before,
-input[type="submit"]:before,
+.wp-block-a8c-blog-posts + .button:before, input[type="submit"]:before,
 .wp-block-button__link:before,
 .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.wp-block-a8c-blog-posts + .button:after, button:not(.components-button):after,
-.button:not(.components-button):after,
-input[type="submit"]:after,
+.wp-block-a8c-blog-posts + .button:after, input[type="submit"]:after,
 .wp-block-button__link:after,
 .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.wp-block-a8c-blog-posts + .button:not(.has-background):hover, button:not(.has-background):hover:not(.components-button),
-.button:not(.has-background):hover:not(.components-button),
-input:not(.has-background):hover[type="submit"],
+.wp-block-a8c-blog-posts + .button:not(.has-background):hover, input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, button:focus:not(.components-button),
-.button:focus:not(.components-button),
-input:focus[type="submit"],
+.wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .wp-block-a8c-blog-posts + .button:focus, input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, button.has-focus:not(.components-button),
-.has-focus.button:not(.components-button),
-input.has-focus[type="submit"],
+.wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .wp-block-a8c-blog-posts + .has-focus.button, input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;
@@ -1651,7 +1619,6 @@ pre.wp-block-verse {
 	width: 100%;
 }
 
-.fse-template-part .main-navigation button:not(.components-button),
 .fse-template-part .main-navigation input[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link,
 .fse-template-part .main-navigation .wp-block-file__button, .fse-template-part .main-navigation .button {
@@ -1669,11 +1636,9 @@ pre.wp-block-verse {
 	padding: 16px 16px;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
-.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation button:not(.components-button):after,
-.fse-template-part .main-navigation input[type="submit"]:after,
+.fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before, .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	content: '';
@@ -1682,28 +1647,23 @@ pre.wp-block-verse {
 	width: 0;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):before,
 .fse-template-part .main-navigation input[type="submit"]:before,
 .fse-template-part .main-navigation .wp-block-button__link:before,
 .fse-template-part .main-navigation .wp-block-file__button:before, .fse-template-part .main-navigation .button:before {
 	margin-bottom: -0.12em;
 }
 
-.fse-template-part .main-navigation button:not(.components-button):after,
 .fse-template-part .main-navigation input[type="submit"]:after,
 .fse-template-part .main-navigation .wp-block-button__link:after,
 .fse-template-part .main-navigation .wp-block-file__button:after, .fse-template-part .main-navigation .button:after {
 	margin-top: -0.11em;
 }
 
-.fse-template-part .main-navigation button:not(.has-background):hover:not(.components-button),
 .fse-template-part .main-navigation input:not(.has-background):hover[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:not(.has-background):hover,
-.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation button:focus:not(.components-button),
-.fse-template-part .main-navigation input:focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:not(.has-background):hover, .fse-template-part .main-navigation .button:not(.has-background):hover, .fse-template-part .main-navigation input:focus[type="submit"],
 .fse-template-part .main-navigation .wp-block-button__link:focus,
-.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation button.has-focus:not(.components-button),
-.fse-template-part .main-navigation input.has-focus[type="submit"],
+.fse-template-part .main-navigation .wp-block-file__button:focus, .fse-template-part .main-navigation .button:focus, .fse-template-part .main-navigation input.has-focus[type="submit"],
 .fse-template-part .main-navigation .has-focus.wp-block-button__link,
 .fse-template-part .main-navigation .has-focus.wp-block-file__button, .fse-template-part .main-navigation .has-focus.button {
 	color: white;


### PR DESCRIPTION
This is a hotfix for https://github.com/Automattic/wp-calypso/issues/50332.

As a follow up I will also test https://github.com/WordPress/gutenberg/pull/29229 to see if it resolves the issue.

D57440-code

**To test**
- Check out this PR onto your sandbox
- Activate Hever or another Varia theme
- Verify the button styles don't leak into the editor UI