### PR TITLE
Quadrat: Remove template_include override from functions.php

### DIFF
--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -41,26 +41,3 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
-
-/**
- * Override the Parent Theme index.html template and load the index.php template from the child instead
- * This may not be needed once https://github.com/WordPress/gutenberg/issues/25612#issuecomment-819419024 is addressed
- */
-function quadrat_override_block_templates( $template ) {
-
-	switch ( $template ) {
-		case is_home() || is_front_page():
-			return locate_template( array( 'index.php' ) );
-		case is_404():
-			return locate_template( array( '404.php' ) );
-		case is_search():
-			return locate_template( array( 'search.php' ) );
-		case is_singular():
-			return locate_template( array( 'singular.php' ) );
-		default:
-			return $template;
-	}
-
-}
-
-add_filter( 'template_include', 'quadrat_override_block_templates' );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the hack that was overriding the way templates load. As of right now, all templates except for index.php are working. I created a new GB PR to solve that one: https://github.com/WordPress/gutenberg/pull/31336

I'm happy to wait until that merges but I wanted to have the PR ready anyway.

