### PR TITLE
Seedlet: fix keyboard navigation selector

### DIFF
--- a/seedlet/assets/js/primary-navigation.js
+++ b/seedlet/assets/js/primary-navigation.js
@@ -39,7 +39,7 @@
 			} 
 			var modal, elements, selectors, lastEl, firstEl, activeEl, tabKey, shiftKey, escKey;
 
-			modal = document.querySelector( '.${ id }-navigation' );
+			modal = document.querySelector( '.' + id + '-navigation' );
 			selectors = "input, a, button";
 			elements = modal.querySelectorAll( selectors );
 			elements = Array.prototype.slice.call( elements );

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.11-wpcom
+Version: 1.1.12-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/package-lock.json
+++ b/seedlet/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.4",
+  "version": "1.1.11-wpcom",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/seedlet/package.json
+++ b/seedlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.11-wpcom",
+  "version": "1.1.12-wpcom",
   "description": "Seedlet",
   "bugs": {
     "url": "https://github.com/Automattic/seedlet/issues"

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.10-wpcom
+Version: 1.1.12-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.10-wpcom
+Version: 1.1.12-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet


### PR DESCRIPTION
This PR addresses #3331.

**To test**
- Activate Seedlet on mobile
- Navigate to the primary menu via keyboard, and verify that the tab navigation is trapped within the modal.
- Verify no console errors appear

![Kapture 2021-02-23 at 14 30 52](https://user-images.githubusercontent.com/5375500/108897287-f0a05f00-75e3-11eb-80f5-f5ab04ecfb70.gif)
