### PR TITLE
Refactored build scripts to standardize

### DIFF
--- a/blank-canvas-blocks/build.js
+++ b/blank-canvas-blocks/build.js
@@ -20,11 +20,12 @@ const buildChildTheme = () => {
 			console.log( "\x1b[32m" + childThemeName + "/experimental-theme.json created successfully." );
 		} );
 	} catch ( error ) {
-		console.error( "\x1b[41m" + error );
+		console.error( "\x1b[31m" + error );
 	}
 };
 
 if ( ! fs.existsSync( childThemeJsonFileName ) ) {
+	console.log( "\x1b[31m" + childThemeJsonFileName + ' not found :(' );
 	return;
 }
 

--- a/blank-canvas-blocks/package.json
+++ b/blank-canvas-blocks/package.json
@@ -13,6 +13,7 @@
     "deepmerge": "^4.2.2",
     "node-sass": "^4.13.1",
     "node-sass-package-importer": "^5.3.2",
+    "npm-run-all": "^4.1.5",
     "rtlcss": "^2.4.0"
   },
   "rtlcssConfig": {
@@ -32,9 +33,9 @@
     "extends @wordpress/browserslist-config"
   ],
   "scripts": {
-    "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
-    "build": "npm run build:ponyfill",
-    "build:ponyfill": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js sass/ponyfill.scss assets/ponyfill.css --output-style expanded --indent-type tab --indent-width 1 --source-map true",
+    "start": "chokidar \"sass/**/*.scss\" -c \"npm run build\" --initial",
+    "start:child": "run-p start \"build:child -- {@} watch\" --",
+    "build": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js sass/ponyfill.scss assets/ponyfill.css --output-style expanded --indent-type tab --indent-width 1 --source-map true",
     "build:child": "node build.js"
   }
 }

--- a/blank-canvas-blocks/package.json
+++ b/blank-canvas-blocks/package.json
@@ -13,7 +13,6 @@
     "deepmerge": "^4.2.2",
     "node-sass": "^4.13.1",
     "node-sass-package-importer": "^5.3.2",
-    "npm-run-all": "^4.1.5",
     "rtlcss": "^2.4.0"
   },
   "rtlcssConfig": {
@@ -33,8 +32,9 @@
     "extends @wordpress/browserslist-config"
   ],
   "scripts": {
-    "start": "npm-run-all --parallel \"build:* -- {@}\" --",
-    "build:ponyfill": "chokidar \"**/*.scss\" -c \"node-sass --importer node_modules/node-sass-package-importer/dist/cli.js sass/ponyfill.scss assets/ponyfill.css --output-style expanded --indent-type tab --indent-width 1 --source-map true\" --initial",
+    "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
+    "build": "npm run build:ponyfill",
+    "build:ponyfill": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js sass/ponyfill.scss assets/ponyfill.css --output-style expanded --indent-type tab --indent-width 1 --source-map true",
     "build:child": "node build.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Automattic public themes",
 	"author": "automattic",
 	"license": "GPL-2.0",
-  "prettier": "@wordpress/prettier-config",
+	"prettier": "@wordpress/prettier-config",
 	"scripts": {
 		"sandbox:clean": "./sandbox.sh clean",
 		"sandbox:push": "./sandbox.sh push",


### PR DESCRIPTION
This change refactors the BCB build scripts to standardize them on the following common commands:

`npm run build`: "Build all the things that need to be built, and just do it once"
`npm start`: "Build the things, whatever they are, then rebuild them when something changes"


Additionally, in order to target a child theme these commands would also be available:

`npm run build:child {CHILDFOLDER}`: "Build the target child's theme.json based on it's child-theme.json and BCB's theme.json and just do it once.
`npm run start:child {CHILDFOLDER}`: "Build the  target child's theme.json, then rebuild when something changes.  ADDITIONALLY also do the same process as `npm start` above (rebuilding BCB css when BCB scss changes).