### PR TITLE
Mayland Blocks: Remove colors from the navigation block

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -264,14 +264,7 @@ ol {
 	border-style: var(--wp--custom--navigation--submenu--border--style);
 	border-width: var(--wp--custom--navigation--submenu--border--width);
 	border-color: var(--wp--custom--navigation--submenu--border--color);
-	color: var(--wp--custom--navigation--submenu--color--text);
-	background-color: var(--wp--custom--navigation--submenu--color--background);
 	box-shadow: var(--wp--custom--navigation--submenu--shadow);
-}
-
-.wp-block-navigation .wp-block-navigation__container .has-child .wp-block-navigation-link__container :hover {
-	color: var(--wp--custom--navigation--submenu--color--hover-text);
-	background-color: var(--wp--custom--navigation--submenu--color--hover-background);
 }
 
 .wp-block-navigation .wp-block-navigation__container .has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -258,16 +258,6 @@ ol {
 	text-indent: -8px;
 }
 
-.wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link {
-	color: var(--wp--custom--navigation--color--text);
-	background-color: var(--wp--custom--navigation--color--background);
-}
-
-.wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link :hover {
-	color: var(--wp--custom--navigation--color--hover-text);
-	background-color: var(--wp--custom--navigation--color--hover-background);
-}
-
 .wp-block-navigation .wp-block-navigation__container .has-child .wp-block-navigation-link__container {
 	padding: 0;
 	border-radius: var(--wp--custom--navigation--submenu--border--radius);

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -256,12 +256,6 @@
 						}
 					},
 					"padding": "10px",
-					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)",
-						"hoverText": "var(--wp--custom--color--secondary)",
-						"hoverBackground": "var(--wp--custom--color--background)"
-					},
 					"submenu": {
 						"padding": "8px",
 						"shadow": "1px 1px 3px 0px rgba(0,0,0,.2)",

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -20,13 +20,8 @@
 				border-style: var(--wp--custom--navigation--submenu--border--style);
 				border-width: var(--wp--custom--navigation--submenu--border--width);
 				border-color: var(--wp--custom--navigation--submenu--border--color);
-				color: var(--wp--custom--navigation--submenu--color--text);
-				background-color: var(--wp--custom--navigation--submenu--color--background);
 				box-shadow: var(--wp--custom--navigation--submenu--shadow);
-				:hover {
-					color: var(--wp--custom--navigation--submenu--color--hover-text);
-					background-color: var(--wp--custom--navigation--submenu--color--hover-background);
-				}
+
 				.wp-block-navigation-link__content {
 					padding: var(--wp--custom--navigation--submenu--padding);
 				}

--- a/blank-canvas-blocks/sass/blocks/_navigation.scss
+++ b/blank-canvas-blocks/sass/blocks/_navigation.scss
@@ -13,14 +13,6 @@
 		text-indent: -8px;
 	}
 	.wp-block-navigation__container {
-		.wp-block-navigation-link {
-			color: var(--wp--custom--navigation--color--text);
-			background-color: var(--wp--custom--navigation--color--background);
-			:hover {
-				color: var(--wp--custom--navigation--color--hover-text);
-				background-color: var(--wp--custom--navigation--color--hover-background);
-			}
-		}
 		.has-child {
 			.wp-block-navigation-link__container {
 				padding: 0;

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -191,6 +191,11 @@
 						"fontSize": "var(--wp--preset--font-size--small)"
 					}
 				},
+				"code": {
+					"typography": {
+						"fontFamily": "monospace"
+					}
+				},
 				"quote": {
 					"typography": {
 						"textAlign": "left"
@@ -266,12 +271,6 @@
 						}
 					},
 					"padding": "10px",
-					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)",
-						"hoverText": "var(--wp--custom--color--secondary)",
-						"hoverBackground": "var(--wp--custom--color--background)"
-					},
 					"submenu": {
 						"padding": "8px",
 						"shadow": "1px 1px 3px 0px rgba(0,0,0,.2)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes some of the color rules that were set for navigation blocks in BCB so that background colors cascade.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/3701