### PR TITLE
Spearhead: Show the Disable Dark Mode checkbox even if the colors aren't modified

### DIFF
--- a/spearhead/assets/sass/style.scss
+++ b/spearhead/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.3.1
+Version: 1.3.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet

--- a/spearhead/inc/wpcom-colors.php
+++ b/spearhead/inc/wpcom-colors.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'spearhead_wpcom_customize_update' ) ) :
 			'fg2'  => '#fafbf6',
 		);
 
-		if ( $default_palette === $wpcom_colors_array['colors'] ) :
+		if ( ! $wpcom_colors_array['colors'] || $default_palette === $wpcom_colors_array['colors'] ) :
 			$wp_customize->add_setting( 'color_darkmode_disable' );
 			$wp_customize->add_control(
 				'color_darkmode_disable',
@@ -40,7 +40,7 @@ if ( ! function_exists( 'spearhead_wpcom_customize_update' ) ) :
 					'section'     => 'colors_manager_tool',
 					'priority'    => 10, // Set to 10 so it appears near the top of the Colors & Backgrounds panel
 					'type'        => 'checkbox',
-					'settings'	  => 'color_darkmode_disable'
+					'settings'    => 'color_darkmode_disable',
 				)
 			);
 		endif;

--- a/spearhead/package-lock.json
+++ b/spearhead/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spearhead",
-  "version": "1.2.4",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spearhead/package.json
+++ b/spearhead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spearhead",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "a podcast theme",
   "keywords": [
     "gutenberg",

--- a/spearhead/style-rtl.css
+++ b/spearhead/style-rtl.css
@@ -7,7 +7,7 @@ Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.3.0
+Version: 1.3.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -7,7 +7,7 @@ Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.3.0
+Version: 1.3.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This changes the condition to show the checkbox to also show when there are no colors set.

To test (on wpcom):
- Add the theme to a site that has never had custom colors set
- Check that the checkbox still shows

#### Related issue(s):
Fixes #3312 