### PR TITLE
Quadrat: Override BCB's index.html template

### DIFF
--- a/quadrat/footer.php
+++ b/quadrat/footer.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * The template for displaying the footer
+ *
+ * Contains the closing of the #content div and all content after.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package WordPress
+ * @subpackage Quadrat
+ * @since 1.0.0
+ */
+
+?>
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -34,6 +34,7 @@ require get_stylesheet_directory() . '/inc/block-styles.php';
 
 /**
  * Override the Parent Theme index.html template and load the index.php template from the child instead
+ * This may not be needed once https://github.com/WordPress/gutenberg/issues/25612#issuecomment-819419024 is addressed
  */
 function quadrat_override_index_template( $template ) {
 	if ( is_home() || is_front_page() ) :

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -31,3 +31,15 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
+
+/**
+ * Override the Parent Theme index.html template and load the index.php template from the child instead
+ */
+function quadrat_override_index_template( $template ) {
+	if ( is_home() || is_front_page() ) :
+		$template = locate_template( array( 'index.php' ) );
+	endif;
+	return $template;
+}
+
+add_filter( 'template_include', 'quadrat_override_index_template' );

--- a/quadrat/header.php
+++ b/quadrat/header.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The header for our theme
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package WordPress
+ * @subpackage çQuadrat
+ * @since 1.0.0
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="profile" href="https://gmpg.org/xfn/11" />
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+
+<?php
+if ( function_exists( 'wp_body_open' ) ) {
+	wp_body_open();
+}
+?>
+

--- a/quadrat/index.php
+++ b/quadrat/index.php
@@ -12,6 +12,8 @@
  * @package Quadrat
  * @since 1.0.0
  */
+get_header();
+
 	// the header
 	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/header.html' ) );
 
@@ -20,3 +22,5 @@
 
 	// the footer
 	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/footer.html' ) );
+	
+get_footer();

--- a/quadrat/index.php
+++ b/quadrat/index.php
@@ -13,10 +13,10 @@
  * @since 1.0.0
  */
 	// the header
-	echo do_blocks( file_get_contents( 'templates/header.html' ) );
+	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/header.html' ) );
 
 	// the query
-	echo do_blocks( file_get_contents( 'templates/query.html' ) );
+	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/query.html' ) );
 
 	// the footer
-	echo do_blocks( file_get_contents( 'templates/footer.html' ) );
+	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/footer.html' ) );

--- a/quadrat/index.php
+++ b/quadrat/index.php
@@ -18,7 +18,7 @@ get_header();
 	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/header.html' ) );
 
 	// the query
-	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/query.html' ) );
+	echo do_blocks( '<!-- wp:post-content {"layout":{"inherit":true}} /-->' );
 
 	// the footer
 	echo do_blocks( file_get_contents( get_stylesheet_directory() . '/templates/footer.html' ) );


### PR DESCRIPTION
This PR overrides the html template when we are on the home or front page and loads index.php instead. 
When using do_blocks on index.php we need a header and footer templates to be defines or else we won't have css (when using html templates, the missing html from header and closing tags for the footer are provided by gutenberg, this is no longer the case when the template is built with php)