### PR TITLE
Allowing overflow of group-wrapped navigation

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -82,6 +82,7 @@ ul ul {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	overflow: inherit;
 }
 
 .image-no-margin {

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -3,5 +3,6 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		overflow: inherit;
 	}
 } 


### PR DESCRIPTION
This is caused by [this fix for alignment fixing here](https://github.com/Automattic/themes/blob/trunk/blank-canvas-blocks/sass/base/_alignment.scss#L21).

This change just works through that by overriding it.

Fixes #3720 