### PR TITLE
BCB + children: added border supports to buttons

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -452,11 +452,9 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
-	border-radius: var(--wp--custom--button--border--radius);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
-	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
@@ -575,11 +573,9 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
-	border-radius: var(--wp--custom--button--border--radius);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
-	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
@@ -654,11 +650,9 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
-	border-radius: var(--wp--custom--button--border--radius);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
-	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 	display: inline-block;

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -127,7 +127,10 @@
 						"lineHeight": 2
 					},
 					"border": {
-						"radius": "4px"
+						"radius": "4px",
+						"width": "0",
+						"style": "solid",
+						"color": "var(--wp--custom--button--color--text)"
 					},
 					"color": {
 						"text": "var(--wp--custom--color--background)",
@@ -319,7 +322,10 @@
 				"lineHeight": "var(--wp--custom--button--typography--line-height)"
 			},
 			"border": {
-				"radius": "var(--wp--custom--button--border--radius)"
+				"radius": "var(--wp--custom--button--border--radius)",
+				"style": "var(--wp--custom--button--border--style)",
+				"width": "var(--wp--custom--button--border--width)",
+				"color": "var(--wp--custom--button--border--color)"
 			}
 		},
 		"core/heading/h1": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -286,6 +286,12 @@
 						"fontWeight": "normal"
 					}
 				}
+			},
+			"border": {
+				"customColor": true,
+				"customRadius": true,
+				"customStyle": true,
+				"customWidth": true
 			}
 		}
 	},

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -7,11 +7,9 @@
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
-	border-radius: var(--wp--custom--button--border--radius);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
 	color: var(--wp--custom--button--color--text);
-	border-color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	padding: calc(.667em + 2px) calc(1.333em + 2px); //The padding found on an unmodified Button Block 
 	svg {

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -312,6 +312,12 @@
 					"default": "750px",
 					"wide": "1022px"
 				}
+			},
+			"border": {
+				"customColor": true,
+				"customRadius": true,
+				"customStyle": true,
+				"customWidth": true
 			}
 		}
 	},

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -142,7 +142,10 @@
 						"lineHeight": 2
 					},
 					"border": {
-						"radius": "4px"
+						"radius": "4px",
+						"width": "0",
+						"style": "solid",
+						"color": "var(--wp--custom--button--color--text)"
 					},
 					"color": {
 						"text": "var(--wp--custom--color--background)",
@@ -163,6 +166,14 @@
 						"text": "var(--wp--custom--color--foreground)",
 						"background": "transparent",
 						"boxShadow": "none"
+					},
+					"label": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--tiny)"
+						}
+					},
+					"typography": {
+						"fontSize": "var(--wp--preset--font-size--normal)"
 					}
 				},
 				"paragraph": {
@@ -198,7 +209,13 @@
 					"citation": {
 						"typography": {
 							"fontSize": "var(--wp--preset--font-size--tiny)",
+							"fontFamily": "inherit",
 							"fontStyle": "italic"
+						},
+						"spacing": {
+							"margin": {
+								"top": "var(--wp--custom--margin--vertical)"
+							}
 						}
 					}
 				},
@@ -331,7 +348,10 @@
 				"lineHeight": "var(--wp--custom--button--typography--line-height)"
 			},
 			"border": {
-				"radius": "var(--wp--custom--button--border--radius)"
+				"radius": "var(--wp--custom--button--border--radius)",
+				"style": "var(--wp--custom--button--border--style)",
+				"width": "var(--wp--custom--button--border--width)",
+				"color": "var(--wp--custom--button--border--color)"
 			}
 		},
 		"core/heading/h1": {

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -342,6 +342,12 @@
 					"family=Fira+Sans:ital,wght@0,400;0,500;1,400",
 					"family=Playfair+Display:ital,wght@0,400;0,700;1,400"
 				]
+			},
+			"border": {
+				"customColor": true,
+				"customRadius": true,
+				"customStyle": true,
+				"customWidth": true
 			}
 		}
 	},

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -179,7 +179,10 @@
 						"lineHeight": 2
 					},
 					"border": {
-						"radius": "4px"
+						"radius": "4px",
+						"width": "0",
+						"style": "solid",
+						"color": "var(--wp--custom--button--color--text)"
 					},
 					"color": {
 						"text": "var(--wp--custom--color--background)",
@@ -375,7 +378,10 @@
 				"lineHeight": "var(--wp--custom--button--typography--line-height)"
 			},
 			"border": {
-				"radius": "var(--wp--custom--button--border--radius)"
+				"radius": "var(--wp--custom--button--border--radius)",
+				"style": "var(--wp--custom--button--border--style)",
+				"width": "var(--wp--custom--button--border--width)",
+				"color": "var(--wp--custom--button--border--color)"
 			}
 		},
 		"core/heading/h1": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

After https://github.com/WordPress/gutenberg/pull/30124 was merged, now we have support for border color, style and width for blocks. BCB was only defining custom values for buttons (and forms, but since those are not blocks, they don't apply here) so this PR removes the custom CSS that BCB was applying to add support for them instead.

I rebuilt Mayland + Seedlet with the changes.

