### PR TITLE
Blank Canvas Blocks: Make Code block's font-family overwritable

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -257,7 +257,7 @@ input[type=checkbox] + label {
 }
 
 .wp-block-code code {
-	font-family: var(--wp--preset--font-family--code);
+	font-family: var(--wp--custom--code--typography--font-family);
 }
 
 .wp-block-gallery .blocks-gallery-image figcaption,

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -256,6 +256,10 @@ input[type=checkbox] + label {
 	margin-bottom: 0;
 }
 
+.wp-block-code code {
+	font-family: var(--wp--preset--font-family--code);
+}
+
 .wp-block-gallery .blocks-gallery-image figcaption,
 .wp-block-gallery .blocks-gallery-item figcaption {
 	font-size: var(--wp--custom--gallery--caption--font-size);

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -85,6 +85,11 @@
 						"fontFamily": "var(--font-headings, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
 						"slug": "headings",
 						"name": "Headings"
+					},
+					{
+						"fontFamily": "monospace",
+						"slug": "code",
+						"name": "Code"
 					}
 				]
 			},
@@ -171,6 +176,11 @@
 				"gallery": {
 					"caption": {
 						"fontSize": "var(--wp--preset--font-size--small)"
+					}
+				},
+				"code": {
+					"typography": {
+						"fontFamily": "var(--wp--preset--font-family--code)"
 					}
 				},
 				"quote": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -85,11 +85,6 @@
 						"fontFamily": "var(--font-headings, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
 						"slug": "headings",
 						"name": "Headings"
-					},
-					{
-						"fontFamily": "monospace",
-						"slug": "code",
-						"name": "Code"
 					}
 				]
 			},
@@ -180,7 +175,7 @@
 				},
 				"code": {
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--code)"
+						"fontFamily": "monospace"
 					}
 				},
 				"quote": {

--- a/blank-canvas-blocks/sass/blocks/_code.scss
+++ b/blank-canvas-blocks/sass/blocks/_code.scss
@@ -1,0 +1,4 @@
+// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code
+.wp-block-code code {
+	font-family: var(--wp--custom--code--typography--font-family);
+}

--- a/blank-canvas-blocks/sass/blocks/_code.scss
+++ b/blank-canvas-blocks/sass/blocks/_code.scss
@@ -1,4 +1,4 @@
-// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code
+// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code (https://github.com/WordPress/gutenberg/issues/31135)
 .wp-block-code code {
 	font-family: var(--wp--custom--code--typography--font-family);
 }

--- a/blank-canvas-blocks/sass/ponyfill.scss
+++ b/blank-canvas-blocks/sass/ponyfill.scss
@@ -10,6 +10,7 @@
 // - These styles replace key Gutenberg Block styles for fonts, colors, and
 //   spacing with CSS-variables overrides
 @import "blocks/button";
+@import "blocks/code";
 @import "blocks/gallery";
 @import "blocks/image";
 @import "blocks/list";


### PR DESCRIPTION
#### Related issue(s):
https://github.com/WordPress/gutenberg/issues/31135

