### PR TITLE
Mayland Blocks: Add support for spacing overrides

### DIFF
--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -100,7 +100,8 @@
 					"headings": 1.125
 				},
 				"margin": {
-					"horizontal": "32px"
+					"horizontal": "32px",
+					"vertical": "32px"
 				},
 				"width": {
 					"default": "750px",

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -65,3 +65,124 @@ body {
 h1, h2, h3 {
 	letter-spacing: -0.015em;
 }
+/**
+ * Spacing Overrides
+ */
+/*
+ * Margins
+ */
+.margin-top-none {
+	margin-top: 0 !important;
+}
+
+.margin-top-half {
+	margin-top: calc(0.5 * var(--wp--custom--margin--vertical)) !important;
+}
+
+.margin-top-default {
+	margin-top: var(--wp--custom--margin--vertical) !important;
+}
+
+.margin-right-none {
+	/*rtl:ignore*/
+	margin-right: 0 !important;
+}
+
+.margin-right-half {
+	/*rtl:ignore*/
+	margin-right: calc(0.5 * var(--wp--custom--margin--horizontal)) !important;
+}
+
+.margin-right-default {
+	/*rtl:ignore*/
+	margin-right: var(--wp--custom--margin--horizontal) !important;
+}
+
+.margin-bottom-none {
+	margin-bottom: 0 !important;
+}
+
+.margin-bottom-half {
+	margin-bottom: calc(0.5 * var(--wp--custom--margin--vertical)) !important;
+}
+
+.margin-bottom-default {
+	margin-bottom: var(--wp--custom--margin--vertical) !important;
+}
+
+.margin-left-none {
+	/*rtl:ignore*/
+	margin-left: 0 !important;
+}
+
+.margin-left-half {
+	/*rtl:ignore*/
+	margin-left: calc(0.5 * var(--wp--custom--margin--horizontal)) !important;
+}
+
+.margin-left-default {
+	/*rtl:ignore*/
+	margin-left: var(--wp--custom--margin--horizontal) !important;
+}
+
+/*
+ * Padding
+ */
+.padding-top-none {
+	padding-top: 0 !important;
+}
+
+.padding-top-half {
+	padding-top: calc(0.5 * var(--wp--custom--margin--vertical)) !important;
+}
+
+.padding-top-default {
+	padding-top: var(--wp--custom--margin--vertical) !important;
+}
+
+.padding-right-none {
+	/*rtl:ignore*/
+	padding-right: 0 !important;
+}
+
+.padding-right-half {
+	/*rtl:ignore*/
+	padding-right: calc(0.5 * var(--wp--custom--margin--horizontal)) !important;
+}
+
+.padding-right-default {
+	/*rtl:ignore*/
+	padding-right: var(--wp--custom--margin--horizontal) !important;
+}
+
+.padding-bottom-none {
+	padding-bottom: 0 !important;
+}
+
+.padding-bottom-half {
+	padding-bottom: calc(0.5 * var(--wp--custom--margin--vertical)) !important;
+}
+
+.padding-bottom-default {
+	padding-bottom: var(--wp--custom--margin--vertical) !important;
+}
+
+.padding-left-none {
+	/*rtl:ignore*/
+	padding-left: 0 !important;
+}
+
+.padding-left-half {
+	/*rtl:ignore*/
+	padding-left: calc(0.5 * var(--wp--custom--margin--horizontal)) !important;
+}
+
+.padding-left-default {
+	/*rtl:ignore*/
+	padding-left: var(--wp--custom--margin--horizontal) !important;
+}
+
+[data-block] {
+	margin-top: var(--wp--custom--margin--vertical);
+	margin-bottom: var(--wp--custom--margin--vertical);
+}


### PR DESCRIPTION
**Changes proposed in this Pull Request:**
Mayland and other Varia child themes have a few classes built-in that help to control the spacing. This PR introduces the same spacing override classes to Mayland Blocks.

**Related issue(s):**
Addresses #3424

**Testing:**

1. Checkout this branch
2. Zip the mayland-blocks theme to upload to a jurassic.ninja website.
3. Import & activate the theme into a WordPress jurassic.ninja site.
4. Open the Gutenberg editor and add two blocks. There should be a margin between them.
5. Open the HTML element inspector and modify the classname of either or both blocks.
6. Include variations of spacing overrides introduced in this PR, like `margin-top-none`, `margin-bottom-none`, `margin-top-half`, etc.
7. Verify that the margins on the blocks are modified.