### PR TITLE
Blank Canvas Blocks: Switch custom variables to camel case

### DIFF
--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -88,7 +88,7 @@
 					"background": "var(--wp--preset--color--white)",
 					"selection": "var(--wp--preset--color--almost-white)"
 				},
-				"line-height": {
+				"lineHeight": {
 					"body": 1.6,
 					"headings": 1.125
 				},
@@ -105,13 +105,13 @@
 					"wide": "1000px"
 				},
 				"button": {
-					"font-weight": "normal",
-					"font-family": "var(--wp--preset--font-family--base)",
-					"font-size": "var(--wp--preset--font-size--small)",
-					"border-radius": "4px",
+					"fontWeight": "normal",
+					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"borderRadius": "4px",
 					"color": {
-						"hover-text": "var(--wp--custom--color--secondary)",
-						"hover-background": "var(--wp--custom--color--primary)"
+						"hoverText": "var(--wp--custom--color--secondary)",
+						"hoverBackground": "var(--wp--custom--color--primary)"
 					}
 				},
 				"form": {
@@ -125,7 +125,7 @@
 					"color": {
 						"text": "var(--wp--custom--color--foreground)",
 						"background": "transparent",
-						"box-shadow": "none"
+						"boxShadow": "none"
 					}
 				},
 				"quote": {
@@ -135,8 +135,8 @@
 					},
 					"citation": {
 						"typography": {
-							"font-size": "var(--wp--preset--font-size--small)",
-							"font-style": "italic"
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "italic"
 						}
 					}
 				},
@@ -148,7 +148,7 @@
 				"video": {
 					"caption":{
 						"margin": "var(--wp--custom--margin--vertical) auto",
-						"text-align": "center"
+						"textAlign": "center"
 					}
 				}
 			}


### PR DESCRIPTION
This PR changes our custom variables in theme.json to use camel case for consistency with the way the GB presets work. No CSS needs to change because the camel case gets transformed to the same hyphenated format we were using before once the variables are created (GB is really smart :D)
