### PR TITLE
Varia: add wrappers to fix WooCommerce styling

### DIFF
--- a/varia/inc/style-wpcom.css
+++ b/varia/inc/style-wpcom.css
@@ -5,7 +5,8 @@
  /**
  * Hide page title on the homepage
  */
-.home.page.hide-homepage-title .entry-header {
+.home.page.hide-homepage-title .entry-header,
+.home.hide-homepage-title .woocommerce-products-header__title {
 	display: none;
 }
 

--- a/varia/inc/woocommerce.php
+++ b/varia/inc/woocommerce.php
@@ -36,14 +36,66 @@ add_action( 'after_setup_theme', 'varia_woocommerce_setup' );
  * Add a custom wrapper for woocomerce content
  */
 function varia_wrapper_start() {
-	echo '<article id="woocommerce-wrapper" class="responsive-max-width">';
+	if( is_shop() ) {
+    	$shop_page = get_post( wc_get_page_id( 'shop' ) );
+
+    	if ( $shop_page ) {
+      		$post = $shop_page;
+    	}
+
+		$classes = get_post_class( '', $post->ID );
+
+		echo '<article id="woocommerce-wrapper post-' . $post->ID . '" class="' . esc_attr( implode( ' ', $classes ) ) . '">';
+	} else {
+		echo '<article id="woocommerce-wrapper" class="responsive-max-width">';
+	}
 }
-add_action('woocommerce_before_main_content', 'varia_wrapper_start', 10);
+add_action( 'woocommerce_before_main_content', 'varia_wrapper_start', 10 );
 
 function varia_wrapper_end() {
 	echo '</article>';
 }
-add_action('woocommerce_after_main_content', 'varia_wrapper_end', 10);
+add_action( 'woocommerce_after_main_content', 'varia_wrapper_end', 10 );
+
+/**
+ * Adjust page content wrapper to preserve styling
+ */
+function varia_product_archive_description() {
+	// Don't display the description on search results page 
+	if ( is_search() ) { 
+		return; 
+	} 
+
+	if ( is_post_type_archive( 'product' ) && 0 === absint( get_query_var( 'paged' ) ) ) { 
+		$shop_page = get_post( wc_get_page_id( 'shop' ) ); 
+	
+		if ( $shop_page ) { 
+			$description = wc_format_content( $shop_page->post_content ); 
+			if ( $description ) { 
+				echo '<div class="page-description entry-content">' . $description . '</div>'; 
+			} 
+		} 
+	}
+}
+remove_action( 'woocommerce_archive_description', 'woocommerce_product_archive_description' );
+add_action( 'woocommerce_archive_description', 'varia_product_archive_description', 10 );
+
+/**
+ * Wrap woocommerce loop
+ */
+function varia_shop_wrapper_start() {	
+	if ( is_shop() ) {
+		echo '<div class="woocommerce-shop-wrapper">';
+	}
+}
+add_action( 'woocommerce_before_shop_loop', 'varia_shop_wrapper_start');
+
+function varia_shop_wrapper_end() {
+	if ( is_shop() ) {
+		echo '</div>';
+	}
+}
+add_action( 'woocommerce_after_shop_loop', 'varia_shop_wrapper_end');
 
 /**
  * Display category image on category archive

--- a/varia/sass/vendors/woocommerce/components/_product-loops.scss
+++ b/varia/sass/vendors/woocommerce/components/_product-loops.scss
@@ -8,6 +8,12 @@ body[class*="woocommerce"] #page .woocommerce-products-header {
 	}
 }
 
+body[class*="woocommerce"] header.woocommerce-products-header ~ [class*="woocommerce"] {
+    max-width: calc( 782px - 32px);
+    margin-right: auto;
+    margin-left: auto;
+}
+
 #woocommerce-wrapper,
 body[class*="woocommerce"] #page #add_payment_method .cart-collaterals .cross-sells,
 body[class*="woocommerce"] #page .cart-collaterals .cross-sells {

--- a/varia/sass/vendors/woocommerce/components/_product-loops.scss
+++ b/varia/sass/vendors/woocommerce/components/_product-loops.scss
@@ -8,7 +8,7 @@ body[class*="woocommerce"] #page .woocommerce-products-header {
 	}
 }
 
-body[class*="woocommerce"] header.woocommerce-products-header ~ [class*="woocommerce"] {
+body[class*="woocommerce"] .woocommerce-shop-wrapper {
     max-width: calc( 782px - 32px);
     margin-right: auto;
     margin-left: auto;

--- a/varia/style-woocommerce.css
+++ b/varia/style-woocommerce.css
@@ -975,7 +975,7 @@ body[class*="woocommerce"] #page .woocommerce-products-header img {
 	display: block;
 }
 
-body[class*="woocommerce"] header.woocommerce-products-header ~ [class*="woocommerce"] {
+body[class*="woocommerce"] .woocommerce-shop-wrapper {
 	max-width: calc( 782px - 32px);
 	margin-right: auto;
 	margin-left: auto;

--- a/varia/style-woocommerce.css
+++ b/varia/style-woocommerce.css
@@ -975,6 +975,12 @@ body[class*="woocommerce"] #page .woocommerce-products-header img {
 	display: block;
 }
 
+body[class*="woocommerce"] header.woocommerce-products-header ~ [class*="woocommerce"] {
+	max-width: calc( 782px - 32px);
+	margin-right: auto;
+	margin-left: auto;
+}
+
 #woocommerce-wrapper .products ul,
 #woocommerce-wrapper ul.products,
 body[class*="woocommerce"] #page #add_payment_method .cart-collaterals .cross-sells .products ul,


### PR DESCRIPTION
## Changes proposed in this Pull Request
In order to allow the current styling to apply to the page content that gets placed into the `page-description` I adjusted the wrappers.

I tried testing this on the child themes but the `build:woocommerce` doesn't seem to run through the child themes. I can continue testing if I can get some pointers on that.

Also, I set the page content `max-width` based on the varia setting, I was not sure if there was a global setting for this.

#### Before
[![Screenshot](https://d.pr/i/JCLMva+)](https://d.pr/i/JCLMva)
[Recording](https://d.pr/i/rSl1RO)

#### After
[![Screenshot](https://d.pr/i/csqenR+)](https://d.pr/i/csqenR)
[Recording](https://d.pr/i/zGcAWp)

#### Related issue(s)

#2361