### PR TITLE
Mayland Blocks: fix site editor alignment

### DIFF
--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -24,20 +24,6 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* Set editor widths. */
-
-.wp-block {
-	max-width: var(--wp--custom--width--default);
-}
-
-.wp-block[data-align="wide"] {
-	max-width: var(--wp--custom--width--wide);
-}
-
-.wp-block[data-align="full"] {
-	max-width: inherit;
-}
-
 /* Adjust header spacing. */
 
 .site-header .wp-block-site-title a {


### PR DESCRIPTION
This PR removes styles that were added before the new alignments system to control the default width of a block.

**To test**
- Check the site editor and see that the blocks are being constrained by these rules
- Apply this PR
- Verify that the default width / alignment is correct in the site and post editor