### PR TITLE
Quadrat: Add table styles

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -50,6 +50,10 @@ ul ul {
 	vertical-align: top;
 }
 
+.wp-block-table tr:first-child td {
+	border-top-width: 1px;
+}
+
 .wp-block-table tr:last-child td {
 	border-bottom-width: 1px;
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -41,7 +41,6 @@ ul ul {
 
 .wp-block-table th {
 	font-weight: 500;
-	text-align: left;
 }
 
 .wp-block-table tbody td {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -44,7 +44,7 @@ ul ul {
 	text-align: left;
 }
 
-.wp-block-table td {
+.wp-block-table tbody td {
 	border-bottom-width: 0;
 	border-top-width: 0;
 	vertical-align: top;

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -29,14 +29,29 @@
 /**
  * Reset the WP Admin page styles for Gutenberg-like pages.
  */
+ul ul {
+	list-style-type: disc;
+}
+
 @media (max-width: 479px) {
 	.wp-block-media-text .wp-block-media-text__content {
 		padding: var(--wp--custom--margin--vertical) 0;
 	}
 }
 
-ul ul {
-	list-style-type: disc;
+.wp-block-table th {
+	font-weight: 500;
+	text-align: left;
+}
+
+.wp-block-table td {
+	border-bottom-width: 0;
+	border-top-width: 0;
+	vertical-align: top;
+}
+
+.wp-block-table tr:last-child td {
+	border-bottom-width: 1px;
 }
 
 .site-header .wp-block-group {

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -1,0 +1,16 @@
+.wp-block-table {
+	th {
+		font-weight: 500;
+		text-align: left;
+	}
+
+	td {
+		border-bottom-width: 0;
+		border-top-width: 0;
+		vertical-align: top;
+	}
+
+	tr:last-child td {
+		border-bottom-width: 1px;
+	}
+}

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -4,10 +4,14 @@
 		text-align: left;
 	}
 
-	tbody td {
+	tbody td { // tbody adds the specificity needed to override the default Gutenberg styles
 		border-bottom-width: 0;
 		border-top-width: 0;
 		vertical-align: top;
+	}
+
+	tr:first-child td {
+		border-top-width: 1px;
 	}
 
 	tr:last-child td {

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -4,7 +4,7 @@
 		text-align: left;
 	}
 
-	td {
+	tbody td {
 		border-bottom-width: 0;
 		border-top-width: 0;
 		vertical-align: top;

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -1,7 +1,6 @@
 .wp-block-table {
 	th {
 		font-weight: 500;
-		text-align: left;
 	}
 
 	tbody td { // tbody adds the specificity needed to override the default Gutenberg styles

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -1,5 +1,6 @@
 @import "../../blank-canvas-blocks/sass/base/breakpoints"; // Get the mobile-only media query and make it available to this theme's styles
-@import "blocks/media-text";
 @import "blocks/list";
+@import "blocks/media-text";
+@import "blocks/table";
 @import "header";
 @import "utility";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Adds table styles for quadrat to match EDoXTvsZt4lMHItzOczFQw-fi-50%3A767

Frontend:
<img width="716" alt="Screenshot 2021-04-28 at 11 45 53" src="https://user-images.githubusercontent.com/275961/116391611-4cbb7580-a817-11eb-8666-1722cdbc4626.png">

Editor:
<img width="775" alt="Screenshot 2021-04-28 at 11 46 32" src="https://user-images.githubusercontent.com/275961/116391693-6492f980-a817-11eb-96ff-7b9a7afe227c.png">

#### Related issue(s):
Part of #3640