### PR TITLE
Blank Canvas: Add `theme name` context to block pattern category string

### DIFF
--- a/blank-canvas/inc/block-patterns.php
+++ b/blank-canvas/inc/block-patterns.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'blank_canvas_register_block_patterns' ) ) :
 
 			register_block_pattern_category(
 				'blank-canvas',
-				array( 'label' => __( 'Blank Canvas', 'blank-canvas' ) )
+				array( 'label' => _x( 'Blank Canvas', 'theme name', 'blank-canvas' ) )
 			);
 
 			register_block_pattern_category(

--- a/blank-canvas/languages/blank-canvas.pot
+++ b/blank-canvas/languages/blank-canvas.pot
@@ -9,18 +9,17 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-02-25T14:20:31+00:00\n"
+"POT-Creation-Date: 2021-03-02T17:27:23+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: blank-canvas\n"
 
 #. Theme Name of the theme
-#: inc/block-patterns.php:21
 msgid "Blank Canvas"
 msgstr ""
 
 #. Theme URI of the theme
-msgid "https://github.com/Automattic/themes/blank-canvas"
+msgid "https://wordpress.com/theme/blank-canvas"
 msgstr ""
 
 #. Description of the theme
@@ -91,6 +90,11 @@ msgstr ""
 #. translators: %s: Name of current post. Only visible to screen readers.
 #: functions.php:154
 msgid "Edit <span class=\"screen-reader-text\">%s</span>"
+msgstr ""
+
+#: inc/block-patterns.php:21
+msgctxt "theme name"
+msgid "Blank Canvas"
 msgstr ""
 
 #: inc/block-patterns.php:26
@@ -290,115 +294,115 @@ msgstr ""
 msgid "Alex Smith — Own Way"
 msgstr ""
 
-#: inc/block-patterns.php:304
+#: inc/block-patterns.php:300
 msgid "SoundCloud"
 msgstr ""
 
-#: inc/block-patterns.php:308
+#: inc/block-patterns.php:304
 msgid "Spotify"
 msgstr ""
 
-#: inc/block-patterns.php:312
+#: inc/block-patterns.php:308
 msgid "Bandcamp"
 msgstr ""
 
-#: inc/block-patterns.php:316
+#: inc/block-patterns.php:312
 msgid "Apple Music"
 msgstr ""
 
-#: inc/block-patterns.php:320
+#: inc/block-patterns.php:316
 msgid "YouTube"
 msgstr ""
 
-#: inc/block-patterns.php:324
+#: inc/block-patterns.php:320
 msgid "Tidal"
 msgstr ""
 
-#: inc/block-patterns.php:346
+#: inc/block-patterns.php:342
 msgid "Product Links"
 msgstr ""
 
-#: inc/block-patterns.php:350
+#: inc/block-patterns.php:346
 msgid "Woman wearing sunglasses"
 msgstr ""
 
-#: inc/block-patterns.php:354
+#: inc/block-patterns.php:350
 msgid "Julia Paxton"
 msgstr ""
 
-#: inc/block-patterns.php:368
+#: inc/block-patterns.php:364
 msgid "Rhinestone Earrings, ASOS"
 msgstr ""
 
-#: inc/block-patterns.php:375
+#: inc/block-patterns.php:371
 msgid "$36"
 msgstr ""
 
-#: inc/block-patterns.php:388
+#: inc/block-patterns.php:384
 msgid "Pink Long Sleeve Tea Dress, Topshop"
 msgstr ""
 
-#: inc/block-patterns.php:395
+#: inc/block-patterns.php:391
 msgid "$45"
 msgstr ""
 
-#: inc/block-patterns.php:408
+#: inc/block-patterns.php:404
 msgid "Chunky Platform Lace-Up Boots, H&amp;M"
 msgstr ""
 
-#: inc/block-patterns.php:415
+#: inc/block-patterns.php:411
 msgid "$60"
 msgstr ""
 
-#: inc/block-patterns.php:428
+#: inc/block-patterns.php:424
 msgid "Oversized Alpaca Crew, Everlane"
 msgstr ""
 
-#: inc/block-patterns.php:435
+#: inc/block-patterns.php:431
 msgid "$70"
 msgstr ""
 
-#: inc/block-patterns.php:459
+#: inc/block-patterns.php:455
 msgid "Text Links"
 msgstr ""
 
-#: inc/block-patterns.php:463
+#: inc/block-patterns.php:459
 msgid "A logo of a circle with a line through it."
 msgstr ""
 
-#: inc/block-patterns.php:471
+#: inc/block-patterns.php:467
 msgid "Patricia Jones"
 msgstr ""
 
-#: inc/block-patterns.php:475
+#: inc/block-patterns.php:471
 msgid "Published work and ephemera."
 msgstr ""
 
-#: inc/block-patterns.php:483
+#: inc/block-patterns.php:479
 msgid "“The Lost Tricycle” Book"
 msgstr ""
 
-#: inc/block-patterns.php:487
+#: inc/block-patterns.php:483
 msgid "\"Why we must own our history\""
 msgstr ""
 
-#: inc/block-patterns.php:487
+#: inc/block-patterns.php:483
 msgid " in <em>The Atlantic</em>"
 msgstr ""
 
-#: inc/block-patterns.php:491
+#: inc/block-patterns.php:487
 msgid "\"Identity and Ownership\""
 msgstr ""
 
-#: inc/block-patterns.php:491
+#: inc/block-patterns.php:487
 msgid " in <em>The New York Times</em>"
 msgstr ""
 
-#: inc/block-patterns.php:495
+#: inc/block-patterns.php:491
 msgid "Sponsor: Crafty Cookies"
 msgstr ""
 
-#: inc/block-patterns.php:499
+#: inc/block-patterns.php:495
 msgid "Donate to help keep us posting!"
 msgstr ""
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add `theme name` context to the `Blank Canvas` string that is used to register block patterns category in order to get it extracted as a separate original string.

#### Testing instructions:
* Review code changes
* Review the generated `blank-canvas/languages/blank-canvas.pot ` and check if it contains `Blank Canvas` string with context. Confirm other changes in the file make sense.

#### Related issue(s):
p1614696959004800-slack-CEM18K8LT