### PR TITLE
Compile Button Styles into BCB

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -267,6 +267,30 @@ h1, h2, h3, h4, h5, h6 {
 	clear: both;
 }
 
+/**
+ * Button
+ */
+/**
+ * Block Options
+ */
+.wp-block-button.wp-block-button__link,
+.wp-block-button .wp-block-button__link {
+	font-weight: var(--wp--custom--button--font-weight);
+	font-family: var(--wp--custom--button--font-family);
+	font-size: var(--wp--custom--button--font-size);
+	line-height: var(--wp--custom--button--line-height);
+	border-radius: var(--wp--custom--button--border-radius);
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	color: var(--wp--custom--button--color--hover-text);
+	background-color: var(--wp--custom--button--color--hover-background);
+	border-color: var(--wp--custom--button--color--hover-background);
+}
+
 p.has-background {
 	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 }

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -148,7 +148,7 @@
 					"wide": "1000px"
 				},
 				"button": {
-					"font-weight": "600",
+					"font-weight": "normal",
 					"font-family": "var(--wp--preset--font-family--base)",
 					"font-size": "var(--wp--preset--font-size--small)",
 					"border-radius": "4px",

--- a/blank-canvas-blocks/sass/blocks/_style.scss
+++ b/blank-canvas-blocks/sass/blocks/_style.scss
@@ -1,4 +1,5 @@
 @import "heading/style";
+@import "button/style";
 @import "paragraph/style";
 @import "navigation/style";
 @import "quote/style";


### PR DESCRIPTION
This change re-introduces the buttons styles into the polyfill.  (It keeps getting removed, probably because of an early .gitignore error...)

While evaluating the buttons block I discovered this error which will be a blocker: WordPress/gutenberg#29675