### PR TITLE
Mayland Blocks: Fix the layout of the frontpage template

### DIFF
--- a/mayland-blocks/block-templates/front-page.html
+++ b/mayland-blocks/block-templates/front-page.html
@@ -1,5 +1,5 @@
 <!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->
 
-<!-- wp:post-content /-->
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- wp:template-part {"slug":"footer","align":"full","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds layout inherit to the frontpage content so that wide and full-width alignments work.

Before | After
--- | ---
<img width="1745" alt="Screenshot 2021-04-30 at 16 35 05" src="https://user-images.githubusercontent.com/3593343/116710648-44f40080-a9d2-11eb-8d7c-cac48404af2c.png"> | <img width="1745" alt="Screenshot 2021-04-30 at 16 34 54" src="https://user-images.githubusercontent.com/3593343/116710650-46252d80-a9d2-11eb-99f7-fca42129ba17.png"> 


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/3692