### PR TITLE
Add default styles to BCB for Image Block

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -263,10 +263,6 @@ h1, h2, h3, h4, h5, h6 {
 	font-family: var(--wp--preset--font-family--headings);
 }
 
-h1, h2, h3, h4, h5, h6 {
-	clear: both;
-}
-
 /**
  * Button
  */
@@ -291,12 +287,28 @@ h1, h2, h3, h4, h5, h6 {
 	border-color: var(--wp--custom--button--color--hover-background);
 }
 
-p.has-background {
+.wp-block-group.has-background .wp-block-group__inner-container {
 	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 }
 
-p.has-text-color a {
-	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
+h1, h2, h3, h4, h5, h6 {
+	clear: both;
+}
+
+.wp-block-image {
+	/* 
+	From what I can tell the below are styles regularly used by themes
+	to fix the image block.  I believe these should go into the block's
+	default styles.  It's difficult to say how this will land, however 
+	based on discussion found in (many) related issues here: 
+	https://github.com/WordPress/gutenberg/issues/28923
+
+	Further gutenberg APPEARS to be defaulting the margin to the same as 
+	the below, however (for reason's that aren't clear to me now) this
+	isn't coming through.
+	*/
+	text-align: center;
+	margin: 0 0 1em 0;
 }
 
 .wp-block-navigation a {
@@ -344,6 +356,14 @@ p.has-text-color a {
 	padding: var(--wp--custom--navigation--submenu--padding);
 }
 
+p.has-background {
+	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
+}
+
+p.has-text-color a {
+	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
+}
+
 .wp-block-quote {
 	border-left: var(--wp--custom--quote--border--width) solid var(--wp--custom--quote--border--color);
 	padding-left: var(--wp--custom--padding--horizontal);
@@ -354,11 +374,6 @@ p.has-text-color a {
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }
 
-.wp-block-group.has-background .wp-block-group__inner-container {
-	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
-}
-
-<<<<<<< HEAD
 .wp-block-separator:not(.is-style-dots) {
 	border-bottom: var(--wp--custom--separator--thickness) solid var(--wp--custom--separator--color);
 }
@@ -370,19 +385,6 @@ p.has-text-color a {
 .wp-block-video figcaption {
 	margin: var(--wp--custom--video--caption--margin);
 	text-align: var(--wp--custom--video--caption--text-align);
-=======
-.wp-block-image {
-	/* 
-	From what I can tell the below are styles regularly used by themes
-	to fix the image block.  I believe these should go into the block's
-	default styles.  It's difficult to say how this will land, however 
-	based on discussion found in (many) related issues here: 
-	https://github.com/WordPress/gutenberg/issues/28923
-	*/
-	text-align: center;
-	margin: 0;
-	margin-bottom: 1em;
->>>>>>> Added default styles for image blocks.
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -60,7 +60,7 @@ p {
 }
 
 /*
- * Alignments, loaded in the front-end only.
+ * Alignments
  */
 body {
 	margin: 0;
@@ -78,6 +78,10 @@ body {
 
 .wp-site-blocks {
 	padding: 0 var(--wp--custom--margin--horizontal);
+}
+
+.wp-block {
+	max-width: var(--wp--custom--width--default);
 }
 
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
@@ -118,29 +122,36 @@ body {
 }
 
 @media only screen and (min-width: 482px) {
+	.block-editor-block-list__layout .alignleft,
+	.block-editor-block-list__layout .alignright,
 	.wp-site-blocks .alignleft,
 	.wp-site-blocks .alignright {
-		--content-width: min( 100vw - var(--wp--custom--margin--horizontal) * 2, var(--wp--custom--width--default) );
-		--alignment-margin: calc( ( 100vw - var(--content-width ) ) / 2 - var(--wp--custom--margin--horizontal) );
-		max-width: var(--wp--custom--width--default);
+		max-width: calc(var(--wp--custom--width--default) / 2);
 	}
-}
-
-@media only screen and (min-width: 482px) {
 	.wp-site-blocks .alignleft {
 		/*rtl:ignore*/
 		float: left;
+	}
+	.wp-site-blocks .alignright {
+		/*rtl:ignore*/
+		float: right;
+	}
+	.block-editor-block-list__layout > .alignleft,
+	.block-editor-block-list__layout > .alignright,
+	.wp-site-blocks .wp-block-post-content > .alignleft,
+	.wp-site-blocks .wp-block-post-content > .alignright {
+		--content-width: min( 100% - var(--wp--custom--margin--horizontal) * 2, var(--wp--custom--width--default) );
+		--alignment-margin: calc( ( 100% - var(--content-width ) ) / 2 );
+	}
+	.block-editor-block-list__layout > .alignleft,
+	.wp-site-blocks .wp-block-post-content > .alignleft {
 		/*rtl:ignore*/
 		margin-left: var(--alignment-margin);
 		/*rtl:ignore*/
 		margin-right: var(--wp--custom--margin--horizontal);
 	}
-}
-
-@media only screen and (min-width: 482px) {
-	.wp-site-blocks .alignright {
-		/*rtl:ignore*/
-		float: right;
+	.block-editor-block-list__layout > .alignright,
+	.wp-site-blocks .wp-block-post-content > .alignright {
 		/*rtl:ignore*/
 		margin-left: var(--wp--custom--margin--horizontal);
 		/*rtl:ignore*/

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -263,6 +263,10 @@ h1, h2, h3, h4, h5, h6 {
 	font-family: var(--wp--preset--font-family--headings);
 }
 
+h1, h2, h3, h4, h5, h6 {
+	clear: both;
+}
+
 /**
  * Button
  */
@@ -287,28 +291,12 @@ h1, h2, h3, h4, h5, h6 {
 	border-color: var(--wp--custom--button--color--hover-background);
 }
 
-.wp-block-group.has-background .wp-block-group__inner-container {
+p.has-background {
 	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 }
 
-h1, h2, h3, h4, h5, h6 {
-	clear: both;
-}
-
-.wp-block-image {
-	/* 
-	From what I can tell the below are styles regularly used by themes
-	to fix the image block.  I believe these should go into the block's
-	default styles.  It's difficult to say how this will land, however 
-	based on discussion found in (many) related issues here: 
-	https://github.com/WordPress/gutenberg/issues/28923
-
-	Further gutenberg APPEARS to be defaulting the margin to the same as 
-	the below, however (for reason's that aren't clear to me now) this
-	isn't coming through.
-	*/
-	text-align: center;
-	margin: 0 0 1em 0;
+p.has-text-color a {
+	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
 }
 
 .wp-block-navigation a {
@@ -356,14 +344,6 @@ h1, h2, h3, h4, h5, h6 {
 	padding: var(--wp--custom--navigation--submenu--padding);
 }
 
-p.has-background {
-	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
-}
-
-p.has-text-color a {
-	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
-}
-
 .wp-block-quote {
 	border-left: var(--wp--custom--quote--border--width) solid var(--wp--custom--quote--border--color);
 	padding-left: var(--wp--custom--padding--horizontal);
@@ -372,6 +352,10 @@ p.has-text-color a {
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {
 	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
+}
+
+.wp-block-group.has-background .wp-block-group__inner-container {
+	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 }
 
 .wp-block-separator:not(.is-style-dots) {
@@ -385,6 +369,22 @@ p.has-text-color a {
 .wp-block-video figcaption {
 	margin: var(--wp--custom--video--caption--margin);
 	text-align: var(--wp--custom--video--caption--text-align);
+}
+
+.wp-block-image {
+	/* 
+	From what I can tell the below are styles regularly used by themes
+	to fix the image block.  I believe these should go into the block's
+	default styles.  It's difficult to say how this will land, however 
+	based on discussion found in (many) related issues here: 
+	https://github.com/WordPress/gutenberg/issues/28923
+
+	Further gutenberg APPEARS to be defaulting the margin to the same as 
+	the below, however (for reason's that aren't clear to me now) this
+	isn't coming through.
+	*/
+	text-align: center;
+	margin: 0 0 1em 0;
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -84,6 +84,14 @@ body {
 	max-width: var(--wp--custom--width--default);
 }
 
+.wp-block[data-align=wide] {
+	max-width: var(--wp--custom--width--wide);
+}
+
+.wp-block[data-align=full] {
+	max-width: none;
+}
+
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
 .wp-site-blocks .wp-block-post-content > * {
 	max-width: var(--wp--custom--width--default);
@@ -105,16 +113,6 @@ body {
 	margin-left: 0;
 	margin-right: 0;
 	box-sizing: content-box;
-}
-
-.wp-site-blocks .wp-block-template-part.alignfull {
-	width: 100%;
-	max-width: 100%;
-}
-
-.wp-site-blocks .wp-block-columns.alignfull {
-	width: 100%;
-	max-width: 100%;
 }
 
 .aligncenter {
@@ -389,12 +387,16 @@ p.has-text-color a {
 	default styles.  It's difficult to say how this will land, however 
 	based on discussion found in (many) related issues here: 
 	https://github.com/WordPress/gutenberg/issues/28923
+	*/
+	text-align: center;
+}
 
+/*
 	Further gutenberg APPEARS to be defaulting the margin to the same as 
 	the below, however (for reason's that aren't clear to me now) this
 	isn't coming through.
-	*/
-	text-align: center;
+*/
+.wp-block-column .wp-block-image {
 	margin: 0 0 1em 0;
 }
 

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -358,6 +358,7 @@ p.has-text-color a {
 	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 }
 
+<<<<<<< HEAD
 .wp-block-separator:not(.is-style-dots) {
 	border-bottom: var(--wp--custom--separator--thickness) solid var(--wp--custom--separator--color);
 }
@@ -369,6 +370,19 @@ p.has-text-color a {
 .wp-block-video figcaption {
 	margin: var(--wp--custom--video--caption--margin);
 	text-align: var(--wp--custom--video--caption--text-align);
+=======
+.wp-block-image {
+	/* 
+	From what I can tell the below are styles regularly used by themes
+	to fix the image block.  I believe these should go into the block's
+	default styles.  It's difficult to say how this will land, however 
+	based on discussion found in (many) related issues here: 
+	https://github.com/WordPress/gutenberg/issues/28923
+	*/
+	text-align: center;
+	margin: 0;
+	margin-bottom: 1em;
+>>>>>>> Added default styles for image blocks.
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -1,6 +1,6 @@
 
 /*
- * Alignments, loaded in the front-end only.
+ * Alignments
  */
 
 body {
@@ -21,6 +21,11 @@ body {
 // Ensure horizontal padding on the page
 .wp-site-blocks {
 	padding: 0 var(--wp--custom--margin--horizontal);
+}
+
+// Set a width for the editor
+.wp-block {
+	max-width: var(--wp--custom--width--default);
 }
 
 // This is the default with of blocks on the page with not assign alignwide or alignfull
@@ -66,36 +71,52 @@ body {
 
 // Align Left and Right
 @include media(mobile) {
+	.block-editor-block-list__layout .alignleft,
+	.block-editor-block-list__layout .alignright,
 	.wp-site-blocks .alignleft,
 	.wp-site-blocks .alignright {
-		// Content width is the lesser of the viewport width (subtracting margins)
-		// or the default site width.
-		// This variable is only used for this element.
-		--content-width: min( 100vw - var(--wp--custom--margin--horizontal) * 2, var(--wp--custom--width--default) );
-		// The alignment margin is the viewport, subtract the content and divide by two
-		// Then subtract the block padding
-		--alignment-margin: calc( ( 100vw - var(--content-width ) ) / 2 - var(--wp--custom--margin--horizontal) );
-		max-width: var(--wp--custom--width--default);
+		max-width: calc(var(--wp--custom--width--default) / 2);
 	}
-}
 
-// Align Left
-@include media(mobile) {
+	// Align Left
 	.wp-site-blocks .alignleft {
 		/*rtl:ignore*/
 		float: left;
+	}
+
+	// Align Right
+	.wp-site-blocks .alignright {
+		/*rtl:ignore*/
+		float: right;
+	}
+
+	// When alignments are applied to top level blocks
+	// we need to add more left/right margin as the block is full width.
+	.block-editor-block-list__layout > .alignleft,
+	.block-editor-block-list__layout > .alignright,
+	.wp-site-blocks .wp-block-post-content > .alignleft,
+	.wp-site-blocks .wp-block-post-content > .alignright {
+		// Content width is the lesser of the viewport width (subtracting margins)
+		// or the default site width.
+		// This variable is only used for this element.
+		--content-width: min( 100% - var(--wp--custom--margin--horizontal) * 2, var(--wp--custom--width--default) );
+		// The alignment margin is the viewport, subtract the content and divide by two
+		// Then subtract the block padding
+		--alignment-margin: calc( ( 100% - var(--content-width ) ) / 2 );
+	}
+
+	// Align Left
+	.block-editor-block-list__layout > .alignleft, // For the editor.
+	.wp-site-blocks .wp-block-post-content > .alignleft {
 		/*rtl:ignore*/
 		margin-left: var(--alignment-margin);
 		/*rtl:ignore*/
 		margin-right: var(--wp--custom--margin--horizontal);
 	}
-}
 
-// Align Right
-@include media(mobile) {
-	.wp-site-blocks .alignright {
-		/*rtl:ignore*/
-		float: right;
+	// Align Right
+	.block-editor-block-list__layout > .alignright, // For the editor.
+	.wp-site-blocks .wp-block-post-content > .alignright {
 		/*rtl:ignore*/
 		margin-left: var(--wp--custom--margin--horizontal);
 		/*rtl:ignore*/

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -23,9 +23,16 @@ body {
 	padding: 0 var(--wp--custom--margin--horizontal);
 }
 
-// Set a width for the editor
-.wp-block {
+.wp-block { // For the editor.
 	max-width: var(--wp--custom--width--default);
+}
+
+.wp-block[data-align=wide] { // For the editor.
+	max-width: var(--wp--custom--width--wide);
+}
+
+.wp-block[data-align=full] { // For the editor.
+	max-width: none;
 }
 
 // This is the default with of blocks on the page with not assign alignwide or alignfull
@@ -52,16 +59,6 @@ body {
 	margin-left: 0;
 	margin-right: 0;
 	box-sizing: content-box;
-}
-
-.wp-site-blocks .wp-block-template-part.alignfull {
-	width: 100%;
-	max-width: 100%;
-}
-
-.wp-site-blocks .wp-block-columns.alignfull {
-	width: 100%;
-	max-width: 100%;
 }
 
 // Align Center
@@ -92,8 +89,8 @@ body {
 
 	// When alignments are applied to top level blocks
 	// we need to add more left/right margin as the block is full width.
-	.block-editor-block-list__layout > .alignleft,
-	.block-editor-block-list__layout > .alignright,
+	.block-editor-block-list__layout > .alignleft, // For the editor.
+	.block-editor-block-list__layout > .alignright, // For the editor.
 	.wp-site-blocks .wp-block-post-content > .alignleft,
 	.wp-site-blocks .wp-block-post-content > .alignright {
 		// Content width is the lesser of the viewport width (subtracting margins)

--- a/blank-canvas-blocks/sass/blocks/_image.scss
+++ b/blank-canvas-blocks/sass/blocks/_image.scss
@@ -5,11 +5,15 @@
 	default styles.  It's difficult to say how this will land, however 
 	based on discussion found in (many) related issues here: 
 	https://github.com/WordPress/gutenberg/issues/28923
+	*/
+	text-align: center;
+}
 
+/*
 	Further gutenberg APPEARS to be defaulting the margin to the same as 
 	the below, however (for reason's that aren't clear to me now) this
 	isn't coming through.
-	*/
-	text-align: center;
+*/
+.wp-block-column .wp-block-image {
 	margin: 0 0 1em 0;
 }

--- a/blank-canvas-blocks/sass/blocks/_image.scss
+++ b/blank-canvas-blocks/sass/blocks/_image.scss
@@ -1,0 +1,12 @@
+.wp-block-image {
+	/* 
+	From what I can tell the below are styles regularly used by themes
+	to fix the image block.  I believe these should go into the block's
+	default styles.  It's difficult to say how this will land, however 
+	based on discussion found in (many) related issues here: 
+	https://github.com/WordPress/gutenberg/issues/28923
+	*/
+	text-align: center;
+	margin: 0;
+	margin-bottom: 1em;
+}

--- a/blank-canvas-blocks/sass/blocks/_image.scss
+++ b/blank-canvas-blocks/sass/blocks/_image.scss
@@ -5,8 +5,11 @@
 	default styles.  It's difficult to say how this will land, however 
 	based on discussion found in (many) related issues here: 
 	https://github.com/WordPress/gutenberg/issues/28923
+
+	Further gutenberg APPEARS to be defaulting the margin to the same as 
+	the below, however (for reason's that aren't clear to me now) this
+	isn't coming through.
 	*/
 	text-align: center;
-	margin: 0;
-	margin-bottom: 1em;
+	margin: 0 0 1em 0;
 }

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -9,11 +9,12 @@
 // Blocks
 // - These styles replace key Gutenberg Block styles for fonts, colors, and
 //   spacing with CSS-variables overrides
-@import "blocks/heading";
 @import "blocks/button";
-@import "blocks/paragraph";
-@import "blocks/navigation";
-@import "blocks/quote";
 @import "blocks/group";
+@import "blocks/heading";
+@import "blocks/image";
+@import "blocks/navigation";
+@import "blocks/paragraph";
+@import "blocks/quote";
 @import "blocks/separator";
 @import "blocks/video";

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -9,12 +9,12 @@
 // Blocks
 // - These styles replace key Gutenberg Block styles for fonts, colors, and
 //   spacing with CSS-variables overrides
-@import "blocks/button";
-@import "blocks/group";
 @import "blocks/heading";
-@import "blocks/image";
-@import "blocks/navigation";
+@import "blocks/button";
 @import "blocks/paragraph";
+@import "blocks/navigation";
 @import "blocks/quote";
+@import "blocks/group";
 @import "blocks/separator";
 @import "blocks/video";
+@import "blocks/image";


### PR DESCRIPTION
There appear to be consistent default styles added to every theme for images and captions.
These are added in this change.  The Gutenberg PR most likely to correct the need for these additions is noted in the change for future reference.

Validated with [Columns](https://theamdemo.wordpress.com/2018/10/24/gutenberg-columns/) and [Image](https://theamdemo.wordpress.com/2019/06/25/gutenberg-image/) theamdemo content.

Before:
![image](https://user-images.githubusercontent.com/146530/110521423-b358c880-80dd-11eb-826f-3820a1e987e3.png)
![image](https://user-images.githubusercontent.com/146530/110521375-a6d47000-80dd-11eb-97f6-4620b87db6c1.png)

After:
![image](https://user-images.githubusercontent.com/146530/110521294-90c6af80-80dd-11eb-80dd-dc24950a74d9.png)
![image](https://user-images.githubusercontent.com/146530/110521318-97552700-80dd-11eb-98cb-a9580dac464c.png)
