### PR TITLE
Add Navigation styling to BCB

### DIFF
--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -43,7 +43,7 @@
 	}
 
 	window.addEventListener( 'load', () => {
-		mobalizeNavigationBlock(document.querySelector( 'header .wp-block-navigation' ) );
+		mobilizeNavigationBlock( document.querySelector( 'header .wp-block-navigation' ) );
 	});
 
 })();

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -15,6 +15,9 @@
 
 	function addMobileMenuOpenButton( navMenu ) {
 		const menuContainer = navMenu.querySelector( '.wp-block-navigation__container' );
+		if( !menuContainer ) {
+			return;
+		}
 		const openButton = document.createElement( 'button' );
 		const openButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--open-label' );
 		openButton.classList.add( 'wp-block-navigation__mobile-menu-open-button' );
@@ -24,7 +27,10 @@
 			menuContainer.scrollTop = 0;
 			if( 0 === clickEvent.detail ) {
 				// Menu was opened with keyboard, apply focus to close button.
-				menuContainer.querySelector('button:first-of-type')?.focus();
+				const firstButton = menuContainer.querySelector('.wp-block-navigation__mobile-menu-close-button');
+				if( firstButton ) {
+					firstButton.focus();
+				}
 			}
 		});
 		navMenu.appendChild( openButton );
@@ -32,6 +38,9 @@
 
 	function addMobileMenuCloseButton( navMenu ) {
 		const menuContainer = navMenu.querySelector( '.wp-block-navigation__container' );
+		if( !menuContainer ) {
+			return;
+		}
 		const closeButton = document.createElement( 'button' );
 		const closeButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--close-label' );
 		closeButton.classList.add( 'wp-block-navigation__mobile-menu-close-button' );

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -28,7 +28,7 @@
 	}
 
 	window.addEventListener( 'load', () => {
-		Array.from( document.querySelectorAll( '.wp-block-navigation.is___experimental-mobile' ) )
+		Array.from( document.querySelectorAll( 'header .wp-block-navigation' ) )
 			.forEach( addMobileMenuButton );
 	});
 

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -22,7 +22,7 @@
 		openButton.addEventListener( 'click', (clickEvent) => {
 			navMenu.classList.add( 'show' );
 			menuContainer.scrollTop = 0;
-			if( 0 === clickEvent.detail) {
+			if( 0 === clickEvent.detail ) {
 				// Menu was opened with keyboard, apply focus to close button.
 				menuContainer.querySelector('button:first-of-type')?.focus();
 			}

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -1,0 +1,35 @@
+/**
+ * File navigation.js.
+ *
+ * Required to open the mobile navigation.
+ */
+(function () {
+
+	function addMobileMenuButton( navMenu ) {
+
+		const menuContainer = navMenu.querySelector( '.wp-block-navigation__container' );
+		const openButton = document.createElement( 'a' );
+		const openButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--label' );
+		openButton.setAttribute( 'href', '#' );
+		openButton.classList.add( 'wp-block-navigation__mobile-menu-open-button' );
+		openButton.innerText = ( openButtonLabel );
+		openButton.addEventListener( 'click', () => {
+			navMenu.classList.add( 'show' );
+			menuContainer.scrollTop = 0;
+		});
+
+		menuContainer.addEventListener( 'click', (mouseEvent) => {
+			if ( mouseEvent.target === menuContainer ) {
+				navMenu.classList.remove( 'show' );
+			}
+		});
+
+		navMenu.appendChild( openButton );
+	}
+
+	window.addEventListener( 'load', () => {
+		Array.from( document.querySelectorAll( '.wp-block-navigation.is___experimental-mobile' ) )
+			.forEach( addMobileMenuButton );
+	});
+
+})();

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -20,7 +20,6 @@
 		openButton.classList.add( 'wp-block-navigation__mobile-menu-open-button' );
 		openButton.innerText = openButtonLabel;
 		openButton.addEventListener( 'click', (clickEvent) => {
-			console.log('clickEvent', clickEvent);
 			navMenu.classList.add( 'show' );
 			menuContainer.scrollTop = 0;
 			if( 0 === clickEvent.detail) {

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -5,7 +5,7 @@
  */
 (function () {
 
-	function mobalizeNavigationBlock( navMenu ) {
+	function mobilizeNavigationBlock( navMenu ) {
 		if( !navMenu ){
 			return;
 		}

--- a/blank-canvas-blocks/assets/navigation.js
+++ b/blank-canvas-blocks/assets/navigation.js
@@ -5,31 +5,46 @@
  */
 (function () {
 
-	function addMobileMenuButton( navMenu ) {
+	function mobalizeNavigationBlock( navMenu ) {
+		if( !navMenu ){
+			return;
+		}
+		addMobileMenuOpenButton( navMenu );
+		addMobileMenuCloseButton( navMenu );
+	}
 
+	function addMobileMenuOpenButton( navMenu ) {
 		const menuContainer = navMenu.querySelector( '.wp-block-navigation__container' );
-		const openButton = document.createElement( 'a' );
-		const openButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--label' );
-		openButton.setAttribute( 'href', '#' );
+		const openButton = document.createElement( 'button' );
+		const openButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--open-label' );
 		openButton.classList.add( 'wp-block-navigation__mobile-menu-open-button' );
-		openButton.innerText = ( openButtonLabel );
-		openButton.addEventListener( 'click', () => {
+		openButton.innerText = openButtonLabel;
+		openButton.addEventListener( 'click', (clickEvent) => {
+			console.log('clickEvent', clickEvent);
 			navMenu.classList.add( 'show' );
 			menuContainer.scrollTop = 0;
-		});
-
-		menuContainer.addEventListener( 'click', (mouseEvent) => {
-			if ( mouseEvent.target === menuContainer ) {
-				navMenu.classList.remove( 'show' );
+			if( 0 === clickEvent.detail) {
+				// Menu was opened with keyboard, apply focus to close button.
+				menuContainer.querySelector('button:first-of-type')?.focus();
 			}
 		});
-
 		navMenu.appendChild( openButton );
 	}
 
+	function addMobileMenuCloseButton( navMenu ) {
+		const menuContainer = navMenu.querySelector( '.wp-block-navigation__container' );
+		const closeButton = document.createElement( 'button' );
+		const closeButtonLabel = getComputedStyle(menuContainer).getPropertyValue( '--wp--custom--navigation--mobile--menu--close-label' );
+		closeButton.classList.add( 'wp-block-navigation__mobile-menu-close-button' );
+		closeButton.innerText = closeButtonLabel;
+		closeButton.addEventListener( 'click', () => {
+			navMenu.classList.remove( 'show' );
+		});
+		menuContainer.prepend( closeButton );
+	}
+
 	window.addEventListener( 'load', () => {
-		Array.from( document.querySelectorAll( 'header .wp-block-navigation' ) )
-			.forEach( addMobileMenuButton );
+		mobalizeNavigationBlock(document.querySelector( 'header .wp-block-navigation' ) );
 	});
 
 })();

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -335,6 +335,7 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-navigation .wp-block-navigation-link__submenu-icon {
 	padding: 0;
+	text-indent: -8px;
 }
 
 .wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link {
@@ -365,6 +366,54 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-navigation .wp-block-navigation__container .has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
 	padding: var(--wp--custom--navigation--submenu--padding);
+}
+
+@media only screen and (min-width: 482px) {
+	.wp-block-navigation.is___experimental-mobile .wp-block-navigation__mobile-menu-open-button {
+		display: none;
+	}
+}
+
+@media only screen and (max-width: 481px) {
+	.wp-block-navigation.is___experimental-mobile:not(.show) .wp-block-navigation__container {
+		display: none;
+	}
+	.wp-block-navigation.is___experimental-mobile:not(.show) {
+		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
+		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
+		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
+		text-align: right;
+	}
+	.wp-block-navigation.is___experimental-mobile.show {
+		opacity: 1;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		width: 100%;
+	}
+	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation__container {
+		background-color: var(--wp--custom--navigation--submenu--color--background);
+		flex-direction: column;
+		align-items: var(--wp--custom--navigation--mobile--horizontal-alignment);
+		justify-content: var(--wp--custom--navigation--mobile--vertical-alignment);
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: 9999;
+		overflow-y: scroll;
+	}
+	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation-link {
+		padding: 0;
+	}
+	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation-link .wp-block-navigation-link__content {
+		padding: var(--wp--custom--navigation--mobile--padding);
+		font-family: var(--wp--custom--navigation--mobile--typography--font-family);
+		font-size: var(--wp--custom--navigation--mobile--typography--font-size);
+		font-weight: var(--wp--custom--navigation--mobile--typography--font-weight);
+	}
 }
 
 .wp-block-quote {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -369,22 +369,22 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 @media only screen and (min-width: 482px) {
-	.wp-block-navigation.is___experimental-mobile .wp-block-navigation__mobile-menu-open-button {
+	header .wp-block-navigation .wp-block-navigation__mobile-menu-open-button {
 		display: none;
 	}
 }
 
 @media only screen and (max-width: 481px) {
-	.wp-block-navigation.is___experimental-mobile:not(.show) .wp-block-navigation__container {
+	header .wp-block-navigation:not(.show) .wp-block-navigation__container {
 		display: none;
 	}
-	.wp-block-navigation.is___experimental-mobile:not(.show) {
+	header .wp-block-navigation:not(.show) {
 		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
 		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
 		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
 		text-align: right;
 	}
-	.wp-block-navigation.is___experimental-mobile.show {
+	header .wp-block-navigation.show {
 		opacity: 1;
 		position: absolute;
 		top: 0;
@@ -392,7 +392,7 @@ p.has-drop-cap:not(:focus):first-letter {
 		right: 0;
 		width: 100%;
 	}
-	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation__container {
+	header .wp-block-navigation.show .wp-block-navigation__container {
 		background-color: var(--wp--custom--navigation--submenu--color--background);
 		flex-direction: column;
 		align-items: var(--wp--custom--navigation--mobile--horizontal-alignment);
@@ -405,10 +405,10 @@ p.has-drop-cap:not(:focus):first-letter {
 		z-index: 9999;
 		overflow-y: scroll;
 	}
-	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation-link {
+	header .wp-block-navigation.show .wp-block-navigation-link {
 		padding: 0;
 	}
-	.wp-block-navigation.is___experimental-mobile.show .wp-block-navigation-link .wp-block-navigation-link__content {
+	header .wp-block-navigation.show .wp-block-navigation-link .wp-block-navigation-link__content {
 		padding: var(--wp--custom--navigation--mobile--padding);
 		font-family: var(--wp--custom--navigation--mobile--typography--font-family);
 		font-size: var(--wp--custom--navigation--mobile--typography--font-size);

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -369,20 +369,30 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 @media only screen and (min-width: 482px) {
-	header .wp-block-navigation .wp-block-navigation__mobile-menu-open-button {
+	header .wp-block-navigation .wp-block-navigation__mobile-menu-open-button,
+	header .wp-block-navigation .wp-block-navigation__mobile-menu-close-button {
 		display: none;
 	}
 }
 
 @media only screen and (max-width: 481px) {
+	header .wp-block-navigation:not(.show) {
+		text-align: right;
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+	}
 	header .wp-block-navigation:not(.show) .wp-block-navigation__container {
 		display: none;
 	}
-	header .wp-block-navigation:not(.show) {
+	header .wp-block-navigation:not(.show) .wp-block-navigation__mobile-menu-open-button {
 		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
 		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
 		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
-		text-align: right;
+		background-color: transparent;
+		border: none;
+	}
+	header .wp-block-navigation:not(.show) .wp-block-navigation__mobile-menu-close-button {
+		display: none;
 	}
 	header .wp-block-navigation.show {
 		opacity: 1;
@@ -391,6 +401,17 @@ p.has-drop-cap:not(:focus):first-letter {
 		bottom: 0;
 		right: 0;
 		width: 100%;
+	}
+	header .wp-block-navigation.show .wp-block-navigation__mobile-menu-close-button {
+		display: inline-block;
+		position: absolute;
+		top: var(--wp--custom--margin--vertical);
+		right: var(--wp--custom--margin--horizontal);
+		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
+		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
+		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
+		background-color: transparent;
+		border: none;
 	}
 	header .wp-block-navigation.show .wp-block-navigation__container {
 		background-color: var(--wp--custom--navigation--submenu--color--background);
@@ -402,7 +423,7 @@ p.has-drop-cap:not(:focus):first-letter {
 		bottom: 0;
 		left: 0;
 		right: 0;
-		z-index: 9999;
+		z-index: 99999;
 		overflow-y: scroll;
 	}
 	header .wp-block-navigation.show .wp-block-navigation-link {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -355,6 +355,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	border-color: var(--wp--custom--navigation--submenu--border--color);
 	color: var(--wp--custom--navigation--submenu--color--text);
 	background-color: var(--wp--custom--navigation--submenu--color--background);
+	box-shadow: var(--wp--custom--navigation--submenu--shadow);
 }
 
 .wp-block-navigation .wp-block-navigation__container .has-child .wp-block-navigation-link__container :hover {

--- a/blank-canvas-blocks/block-template-parts/header.html
+++ b/blank-canvas-blocks/block-template-parts/header.html
@@ -1,0 +1,2 @@
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
+<!-- /wp:navigation -->

--- a/blank-canvas-blocks/block-templates/index.html
+++ b/blank-canvas-blocks/block-templates/index.html
@@ -1,5 +1,4 @@
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
-<!-- /wp:navigation -->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query -->
 	<!-- wp:query-loop -->

--- a/blank-canvas-blocks/block-templates/index.html
+++ b/blank-canvas-blocks/block-templates/index.html
@@ -1,3 +1,6 @@
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
+<!-- /wp:navigation -->
+
 <!-- wp:query -->
 	<!-- wp:query-loop -->
 		<!-- wp:post-title {"isLink":true} /-->

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -183,7 +183,8 @@
 				"navigation": {
 					"mobile": {
 						"menu": {
-							"label": "☰",
+							"openLabel": "☰",
+							"closeLabel": "╳",
 							"color": {
 								"text": "var(--wp--custom--color--foreground)"
 							},

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -181,12 +181,33 @@
 					}
 				},
 				"navigation": {
+					"mobile": {
+						"menu": {
+							"label": "☰",
+							"color": {
+								"text": "var(--wp--custom--color--foreground)"
+							},
+							"typography": {
+								"fontWeight": 500,
+								"fontSize": "24px",
+								"fontFamily": "var(--wp--custom--font-family--base)"
+							}
+						},
+						"padding": "10px",
+						"verticalAlignment": "center",
+						"horizontalAlignment": "center",
+						"typography": {
+							"fontWeight": 200,
+							"fontSize": "20px",
+							"fontFamily": "var(--wp--custom--font-family--base)"
+						}
+					},
 					"padding": "10px",
 					"color": {
 						"text": "var(--wp--custom--color--foreground)",
 						"background": "var(--wp--custom--color--background)",
-						"hover-text": "var(--wp--custom--color--secondary)",
-						"hover-background": "var(--wp--custom--color--background)"
+						"hoverText": "var(--wp--custom--color--secondary)",
+						"hoverBackground": "var(--wp--custom--color--background)"
 					},
 					"submenu": {
 						"padding": "8px",
@@ -200,8 +221,8 @@
 						"color": {
 							"text": "var(--wp--custom--color--foreground)",
 							"background": "var(--wp--custom--color--background)",
-							"hover-text": "var(--wp--custom--color--secondary)",
-							"hover-background": "var(--wp--custom--color--background)"
+							"hoverText": "var(--wp--custom--color--secondary)",
+							"hoverBackground": "var(--wp--custom--color--background)"
 						}
 					}
 				}

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -179,6 +179,31 @@
 					"padding": {
 						"left": "calc( 2 * var(--wp--custom--padding--horizontal) )"
 					}
+				},
+				"navigation": {
+					"padding": "10px",
+					"color": {
+						"text": "var(--wp--custom--color--foreground)",
+						"background": "var(--wp--custom--color--background)",
+						"hover-text": "var(--wp--custom--color--secondary)",
+						"hover-background": "var(--wp--custom--color--background)"
+					},
+					"submenu": {
+						"padding": "8px",
+						"shadow": "1px 1px 3px 0px rgba(0,0,0,.2)",
+						"border": {
+							"radius": "0",
+							"color": "0",
+							"width": "1px",
+							"style": "none"
+						},
+						"color": {
+							"text": "var(--wp--custom--color--foreground)",
+							"background": "var(--wp--custom--color--background)",
+							"hover-text": "var(--wp--custom--color--secondary)",
+							"hover-background": "var(--wp--custom--color--background)"
+						}
+					}
 				}
 			}
 		}

--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -36,7 +36,7 @@ function blank_canvas_blocks_scripts() {
 	// Enqueue Google fonts
 	wp_enqueue_style( 'blank-canvas-blocks-fonts', blank_canvas_blocks_fonts_url(), array(), null );
 
-	wp_enqueue_script( 'blank-canvas-navigation-script', get_template_directory_uri().'/assets/navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
+	wp_enqueue_script( 'blank-canvas-navigation-script', get_template_directory_uri() . '/assets/navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_style( 'blank_canvas_blocks-ponyfill', get_template_directory_uri() . '/assets/ponyfill.css', array(), wp_get_theme()->get( 'Version' )  );
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_blocks_scripts', 11 );

--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -36,6 +36,7 @@ function blank_canvas_blocks_scripts() {
 	// Enqueue Google fonts
 	wp_enqueue_style( 'blank-canvas-blocks-fonts', blank_canvas_blocks_fonts_url(), array(), null );
 
+	wp_enqueue_script( 'blank-canvas-navigation-script', get_template_directory_uri().'/assets/navigation.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_style( 'blank_canvas_blocks-ponyfill', get_template_directory_uri() . '/assets/ponyfill.css', array(), wp_get_theme()->get( 'Version' )  );
 }
 add_action( 'wp_enqueue_scripts', 'blank_canvas_blocks_scripts', 11 );

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -47,7 +47,8 @@
 
 @include media(mobile) {
 	header .wp-block-navigation {
-		.wp-block-navigation__mobile-menu-open-button {
+		.wp-block-navigation__mobile-menu-open-button,
+		.wp-block-navigation__mobile-menu-close-button {
 			display:none;
 		}
 	}
@@ -55,23 +56,46 @@
 
 @include media(mobile-only) {
 	header .wp-block-navigation:not(.show) {
+		text-align: right;
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+
 		.wp-block-navigation__container {
 			display: none;
 		}
+
+		.wp-block-navigation__mobile-menu-open-button {
+			font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
+			font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
+			font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
+			background-color: transparent;
+			border: none;
+		}
+
+		.wp-block-navigation__mobile-menu-close-button {
+			display: none;
+		}
 	}
-	header .wp-block-navigation:not(.show) {
-		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
-		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
-		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
-		text-align: right;
-	}
+
 	header .wp-block-navigation.show {
 		opacity: 1;
 		position:absolute;
-		top: 0;
+		top: 0; 
 		bottom: 0;
 		right: 0;	
 		width: 100%;
+
+		.wp-block-navigation__mobile-menu-close-button {
+			display: inline-block;
+			position: absolute;
+			top: var(--wp--custom--margin--vertical);
+			right: var(--wp--custom--margin--horizontal);
+			font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
+			font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
+			font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
+			background-color: transparent;
+			border: none;
+		}
 
 		.wp-block-navigation__container {
 			background-color: var(--wp--custom--navigation--submenu--color--background);
@@ -79,11 +103,11 @@
 			align-items: var(--wp--custom--navigation--mobile--horizontal-alignment);
 			justify-content: var(--wp--custom--navigation--mobile--vertical-alignment);
 			position:fixed;
-			top: 0; 
+			top: 0;
 			bottom: 0;
 			left: 0;
 			right: 0;	
-			z-index: 9999;
+			z-index: 99999;
 			overflow-y: scroll;
 		}
 		.wp-block-navigation-link {

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -1,5 +1,6 @@
-.wp-block-navigation {
 
+
+.wp-block-navigation {
 	a {
 		border-bottom: none;
 	}
@@ -11,17 +12,16 @@
 	}
 	.wp-block-navigation-link__submenu-icon {
 		padding: 0;
+		text-indent: -8px;
 	}
 	.wp-block-navigation__container {
 		.wp-block-navigation-link {
-
-				color: var(--wp--custom--navigation--color--text);
-				background-color: var(--wp--custom--navigation--color--background);
-				:hover {
-					color: var(--wp--custom--navigation--color--hover-text);
-					background-color: var(--wp--custom--navigation--color--hover-background);
-				}
-	
+			color: var(--wp--custom--navigation--color--text);
+			background-color: var(--wp--custom--navigation--color--background);
+			:hover {
+				color: var(--wp--custom--navigation--color--hover-text);
+				background-color: var(--wp--custom--navigation--color--hover-background);
+			}
 		}	
 		.has-child {
 			.wp-block-navigation-link__container {
@@ -40,6 +40,59 @@
 				.wp-block-navigation-link__content {
 					padding: var(--wp--custom--navigation--submenu--padding);
 				}
+			}
+		}
+	}
+}
+
+@include media(mobile) {
+	.wp-block-navigation.is___experimental-mobile {
+		.wp-block-navigation__mobile-menu-open-button {
+			display:none;
+		}
+	}
+}
+
+@include media(mobile-only) {
+	.wp-block-navigation.is___experimental-mobile:not(.show) {
+		.wp-block-navigation__container {
+			display: none;
+		}
+	}
+	.wp-block-navigation.is___experimental-mobile:not(.show) {
+		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
+		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
+		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
+		text-align: right;
+	}
+	.wp-block-navigation.is___experimental-mobile.show {
+		opacity: 1;
+		position:absolute;
+		top: 0;
+		bottom: 0;
+		right: 0;	
+		width: 100%;
+
+		.wp-block-navigation__container {
+			background-color: var(--wp--custom--navigation--submenu--color--background);
+			flex-direction: column;
+			align-items: var(--wp--custom--navigation--mobile--horizontal-alignment);
+			justify-content: var(--wp--custom--navigation--mobile--vertical-alignment);
+			position:fixed;
+			top: 0; 
+			bottom: 0;
+			left: 0;
+			right: 0;	
+			z-index: 9999;
+			overflow-y: scroll;
+		}
+		.wp-block-navigation-link {
+			padding: 0;
+			.wp-block-navigation-link__content {
+				padding: var(--wp--custom--navigation--mobile--padding);
+				font-family: var(--wp--custom--navigation--mobile--typography--font-family);
+				font-size: var(--wp--custom--navigation--mobile--typography--font-size);
+				font-weight: var(--wp--custom--navigation--mobile--typography--font-weight);
 			}
 		}
 	}

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -3,22 +3,15 @@
 	a {
 		border-bottom: none;
 	}
-
 	.wp-block-navigation-link {
 		padding: 0;
-
 		.wp-block-navigation-link__content {
 			padding: var(--wp--custom--navigation--padding);
-
-	
 		}
-
 	}
-
 	.wp-block-navigation-link__submenu-icon {
 		padding: 0;
 	}
-
 	.wp-block-navigation__container {
 		.wp-block-navigation-link {
 
@@ -39,6 +32,7 @@
 				border-color: var(--wp--custom--navigation--submenu--border--color);
 				color: var(--wp--custom--navigation--submenu--color--text);
 				background-color: var(--wp--custom--navigation--submenu--color--background);
+				box-shadow: var(--wp--custom--navigation--submenu--shadow);
 				:hover {
 					color: var(--wp--custom--navigation--submenu--color--hover-text);
 					background-color: var(--wp--custom--navigation--submenu--color--hover-background);
@@ -49,5 +43,4 @@
 			}
 		}
 	}
-
 }

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -46,7 +46,7 @@
 }
 
 @include media(mobile) {
-	.wp-block-navigation.is___experimental-mobile {
+	header .wp-block-navigation {
 		.wp-block-navigation__mobile-menu-open-button {
 			display:none;
 		}
@@ -54,18 +54,18 @@
 }
 
 @include media(mobile-only) {
-	.wp-block-navigation.is___experimental-mobile:not(.show) {
+	header .wp-block-navigation:not(.show) {
 		.wp-block-navigation__container {
 			display: none;
 		}
 	}
-	.wp-block-navigation.is___experimental-mobile:not(.show) {
+	header .wp-block-navigation:not(.show) {
 		font-size: var(--wp--custom--navigation--mobile--menu--typography--font-size);
 		font-weight: var(--wp--custom--navigation--mobile--menu--typography--font-weight);
 		font-family: var(--wp--custom--navigation--mobile--menu--typography--font-family);
 		text-align: right;
 	}
-	.wp-block-navigation.is___experimental-mobile.show {
+	header .wp-block-navigation.show {
 		opacity: 1;
 		position:absolute;
 		top: 0;


### PR DESCRIPTION
This change just adds configuration to the already-present navigation styles.
You'll have to add the navigation elements in FSE for this to show up.

This change also adds the drop shadow setting to match existing Blank Canvas style.

![image](https://user-images.githubusercontent.com/146530/110992981-b7d2ea80-8344-11eb-9893-8dece41bb700.png)

Additionally any `core/navigation` block that is in a `<header>` will receive "mobile" styling.
![image](https://user-images.githubusercontent.com/146530/111335400-bc501980-864a-11eb-87b6-486f8658d4c0.png)
![image](https://user-images.githubusercontent.com/146530/111356622-edd2e000-865e-11eb-926b-467845570177.png)

To support mobile styling quite a few additional custom styles have been added under `custom.navigation.mobile`.

Additionally javascript is loaded to support that menu by adding the button that opens the mobile menu.  It's as small an amount of JavaScript as I could add and still be functional simply creating two buttons - open and close - and labeling them based on CSS variables which add/remove a `show` class to the menu block.