### PR TITLE
Blank Canvas: Update license URI

### DIFF
--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -9,7 +9,7 @@ Tested up to: 5.6
 Requires PHP: 5.6.2
 Version: 1.2.4-wpcom
 License: GNU General Public License v2 or later
-License URI: LICENSE
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: seedlet
 Text Domain: blank-canvas
 Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready, auto-loading-homepage


### PR DESCRIPTION
Previously, this referred to a LICENSE file that didn't exist. Rather than add one, I've just added a link to the official license, [like Twenty Twenty-One does](https://themes.trac.wordpress.org/browser/twentytwentyone/1.1/style.css#L14). 