### PR TITLE
Adjusted theme.json to match expected shape

### DIFF
--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -7,8 +7,8 @@
 			"area": "footer"
 		}
 	},
-	"global": {
-		"settings": {
+	"settings": {
+		"defaults": {
 			"color": {
 				"gradients": [
 					{


### PR DESCRIPTION
Seedlet Block's theme.json was still expressed with the old structure.  This change brings it up-to-date.

In some recent versions of Gutenberg (doesn't appear to be happening in /trunk) this invalid structure may be causing a WSOD.

