### PR TITLE
Limit content width for things aligned left/right

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -69,6 +69,23 @@ img {
 	margin-right: calc(-1 * var(--wp--custom--margin--horizontal));
 }
 
+@media only screen and (min-width: 482px) {
+	.wp-block[data-align="left"],
+	.wp-block[data-align="right"],
+	.wp-site-blocks .alignleft,
+	.wp-site-blocks .alignright {
+		max-width: var(--wp--custom--alignment--aligned-max-with);
+	}
+}
+
+.wp-block-group:after {
+	content: ".";
+	visibility: hidden;
+	display: block;
+	height: 0;
+	clear: both;
+}
+
 ::selection {
 	background-color: var(--wp--custom--color--selection);
 }

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -74,16 +74,16 @@ img {
 	.wp-block[data-align="right"],
 	.wp-site-blocks .alignleft,
 	.wp-site-blocks .alignright {
-		max-width: var(--wp--custom--alignment--aligned-max-with);
+		max-width: var(--wp--custom--alignment--aligned-max-width);
 	}
 }
 
 .wp-block-group:after {
-	content: ".";
-	visibility: hidden;
-	display: block;
-	height: 0;
 	clear: both;
+	content: ".";
+	display: block;
+	position: unset;
+	visibility: hidden;
 }
 
 ::selection {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -101,6 +101,9 @@
 					"horizontal": "20px",
 					"vertical": "20px"
 				},
+				"alignment": {
+					"alignedMaxWith": "50%"
+				},
 				"button": {
 					"typography": {
 						"fontWeight": "normal",

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -102,7 +102,7 @@
 					"vertical": "20px"
 				},
 				"alignment": {
-					"alignedMaxWith": "50%"
+					"alignedMaxWidth": "50%"
 				},
 				"button": {
 					"typography": {

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -12,13 +12,14 @@
 		max-width: var(--wp--custom--alignment--aligned-max-width);
 	}
 }
+
 // When content is aligned left/right (particularly inside of a container) it is floated left/right
 // and needs something to ensure that the content follows the block rather than nestling up beside the floated element.  
-// Perhaps this (or something like this) should be supplied by Gutenberg?
+// The issue should be resolved upstream: https://github.com/WordPress/gutenberg/issues/10299
 .wp-block-group:after { 
-   content: "."; 
-   visibility: hidden; 
-   display: block; 
-   height: 0; 
-   clear: both;
+	clear: both;
+	content: ".";
+	display: block;
+	position: unset;
+	visibility: hidden;
 }

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -3,3 +3,22 @@
 	margin-right: calc(-1 * var(--wp--custom--margin--horizontal));
 }
 
+@include media(mobile) {
+	// limit size of any element that is aligned left/right 
+	.wp-block[data-align="left"], // This is for the editor
+	.wp-block[data-align="right"], // This is for the editor
+	.wp-site-blocks .alignleft,
+	.wp-site-blocks .alignright {
+		max-width: var(--wp--custom--alignment--aligned-max-with);
+	}
+}
+// When content is aligned left/right (particularly inside of a container) it is floated left/right
+// and needs something to ensure that the content follows the block rather than nestling up beside the floated element.  
+// Perhaps this (or something like this) should be supplied by Gutenberg?
+.wp-block-group:after { 
+   content: "."; 
+   visibility: hidden; 
+   display: block; 
+   height: 0; 
+   clear: both;
+}

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -9,7 +9,7 @@
 	.wp-block[data-align="right"], // This is for the editor
 	.wp-site-blocks .alignleft,
 	.wp-site-blocks .alignright {
-		max-width: var(--wp--custom--alignment--aligned-max-with);
+		max-width: var(--wp--custom--alignment--aligned-max-width);
 	}
 }
 // When content is aligned left/right (particularly inside of a container) it is floated left/right


### PR DESCRIPTION
This change limits the size to a configurable width (set to 50%) for any elements that are aligned left/right.

Additionally a "float reset" is added as an :after to the group block in order to get content that follows the block to stay out of it. 

There are still differences between the view and editor that are the responsibility of Gutenberg; Content doesn't appear to follow the "normal width" constraints of the view.

This leverages primarily the demo content found here: https://theamdemo.wordpress.com/2019/06/25/gutenberg-image/
But in order to achieve the design the local content I used put all 3 image blocks demoing alignment into a single group that was constrained to "normal" width.  Additionally the "float reset" applied to the group block for the view (noted above) doesn't work for the editor.

View:
![image](https://user-images.githubusercontent.com/146530/112019698-126b0400-8b06-11eb-8fac-1091a774d395.png)

