### PR TITLE
Added padding to code block styles

### DIFF
--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -338,6 +338,14 @@
 			}
 		},
 		"core/code": {
+			"spacing": {
+				"padding": {
+					"left": "var(--wp--custom--margin--horizontal)",
+					"right": "var(--wp--custom--margin--horizontal)",
+					"top": "var(--wp--custom--margin--vertical)",
+					"bottom": "var(--wp--custom--margin--vertical)"
+				}
+			},
 			"border": {
 				"radius": "0px",
 				"color": "#CCCCCC",


### PR DESCRIPTION
This change adds padding configuration to the "core/code" block.

![image](https://user-images.githubusercontent.com/146530/112035046-8d87e680-8b15-11eb-83b3-d2dace2b7a06.png)

This is a part of #3413