### PR TITLE
Blan Canvas Blocks: Add default styles for Video block

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -366,4 +366,9 @@ p.has-text-color a {
 	max-width: var(--wp--custom--separator--width);
 }
 
+.wp-block-video figcaption {
+	margin: var(--wp--custom--video--caption--margin);
+	text-align: var(--wp--custom--video--caption--text-align);
+}
+
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -187,6 +187,12 @@
 					"color": "#ccc",
 					"thickness": "2px",
 					"width": "150px"
+				},
+				"video": {
+					"caption":{
+						"margin": "var(--wp--custom--margin--vertical) auto",
+						"text-align": "center"
+					}
 				}
 			}
 		}

--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -8,6 +8,10 @@ if ( ! function_exists( 'blank_canvas_blocks_support' ) ) :
 		// Add support for experimental link color control.
 		add_theme_support( 'experimental-link-color' );
 
+		// Add support for responsive embedded content.
+		// https://github.com/WordPress/gutenberg/issues/26901
+		add_theme_support( 'responsive-embeds' );
+
 		// Add support for "reasonable default" block styles
 		add_theme_support( 'wp-block-styles');
 

--- a/blank-canvas-blocks/sass/blocks/_video.scss
+++ b/blank-canvas-blocks/sass/blocks/_video.scss
@@ -1,13 +1,6 @@
-* > figure > video {
-	max-width: unset;
-	width: 100%;
-	vertical-align: middle;
-}
-
 .wp-block-video {
 	figcaption {
-		margin-top: var(--wp--custom--margin--vertical);
-		margin-bottom: var(--wp--custom--margin--vertical);
-		text-align: center;
+		margin: var(--wp--custom--video--caption--margin);
+		text-align: var(--wp--custom--video--caption--text-align);
 	}
 }

--- a/blank-canvas-blocks/sass/blocks/_video.scss
+++ b/blank-canvas-blocks/sass/blocks/_video.scss
@@ -1,0 +1,13 @@
+* > figure > video {
+	max-width: unset;
+	width: 100%;
+	vertical-align: middle;
+}
+
+.wp-block-video {
+	figcaption {
+		margin-top: var(--wp--custom--margin--vertical);
+		margin-bottom: var(--wp--custom--margin--vertical);
+		text-align: center;
+	}
+}

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -16,3 +16,4 @@
 @import "blocks/quote";
 @import "blocks/group";
 @import "blocks/separator";
+@import "blocks/video";


### PR DESCRIPTION
Part of #3413

I added `add_theme_support( 'responsive-embeds' );` because that adds the editor styles for responsive videos. The markup of the blocks on Theam demo site wasn't the correct one and I had to re create the blocks in order for the support to work on the video blocks.