### PR TITLE
Add/varia experimental link color

### DIFF
--- a/hever/experimental-theme.json
+++ b/hever/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/hever/functions.php
+++ b/hever/functions.php
@@ -69,6 +69,9 @@ if ( ! function_exists( 'hever_setup' ) ) :
 		if ( function_exists( 'varia_mobile_nav_on_side_setup' ) ) {
 			varia_mobile_nav_on_side_setup();
 		}
+
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'hever_setup', 12 );

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.4.6",
+  "version": "1.5.6",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/experimental-theme.json
+++ b/morden/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/morden/functions.php
+++ b/morden/functions.php
@@ -68,6 +68,9 @@ if ( ! function_exists( 'morden_setup' ) ) :
 		if ( function_exists( 'varia_mobile_nav_on_side_setup' ) ) {
 			varia_mobile_nav_on_side_setup();
 		}
+
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'morden_setup', 12 );

--- a/rockfield/experimental-theme.json
+++ b/rockfield/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/rockfield/functions.php
+++ b/rockfield/functions.php
@@ -64,6 +64,8 @@ if ( ! function_exists( 'rockfield_setup' ) ) :
 			)
 		);
 
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'rockfield_setup', 12 );

--- a/shawburn/experimental-theme.json
+++ b/shawburn/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/shawburn/functions.php
+++ b/shawburn/functions.php
@@ -66,6 +66,9 @@ if ( ! function_exists( 'shawburn_setup' ) ) :
 
 		// Enable Full Site Editing
 		add_theme_support( 'full-site-editing' );
+
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'shawburn_setup', 12 );

--- a/stow/experimental-theme.json
+++ b/stow/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/stow/functions.php
+++ b/stow/functions.php
@@ -64,6 +64,8 @@ if ( ! function_exists( 'stow_setup' ) ) :
 			)
 		);
 
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'stow_setup', 12 );

--- a/stratford/experimental-theme.json
+++ b/stratford/experimental-theme.json
@@ -1,0 +1,9 @@
+{
+	"styles": {
+		"root": {
+			"color": {
+				"link": "var(--wp--preset--color--primary)"
+			}
+		}
+	}
+} 

--- a/stratford/functions.php
+++ b/stratford/functions.php
@@ -66,6 +66,9 @@ if ( ! function_exists( 'stratford_setup' ) ) :
 
 		// Remove footer menu
 		unregister_nav_menu( 'menu-2' );
+
+		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
+		add_theme_support( 'experimental-link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'stratford_setup', 12 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds Experimental Link Color to those Varia Themes that can support it (those with CSS variable-based color supports)

Hever, Morden, Rockfield, Shawburn, Stow, Stratford

#### Related issue(s):

Replaces #3255 as a fix for #2566 

#### Diff

D57442-code