### PR TITLE
Blank Canvas Blocks: Add default styles for search block

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -127,7 +127,7 @@ input[type="datetime-local"],
 input[type="color"],
 textarea {
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-	border-radius: var(--wp--custom--form--border-radius);
+	border-radius: var(--wp--custom--form--border--radius);
 	color: var(--wp--custom--form--color--text);
 	padding: var(--wp--custom--form--padding);
 	background: var(--wp--custom--form--color--background);
@@ -343,6 +343,39 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {
 	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	border-radius: var(--wp--custom--form--border-radius);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+	padding: var(--wp--custom--form--padding);
+}
+
+.wp-block-search .wp-block-search__input {
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	border-radius: var(--wp--custom--form--border--radius);
+	color: var(--wp--custom--form--color--text);
+	padding: var(--wp--custom--form--padding);
+	background: var(--wp--custom--form--color--background);
+	font-size: var(--wp--custom--form--font-size);
+	line-height: var(--wp--custom--typography--line-height);
+}
+
+.wp-block-search .wp-block-search__button {
+	font-weight: var(--wp--custom--button--font-weight);
+	font-family: var(--wp--custom--button--font-family);
+	font-size: var(--wp--custom--button--font-size);
+	line-height: var(--wp--custom--button--line-height);
+	border-radius: var(--wp--custom--button--border-radius);
+}
+
+.wp-block-search .wp-block-search__button:hover, .wp-block-search .wp-block-search__button:focus, .wp-block-search .wp-block-search__button.has-focus {
+	color: var(--wp--custom--button--color--hover-text);
+	background-color: var(--wp--custom--button--color--hover-background);
+	border-color: var(--wp--custom--button--color--hover-background);
 }
 
 .wp-block-separator:not(.is-style-dots) {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -366,7 +366,6 @@ p.has-drop-cap:not(:focus):first-letter {
 	background: var(--wp--custom--form--color--background);
 	font-size: var(--wp--custom--form--font-size);
 	line-height: var(--wp--custom--typography--line-height);
-	margin: var(--wp--custom--search--input--margin);
 }
 
 .wp-block-search .wp-block-search__button {
@@ -377,6 +376,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	line-height: var(--wp--custom--button--border--line-height);
 	text-decoration: none;
 	padding: var(--wp--custom--search--button--padding);
+	margin: var(--wp--custom--search--button--margin);
 	line-height: var(--wp--custom--search--button--line-height);
 }
 

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -213,17 +213,6 @@ ol {
 	padding-left: var(--wp--custom--list--padding--left);
 }
 
-p.has-text-color a {
-	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
-}
-
-p.has-drop-cap:not(:focus):first-letter {
-	font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
-	font-family: var(--wp--custom--paragraph--dropcap--typography--font-family);
-	font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
-	margin: var(--wp--custom--paragraph--dropcap--margin);
-}
-
 .wp-block-navigation a {
 	border-bottom: none;
 }
@@ -338,6 +327,17 @@ p.has-drop-cap:not(:focus):first-letter {
 		font-size: var(--wp--custom--navigation--mobile--typography--font-size);
 		font-weight: var(--wp--custom--navigation--mobile--typography--font-weight);
 	}
+}
+
+p.has-text-color a {
+	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
+}
+
+p.has-drop-cap:not(:focus):first-letter {
+	font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
+	font-family: var(--wp--custom--paragraph--dropcap--typography--font-family);
+	font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
+	margin: var(--wp--custom--paragraph--dropcap--margin);
 }
 
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -191,6 +191,13 @@ input[type=checkbox] + label {
 	border-color: var(--wp--custom--button--color--hover-background);
 }
 
+.wp-block-button.wp-block-button__link:hover svg, .wp-block-button.wp-block-button__link:focus svg, .wp-block-button.wp-block-button__link.has-focus svg,
+.wp-block-button .wp-block-button__link:hover svg,
+.wp-block-button .wp-block-button__link:focus svg,
+.wp-block-button .wp-block-button__link.has-focus svg {
+	fill: var(--wp--custom--button--color--hover-text);
+}
+
 .wp-block-gallery .blocks-gallery-image figcaption,
 .wp-block-gallery .blocks-gallery-item figcaption {
 	font-size: var(--wp--custom--gallery--caption--font-size);
@@ -345,29 +352,49 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }
 
+/**
+ * Button
+ */
+/**
+ * Block Options
+ */
+.wp-block-button.wp-block-button__link,
+.wp-block-button .wp-block-button__link {
+	text-decoration: none;
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	color: var(--wp--custom--button--color--hover-text);
+	background-color: var(--wp--custom--button--color--hover-background);
+	border-color: var(--wp--custom--button--color--hover-background);
+}
+
+.wp-block-button.wp-block-button__link:hover svg, .wp-block-button.wp-block-button__link:focus svg, .wp-block-button.wp-block-button__link.has-focus svg,
+.wp-block-button .wp-block-button__link:hover svg,
+.wp-block-button .wp-block-button__link:focus svg,
+.wp-block-button .wp-block-button__link.has-focus svg {
+	fill: var(--wp--custom--button--color--hover-text);
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	padding: var(--wp--custom--form--padding);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-	border-radius: var(--wp--custom--form--border-radius);
+	border-radius: var(--wp--custom--form--border--radius);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
-	padding: var(--wp--custom--form--padding);
-}
-
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
-	padding: var(--wp--custom--search--button--padding);
+	padding: 0;
 }
 
 .wp-block-search .wp-block-search__input {
-	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-	border-radius: var(--wp--custom--form--border--radius);
-	color: var(--wp--custom--form--color--text);
 	padding: var(--wp--custom--form--padding);
-	background: var(--wp--custom--form--color--background);
-	font-size: var(--wp--custom--form--font-size);
-	line-height: var(--wp--custom--typography--line-height);
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 .wp-block-search .wp-block-search__button {
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
@@ -375,15 +402,35 @@ p.has-drop-cap:not(:focus):first-letter {
 	border-radius: var(--wp--custom--button--border--radius);
 	line-height: var(--wp--custom--button--border--line-height);
 	text-decoration: none;
-	padding: var(--wp--custom--search--button--padding);
-	margin: var(--wp--custom--search--button--margin);
-	line-height: var(--wp--custom--search--button--line-height);
+	color: var(--wp--custom--button--color--text);
+	border-color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
-.wp-block-search .wp-block-search__button:hover, .wp-block-search .wp-block-search__button:focus, .wp-block-search .wp-block-search__button.has-focus {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
+.wp-block-search .wp-block-search__button svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus,
+.wp-block-search .wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button.has-focus {
 	color: var(--wp--custom--button--color--hover-text);
 	background-color: var(--wp--custom--button--color--hover-background);
 	border-color: var(--wp--custom--button--color--hover-background);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus svg,
+.wp-block-search .wp-block-search__button:hover svg,
+.wp-block-search .wp-block-search__button:focus svg,
+.wp-block-search .wp-block-search__button.has-focus svg {
+	fill: var(--wp--custom--button--color--hover-text);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
+.wp-block-search .wp-block-search__button.has-icon {
+	line-height: 0;
 }
 
 .wp-block-separator:not(.is-style-dots) {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -354,6 +354,10 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding: var(--wp--custom--form--padding);
 }
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
+	padding: var(--wp--custom--search--button--padding);
+}
+
 .wp-block-search .wp-block-search__input {
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	border-radius: var(--wp--custom--form--border--radius);
@@ -362,14 +366,18 @@ p.has-drop-cap:not(:focus):first-letter {
 	background: var(--wp--custom--form--color--background);
 	font-size: var(--wp--custom--form--font-size);
 	line-height: var(--wp--custom--typography--line-height);
+	margin: var(--wp--custom--search--input--margin);
 }
 
 .wp-block-search .wp-block-search__button {
-	font-weight: var(--wp--custom--button--font-weight);
-	font-family: var(--wp--custom--button--font-family);
-	font-size: var(--wp--custom--button--font-size);
-	line-height: var(--wp--custom--button--line-height);
-	border-radius: var(--wp--custom--button--border-radius);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	border-radius: var(--wp--custom--button--border--radius);
+	line-height: var(--wp--custom--button--border--line-height);
+	text-decoration: none;
+	padding: var(--wp--custom--search--button--padding);
+	line-height: var(--wp--custom--search--button--line-height);
 }
 
 .wp-block-search .wp-block-search__button:hover, .wp-block-search .wp-block-search__button:focus, .wp-block-search .wp-block-search__button.has-focus {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -400,11 +400,12 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	border-radius: var(--wp--custom--button--border--radius);
-	line-height: var(--wp--custom--button--border--line-height);
+	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -128,8 +128,7 @@
 					}
 				},
 				"form": {
-					"padding": "calc( 0.5 * var(--wp--custom--padding--horizontal) )",
-					"fontSize": "var(--wp--preset--font-size--normal)",
+					"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
 					"border": {
 						"radius": "0",
 						"color": "#EFEFEF",
@@ -169,13 +168,6 @@
 					"color": "#ccc",
 					"thickness": "2px",
 					"width": "150px"
-				},
-				"search": {
-					"button": {
-						"lineHeight": "27px",
-						"padding": "calc( .9 * var(--wp--custom--padding--horizontal) )",
-						"margin": "0 0 0 calc( 1.4 * var(--wp--custom--padding--horizontal))"
-					}
 				},
 				"video": {
 					"caption": {
@@ -279,12 +271,6 @@
 			},
 			"border": {
 				"radius": "var(--wp--custom--button--border--radius)"
-			}
-		},
-		"core/search": {
-			"color": {
-				"text": "var(--wp--custom--color--background)",
-				"background": "var(--wp--custom--color--secondary)"
 			}
 		},
 		"core/heading/h1": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -88,7 +88,16 @@
 				"contentSize": "620px",
 				"wideSize": "1000px"
 			},
+			"custom-comments":{
+				"root": "I copied the root typography preset variables to custom until this (or a similar PR) gets merged: https://github.com/WordPress/gutenberg/pull/29714",
+				"search-block": "the core/search variables won't work until https://github.com/WordPress/gutenberg/pull/29830 is merged"
+			},
 			"custom": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"lineHeight": "1.6",
+					"fontFamily": "var(--wp--preset--font-family--base)"
+				},
 				"color": {
 					"primary": "var(--wp--preset--color--black)",
 					"secondary": "var(--wp--preset--color--blue)",
@@ -119,10 +128,11 @@
 					}
 				},
 				"form": {
-					"padding": "5px",
+					"padding": "calc( 0.5 * var(--wp--custom--padding--horizontal) )",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"border": {
 						"radius": "0",
-						"color": "#cccccc",
+						"color": "#EFEFEF",
 						"width": "2px",
 						"style": "solid"
 					},
@@ -262,6 +272,12 @@
 			},
 			"border": {
 				"radius": "var(--wp--custom--button--border--radius)"
+			}
+		},
+		"core/search": {
+			"color": {
+				"text": "var(--wp--custom--color--background)",
+				"background": "var(--wp--custom--color--secondary)"
 			}
 		},
 		"core/heading/h1": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -173,10 +173,8 @@
 				"search": {
 					"button": {
 						"lineHeight": "27px",
-						"padding": "calc( .9 * var(--wp--custom--padding--horizontal) )"
-					},
-					"input": {
-						"margin": "0 calc( .66 * var(--wp--custom--padding--horizontal)) 0 0"
+						"padding": "calc( .9 * var(--wp--custom--padding--horizontal) )",
+						"margin": "0 0 0 calc( 1.4 * var(--wp--custom--padding--horizontal))"
 					}
 				},
 				"video": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -89,7 +89,7 @@
 				"wideSize": "1000px"
 			},
 			"custom-comments":{
-				"root": "I copied the root typography preset variables to custom until this (or a similar PR) gets merged: https://github.com/WordPress/gutenberg/pull/29714",
+				"root": "TODO: removed copied root typography preset variables to custom when this (or a similar PR) gets merged: https://github.com/WordPress/gutenberg/pull/29714",
 				"search-block": "the core/search variables won't work until https://github.com/WordPress/gutenberg/pull/29830 is merged"
 			},
 			"custom": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -88,16 +88,7 @@
 				"contentSize": "620px",
 				"wideSize": "1000px"
 			},
-			"custom-comments":{
-				"root": "TODO: removed copied root typography preset variables to custom when this (or a similar PR) gets merged: https://github.com/WordPress/gutenberg/pull/29714",
-				"search-block": "the core/search variables won't work until https://github.com/WordPress/gutenberg/pull/29830 is merged"
-			},
 			"custom": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"lineHeight": "1.6",
-					"fontFamily": "var(--wp--preset--font-family--base)"
-				},
 				"color": {
 					"primary": "var(--wp--preset--color--black)",
 					"secondary": "var(--wp--preset--color--blue)",

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -170,6 +170,15 @@
 					"thickness": "2px",
 					"width": "150px"
 				},
+				"search": {
+					"button": {
+						"lineHeight": "27px",
+						"padding": "calc( .9 * var(--wp--custom--padding--horizontal) )"
+					},
+					"input": {
+						"margin": "0 calc( .66 * var(--wp--custom--padding--horizontal)) 0 0"
+					}
+				},
 				"video": {
 					"caption": {
 						"margin": "var(--wp--custom--margin--vertical) auto",

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -8,9 +8,14 @@
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	border-radius: var(--wp--custom--button--border--radius);
-	//border-width: var(--wp--custom--button--border--width); //TODO: <---- that
 	line-height: var(--wp--custom--button--border--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
+	color: var(--wp--custom--button--color--text);
+	border-color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	svg {
+		fill: var(--wp--custom--button--color--text);
+	}
 }
 
 // NOTE: These remain for the hover styling of blocks.  This can be removed when the button block has configurable hover states.
@@ -21,6 +26,9 @@
 		color: var(--wp--custom--button--color--hover-text);
 		background-color: var(--wp--custom--button--color--hover-background);
 		border-color: var(--wp--custom--button--color--hover-background);
+		svg {
+			fill: var(--wp--custom--button--color--hover-text);
+		}
 	}
 }
 

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -8,6 +8,7 @@
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	border-radius: var(--wp--custom--button--border--radius);
+	//border-width: var(--wp--custom--button--border--width); //TODO: <---- that
 	line-height: var(--wp--custom--button--border--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
 }

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -8,11 +8,12 @@
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	border-radius: var(--wp--custom--button--border--radius);
-	line-height: var(--wp--custom--button--border--line-height);
+	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
 	color: var(--wp--custom--button--color--text);
 	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	padding: calc(.667em + 2px) calc(1.333em + 2px); //The padding found on an unmodified Button Block 
 	svg {
 		fill: var(--wp--custom--button--color--text);
 	}

--- a/blank-canvas-blocks/sass/blocks/_search.scss
+++ b/blank-canvas-blocks/sass/blocks/_search.scss
@@ -20,13 +20,13 @@
 		background: var(--wp--custom--form--color--background);	
 		font-size: var(--wp--custom--form--font-size);
 		line-height: var(--wp--custom--typography--line-height);
-		margin: var(--wp--custom--search--input--margin);
 	}
 
 	.wp-block-search__button {
 		@include button-main-styles;
 		@include button-hover-styles;
 		padding: var(--wp--custom--search--button--padding);
+		margin: var(--wp--custom--search--button--margin);
 		line-height: var(--wp--custom--search--button--line-height);
 	}
 }

--- a/blank-canvas-blocks/sass/blocks/_search.scss
+++ b/blank-canvas-blocks/sass/blocks/_search.scss
@@ -1,32 +1,30 @@
+@import 'button';
+
 .wp-block-search {
+
 	&.wp-block-search__button-inside {
 		.wp-block-search__inside-wrapper{
+			padding: var(--wp--custom--form--padding);
 			border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-			border-radius: var(--wp--custom--form--border-radius);
+			border-radius: var(--wp--custom--form--border--radius);
 			.wp-block-search__input {
-				padding: var(--wp--custom--form--padding);
-			}
-			.wp-block-search__button {
-				padding: var(--wp--custom--search--button--padding);
+				padding: 0;
 			}
 		}
 	}
 
 	.wp-block-search__input {
-		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-		border-radius: var(--wp--custom--form--border--radius);
-		color: var(--wp--custom--form--color--text);
 		padding: var(--wp--custom--form--padding);
-		background: var(--wp--custom--form--color--background);	
-		font-size: var(--wp--custom--form--font-size);
-		line-height: var(--wp--custom--typography--line-height);
+		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	}
 
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 	.wp-block-search__button {
 		@include button-main-styles;
 		@include button-hover-styles;
-		padding: var(--wp--custom--search--button--padding);
-		margin: var(--wp--custom--search--button--margin);
-		line-height: var(--wp--custom--search--button--line-height);
+		&.has-icon {
+			line-height: 0;
+		}
 	}
+
 }

--- a/blank-canvas-blocks/sass/blocks/_search.scss
+++ b/blank-canvas-blocks/sass/blocks/_search.scss
@@ -1,0 +1,26 @@
+.wp-block-search {
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper{
+			border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+			border-radius: var(--wp--custom--form--border-radius);
+			.wp-block-search__input {
+				padding: var(--wp--custom--form--padding);
+			}
+		}
+	}
+
+	.wp-block-search__input {
+		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+		border-radius: var(--wp--custom--form--border--radius);
+		color: var(--wp--custom--form--color--text);
+		padding: var(--wp--custom--form--padding);
+		background: var(--wp--custom--form--color--background);	
+		font-size: var(--wp--custom--form--font-size);
+		line-height: var(--wp--custom--typography--line-height);
+	}
+
+	.wp-block-search__button {
+		@include button-main-styles;
+		@include button-hover-styles;
+	}
+}

--- a/blank-canvas-blocks/sass/blocks/_search.scss
+++ b/blank-canvas-blocks/sass/blocks/_search.scss
@@ -6,6 +6,9 @@
 			.wp-block-search__input {
 				padding: var(--wp--custom--form--padding);
 			}
+			.wp-block-search__button {
+				padding: var(--wp--custom--search--button--padding);
+			}
 		}
 	}
 
@@ -17,10 +20,13 @@
 		background: var(--wp--custom--form--color--background);	
 		font-size: var(--wp--custom--form--font-size);
 		line-height: var(--wp--custom--typography--line-height);
+		margin: var(--wp--custom--search--input--margin);
 	}
 
 	.wp-block-search__button {
 		@include button-main-styles;
 		@include button-hover-styles;
+		padding: var(--wp--custom--search--button--padding);
+		line-height: var(--wp--custom--search--button--line-height);
 	}
 }

--- a/blank-canvas-blocks/sass/elements/_forms.scss
+++ b/blank-canvas-blocks/sass/elements/_forms.scss
@@ -15,7 +15,7 @@ input[type="datetime-local"],
 input[type="color"],
 textarea {
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-	border-radius: var(--wp--custom--form--border-radius);
+	border-radius: var(--wp--custom--form--border--radius);
 	color: var(--wp--custom--form--color--text);
 	padding: var(--wp--custom--form--padding);
 	background: var(--wp--custom--form--color--background);

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -13,8 +13,9 @@
 @import "blocks/gallery";
 @import "blocks/image";
 @import "blocks/list";
-@import "blocks/paragraph";
 @import "blocks/navigation";
+@import "blocks/paragraph";
 @import "blocks/quote";
+@import "blocks/search";
 @import "blocks/separator";
 @import "blocks/video";


### PR DESCRIPTION
This PR adds styles for the search block. I went ahead and tweaked it as much as I could so it will look fine for Seedlet. This block required a little extra customization on the padding and line heights for all the variations to look the same height.

Part of https://github.com/Automattic/themes/issues/3419

View: 
![image](https://user-images.githubusercontent.com/146530/111812238-4cda6400-88ae-11eb-896a-d27e42f231fe.png)

Editor:
![image](https://user-images.githubusercontent.com/146530/111812291-59f75300-88ae-11eb-96ad-8689bd9b5342.png)

(note that the emboldened "Search" is caused by the editor improperly loading the "theme.css" files)