### PR TITLE
Added tools to import/export content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ vendor/
 .svn
 .sandbox-config
 .wp-env.override.json
+export/*
 
 #Ignoring headstart and language files
 */languages/*

--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -7,4 +7,5 @@ package-lock.json
 sandbox.sh
 vendor
 node_modules
+export
 **/*.zip

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,12 @@
 {
   "themes": [
     "."
-  ]
+  ],
+  "plugins": [
+    "https://downloads.wordpress.org/plugin/wordpress-importer.0.7.zip"
+  ],
+  "mappings": {
+    "./export": "./export",
+    "./theme-unit-test":"WPTT/theme-unit-test#master"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -75,3 +75,29 @@ NOTE: When pushing changes if your local branch is not current with /trunk you w
 - In addition to pushing your local changes you can also WATCH for any local changes and trigger the sandbox sync by using the `npm run sandbox:watch` Any changes to your local files will trigger the rsync.  Make sure that you have executed `npm install` to ensure the needed dependencies for this are installed.
 
 Note: The first time you run the `sandbox.sh` shell script you will be prompted for details about your sandbox which will be stored in a `.sandbox-config` file. Edit (or delete and be re-prompted) if details about your sandbox change.  This file will not be comitted to version controll and will not sync to your sandbox.
+
+- Content can be exported from your sandbox to a local XML file using the command `./sandbox.sh export`.  The resulting XML file will be found in `./export/sandbox.wordpress.xml`.  Alternately you may use the command `./sandbox.sh export-theam` to export the content from the Theam Demo site `theamdemo.wordpress.com`.  That XML file will be found in `./export/theamdemo.wordpress.com`.
+
+## wp-env
+
+wp-env is a handy solution to spin up local WordPress environments.  Details can be found here: https://developer.wordpress.org/block-editor/packages/packages-env/
+
+A default `.wp-env.json` file is included in this project which can be used to spin up an instance of WordPress for development of the Theams.  The command `npx wp-env start` will spin this up based on those settings.  You can also add a `.wp-env.override.json` file to supply your own values (such as mapping to a local instance of Gutenberg) (Note: When supplying some values such as 'plugins' in the .wp-env.override.json the values are OVERRIDDEN and not MERGED thus all plugins need to be supplied.  See here.)
+
+The WordPress Importer plugin and Gutenberg (/master branch in the git repository) are supplied by default as well as the theam-unit-test data and a local mapping for importing/exporting content. 
+
+There are a number of npm scripts available to make working with this wp-env instance of WordPress easier.  Any of these commands are executed via `npm run [COMMAND]`
+
+- wp-env : A shortcut (not much of one) to the `wp-env start` command.
+
+Note: The rest of these commands must be executed with the instance of wp-env running (with the execption of those that leverage sandbox.sh script)
+
+- wp-env:empty : Remove all content from the local wp-env instance (via `wp site empty`)
+- wp-env:export:local : Export the content from your wp-env instance to `./export/local.wordpress.xml`
+- wp-env:export:theam : Export the content from theamdemo.wordpress.com to `./export/theamdemo.wordpress.xml` This command leverages the `sandbox.sh export-theam` command noted above
+- wp-env:export:sandbox : Export the content from your sandbox to `./export/sandbox.wordpress.xml` This command leverages the `sandbox.sh export` command noted above
+- wp-env:import:local : Import the content from `./export/local.wordpress.xml` to your local wp-env site
+- wp-env:import:theam : Import the content from `./export/theamdemo.wordpress.xml` to your local wp-env site
+- wp-env:import:sandbox : Import the content from `./export/sandbox.wordpress.xml` to your local wp-env site
+- wp-env:import:unittest : Import the content from the github repository `WPTT/theme-unit-test` to your local wp-env site
+- wp-env:cleanslate : A multi-command that cleans the local site, downloads the content from theamdemo.wordpress.com and imports it into your local instance

--- a/package.json
+++ b/package.json
@@ -9,7 +9,23 @@
 		"sandbox:push": "./sandbox.sh push",
 		"sandbox:push:ignore": "./sandbox.sh push --ignore",
 		"sandbox:push:force": "./sandbox.sh push --force",
-		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial"
+		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
+
+		"wp-env": "wp-env start",
+
+		"wp-env:cleanslate": "npm run wp-env:empty ; npm run wp-env:export:theam ; npm run wp-env:import:theam",
+
+		"wp-env:empty": "wp-env run cli 'wp site empty --uploads --yes'",
+
+		"wp-env:import:local": "wp-env run cli 'wp import ./theme-unit-test/local.wordpress.xml --authors=create'",
+		"wp-env:import:theam": "wp-env run cli 'wp import ./export/theamdemo.wordpress.xml --authors=create'",
+		"wp-env:import:sandbox": "wp-env run cli 'wp import ./export/sandbox.wordpress.xml --authors=create'",
+		"wp-env:import:unittest": "wp-env run cli 'wp import ./theme-unit-test/themeunittestdata.wordpress.xml --authors=create'",
+
+		"wp-env:export:local": "wp-env run cli 'wp export --dir=./export/ --filename_format=local.wordpress.xml'",
+		"wp-env:export:theam": "./sandbox.sh export-theam",
+		"wp-env:export:sandbox": "./sandbox.sh export"
+		
 	},
 	"devDependencies": {
 		"chokidar-cli": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -11,18 +11,18 @@
 		"sandbox:push:force": "./sandbox.sh push --force",
 		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
 
-		"wp-env": "wp-env start",
+		"wp-env": "npx wp-env start",
 
 		"wp-env:cleanslate": "npm run wp-env:empty ; npm run wp-env:export:theam ; npm run wp-env:import:theam",
 
-		"wp-env:empty": "wp-env run cli 'wp site empty --uploads --yes'",
+		"wp-env:empty": "npx wp-env run cli 'wp site empty --uploads --yes'",
 
-		"wp-env:import:local": "wp-env run cli 'wp import ./theme-unit-test/local.wordpress.xml --authors=create'",
-		"wp-env:import:theam": "wp-env run cli 'wp import ./export/theamdemo.wordpress.xml --authors=create'",
-		"wp-env:import:sandbox": "wp-env run cli 'wp import ./export/sandbox.wordpress.xml --authors=create'",
-		"wp-env:import:unittest": "wp-env run cli 'wp import ./theme-unit-test/themeunittestdata.wordpress.xml --authors=create'",
+		"wp-env:import:local": "npx wp-env run cli 'wp import ./theme-unit-test/local.wordpress.xml --authors=create'",
+		"wp-env:import:theam": "npx wp-env run cli 'wp import ./export/theamdemo.wordpress.xml --authors=create'",
+		"wp-env:import:sandbox": "npx wp-env run cli 'wp import ./export/sandbox.wordpress.xml --authors=create'",
+		"wp-env:import:unittest": "npx wp-env run cli 'wp import ./theme-unit-test/themeunittestdata.wordpress.xml --authors=create'",
 
-		"wp-env:export:local": "wp-env run cli 'wp export --dir=./export/ --filename_format=local.wordpress.xml'",
+		"wp-env:export:local": "npx wp-env run cli 'wp export --dir=./export/ --filename_format=local.wordpress.xml'",
 		"wp-env:export:theam": "./sandbox.sh export-theam",
 		"wp-env:export:sandbox": "./sandbox.sh export"
 		

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -143,7 +143,7 @@ How do you wish to proceed? [1]"
 
 elif [[ $1 == "export" ]]; then
   # Export the site content from your sandbox to a local file
-  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export"'
+  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; rm /home/wpcom/export/* ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export"'
   download_command='mkdir ./export ; scp $SANDBOX_USER@$SANDBOX_LOCATION:/home/wpcom/export/* ./export/sandbox.wordpress.xml'
   eval $export_command
   eval $download_command
@@ -155,7 +155,7 @@ elif [[ $1 == "export" ]]; then
 
 elif [[ $1 == "export-theam" ]]; then
   # Export the site content from theamdemo to a local file
-  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export --url=theamdemo.wordpress.com"'
+  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; rm /home/wpcom/export/* ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export --url=theamdemo.wordpress.com"'
   download_command='mkdir ./export ; scp $SANDBOX_USER@$SANDBOX_LOCATION:/home/wpcom/export/* ./export/theamdemo.wordpress.xml'
   eval $export_command
   eval $download_command

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -141,7 +141,30 @@ How do you wish to proceed? [1]"
   cmd="rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude=$ignore_string ./ $SANDBOX_USER@$SANDBOX_LOCATION:$SANDBOX_PUBLIC_THEMES_FOLDER/"
   eval $cmd
 
+elif [[ $1 == "export" ]]; then
+  # Export the site content from your sandbox to a local file
+  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export"'
+  download_command='mkdir ./export ; scp $SANDBOX_USER@$SANDBOX_LOCATION:/home/wpcom/export/* ./export/sandbox.wordpress.xml'
+  eval $export_command
+  eval $download_command
+  echo "
+  
+  Export Complete!
+  
+  You can find the exported file in ./export/sandbox.wordpress.xml"
+
+elif [[ $1 == "export-theam" ]]; then
+  # Export the site content from theamdemo to a local file
+  export_command='ssh $SANDBOX_USER@$SANDBOX_LOCATION "mkdir /home/wpcom/export ; /home/wpcom/public_html/bin/wp export --dir=/home/wpcom/export --url=theamdemo.wordpress.com"'
+  download_command='mkdir ./export ; scp $SANDBOX_USER@$SANDBOX_LOCATION:/home/wpcom/export/* ./export/theamdemo.wordpress.xml'
+  eval $export_command
+  eval $download_command
+  echo "
+  
+  Export Complete!
+  
+  You can find the exported file in ./export/theamdemo.wordpress.xml"
 else 
-  echo 'No known command given. [clean, push]'
+  echo 'No known command given. [clean, push, export, export-theam]'
 
 fi


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change adds tools to import/export content from the local [wp-env](https://developer.wordpress.org/block-editor/packages/packages-env/)
instance.

Content can be pulled from your sandbox, [themedemo.wordpress.com](7z3nx-p2) or from
the [theme-unit-test repository](https://github.com/WPTT/theme-unit-test).

The sandbox.sh script was changed to power the "export" (from sandbox or
themedemo) functionality.

The .wp-env.json was changed to supply the content from theme-unit-test
repository, map local folders for import/export of the rest of the
resources and to provide the import plugin.

npm scripts have been added to package.json in order to drive the
commands.

Documentation in readme has been updated to reflect the additional
capabilities.

### Testing

#### Theam and Sandbox content export

From the root of the project run `npm run wp-env:export:theam` (or `./sandbox.sh export-theam`) and note the file copied to ./export/theamdemo.wordpress.xml reflects the content on theamdemo.wordpress.com

From the root of the project run `npm run wp-env:export:sandbox` (or `./sandbox.sh export`) and note the file copied to ./export/sandbox.wordpress.xml reflects the content on your sandbox

NOTE: The following will remove & replace all of the content in the targeted instance of WordPress.  Make sure you don't mind it going away.

Make sure there are no instances of wp-env running.  (Checking Docker Dashboard is helpful for this just to make sure...)

Spin up a new wp-env instance from the root of the project folder: `npm run wp-env` and ensure that it's running properly: http://localhost:8888 

Run `npm run wp-env:empty` and ensure that there is no content to be found on our local wp-env instance

Run `npm run wp-env:import:sandbox` and ensure that the content on your local wp-env instance reflects the same content found on your sandbox. (Ensure you have downloaded the ./export/sandbox.wordpress.xml file from above instructions first.)

Run `npm run wp-env:empty` again to clean our your local environment and then `npm run wp-env:import:theam` and ensure that the content on your local wp-env instance reflects the same content found on theamdemo.wordpress.com (Ensure you have downloaded the ./export/theamdemo.wordpress.xml file from above instructions first.)

Run `npm run wp-env:empty` again to clean our your local environment and then `npm run wp-env:import:unittest` and ensure that the content on your local wp-env instance reflects the content from the theme-unit-test repository. (For this one you don't have to download anything first, it should be made available due to the mappings configuration in .wp-env.json.  However that is dependent on [this change](https://github.com/WordPress/gutenberg/pull/28930) which might not be available via npm yet so ymmv.)

Run `npm run wp-env:export:local` and ensure that the file `./export/local.wordpress.xml` reflects the same XML content found in the theme-unit-test repository (since that's the content that you last imported if you're playing along in order).

Lastly run `npm run wp-env:cleanslate`. Your local content will be wiped, the content from theamdemo.wordpress.com will be downloaded to your local `./export` folder and then imported into your wp-env instance.