### PR TITLE
Added default WP Prettier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To set this up follow these instructions:
 
 Now when you commit changes to a file PHPCBF will attempt to fix any issues with the file.
 
+This will also install the [WordPress-standard Prettier Configuration](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-prettier-config/) which can (optionally) be used in your IDE or command-line to format your code via (Prettier)[https://prettier.io/docs/en/editors.html].
+
 ## Packaging for WordPress.org Themes Showcase
 
 The code in this repository mirrors the code needed for the theme to function correctly on _WordPress.com_. To prepare a theme.zip that passes the _WordPress.org_ theme review automated test, do the following:

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@wordpress/prettier-config": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.1.tgz",
+			"integrity": "sha512-LgnivcSTWqUgy5JE24+AKygtQsVvcdvNUGEyeM4K4urWgnyvmkeyZDfbN1nuK2b7E1oRMSSCCwxqQJDoxlFgUg==",
+			"dev": true
+		},
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Automattic public themes",
 	"author": "automattic",
 	"license": "GPL-2.0",
+  "prettier": "@wordpress/prettier-config",
 	"scripts": {
 		"sandbox:clean": "./sandbox.sh clean",
 		"sandbox:push": "./sandbox.sh push",
@@ -12,6 +13,7 @@
 		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial"
 	},
 	"devDependencies": {
+		"@wordpress/prettier-config": "^1.0.1",
 		"chokidar-cli": "^2.1.0",
 		"husky": "^4.3.0",
 		"lodash": "^4.17.20"


### PR DESCRIPTION
With this change run `npm install` to install the [@wordpress/pretter-config](https://github.com/WordPress/gutenberg/blob/trunk/packages/prettier-config/README.md) which is loaded via package.json

Anybody not using [prettier](https://prettier.io/) shouldn't notice the change.