### PR TITLE
Quadrat: Add Join pattern

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -29,6 +29,17 @@
 /**
  * Reset the WP Admin page styles for Gutenberg-like pages.
  */
+@media (max-width: 479px) {
+	.headlines-pattern {
+		padding-top: 50px !important;
+		padding-bottom: 50px !important;
+	}
+}
+
+.subscription-column {
+	text-align: right;
+}
+
 .wp-block-cover.is-style-quadrat-cover-diamond::after {
 	background-image: url(rotated.svg);
 	background-position: center;
@@ -116,13 +127,6 @@ ul ul {
 	border-bottom-width: 1px;
 }
 
-@media (max-width: 479px) {
-	.headlines-pattern {
-		padding-top: 50px !important;
-		padding-bottom: 50px !important;
-	}
-}
-
 .site-header .wp-block-group {
 	display: flex;
 	justify-content: space-between;
@@ -132,10 +136,6 @@ ul ul {
 
 .wp-block-post-featured-image {
 	margin-top: 0;
-}
-
-.subscription-column {
-	text-align: right;
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -134,4 +134,8 @@ ul ul {
 	margin-top: 0;
 }
 
+.subscription-column {
+	text-align: right;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -41,4 +41,4 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 	}
 endif;
 
-add_action( 'init', 'quadrat_register_block_patterns', 1 );
+add_action( 'init', 'quadrat_register_block_patterns' );

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				'listen-to-the-podcast',
 			);
 
-			if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+			if ( class_exists( 'WP_Block_Type_Registry' ) && \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
 				$block_patterns[] = 'join';
 			}
 
@@ -41,4 +41,4 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 	}
 endif;
 
-add_action( 'init', 'quadrat_register_block_patterns' );
+add_action( 'init', 'quadrat_register_block_patterns', 1 );

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -17,7 +17,6 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 		}
 
 		if ( function_exists( 'register_block_pattern' ) ) {
-
 			$block_patterns = array(
 				'headline-button',
 				'media-text-button',
@@ -28,15 +27,18 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				'listen-to-the-podcast',
 			);
 
+			if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+				$block_patterns[] = 'join';
+			}
+
 			foreach ( $block_patterns as $block_pattern ) {
 				register_block_pattern(
 					'quadrat/' . $block_pattern,
 					require __DIR__ . '/patterns/' . $block_pattern . '.php'
 				);
 			}
-
 		}
 	}
 endif;
 
-add_action( 'after_setup_theme', 'quadrat_register_block_patterns', 12 );
+add_action( 'init', 'quadrat_register_block_patterns' );

--- a/quadrat/inc/patterns/join.php
+++ b/quadrat/inc/patterns/join.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Join.
+ *
+ * @package Quadrat
+ */
+
+return array(
+	'title'      => __( 'Join', 'quadrat' ),
+	'categories' => array( 'quadrat' ),
+	'content'    => '<!-- wp:columns -->
+		<div class="wp-block-columns"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:heading {"level":3} -->
+		<h3>' . esc_html( 'Join the Community' ) . '</h3>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph -->
+		<p>' . esc_html__( 'We’re thrilled to have you here! Now, if you don’t want to miss an article or an episode, you can subscribe to our newsletter.' ) . '</p>
+		<!-- /wp:paragraph --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"center","className":"subscription-column"} -->
+		<div class="wp-block-column is-vertically-aligned-center subscription-column"><!-- wp:jetpack/subscriptions {"buttonOnNewLine":true} -->
+		<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline wp-block-jetpack-subscriptions__use-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="true" custom_font_size="16px" custom_border_radius="0" custom_border_weight="1" custom_padding="15" custom_spacing="10" submit_button_classes="" email_field_classes="" show_only_email_and_button="true"]</div>
+		<!-- /wp:jetpack/subscriptions --></div>
+		<!-- /wp:column --></div>
+		<!-- /wp:columns -->',
+);

--- a/quadrat/inc/patterns/join.php
+++ b/quadrat/inc/patterns/join.php
@@ -8,8 +8,9 @@
 return array(
 	'title'      => __( 'Join', 'quadrat' ),
 	'categories' => array( 'quadrat' ),
-	'content'    => '<!-- wp:columns -->
-		<div class="wp-block-columns"><!-- wp:column -->
+	'content'    => '<!-- wp:columns {"align":"wide"} -->
+		<div class="wp-block-columns alignwide">
+		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:heading {"level":3} -->
 		<h3>' . esc_html( 'Join the Community' ) . '</h3>
 		<!-- /wp:heading -->

--- a/quadrat/sass/block-patterns/_join.scss
+++ b/quadrat/sass/block-patterns/_join.scss
@@ -1,0 +1,3 @@
+.subscription-column {
+	text-align: right;
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -10,3 +10,7 @@
 .wp-block-post-featured-image {
 	margin-top: 0;
 }
+
+.subscription-column {
+	text-align: right;
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -1,16 +1,13 @@
 @import "../../blank-canvas-blocks/sass/base/breakpoints"; // Get the mobile-only media query and make it available to this theme's styles
+@import "block-patterns/headlines";
+@import "block-patterns/join";
 @import "blocks/cover";
 @import "blocks/list";
 @import "blocks/media-text";
 @import "blocks/post-navigation-link";
 @import "blocks/table";
-@import "block-patterns/headlines";
 @import "header";
 
 .wp-block-post-featured-image {
 	margin-top: 0;
-}
-
-.subscription-column {
-	text-align: right;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Adds a "Join" pattern.

To test you need Jetpack installed and running on a custom domain, to make the subscription block work. It might be easier to test on a simple site.

<img width="780" alt="Screenshot 2021-05-04 at 14 09 25" src="https://user-images.githubusercontent.com/275961/117008163-56931c00-ace2-11eb-86a0-879d90f10d2c.png">

Note: The button / input on the subscription form doesn't match the theme. This is because of this issue:https://github.com/Automattic/jetpack/issues/17590

It would also be really good to get this done so we don't need the custom CSS: https://github.com/WordPress/gutenberg/issues/31459

#### Related issue(s):
https://github.com/Automattic/themes/issues/3642