### PR TITLE
Blank Canvas: Bump version to 1.2.5

### DIFF
--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -16,6 +16,9 @@ The theme’s default styles are conservative, relying on simple sans-serif font
 
 == Changelog ==
 
+= 1.2.5 =
+* Code cleanup.
+
 = 1.2.4 =
 * Add additional block patterns.
 * Tidy up footer spacing. 

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -7,7 +7,7 @@ Description: Blank Canvas is a minimalist theme, designed for single-page websit
 Requires at least: 4.9.6
 Tested up to: 5.6
 Requires PHP: 5.6.2
-Version: 1.2.4-wpcom
+Version: 1.2.5-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: seedlet


### PR DESCRIPTION
Small version bump for Blank Canvas, so we can re-upload to WP.org. 