### PR TITLE
Add image resets

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -15,6 +15,11 @@ p {
 	margin: 0;
 }
 
+img {
+	height: auto;
+	max-width: 100%;
+}
+
 /**
  * Required Variables
  */

--- a/blank-canvas-blocks/sass/base/_normalize.scss
+++ b/blank-canvas-blocks/sass/base/_normalize.scss
@@ -13,3 +13,9 @@ body {
 p {
   margin: 0;
 }
+
+// Needed until https://github.com/WordPress/gutenberg/pull/27518/ is merged.
+img {
+	height: auto;
+	max-width: 100%;
+}


### PR DESCRIPTION
This PR adds some image reset styles. Without them, you get stretched out images when you place images inside containers. 