### PR TITLE
Mayland Blocks - fix block validation errors from single.html

### DIFF
--- a/mayland-blocks/block-templates/single.html
+++ b/mayland-blocks/block-templates/single.html
@@ -10,7 +10,7 @@
 
 <!-- wp:template-part {"slug":"post-meta"} /-->
 
-<!-- wp:spacer {"height":16px} -->
+<!-- wp:spacer {"height":16} -->
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -22,7 +22,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 
-<!-- wp:spacer {"height":16px} -->
+<!-- wp:spacer {"height":16} -->
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
If you open the single template in the site editor, there are block validation errors regarding the spacer block:

![image](https://user-images.githubusercontent.com/28742426/115552931-d8169300-a27a-11eb-8353-e022805da9ee.png)

![image](https://user-images.githubusercontent.com/28742426/115552985-e95f9f80-a27a-11eb-9513-1c79236f6083.png)

This seems to be a result of the markup comments for these two spacer blocks using 'px' units.  After removing the unnecessary units these blocks seems to validate correctly and are set to their 16px height attribute without errors as expected.

#### Related issue(s):
