### PR TITLE
Mayland Blocks: remove theme supports

### DIFF
--- a/mayland-blocks/functions.php
+++ b/mayland-blocks/functions.php
@@ -3,21 +3,6 @@
 if ( ! function_exists( 'mayland_blocks_support' ) ) :
 	function mayland_blocks_support() {
 
-		// Alignwide and alignfull classes in the block editor.
-		add_theme_support( 'align-wide' );
-
-		// Adding support for core block visual styles.
-		add_theme_support( 'wp-block-styles' );
-
-		// Adding support for responsive embedded content.
-		add_theme_support( 'responsive-embeds' );
-
-		// Add support for experimental link color control.
-		add_theme_support( 'experimental-link-color' );
-
-		// Add support for editor styles.
-		add_theme_support( 'editor-styles' );
-
 		// Enqueue editor styles.
 		add_editor_style(
 			array(


### PR DESCRIPTION
This PR removes theme supports that are no longer needed since they are being loaded by the theme's parent.