### PR TITLE
Adjusted Group Alignment especially for nested groups

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -92,6 +92,7 @@ body {
 	max-width: none;
 }
 
+.wp-block-group .wp-block-group,
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
 .wp-site-blocks .wp-block-post-content > * {
 	max-width: var(--wp--custom--width--default);
@@ -113,6 +114,12 @@ body {
 	margin-left: 0;
 	margin-right: 0;
 	box-sizing: content-box;
+}
+
+.wp-site-blocks *[class*="__inner-container"] .alignfull {
+	box-sizing: border-box;
+	transform: unset;
+	width: 100%;
 }
 
 .aligncenter {
@@ -361,6 +368,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {
 	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
+}
+
+.wp-block-group.has-background {
+	padding: unset;
 }
 
 .wp-block-group.has-background .wp-block-group__inner-container {

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -36,6 +36,7 @@ body {
 }
 
 // This is the default with of blocks on the page with not assign alignwide or alignfull
+.wp-block-group .wp-block-group, // When a group is in a group return alignment to default
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
 .wp-site-blocks .wp-block-post-content > * {
 	max-width: var(--wp--custom--width--default);
@@ -59,6 +60,14 @@ body {
 	margin-left: 0;
 	margin-right: 0;
 	box-sizing: content-box;
+}
+
+// If a block is inside of a container and set to alignfull
+// then it should be as wide as the container it's in, however wide that is.
+.wp-site-blocks *[class*="__inner-container"] .alignfull {
+	box-sizing: border-box;
+	transform: unset;
+	width: 100%;
 }
 
 // Align Center

--- a/blank-canvas-blocks/sass/blocks/_group.scss
+++ b/blank-canvas-blocks/sass/blocks/_group.scss
@@ -1,3 +1,10 @@
+// NOTE: Gutenberg sets a padding value by default for groups with a background.
+// However when this top level element has padding applied it mucks up the alignment
+// calculations, so it's removed and set instead (to a configurable value) on the inner-container instead.
+.wp-block-group.has-background {
+	padding: unset;
+}
+
 .wp-block-group {
 	&.has-background {
 		.wp-block-group__inner-container {

--- a/blank-canvas-blocks/sass/blocks/_group.scss
+++ b/blank-canvas-blocks/sass/blocks/_group.scss
@@ -3,12 +3,7 @@
 // calculations, so it's removed and set instead (to a configurable value) on the inner-container instead.
 .wp-block-group.has-background {
 	padding: unset;
-}
-
-.wp-block-group {
-	&.has-background {
-		.wp-block-group__inner-container {
-			padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
-		}
+	.wp-block-group__inner-container {
+		padding: var(--wp--custom--margin--vertical) var(--wp--custom--margin--horizontal);
 	}
 }


### PR DESCRIPTION
Adjusted Group alignment, especially for nested groups, according to the content found here: https://theamdemo.wordpress.com/2019/06/25/group/

#### Changes proposed in this Pull Request:
* The "padding" to groups with a background color was removed and instead applied to the inner container.
* Any blocks, inside of a group, set to alignwide should be as wide as it's container, however wide that is.
* When a group is nested in another group, and no alignment value is assigned, that groups width defaults to the theme default.

#### Related issue(s):
#3413 (Groups)

#### NOTE

This works dandily on the front end.  (At least I think the blocks are all laying out as I would expect them to in the content test.  However the editor is NOT currently playing nice with all of the situations demoed in that content and I'm just not sure how to get it to.

Before:
![image](https://user-images.githubusercontent.com/146530/110697639-a1008c80-81ba-11eb-9cc0-c7bb6e94e060.png)
![image](https://user-images.githubusercontent.com/146530/110697670-ab228b00-81ba-11eb-9251-d38fd949da69.png)

After:
![image](https://user-images.githubusercontent.com/146530/110697557-84fceb00-81ba-11eb-9895-f88147b17d87.png)
