### PR TITLE
Add CORE/CODE configurable styles to BCB

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -77,24 +77,27 @@ body {
 
 .wp-site-blocks *[class*="__inner-container"] > .wp-block-group,
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
-.wp-site-blocks .wp-block-post-content > * {
+.wp-block-post-content > * {
 	max-width: var(--wp--custom--width--default);
 	margin-left: auto;
 	margin-right: auto;
-	padding: 0 var(--wp--custom--margin--horizontal);
+	padding-left: var(--wp--custom--margin--horizontal);
+	padding-right: var(--wp--custom--margin--horizontal);
 }
 
 .wp-site-blocks *[class*="__inner-container"] > .alignwide,
-.wp-site-blocks .alignwide {
+.alignwide {
 	width: var(--wp--custom--width--wide);
 	max-width: 100%;
 }
 
 .wp-site-blocks *[class*="__inner-container"] > .alignfull,
-.wp-site-blocks .alignfull {
+.alignfull {
 	max-width: unset;
 	margin-left: unset;
 	margin-right: unset;
+	padding-left: unset;
+	padding-right: unset;
 }
 
 .aligncenter {
@@ -471,6 +474,15 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-video figcaption {
 	margin: var(--wp--custom--video--caption--margin);
 	text-align: var(--wp--custom--video--caption--text-align);
+}
+
+.wp-block-code {
+	border-radius: var(--wp--custom--code--border--radius);
+	border-width: var(--wp--custom--code--border--width);
+	border-style: var(--wp--custom--code--border--style);
+	border-color: var(--wp--custom--code--border--color);
+	color: var(--wp--custom--code--color--text);
+	background-color: var(--wp--custom--code--color--background);
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -180,6 +180,18 @@
 						"left": "calc( 2 * var(--wp--custom--padding--horizontal) )"
 					}
 				},
+				"code": {
+					"color": {
+						"text": "inherit",
+						"background": "none"
+					},
+					"border": {
+						"radius": "0",
+						"color": "#cccccc",
+						"width": "2px",
+						"style": "solid"
+					}
+				},
 				"navigation": {
 					"mobile": {
 						"menu": {

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -15,26 +15,29 @@ body {
 // This is the default with of blocks on the page with not assign alignwide or alignfull
 .wp-site-blocks *[class*="__inner-container"] > .wp-block-group,
 .wp-site-blocks > *:not(.wp-block-post-content):not(.wp-block-template-part),
-.wp-site-blocks .wp-block-post-content > * {
+.wp-block-post-content > * {
 	max-width: var(--wp--custom--width--default);
 	margin-left: auto;
 	margin-right: auto;
- 	padding: 0 var(--wp--custom--margin--horizontal);
+	padding-left: var(--wp--custom--margin--horizontal);
+	padding-right: var(--wp--custom--margin--horizontal);
 }
 
 // Align the block to be on the "wider" side of things
 .wp-site-blocks *[class*="__inner-container"] > .alignwide,
-.wp-site-blocks .alignwide {
+.alignwide {
 	width: var(--wp--custom--width--wide);
 	max-width: 100%;
 }
 
 // The block should span the full width of the page
 .wp-site-blocks *[class*="__inner-container"] > .alignfull,
-.wp-site-blocks .alignfull {
+.alignfull {
 	max-width: unset;
 	margin-left: unset;
 	margin-right: unset;
+	padding-left: unset;
+	padding-right: unset;
 }
 
 // Align Center

--- a/blank-canvas-blocks/sass/blocks/_code.scss
+++ b/blank-canvas-blocks/sass/blocks/_code.scss
@@ -1,0 +1,9 @@
+// TODO: This shouldn't be necessary when either of these land: https://github.com/WordPress/gutenberg/pull/27582 || https://github.com/WordPress/gutenberg/issues/29778
+.wp-block-code {
+	border-radius: var(--wp--custom--code--border--radius);
+	border-width: var(--wp--custom--code--border--width);
+	border-style: var(--wp--custom--code--border--style);
+	border-color: var(--wp--custom--code--border--color);
+	color: var(--wp--custom--code--color--text);
+	background-color: var(--wp--custom--code--color--background);
+}

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -20,3 +20,4 @@
 @import "blocks/group";
 @import "blocks/separator";
 @import "blocks/video";
+@import "blocks/code";


### PR DESCRIPTION
This change adds configurable border (color/style/width/radius) and color (text/background) to the core/code block via custom theme.json configuration.

The [code block example for Blank Canvas](https://theamdemo.wordpress.com/2020/03/05/gutenberg-misc-formatting/) doesn't seem to be behaving properly (I couldn't say why...) so the styles from the form configuration were used for this block's border configuration value.

Additionally the "padding" attributes applied in _alignment have been r[efactored slightly to be less specific](https://github.com/Automattic/themes/pull/3485/files#diff-24c1332a2754d3bffa38ace74a2f607b1c1a1b7fb3fc2cebb951ecea826cf811L22).  As it was a block was unable to define a padding variable without additional specificity hacking.  This was discovered while attempting to add custom padding configuration to this core/code block per the linked Gutenberg PR.  Additionally that code was (inappropriately) enforcing a top/bottom padding of 0 on all the blocks, even if that wasn't their natural state.

In the [Gutenberg change that adds the ability to configure this block](https://github.com/WordPress/gutenberg/pull/27582) additionally the font-stylings were discussed as something to be added.  However there wasn't a need to do that and bring the styles in alignment with Blank Canvas so that customization option has been deferred until it's needed (and hopefully that will be after [something like this](https://github.com/WordPress/gutenberg/issues/29778) is complete).

Before:
![image](https://user-images.githubusercontent.com/146530/111512892-9bf58d00-8726-11eb-87a4-bcb565a47a12.png)

After:
![image](https://user-images.githubusercontent.com/146530/111512926-a44dc800-8726-11eb-8a76-fcf868d7f1bc.png)
