### PR TITLE
Blank canvas: textdomain fixes + version bump to 1.2.7

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -72,11 +72,11 @@ add_action( 'after_setup_theme', 'blank_canvas_setup', 11 );
  */
 function blank_canvas_colors() {
 	return array(
-		array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'seedlet' ) ),
-		array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'seedlet' ) ),
-		array( '--global--color-primary', '#000000', __( 'Primary Color', 'seedlet' ) ),
-		array( '--global--color-secondary', '#007cba', __( 'Secondary Color', 'seedlet' ) ),
-		array( '--global--color-tertiary', '#FAFAFA', __( 'Tertiary Color', 'seedlet' ) ),
+		array( '--global--color-background', '#FFFFFF', __( 'Background Color', 'blank-canvas' ) ),
+		array( '--global--color-foreground', '#333333', __( 'Foreground Color', 'blank-canvas' ) ),
+		array( '--global--color-primary', '#000000', __( 'Primary Color', 'blank-canvas' ) ),
+		array( '--global--color-secondary', '#007cba', __( 'Secondary Color', 'blank-canvas' ) ),
+		array( '--global--color-tertiary', '#FAFAFA', __( 'Tertiary Color', 'blank-canvas' ) ),
 	);
 }
 add_filter( 'seedlet_colors', 'blank_canvas_colors' );

--- a/blank-canvas/inc/block-patterns.php
+++ b/blank-canvas/inc/block-patterns.php
@@ -351,7 +351,7 @@ if ( ! function_exists( 'blank_canvas_register_block_patterns' ) ) :
 									<!-- /wp:image -->
 
 									<!-- wp:heading {"textAlign":"center","level":1,"textColor":"primary"} -->
-									<h1 class="has-text-align-center has-primary-color has-text-color"><strong>' . esc_html__( 'Julia Paxton' ) . '</strong></h1>
+									<h1 class="has-text-align-center has-primary-color has-text-color"><strong>' . esc_html__( 'Julia Paxton', 'blank-canvas' ) . '</strong></h1>
 									<!-- /wp:heading -->
 
 									<!-- wp:spacer {"height":1} -->

--- a/blank-canvas/languages/blank-canvas.pot
+++ b/blank-canvas/languages/blank-canvas.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-02-24T18:13:36+00:00\n"
+"POT-Creation-Date: 2021-02-25T14:20:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: blank-canvas\n"
@@ -53,6 +53,26 @@ msgstr ""
 
 #: functions.php:60
 msgid "Background"
+msgstr ""
+
+#: functions.php:75
+msgid "Background Color"
+msgstr ""
+
+#: functions.php:76
+msgid "Foreground Color"
+msgstr ""
+
+#: functions.php:77
+msgid "Primary Color"
+msgstr ""
+
+#: functions.php:78
+msgid "Secondary Color"
+msgstr ""
+
+#: functions.php:79
+msgid "Tertiary Color"
 msgstr ""
 
 #: functions.php:133
@@ -300,6 +320,10 @@ msgstr ""
 
 #: inc/block-patterns.php:350
 msgid "Woman wearing sunglasses"
+msgstr ""
+
+#: inc/block-patterns.php:354
+msgid "Julia Paxton"
 msgstr ""
 
 #: inc/block-patterns.php:368

--- a/blank-canvas/languages/blank-canvas.pot
+++ b/blank-canvas/languages/blank-canvas.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Blank Canvas 1.2.6-wpcom\n"
+"Project-Id-Version: Blank Canvas 1.2.7-wpcom\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/blank-canvas\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/blank-canvas/readme.txt
+++ b/blank-canvas/readme.txt
@@ -16,7 +16,7 @@ The theme’s default styles are conservative, relying on simple sans-serif font
 
 == Changelog ==
 
-= 1.2.6 =
+= 1.2.7 =
 * Code cleanup.
 
 = 1.2.4 =

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -7,7 +7,7 @@ Description: Blank Canvas is a minimalist theme, designed for single-page websit
 Requires at least: 4.9.6
 Tested up to: 5.6
 Requires PHP: 5.6.2
-Version: 1.2.6-wpcom
+Version: 1.2.7-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: seedlet


### PR DESCRIPTION
Fixes a couple textdomain fixes in Blank Canvas: 

- Missing textdomain in `inc/block-patterns.php`
- Incorrect textdomains in `functions.php`

It also updates the .pot file to include these new strings, and bumps the version so we can re-upload to WP.org.