### PR TITLE
Blank Canvas Blocks: Add Pullquote Block styles

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -347,6 +347,39 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin: var(--wp--custom--paragraph--dropcap--margin);
 }
 
+.wp-block-pullquote {
+	border-style: solid;
+	border-width: 1px 0;
+	font-size: var(--wp--custom--pullquote--typograpghy--font-size);
+	padding: 3em 0;
+}
+
+.wp-block-pullquote blockquote p:first-child {
+	margin-top: 0;
+}
+
+.wp-block-pullquote p {
+	font-size: var(--wp--custom--pullquote--typography--font-size);
+}
+
+.wp-block-pullquote:not(.is-style-solid-color) blockquote {
+	margin: 1em;
+}
+
+.wp-block-pullquote .wp-block-pullquote__citation,
+.wp-block-pullquote cite {
+	font-style: var(--wp--custom--quote--citation--typography--font-style);
+}
+
+.wp-block-pullquote.is-style-solid-color {
+	background-color: var(--wp--preset--color--almost-black);
+	color: var(--wp--preset--color--white);
+}
+
+.wp-block-pullquote.is-style-solid-color blockquote p {
+	font-size: var(--wp--custom--pullquote--typography--font-size);
+}
+
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {
 	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -347,37 +347,36 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin: var(--wp--custom--paragraph--dropcap--margin);
 }
 
+.wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
-	border-style: solid;
-	border-width: 1px 0;
-	font-size: var(--wp--custom--pullquote--typograpghy--font-size);
-	padding: 3em 0;
+	text-align: var(--wp--custom--quote--typography--text-align);
 }
 
-.wp-block-pullquote blockquote p:first-child {
-	margin-top: 0;
+.wp-block-pullquote.is-style-solid-color blockquote,
+.wp-block-pullquote blockquote {
+	padding: 0;
+	margin: 0;
 }
 
-.wp-block-pullquote p {
-	font-size: var(--wp--custom--pullquote--typography--font-size);
+.wp-block-pullquote.is-style-solid-color blockquote p,
+.wp-block-pullquote blockquote p {
+	font-size: 1em;
+	padding: 0;
+	margin: 0;
 }
 
-.wp-block-pullquote:not(.is-style-solid-color) blockquote {
-	margin: 1em;
-}
-
-.wp-block-pullquote .wp-block-pullquote__citation,
-.wp-block-pullquote cite {
+.wp-block-pullquote.is-style-solid-color blockquote .wp-block-pullquote__citation,
+.wp-block-pullquote.is-style-solid-color blockquote cite,
+.wp-block-pullquote blockquote .wp-block-pullquote__citation,
+.wp-block-pullquote blockquote cite {
+	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }
 
+.wp-block-pullquote.is-style-solid-color.is-style-solid-color,
 .wp-block-pullquote.is-style-solid-color {
-	background-color: var(--wp--preset--color--almost-black);
-	color: var(--wp--preset--color--white);
-}
-
-.wp-block-pullquote.is-style-solid-color blockquote p {
-	font-size: var(--wp--custom--pullquote--typography--font-size);
+	background-color: var(--wp--custom--color--foreground);
+	color: var(--wp--custom--color--background);
 }
 
 .wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -369,8 +369,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-pullquote.is-style-solid-color blockquote cite,
 .wp-block-pullquote blockquote .wp-block-pullquote__citation,
 .wp-block-pullquote blockquote cite {
+	display: block;
 	font-size: var(--wp--custom--pullquote--citation--typography--font-size);
 	font-style: var(--wp--custom--pullquote--citation--typography--font-style);
+	margin-top: var(--wp--custom--margin--vertical);
 }
 
 .wp-block-pullquote.is-style-solid-color.is-style-solid-color,

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -349,7 +349,7 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
-	text-align: var(--wp--custom--quote--typography--text-align);
+	text-align: var(--wp--custom--pullquote--typography--text-align);
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote,
@@ -369,8 +369,8 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-pullquote.is-style-solid-color blockquote cite,
 .wp-block-pullquote blockquote .wp-block-pullquote__citation,
 .wp-block-pullquote blockquote cite {
-	font-size: var(--wp--custom--quote--citation--typography--font-size);
-	font-style: var(--wp--custom--quote--citation--typography--font-style);
+	font-size: var(--wp--custom--pullquote--citation--typography--font-size);
+	font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 }
 
 .wp-block-pullquote.is-style-solid-color.is-style-solid-color,
@@ -379,7 +379,15 @@ p.has-drop-cap:not(:focus):first-letter {
 	color: var(--wp--custom--color--background);
 }
 
-.wp-block-quote cite, .wp-block-quote .wp-block-quote__citation {
+.wp-block-quote.is-style-large p,
+.wp-block-quote p {
+	font-style: unset;
+}
+
+.wp-block-quote.is-style-large .wp-block-quote__citation,
+.wp-block-quote.is-style-large cite,
+.wp-block-quote .wp-block-quote__citation,
+.wp-block-quote cite {
 	font-size: var(--wp--custom--quote--citation--typography--font-size);
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -155,6 +155,12 @@
 						}
 					}
 				},
+				"pullquote": {
+					"typography": {
+						"fontSize": "var(--wp--preset--font-size--large)",
+						"fontStyle": "italic"
+					}
+				},
 				"separator": {
 					"color": "#ccc",
 					"thickness": "2px",

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -153,7 +153,7 @@
 					},
 					"citation": {
 						"typography": {
-							"fontSize": "0.8em",
+							"fontSize": "var(--wp--preset--font-size--tiny)",
 							"fontStyle": "italic"
 						}
 					}
@@ -164,7 +164,7 @@
 					},
 					"citation": {
 						"typography": {
-							"fontSize": "0.5em",
+							"fontSize": "var(--wp--preset--font-size--tiny)",
 							"fontStyle": "italic"
 						}
 					}

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -148,9 +148,12 @@
 					}
 				},
 				"quote": {
+					"typography": {
+						"textAlign": "left"
+					},
 					"citation": {
 						"typography": {
-							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontSize": "0.5em",
 							"fontStyle": "italic"
 						}
 					}
@@ -359,6 +362,24 @@
 			"spacing": {
 				"padding": {
 					"left": "var(--wp--custom--margin--horizontal)"
+				}
+			}
+		},
+		"core/pullquote": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--huge)",
+				"fontStyle": "italic"
+			},
+			"border": {
+				"style": "solid",
+				"width": "1px 0"
+			},
+			"spacing": {
+				"padding": {
+					"left": "var(--wp--custom--margin--horizontal)",
+					"right": "var(--wp--custom--margin--horizontal)",
+					"top": "var(--wp--custom--margin--horizontal)",
+					"bottom": "var(--wp--custom--margin--horizontal)"
 				}
 			}
 		}

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -153,15 +153,20 @@
 					},
 					"citation": {
 						"typography": {
-							"fontSize": "0.5em",
+							"fontSize": "0.8em",
 							"fontStyle": "italic"
 						}
 					}
 				},
 				"pullquote": {
 					"typography": {
-						"fontSize": "var(--wp--preset--font-size--large)",
-						"fontStyle": "italic"
+						"textAlign": "left"
+					},
+					"citation": {
+						"typography": {
+							"fontSize": "0.5em",
+							"fontStyle": "italic"
+						}
 					}
 				},
 				"separator": {
@@ -355,9 +360,14 @@
 			}
 		},
 		"core/quote": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--normal)",
+				"fontStyle": "normal"
+			},
 			"border": {
 				"color": "var(--wp--custom--color--secondary)",
-				"width": "1px"
+				"style": "solid",
+				"width": "0 0 0 1px"
 			},
 			"spacing": {
 				"padding": {

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -1,32 +1,24 @@
+.wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
-	border-style: solid;
-	border-width: 1px 0;
-	font-size: var(--wp--custom--pullquote--typograpghy--font-size);
-	padding: 3em 0;
+	text-align: var(--wp--custom--quote--typography--text-align);
+	blockquote {
+		padding: 0;
+		margin: 0;
+		p {
+			font-size: 1em;
+			padding: 0;
+			margin: 0;
+		}
 
-	blockquote p:first-child {
-		margin-top: 0;
-	}
-
-	p {
-		font-size: var(--wp--custom--pullquote--typography--font-size);
-	}
-
-	&:not(.is-style-solid-color) blockquote {
-		margin: 1em;
-	}
-
-	.wp-block-pullquote__citation, // For the editor
-	cite {
-		font-style: var(--wp--custom--quote--citation--typography--font-style);
+		.wp-block-pullquote__citation, // For the editor
+		cite {
+			font-size: var(--wp--custom--quote--citation--typography--font-size);
+			font-style: var(--wp--custom--quote--citation--typography--font-style);
+		}
 	}
 
 	&.is-style-solid-color {
-		background-color: var(--wp--preset--color--almost-black);
-		color: var(--wp--preset--color--white);
-
-		blockquote p {
-			font-size: var(--wp--custom--pullquote--typography--font-size);
-		}
+		background-color: var(--wp--custom--color--foreground);
+		color: var(--wp--custom--color--background);
 	}
 }

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -1,0 +1,32 @@
+.wp-block-pullquote {
+	border-style: solid;
+	border-width: 1px 0;
+	font-size: var(--wp--custom--pullquote--typograpghy--font-size);
+	padding: 3em 0;
+
+	blockquote p:first-child {
+		margin-top: 0;
+	}
+
+	p {
+		font-size: var(--wp--custom--pullquote--typography--font-size);
+	}
+
+	&:not(.is-style-solid-color) blockquote {
+		margin: 1em;
+	}
+
+	.wp-block-pullquote__citation, // For the editor
+	cite {
+		font-style: var(--wp--custom--quote--citation--typography--font-style);
+	}
+
+	&.is-style-solid-color {
+		background-color: var(--wp--preset--color--almost-black);
+		color: var(--wp--preset--color--white);
+
+		blockquote p {
+			font-size: var(--wp--custom--pullquote--typography--font-size);
+		}
+	}
+}

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -1,6 +1,6 @@
 .wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
-	text-align: var(--wp--custom--quote--typography--text-align);
+	text-align: var(--wp--custom--pullquote--typography--text-align);
 	blockquote {
 		padding: 0;
 		margin: 0;
@@ -12,8 +12,8 @@
 
 		.wp-block-pullquote__citation, // For the editor
 		cite {
-			font-size: var(--wp--custom--quote--citation--typography--font-size);
-			font-style: var(--wp--custom--quote--citation--typography--font-style);
+			font-size: var(--wp--custom--pullquote--citation--typography--font-size);
+			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 		}
 	}
 

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -12,8 +12,10 @@
 
 		.wp-block-pullquote__citation, // For the editor
 		cite {
+			display: block;
 			font-size: var(--wp--custom--pullquote--citation--typography--font-size);
 			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
+			margin-top: var(--wp--custom--margin--vertical);
 		}
 	}
 

--- a/blank-canvas-blocks/sass/blocks/_quote.scss
+++ b/blank-canvas-blocks/sass/blocks/_quote.scss
@@ -1,5 +1,10 @@
+.wp-block-quote.is-style-large,
 .wp-block-quote {
-	cite, .wp-block-quote__citation {
+	p {
+		font-style: unset;
+	}
+	.wp-block-quote__citation, // For the editor
+	cite {
 		font-size: var(--wp--custom--quote--citation--typography--font-size);
 		font-style: var(--wp--custom--quote--citation--typography--font-style);
 	}

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -15,6 +15,7 @@
 @import "blocks/list";
 @import "blocks/navigation";
 @import "blocks/paragraph";
+@import "blocks/pullquote";
 @import "blocks/quote";
 @import "blocks/search";
 @import "blocks/file";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds styles for the Pullquote block in Blank Canvas Blocks

Editor:
<img width="1440" alt="Screenshot 2021-03-22 at 13 52 13" src="https://user-images.githubusercontent.com/275961/112000592-09822e80-8b16-11eb-8e2d-2403d7c6d52d.png">

Frontend:
<img width="1440" alt="Screenshot 2021-03-22 at 13 52 20" src="https://user-images.githubusercontent.com/275961/112000608-0e46e280-8b16-11eb-9ca6-d343ee5fb1d6.png">

#### Related issue(s):
Part of https://github.com/Automattic/themes/issues/3413