### PR TITLE
Seedlet: Add alignment support to the separator block

### DIFF
--- a/seedlet/assets/sass/blocks/separator/_style.scss
+++ b/seedlet/assets/sass/blocks/separator/_style.scss
@@ -17,6 +17,14 @@ hr {
 		 */
 		&.is-style-wide {
 			@extend %responsive-aligndefault-width;
+
+			&.alignwide {
+				@extend %responsive-alignwide-width;
+			}
+
+			&.alignfull {
+				@extend %responsive-alignfull-width;
+			}
 		}
 
 		&.is-style-dots {

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -345,14 +345,14 @@ Included in theme screenshot and in block patterns.
 	margin-left: auto;
 }
 
-.wide-max-width, .alignwide {
+.wide-max-width, hr.wp-block-separator.is-style-wide.alignwide, .alignwide {
 	max-width: var(--responsive--alignwide-width);
 	margin-right: auto;
 	margin-left: auto;
 }
 
 @media only screen and (min-width: 482px) {
-	.full-max-width, .alignfull, .singular .post-thumbnail {
+	.full-max-width, hr.wp-block-separator.is-style-wide.alignfull, .alignfull, .singular .post-thumbnail {
 		max-width: var(--responsive--alignfull-width);
 		width: auto;
 		margin-right: auto;

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -345,14 +345,14 @@ Included in theme screenshot and in block patterns.
 	margin-right: auto;
 }
 
-.wide-max-width, .alignwide {
+.wide-max-width, hr.wp-block-separator.is-style-wide.alignwide, .alignwide {
 	max-width: var(--responsive--alignwide-width);
 	margin-left: auto;
 	margin-right: auto;
 }
 
 @media only screen and (min-width: 482px) {
-	.full-max-width, .alignfull, .singular .post-thumbnail {
+	.full-max-width, hr.wp-block-separator.is-style-wide.alignfull, .alignfull, .singular .post-thumbnail {
 		max-width: var(--responsive--alignfull-width);
 		width: auto;
 		margin-left: auto;


### PR DESCRIPTION
This PR adds proper front-end alignment support to the separator block. This is only needed for the "Wide" block style, since the standard and dots separators don't extend wide anyway. 

---

Editor: 

<img width="1230" alt="Screen Shot 2021-04-20 at 9 16 41 AM" src="https://user-images.githubusercontent.com/1202812/115402799-c0c3a100-a1b9-11eb-9f1e-301443836a23.png">

Frontend Before: 

<img width="1231" alt="Screen Shot 2021-04-20 at 9 16 26 AM" src="https://user-images.githubusercontent.com/1202812/115402834-c9b47280-a1b9-11eb-9a72-d479b26d90d7.png">


Frontend After: 

<img width="1231" alt="Screen Shot 2021-04-20 at 9 17 10 AM" src="https://user-images.githubusercontent.com/1202812/115402817-c7eaaf00-a1b9-11eb-9a99-031fc37ead6c.png">
