### PR TITLE
Mayland Blocks: add padding to header

### DIFF
--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,7 +1,5 @@
-<!-- wp:spacer {"height":14} -->
-<div style="height:14px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"14px","right":"32px","left":"32px"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:14px;padding-right:32px;padding-left:32px;">
 <!-- wp:columns {"verticalAlignment":null, "align":"full"} -->
 <div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title /--></div>
@@ -24,4 +22,5 @@
 <!-- /wp:social-links -->
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
-<!-- /wp:columns -->
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -20,4 +20,4 @@
 <!-- /wp:social-links -->
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+<!-- /wp:columns -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,5 +1,3 @@
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"14px","right":"32px","left":"32px"}}}} -->
-<div class="wp-block-group alignfull" style="padding-top:14px;padding-right:32px;padding-left:32px;">
 <!-- wp:columns {"verticalAlignment":null, "align":"full"} -->
 <div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title /--></div>
@@ -23,4 +21,3 @@
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
-<!-- /wp:group -->

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -84,3 +84,6 @@ img {
 	background: url(assets/svg/post-tag.svg) no-repeat;
 }
 	
+.site-header > .wp-block-columns {
+	padding: 0 var(--wp--custom--margin--horizontal);
+}


### PR DESCRIPTION
Addresses #3699.

Before | After
------ | -------
<img width="1265" alt="Screen Shot 2021-04-30 at 10 29 51 AM" src="https://user-images.githubusercontent.com/5375500/116709799-e0ab4f80-a985-11eb-8071-6690f054d295.png"> | <img width="1262" alt="Screen Shot 2021-04-30 at 10 29 33 AM" src="https://user-images.githubusercontent.com/5375500/116709809-e3a64000-a985-11eb-9201-72d75a722cc8.png">
