### PR TITLE
Handle nested blocks and remove Gutenberg theme CSS.

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -363,8 +363,18 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }
 
+.wp-block-group.has-background {
+	padding: unset;
+}
+
 .wp-block-group.has-background .wp-block-group__inner-container {
 	padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
+}
+
+.wp-block-group.has-background .wp-block-group__inner-container .wp-block-group:not(.alignfull):not(.alignwide) {
+	max-width: var(--wp--custom--width--default);
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .wp-block-separator:not(.is-style-dots) {

--- a/blank-canvas-blocks/sass/blocks/_group.scss
+++ b/blank-canvas-blocks/sass/blocks/_group.scss
@@ -1,7 +1,13 @@
 .wp-block-group {
 	&.has-background {
+		padding: unset; // Remove Gutenberg-supplied theme CSS
 		.wp-block-group__inner-container {
 			padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
+			.wp-block-group:not(.alignfull):not(.alignwide) {
+				max-width: var(--wp--custom--width--default);
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I am not sure if I'm heading in the right direction here: 

Before | This PR
------ | -------
![screencapture-localhost-4759-2021-03-10-12_47_40](https://user-images.githubusercontent.com/5375500/110695563-e7e08900-819e-11eb-9708-0ac13a5f53d8.png) | ![screencapture-localhost-4759-2021-03-10-12_47_15](https://user-images.githubusercontent.com/5375500/110695613-f62ea500-819e-11eb-85ee-b82f83220caa.png)

Right now Gutenberg adds a bunch of padding via its theme.css. My thought was to remove this so that only the group block's custom padding values supplied via CSS variables are applied.

I also added a patch for nested alignfull and alignwide group blocks, but I'm not sure how we should handle nested default, wide, and full aligned blocks. Should we just mirror exactly what [Blank Canvas](scrugM-group-p2?theme=pub/blank-canvas) / Seedlet does? 