### PR TITLE
BCB: fix custom fonts loading conditional

### DIFF
--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -68,7 +68,7 @@ function blank_canvas_blocks_fonts_url() {
 	}
 
 	$custom_data = $theme_data['defaults']['custom'];
-	if ( array_key_exists( 'fontsToLoadFromGoogle', $custom_data ) ) {
+	if ( ! array_key_exists( 'fontsToLoadFromGoogle', $custom_data ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
This PR changes a conditional in BCB so that the custom font loading function does not exit early / incorrectly.

To test, load a child theme of BCB with a custom font defined (e.g. Seedlet Blocks). 

Verify the theme loads the fonts properly.