### PR TITLE
Mayland Blocks: Update buttons colors

### DIFF
--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -182,6 +182,11 @@
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)"
 			}
+		},
+		"core/button": {
+			"color": {
+				"background": "var(--wp--preset--color--primary)"
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This implements button colors using theme.json:

<img width="464" alt="Screenshot 2021-03-03 at 19 08 19" src="https://user-images.githubusercontent.com/275961/109858666-005b1b80-7c54-11eb-9ea1-97ae9df5f5e0.png">
