### PR TITLE
Add/bcb index query

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -114,6 +114,10 @@ img {
 	overflow: auto;
 }
 
+.aligncenter {
+	text-align: center;
+}
+
 ::selection {
 	background-color: var(--wp--custom--color--selection);
 }

--- a/blank-canvas-blocks/block-template-parts/header.html
+++ b/blank-canvas-blocks/block-template-parts/header.html
@@ -8,6 +8,3 @@
 	<!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 </div>
 <!-- /wp:group -->
-<!-- wp:spacer {"height":60} -->
-<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->

--- a/blank-canvas-blocks/block-template-parts/header.html
+++ b/blank-canvas-blocks/block-template-parts/header.html
@@ -1,5 +1,10 @@
+<!-- wp:spacer {"height":90} -->
+<div style="height:90px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 <!-- wp:group -->
-<div class="wp-block-group"><!-- wp:site-title {"textAlign":"center"} /-->
+<div class="wp-block-group">
+	<!-- wp:site-logo {"align":"center","width":128} /-->
+	<!-- wp:site-title {"textAlign":"center"} /-->
 	<!-- wp:site-tagline {"textAlign":"center"} /-->
 </div>
 <!-- /wp:group -->

--- a/blank-canvas-blocks/block-template-parts/header.html
+++ b/blank-canvas-blocks/block-template-parts/header.html
@@ -3,8 +3,11 @@
 <!-- /wp:spacer -->
 <!-- wp:group -->
 <div class="wp-block-group">
-	<!-- wp:site-logo {"align":"center","width":128} /-->
+	<!-- wp:site-logo {"align":"center","width":120} /-->
 	<!-- wp:site-title {"textAlign":"center"} /-->
-	<!-- wp:site-tagline {"textAlign":"center"} /-->
+	<!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 </div>
 <!-- /wp:group -->
+<!-- wp:spacer {"height":60} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/blank-canvas-blocks/block-template-parts/navigation.html
+++ b/blank-canvas-blocks/block-template-parts/navigation.html
@@ -1,2 +1,5 @@
 <!-- wp:navigation {"orientation":"horizontal","itemsJustification":"center"} -->
 <!-- /wp:navigation -->
+<!-- wp:spacer {"height":60} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/blank-canvas-blocks/block-templates/404.html
+++ b/blank-canvas-blocks/block-templates/404.html
@@ -1,5 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:template-part {"slug":"navigation","tagName":"navigation"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"navigation","tagName":"navigation","layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
@@ -16,4 +16,4 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->

--- a/blank-canvas-blocks/block-templates/index.html
+++ b/blank-canvas-blocks/block-templates/index.html
@@ -1,1 +1,13 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"navigation","tagName":"navigation"} /-->
+
+<!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query-loop -->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true} /-->
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+<!-- /wp:query-loop -->
+<!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/blank-canvas-blocks/block-templates/index.html
+++ b/blank-canvas-blocks/block-templates/index.html
@@ -1,13 +1,18 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:template-part {"slug":"navigation","tagName":"navigation"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"navigation","tagName":"navigation","layout":{"inherit":true}} /-->
 
 <!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <!-- wp:query-loop -->
 
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
 <!-- wp:post-title {"textAlign":"center","isLink":true} /-->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- /wp:query-loop -->
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->

--- a/blank-canvas-blocks/block-templates/search.html
+++ b/blank-canvas-blocks/block-templates/search.html
@@ -1,5 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:template-part {"slug":"navigation","tagName":"navigation"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"navigation","tagName":"navigation","layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
@@ -20,4 +20,4 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->

--- a/blank-canvas-blocks/block-templates/singular.html
+++ b/blank-canvas-blocks/block-templates/singular.html
@@ -1,0 +1,1 @@
+<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/blank-canvas-blocks/sass/base/_alignment.scss
+++ b/blank-canvas-blocks/sass/base/_alignment.scss
@@ -20,3 +20,10 @@
 .wp-block-group { 
 	overflow: auto;
 }
+
+// This was added for the 'site-logo' block which centers with an 'align:center' attribute
+// instead of 'textAlign' center which sets an .aligncenter class instead of a has-text-align-center
+// class which would do this for us.  I'm not sure why but this centers things appropriately.
+.aligncenter {
+	text-align: center;
+}


### PR DESCRIPTION
> Currently, Blank Canvas Blocks contains no archive page templates at all — the index.html template only shows the post/page content. Are there plans to change that? The original Blank Canvas shows a list of posts in its index template, and only the post/page content on its singular template.

This change:

Adds the site-logo to the header (and centers it).
Adds a singular template (with exclusively content, just like index template was).
Added query loop (including post/page title) to index page template.
Added header/footer template parts to index page.

![image](https://user-images.githubusercontent.com/146530/113311567-71cfcd80-92d7-11eb-977d-f31b36a70151.png)
