### PR TITLE
Adjusting font size configuration to match Blank Canvas

### DIFF
--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -1,48 +1,5 @@
 {
 	"settings": {
-		"root": {
-			"color": {
-				"note": "These are the 'Semantic' colors.  These colors should ALWAYS be provided.  They can have the same VALUES as the colors in the palette but can't currently use those variables and render correctly in the FSE GSE.  The variables generated for these values are what should be used throughout the theme to style things.  These WILL be provided as CSS variables in the page but will NOT be offered to the user for color customization options.",
-
-				"palette": [
-					{
-						"slug": "primary",
-						"color": "#000000",
-						"name": "Primary"
-					},
-					{
-						"slug": "secondary",
-						"color": "#000000",
-						"name": "Secondary"
-					},
-					{
-						"slug": "tertiary",
-						"color": "#B62020",
-						"name": "Tertiary"
-					},
-					{
-						"slug": "foreground",
-						"color": "#294E5B",
-						"name": "Foreground"
-					},
-					{
-						"slug": "background",
-						"color": "#AFEBEB",
-						"name": "Background"
-					},
-					{
-						"slug": "link",
-						"color": "#294E5B",
-						"name": "Link"
-					},
-					{
-						"slug": "selection",
-						"color": "#CDC058",
-						"name": "Selection"
-					}
-				]
-			}
-		},
 		"defaults": {
 			"color": {
 				"gradients": [],
@@ -79,28 +36,28 @@
 				"customLineHeight": true,
 				"fontSizes": [
 					{
-						"name": "Extra Small",
-						"size": "9px",
-						"slug": "x-small"
+						"name": "Tiny",
+						"size": "14px",
+						"slug": "tiny"
 					},
 					{
 						"name": "Small",
-						"size": "16.6px",
+						"size": "16px",
 						"slug": "small"
 					},
 					{
 						"name": "Normal",
-						"size": "20px",
+						"size": "18px",
 						"slug": "normal"
 					},
 					{
 						"name": "Large",
-						"size": "28.8px",
+						"size": "24px",
 						"slug": "large"
 					},
 					{
 						"name": "Huge",
-						"size": "34.56px",
+						"size": "28px",
 						"slug": "huge"
 					}
 				],


### PR DESCRIPTION
Adjusting font size configuration to match Blank Canvas.
Values in Blank Canvas were derived from [Seedlet definitions](https://github.com/Automattic/themes/blob/trunk/seedlet/functions.php#L124).

Also removed inappropriate color definitions.

Before:
![image](https://user-images.githubusercontent.com/146530/110526607-fe75da00-80e3-11eb-901f-cc5708316c26.png)

After:
![image](https://user-images.githubusercontent.com/146530/110526673-12214080-80e4-11eb-9688-319a64b25b3d.png)
