### PR TITLE
Seedlet: fix wp_localize_script argument

### DIFF
--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.12-wpcom
+Version: 1.1.13-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/classes/class-seedlet-custom-colors.php
+++ b/seedlet/classes/class-seedlet-custom-colors.php
@@ -308,7 +308,7 @@ class Seedlet_Custom_Colors {
 		wp_script_add_data( $handle, 'data', sprintf( 'var seedletValidateWCAGColorContrastExports = %s;', wp_json_encode( $exports ) ) );
 
 		// Custom color contrast validation text
-		wp_localize_script( $handle, 'seedletValidateContrastText', esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ) );
+		wp_localize_script( $handle, 'seedletValidateContrastText', array( esc_html__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker foreground color.', 'seedlet' ) ) );
 	}
 
 	/**

--- a/seedlet/package.json
+++ b/seedlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.12-wpcom",
+  "version": "1.1.13-wpcom",
   "description": "Seedlet",
   "bugs": {
     "url": "https://github.com/Automattic/seedlet/issues"

--- a/seedlet/readme.txt
+++ b/seedlet/readme.txt
@@ -18,6 +18,10 @@ Seedlet is a great option for professionals and creatives looking for a sophisti
 
 == Changelog ==
 
+= 1.1.13 =
+* Responsive menu fix 
+* Customizer 5.7 fix
+
 = 1.1.4 - 1.1.7 =
 * Allow header and footer to be hidden via customizer 
 * Bug fixes and improvements

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.12-wpcom
+Version: 1.1.13-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.12-wpcom
+Version: 1.1.13-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet


### PR DESCRIPTION
Addresses #3358.

I couldn't recreate this error. But according to the notice the last argument of this function needs to be an array, so I changed it anyways.

**To test**
- Install the [WP beta testing](https://wordpress.org/plugins/wordpress-beta-tester/) plugin and use the bleeding edge nightly build
- Activate Seedlet and ensure debugging is enabled
- Visit the customizer, change some colors that trigger the contrast warning, ensure no errors are logged