### PR TITLE
Mayland Blocks: Preserve image ratios

### DIFF
--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -65,3 +65,12 @@ body {
 h1, h2, h3 {
 	letter-spacing: -0.015em;
 }
+
+/* 
+ * Preserve image ratios.
+ * Needed until https://github.com/WordPress/gutenberg/pull/27518/ is merged. 
+ */
+img {
+	height: auto;
+	max-width: 100%;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/3382.

Adds some temporary CSS to preserve correct image ratios for wide/full/full-size images. Same as #3450, but for Mayland Blocks. 

@ianstewart noted that this issue is blocking testing on WP.com, so I recommend we add this in temporarily rather than wait for [a permanent solution in Gutenberg](https://href.li/?https://github.com/WordPress/gutenberg/pull/30092).

---

Before|After
---|---
![Screen Shot 2021-03-26 at 8 29 21 AM](https://user-images.githubusercontent.com/1202812/112632054-033dcc00-8e0e-11eb-83e9-74e7eff5f9d7.png)|![Screen Shot 2021-03-26 at 8 29 33 AM](https://user-images.githubusercontent.com/1202812/112632055-033dcc00-8e0e-11eb-8cc3-fcde376100ed.png)
