### PR TITLE
Seedlet: fix color utils

### DIFF
--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.14-wpcom
+Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/inc/wpcom-colors-utils.php
+++ b/seedlet/inc/wpcom-colors-utils.php
@@ -102,19 +102,20 @@ if ( ! function_exists( 'rgb_to_hsvl' ) ) {
 		$min_rgb           = min( $r, $g, $b );
 		$chroma            = $max_rgb - $min_rgb;
 		$v                 = 100 * $max_rgb;
-		if ( 0 === $chroma ) {
+		if ( $chroma > 0) {
+			$s = 100 * ( $chroma / $max_rgb );
+			if ( $r === $min_rgb ) {
+				$h = 3 - ( ( $g - $b ) / $chroma );
+			} elseif ( $b === $min_rgb ) {
+				$h = 1 - ( ( $r - $g ) / $chroma );
+			} else { // $g === $min_rgb
+				$h = 5 - ( ( $b - $r ) / $chroma );
+			}
+			$h = 60 * $h;
+			return array( $h, $s, $v, $l );
+		} else {
 			return array( 0, 0, $v, $l );
 		}
-		$s = 100 * ( $chroma / $max_rgb );
-		if ( $r === $min_rgb ) {
-			$h = 3 - ( ( $g - $b ) / $chroma );
-		} elseif ( $b === $min_rgb ) {
-			$h = 1 - ( ( $r - $g ) / $chroma );
-		} else { // $g === $min_rgb
-			$h = 5 - ( ( $b - $r ) / $chroma );
-		}
-		$h = 60 * $h;
-		return array( $h, $s, $v, $l );
 	}
 }
 

--- a/seedlet/package.json
+++ b/seedlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.14-wpcom",
+  "version": "1.1.15-wpcom",
   "description": "Seedlet",
   "bugs": {
     "url": "https://github.com/Automattic/seedlet/issues"

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.14-wpcom
+Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.14-wpcom
+Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet


### PR DESCRIPTION
This PR fixes a 'divide by 0' warning resulting from some leaky logical comparisons. Same fix as https://github.com/Automattic/themes/pull/3470

To test
- Check this PR onto your sandbox
- Open the customizer
- Change some colors, make sure nothing breaks