### PR TITLE
Blank Canvas Blocks: Add table styles

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -503,7 +503,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-table figcaption {
-	font-size: var(--wp--custom--table--typography--font-size);
+	font-size: var(--wp--custom--table--figcaption--typography--font-size);
 	text-align: center;
 }
 

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -502,4 +502,14 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-align: var(--wp--custom--video--caption--text-align);
 }
 
+.wp-block-table figcaption {
+	font-size: var(--wp--custom--table--typography--font-size);
+	text-align: center;
+}
+
+.wp-block-table td, .wp-block-table th {
+	border: 1px solid;
+	padding: calc(0.5*var(--wp--custom--margin--vertical)) calc(0.5*var(--wp--custom--margin--horizontal));
+}
+
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -224,6 +224,11 @@
 							"hoverBackground": "var(--wp--custom--color--background)"
 						}
 					}
+				},
+				"table": {
+					"typography": {
+						"fontSize": "var(--wp--preset--font-size--tiny)"
+					}
 				}
 			}
 		}

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -226,8 +226,10 @@
 					}
 				},
 				"table": {
-					"typography": {
-						"fontSize": "var(--wp--preset--font-size--tiny)"
+					"figcaption": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--tiny)"
+						}
 					}
 				}
 			}

--- a/blank-canvas-blocks/sass/blocks/_table.scss
+++ b/blank-canvas-blocks/sass/blocks/_table.scss
@@ -1,6 +1,6 @@
 .wp-block-table {
 	figcaption {
-		font-size: var(--wp--custom--table--typography--font-size);
+		font-size: var(--wp--custom--table--figcaption--typography--font-size);
 		text-align: center;
 	}
 

--- a/blank-canvas-blocks/sass/blocks/_table.scss
+++ b/blank-canvas-blocks/sass/blocks/_table.scss
@@ -1,0 +1,11 @@
+.wp-block-table {
+	figcaption {
+		font-size: var(--wp--custom--table--typography--font-size);
+		text-align: center;
+	}
+
+	td, th {
+		border: 1px solid;
+		padding: calc(0.5*var(--wp--custom--margin--vertical)) calc(0.5*var(--wp--custom--margin--horizontal));
+	}
+}

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -20,3 +20,4 @@
 @import "blocks/file";
 @import "blocks/separator";
 @import "blocks/video";
+@import "blocks/table";

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -19,5 +19,5 @@
 @import "blocks/search";
 @import "blocks/file";
 @import "blocks/separator";
-@import "blocks/video";
 @import "blocks/table";
+@import "blocks/video";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds CSS to match the frontend to the editor for tables

#### Related issue(s):
https://github.com/Automattic/themes/issues/3413

Editor:
<img width="1440" alt="Screenshot 2021-03-22 at 15 39 56" src="https://user-images.githubusercontent.com/275961/112016812-f591f900-8b24-11eb-8aeb-6fcca5b5a8b0.png">


Frontend:
<img width="723" alt="Screenshot 2021-03-22 at 15 40 02" src="https://user-images.githubusercontent.com/275961/112016751-e90da080-8b24-11eb-89bb-fb27e5344687.png">
