### PR TITLE
Varia: fix color utils

### DIFF
--- a/varia/inc/color-utils.php
+++ b/varia/inc/color-utils.php
@@ -28,19 +28,20 @@ if ( ! function_exists( 'rgb_to_hsvl' ) ) {
 		$min_rgb           = min( $r, $g, $b );
 		$chroma            = $max_rgb - $min_rgb;
 		$v                 = 100 * $max_rgb;
-		if ( 0 === $chroma ) {
+		if ( $chroma > 0 ) {
+			$s = 100 * ( $chroma / $max_rgb );
+			if ( $r === $min_rgb ) {
+				$h = 3 - ( ( $g - $b ) / $chroma );
+			} elseif ( $b === $min_rgb ) {
+				$h = 1 - ( ( $r - $g ) / $chroma );
+			} else { // $g === $min_rgb
+				$h = 5 - ( ( $b - $r ) / $chroma );
+			}
+			$h = 60 * $h;
+			return array( $h, $s, $v, $l );
+		} else {
 			return array( 0, 0, $v, $l );
 		}
-		$s = 100 * ( $chroma / $max_rgb );
-		if ( $r === $min_rgb ) {
-			$h = 3 - ( ( $g - $b ) / $chroma );
-		} elseif ( $b === $min_rgb ) {
-			$h = 1 - ( ( $r - $g ) / $chroma );
-		} else { // $g === $min_rgb
-			$h = 5 - ( ( $b - $r ) / $chroma );
-		}
-		$h = 60 * $h;
-		return array( $h, $s, $v, $l );
 	}
 }
 

--- a/varia/package.json
+++ b/varia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A variable-based design system for WordPress sites built with Gutenberg.",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues?q=is%3Aopen+is%3Aissue+label%3Avaria"

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia

--- a/varia/style.css
+++ b/varia/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.5
+Version: 1.6.6
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia


### PR DESCRIPTION
This PR attempts to address a 'Division by Zero: warning'. I'm not sure why the exact equality comparison is failing to catch when `$chroma` is zero, so this is a different approach.