### PR TITLE
Add the hosts block pattern.

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -1,2 +1,38 @@
+/**
+ * Breakpoints & Media Queries
+ */
+/**
+ * Breakpoint mixins
+ */
+/**
+ * Long content fade mixin
+ *
+ * Creates a fading overlay to signify that the content is longer
+ * than the space allows.
+ */
+/**
+ * Focus styles.
+ */
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+/**
+ * Styles that are reused verbatim in a few places
+ */
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+/**
+ * Reset default styles for JavaScript UI based pages.
+ * This is a WP-admin agnostic reset
+ */
+/**
+ * Reset the WP Admin page styles for Gutenberg-like pages.
+ */
+@media (max-width: 479px) {
+	.wp-block-media-text .wp-block-media-text__content {
+		padding: var(--wp--custom--margin--vertical) 0;
+	}
+}
 
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -372,7 +372,7 @@
 			"typography": {
 				"fontSize": "16px",
 				"fontFamily": "var(--wp--preset--font-family--headings)",
-				"lineHeight": "vvar(--wp--custom--line-height--headings--h6)",
+				"lineHeight": "var(--wp--custom--line-height--headings--h6)",
 				"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
 			}
 		},

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -19,9 +19,9 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 		if ( function_exists( 'register_block_pattern' ) ) {
 
 			register_block_pattern(
-				'quadrat/the-hosts',
+				'quadrat/headline-button',
 				array(
-					'title'      => __( 'The Hosts', 'quadrat' ),
+					'title'      => __( 'Headline and button', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
 					'content'    => '<!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:paragraph -->
@@ -46,9 +46,9 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 			);
 
 			register_block_pattern(
-				'quadrat/media-text',
+				'quadrat/media-text-button',
 				array(
-					'title'      => __( 'Media & Text', 'quadrat' ),
+					'title'      => __( 'Media and text with button', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
 					'content'    => '<!-- wp:media-text {"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png","mediaType":"image"} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png" alt="' . esc_attr__( 'Illustration of two women.' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -11,19 +11,64 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 
 		if ( function_exists( 'register_block_pattern_category' ) ) {
 			register_block_pattern_category(
-				'quadrat-blocks',
-				array( 'label' => __( 'Quadrat', 'quadrat-blocks' ) )
+				'quadrat',
+				array( 'label' => __( 'Quadrat', 'quadrat' ) )
 			);
 		}
 
 		if ( function_exists( 'register_block_pattern' ) ) {
 
 			register_block_pattern(
-				'quadrat-blocks/example',
+				'quadrat-blocks/the-hosts',
 				array(
-					'title'      => __( 'Alternating Grid of Latest Posts', 'quadrat-blocks' ),
-					'categories' => array( 'quadrat-blocks' ),
-					'content'    => '<!-- wp:latest-posts {"displayPostContent":true,"columns":5,"className":"is-style-quadrat-alternating-grid"} /-->',
+					'title'      => __( 'The Hosts', 'quadrat' ),
+					'categories' => array( 'quadrat' ),
+					'content'    => '<!-- wp:group {"align":"wide"} -->
+					<div class="wp-block-group alignwide"><!-- wp:paragraph -->
+					<p>' . esc_html__( 'The Hosts', 'quadrat') . '</p>
+					<!-- /wp:paragraph -->
+					
+					<!-- wp:heading -->
+					<h2>' . esc_html__( 'Samantha and Olivia are both writers and activists.', 'quadrat') . '</h2>
+					<!-- /wp:heading -->
+					
+					<!-- wp:spacer {"height":36} -->
+					<div style="height:36px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+					
+					<!-- wp:buttons -->
+					<div class="wp-block-buttons"><!-- wp:button -->
+					<div class="wp-block-button"><a class="wp-block-button__link">' . esc_html__( 'Learn More', 'quadrat') . '</a></div>
+					<!-- /wp:button --></div>
+					<!-- /wp:buttons --></div>
+					<!-- /wp:group -->',
+				)
+			);
+
+			register_block_pattern(
+				'quadrat-blocks/media-text',
+				array(
+					'title'      => __( 'Media & Text', 'quadrat' ),
+					'categories' => array( 'quadrat' ),
+					'content'    => '<!-- wp:media-text {"mediaLink":"http://localhost:4759/?attachment_id=287","mediaType":"image"} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost:4759/wp-content/uploads/2021/04/girls-illustration-921x1024.png" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
+					<p>' . esc_html__( 'The Hosts', 'quadrat') . '</p>
+					<!-- /wp:paragraph -->
+					
+					<!-- wp:heading -->
+					<h2>' . esc_html__( 'Sarah &amp; Olivia are both writers and activists.', 'quadrat') . '</h2>
+					<!-- /wp:heading -->
+					
+					<!-- wp:spacer {"height":36} -->
+					<div style="height:36px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+					
+					<!-- wp:buttons -->
+					<div class="wp-block-buttons"><!-- wp:button -->
+					<div class="wp-block-button"><a class="wp-block-button__link">' . esc_html__( 'Learn More', 'quadrat') . '</a></div>
+					<!-- /wp:button --></div>
+					<!-- /wp:buttons --></div></div>
+					<!-- /wp:media-text -->',
 				)
 			);
 

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -50,8 +50,8 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				array(
 					'title'      => __( 'Media & Text', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
-					'content'    => '<!-- wp:media-text {"mediaLink":"http://localhost:4759/?attachment_id=287","mediaType":"image"} -->
-					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost:4759/wp-content/uploads/2021/04/girls-illustration-921x1024.png" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
+					'content'    => '<!-- wp:media-text {"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png","mediaType":"image"} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
 					<p>' . esc_html__( 'The Hosts', 'quadrat') . '</p>
 					<!-- /wp:paragraph -->
 					

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 		if ( function_exists( 'register_block_pattern' ) ) {
 
 			register_block_pattern(
-				'quadrat-blocks/the-hosts',
+				'quadrat/the-hosts',
 				array(
 					'title'      => __( 'The Hosts', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
@@ -46,7 +46,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 			);
 
 			register_block_pattern(
-				'quadrat-blocks/media-text',
+				'quadrat/media-text',
 				array(
 					'title'      => __( 'Media & Text', 'quadrat' ),
 					'categories' => array( 'quadrat' ),

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -51,7 +51,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					'title'      => __( 'Media & Text', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
 					'content'    => '<!-- wp:media-text {"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png","mediaType":"image"} -->
-					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/girls-illustration.png" alt="' . esc_attr__( 'Illustration of two women.' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
 					<p>' . esc_html__( 'The Hosts', 'quadrat') . '</p>
 					<!-- /wp:paragraph -->
 					

--- a/quadrat/sass/blocks/_media-text.scss
+++ b/quadrat/sass/blocks/_media-text.scss
@@ -1,0 +1,5 @@
+.wp-block-media-text .wp-block-media-text__content {
+	@include break-mobile-only(){
+		padding: var(--wp--custom--margin--vertical) 0;
+	}
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -1,0 +1,2 @@
+@import '../../blank-canvas-blocks/sass/base/breakpoints'; // Get the mobile-only media query and make it available to this theme's styles
+@import 'blocks/media-text';


### PR DESCRIPTION
This PR adds two block patterns and a few lines of CSS to adjust the padding of a nested container inside a media & text block.

<img width="1152" alt="Screen Shot 2021-04-15 at 12 10 42 PM" src="https://user-images.githubusercontent.com/5375500/114902356-96916e00-9dca-11eb-9356-238347749450.png">

<img width="1280" alt="Screen Shot 2021-04-15 at 12 11 12 PM" src="https://user-images.githubusercontent.com/5375500/114902361-97c29b00-9dca-11eb-9122-72eccafe7b36.png">

~_Note I am waiting for access to the staging site so I can upload the illustrations and reference their img URLs in the pattern from there, so marking this as a draft for now._~