### PR TITLE
Quadrat: Add featured image styles

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -135,4 +135,8 @@ ul ul {
 	margin-left: 20%;
 }
 
+.wp-block-post-featured-image {
+	margin-top: 0;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -25,3 +25,7 @@
 		}
 	}
 }
+
+.wp-block-post-featured-image {
+	margin-top: 0;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds CSS to remove the top margin from the featured image in Quadrat:

<img width="1440" alt="Screenshot 2021-05-04 at 11 30 45" src="https://user-images.githubusercontent.com/275961/116991242-2c366400-accc-11eb-8554-2557498695b9.png">

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/3641