### PR TITLE
Mayland Blocks: refactor social links in header

### DIFF
--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -2,15 +2,13 @@
 <div style="height:14px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:columns {"verticalAlignment":"center", "align":"full"} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"100%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:100%"><!-- wp:columns {"verticalAlignment":null,"align":"full"} -->
+<!-- wp:columns {"verticalAlignment":null, "align":"full"} -->
 <div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"top","className":"is-vertically-aligned-bottom"} -->
-<div class="wp-block-column is-vertically-aligned-top is-vertically-aligned-bottom"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
+<!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 
 <!-- wp:navigation-link {"label":"About","url":"#"} /-->
@@ -25,7 +23,5 @@
 <!-- wp:social-link {"url":"twitter.com/wordpress","service":"twitter"} /--></ul>
 <!-- /wp:social-links -->
 <!-- /wp:navigation --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -2,13 +2,15 @@
 <div style="height:14px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:columns {"verticalAlignment":"bottom","align":"full"} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-bottom"><!-- wp:column {"verticalAlignment":"bottom"} -->
-<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:site-title /--></div>
+<!-- wp:columns {"verticalAlignment":"center", "align":"full"} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"100%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:100%"><!-- wp:columns {"verticalAlignment":null,"align":"full"} -->
+<div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","className":"is-vertically-aligned-bottom"} -->
-<div class="wp-block-column is-vertically-aligned-center is-vertically-aligned-bottom"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
+<!-- wp:column {"verticalAlignment":"top","className":"is-vertically-aligned-bottom"} -->
+<div class="wp-block-column is-vertically-aligned-top is-vertically-aligned-bottom"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 
 <!-- wp:navigation-link {"label":"About","url":"#"} /-->
@@ -23,5 +25,7 @@
 <!-- wp:social-link {"url":"twitter.com/wordpress","service":"twitter"} /--></ul>
 <!-- /wp:social-links -->
 <!-- /wp:navigation --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -10,12 +10,6 @@
 <!-- wp:column {"verticalAlignment":"center","className":"is-vertically-aligned-bottom"} -->
 <div class="wp-block-column is-vertically-aligned-center is-vertically-aligned-bottom">
 	
-<!-- wp:social-links {"iconColor":"primary","iconColorValue":"#000000","align":"right","className":"is-style-logos-only"} -->
-<ul class="wp-block-social-links alignright has-icon-color is-style-logos-only" style="--wp--social-links--icon-color:#000000"><!-- wp:social-link {"url":"https://instagram.com","service":"instagram"} /-->
-
-<!-- wp:social-link {"url":"https://twitter.com","service":"twitter"} /--></ul>
-<!-- /wp:social-links -->
-
 <!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -8,9 +8,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","className":"is-vertically-aligned-bottom"} -->
-<div class="wp-block-column is-vertically-aligned-center is-vertically-aligned-bottom">
-	
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
+<div class="wp-block-column is-vertically-aligned-center is-vertically-aligned-bottom"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right"} -->
 <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
 
 <!-- wp:navigation-link {"label":"About","url":"#"} /-->
@@ -18,6 +16,12 @@
 <!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
 
 <!-- wp:navigation-link {"label":"Contact","url":"#"} /-->
+
+<!-- wp:social-links {"iconColor":"black","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"instagram.com/wordpress","service":"instagram"} /-->
+
+<!-- wp:social-link {"url":"twitter.com/wordpress","service":"twitter"} /--></ul>
+<!-- /wp:social-links -->
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -24,20 +24,6 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* Set editor widths. */
-
-.wp-block {
-	max-width: var(--wp--custom--width--default);
-}
-
-.wp-block[data-align="wide"] {
-	max-width: var(--wp--custom--width--wide);
-}
-
-.wp-block[data-align="full"] {
-	max-width: inherit;
-}
-
 /* Adjust header spacing. */
 
 .site-header .wp-block-site-title a {


### PR DESCRIPTION
This PR refactors the social links in the header template part.

Before | After
------ | ------
<img width="1498" alt="Screen Shot 2021-04-07 at 5 13 18 PM" src="https://user-images.githubusercontent.com/5375500/113935604-96321b00-97ab-11eb-8850-d7d5fa3ad9db.png"> | <img width="1524" alt="Screen Shot 2021-04-07 at 5 12 55 PM" src="https://user-images.githubusercontent.com/5375500/113935624-992d0b80-97ab-11eb-9388-98b7e5e91877.png">
