### PR TITLE
Update Blank Canvas to 1.2.6

### DIFF
--- a/blank-canvas/languages/blank-canvas.pot
+++ b/blank-canvas/languages/blank-canvas.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Blank Canvas 1.2.5-wpcom\n"
+"Project-Id-Version: Blank Canvas 1.2.6-wpcom\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/blank-canvas\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -16,7 +16,7 @@ The theme’s default styles are conservative, relying on simple sans-serif font
 
 == Changelog ==
 
-= 1.2.5 =
+= 1.2.6 =
 * Code cleanup.
 
 = 1.2.4 =

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -7,7 +7,7 @@ Description: Blank Canvas is a minimalist theme, designed for single-page websit
 Requires at least: 4.9.6
 Tested up to: 5.6
 Requires PHP: 5.6.2
-Version: 1.2.5-wpcom
+Version: 1.2.6-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: seedlet


### PR DESCRIPTION
Turned out #3352 should've bumped the version up to 1.2.6, so we're 1 version ahead of [the version submitted to .org last time](https://themes.trac.wordpress.org/ticket/94482#comment:15). This uses the correct version number. 

(We originally bumped up to 1.2.5 in https://github.com/Automattic/themes/pull/3323, but then never merged that over to WP.com. hence the discrepancy). 