### PR TITLE
Quadrat: Add Latest episodes block pattern

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -35,4 +35,12 @@
 	}
 }
 
+.image-no-margin {
+	margin: 0;
+}
+
+.image-no-margin > * {
+	vertical-align: bottom;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -87,7 +87,7 @@
 					"horizontal": "20px"
 				},
 				"line-height": {
-					"body": 1.6,
+					"body": 1.7,
 					"headings": {
 						"h1": 1.2,
 						"h2": 1.2,

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -278,7 +278,7 @@
 					"family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400"
 				],
 				"line-height": {
-					"body": 1.6,
+					"body": 1.7,
 					"headings": {
 						"h1": 1.2,
 						"h2": 1.2,

--- a/quadrat/header.php
+++ b/quadrat/header.php
@@ -7,7 +7,7 @@
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
  * @package WordPress
- * @subpackage çQuadrat
+ * @subpackage Quadrat
  * @since 1.0.0
  */
 ?><!doctype html>

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -80,32 +80,32 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="Screen usage" class="wp-image-1438"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_html__( 'Screen usage', 'quadrat') . '" class="wp-image-1438"/></figure>
 					<!-- /wp:image -->
 					
 					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
 					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
-					<h3 class="has-pink-color has-text-color">Episode 1: How Screens Affect Hormones</h3>
+					<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 1: How Screens Affect Hormones', 'quadrat') . '</h3>
 					<!-- /wp:heading -->
 					
 					<!-- wp:paragraph {"textColor":"pink"} -->
-					<p class="has-pink-color has-text-color">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Metus dictum at tempor commodo ullamcorper a lacus vestibulum sed.</p>
+					<p class="has-pink-color has-text-color">' . esc_html__( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Metus dictum at tempor commodo ullamcorper a lacus vestibulum sed.', 'quadrat') . '</p>
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
 					<!-- /wp:column -->
 					
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="Leadership" class="wp-image-1439"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_html__( 'Leadership', 'quadrat') . '" class="wp-image-1439"/></figure>
 					<!-- /wp:image -->
 					
 					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
 					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
-					<h3 class="has-pink-color has-text-color">Episode 2: Female Leaders, Where Are They?</h3>
+					<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 2: Female Leaders, Where Are They?', 'quadrat') . '</h3>
 					<!-- /wp:heading -->
 					
 					<!-- wp:paragraph {"textColor":"pink"} -->
-					<p class="has-pink-color has-text-color">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+					<p class="has-pink-color has-text-color">' . esc_html__( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.', 'quadrat') . '</p>
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
 					<!-- /wp:column --></div>

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -73,39 +73,39 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 			);
 
 			register_block_pattern(
-				'quadrat-blocks/example',
+				'quadrat/latest-episodes',
 				array(
 					'title'      => __( 'Latest Episodes', 'quadrat' ),
 					'categories' => array( 'quadrat' ),
 					'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_html__( 'Screen usage', 'quadrat') . '" class="wp-image-1438"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman working on a laptop.', 'quadrat') . '" class="wp-image-1438"/></figure>
 					<!-- /wp:image -->
 					
-					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
-					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
+					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
 					<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 1: How Screens Affect Hormones', 'quadrat') . '</h3>
 					<!-- /wp:heading -->
 					
-					<!-- wp:paragraph {"textColor":"pink"} -->
-					<p class="has-pink-color has-text-color">' . esc_html__( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Metus dictum at tempor commodo ullamcorper a lacus vestibulum sed.', 'quadrat') . '</p>
+					<!-- wp:paragraph {"textColor":"pink","fontSize":"small"} -->
+					<p class="has-pink-color has-text-color has-small-font-size">' . esc_html__( 'In this episode, Sarah and Olivia talk with female hormone specialist Diana Roth about the impact that gadgets and technology have on hormone and fertility health.', 'quadrat') . '</p>
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
 					<!-- /wp:column -->
 					
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_html__( 'Leadership', 'quadrat') . '" class="wp-image-1439"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman climbing steps.', 'quadrat') . '" class="wp-image-1439"/></figure>
 					<!-- /wp:image -->
 					
-					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
-					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
+					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
 					<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 2: Female Leaders, Where Are They?', 'quadrat') . '</h3>
 					<!-- /wp:heading -->
 					
-					<!-- wp:paragraph {"textColor":"pink"} -->
-					<p class="has-pink-color has-text-color">' . esc_html__( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.', 'quadrat') . '</p>
+					<!-- wp:paragraph {"textColor":"pink","fontSize":"small"} -->
+					<p class="has-pink-color has-text-color has-small-font-size">' . esc_html__( 'After years of revolution, the big question remains: why aren’t there more women in leadership? Sarah and Olivia get deep into the subject.', 'quadrat') . '</p>
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
 					<!-- /wp:column --></div>

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -79,7 +79,8 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					'categories' => array( 'quadrat' ),
 					'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
+					<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"30px"}}}} -->
+					<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:30px"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
 					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman working on a laptop.', 'quadrat') . '" class="wp-image-1438"/></figure>
 					<!-- /wp:image -->
 					
@@ -92,10 +93,12 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					<p class="has-pink-color has-text-color has-small-font-size">' . esc_html__( 'In this episode, Sarah and Olivia talk with female hormone specialist Diana Roth about the impact that gadgets and technology have on hormone and fertility health.', 'quadrat') . '</p>
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
+					<!-- /wp:group --></div>
 					<!-- /wp:column -->
 					
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
+					<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"30px"}}}} -->
+					<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:30px"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
 					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman climbing steps.', 'quadrat') . '" class="wp-image-1439"/></figure>
 					<!-- /wp:image -->
 					
@@ -109,6 +112,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					<!-- /wp:paragraph --></div></div>
 					<!-- /wp:cover --></div>
 					<!-- /wp:column --></div>
+					<!-- /wp:group --></div>
 					<!-- /wp:columns -->',
 				)
 			);

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -80,7 +80,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_html__( 'Screen usage', 'quadrat') . '" class="wp-image-1438"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_html__( 'Screen usage', 'quadrat') . '" class="wp-image-1438"/></figure>
 					<!-- /wp:image -->
 					
 					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
@@ -96,7 +96,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
-					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_html__( 'Leadership', 'quadrat') . '" class="wp-image-1439"/></figure>
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_html__( 'Leadership', 'quadrat') . '" class="wp-image-1439"/></figure>
 					<!-- /wp:image -->
 					
 					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -72,6 +72,47 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				)
 			);
 
+			register_block_pattern(
+				'quadrat-blocks/example',
+				array(
+					'title'      => __( 'Latest Episodes', 'quadrat' ),
+					'categories' => array( 'quadrat' ),
+					'content'    => '<!-- wp:columns {"align":"wide"} -->
+					<div class="wp-block-columns alignwide"><!-- wp:column -->
+					<div class="wp-block-column"><!-- wp:image {"id":1438,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="Screen usage" class="wp-image-1438"/></figure>
+					<!-- /wp:image -->
+					
+					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
+					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
+					<h3 class="has-pink-color has-text-color">Episode 1: How Screens Affect Hormones</h3>
+					<!-- /wp:heading -->
+					
+					<!-- wp:paragraph {"textColor":"pink"} -->
+					<p class="has-pink-color has-text-color">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Metus dictum at tempor commodo ullamcorper a lacus vestibulum sed.</p>
+					<!-- /wp:paragraph --></div></div>
+					<!-- /wp:cover --></div>
+					<!-- /wp:column -->
+					
+					<!-- wp:column -->
+					<div class="wp-block-column"><!-- wp:image {"id":1439,"sizeSlug":"large","linkDestination":"none","className":"image-no-margin mb-0"} -->
+					<figure class="wp-block-image size-large image-no-margin mb-0"><img src="http://freethemes.local/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="Leadership" class="wp-image-1439"/></figure>
+					<!-- /wp:image -->
+					
+					<!-- wp:cover {"overlayColor":"darker-blue","minHeight":425,"className":"mt-0","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
+					<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;min-height:425px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
+					<h3 class="has-pink-color has-text-color">Episode 2: Female Leaders, Where Are They?</h3>
+					<!-- /wp:heading -->
+					
+					<!-- wp:paragraph {"textColor":"pink"} -->
+					<p class="has-pink-color has-text-color">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+					<!-- /wp:paragraph --></div></div>
+					<!-- /wp:cover --></div>
+					<!-- /wp:column --></div>
+					<!-- /wp:columns -->',
+				)
+			);
+
 		}
 	}
 endif;

--- a/quadrat/sass/_utility.scss
+++ b/quadrat/sass/_utility.scss
@@ -1,0 +1,7 @@
+.image-no-margin {
+	margin: 0;
+	& > * { //the first sibling is a div on the editor and an image on the frontend
+		vertical-align: bottom;
+	}
+}
+

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -1,2 +1,3 @@
 @import '../../blank-canvas-blocks/sass/base/breakpoints'; // Get the mobile-only media query and make it available to this theme's styles
 @import 'blocks/media-text';
+@import "utility";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds the "Latest Episodes" block pattern. This pattern uses one new utility class to remove the bottom margin from the image block so that it sits flush with the following block. To do: upload the images to the staging website. ✅ 

<img width="1221" alt="Screenshot 2021-04-16 at 12 39 40" src="https://user-images.githubusercontent.com/3593343/115013769-c23b5380-9eb1-11eb-87a5-6507932fc9dc.png">

#### Related issue(s):

Partially addresses #3642
