### PR TITLE
Block themes - update templateParts json

### DIFF
--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -1,4 +1,14 @@
 {
+	"templateParts": [
+		{
+			"name": "header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"area": "footer"
+		}
+	],
 	"settings": {
 		"defaults": {
 			"color": {

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -1,12 +1,14 @@
 {
-	"templateParts": {
-		"header": {
+	"templateParts": [
+		{
+			"name": "header",
 			"area": "header"
 		},
-		"footer": {
+		{
+			"name": "footer",
 			"area": "footer"
 		}
-	},
+	],
 	"settings": {
 		"defaults": {
 			"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
json schema for template parts and their area terms was recently updated in https://github.com/WordPress/gutenberg/pull/29828.  Here, we update this for seedlet-blocks as well as add this json for mayland-blocks.  This allows template parts defined by the theme to render under their corresponding block variations by default.

For example, when inspecting the header for mayland-blocks, we can see the block has the expected 'header' variation by presence of the block variations icon throughout the interface:

![Screen Shot 2021-03-22 at 5 22 40 PM](https://user-images.githubusercontent.com/28742426/112061061-51b04980-8b34-11eb-86c6-58c6fed6502f.png)


#### Related issue(s):
