### PR TITLE
Quadrat: Add listen pattern

### DIFF
--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -124,10 +124,10 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 					'categories' => array( 'quadrat' ),
 
 					'content'    => '<!-- wp:media-text {"mediaId":1497,"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg","mediaType":"image","mediaWidth":40,"mediaSizeSlug":"large","imageFill":false,"className":"has-pink-color has-darker-blue-background-color has-text-color has-background is-style-default"} -->
-					<div class="wp-block-media-text alignwide is-stacked-on-mobile has-pink-color has-darker-blue-background-color has-text-color has-background is-style-default" style="grid-template-columns:40% auto"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg" alt="' . esc_attr__( 'Illustration of an introspective woman.', 'quadrat') . '" class="wp-image-1497 size-large"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"level":3} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile has-pink-color has-darker-blue-background-color has-text-color has-background is-style-default" style="grid-template-columns:40% auto"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg" alt="' . esc_attr__( 'Illustration of an introspective woman.', 'quadrat' ) . '" class="wp-image-1497 size-large"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"level":3} -->
 					<h3>' . esc_html__( 'Episode 3: A Cycle of Emotions', 'quadrat' ) . '</h3>
 					<!-- /wp:heading -->
-					
+
 					<!-- wp:paragraph {"fontSize":"small"} -->
 					<p class="has-small-font-size">' . wp_kses_post( __( '<em>“Do we need periods if they make us crazy?”</em>, Sarah asks. We reached out to our friend Diana Roth, an endocrinologist specialized in women’s hormonal health to know how menstrual cycles impact women’s brains and emotions. Hint: yes, we do.', 'quadrat' ) ) . '</p>
 					<!-- /wp:paragraph --></div></div>
@@ -222,6 +222,24 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				)
 			);
 
+			register_block_pattern(
+				'quadrat/listen-to-the-podcast',
+				array(
+					'title'      => __( 'Listen to the podcast', 'quadrat' ),
+					'categories' => array( 'quadrat' ),
+					'content'    => '<!-- wp:heading {"textAlign":"center","level":4} -->
+						<h4 class="has-text-align-center">' . esc_html__( 'Listen to the podcast' ) . '</h4>
+						<!-- /wp:heading -->
+
+						<!-- wp:audio {"id":102} -->
+						<figure class="wp-block-audio"><audio controls src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/05/quadrat.mp3"></audio></figure>
+						<!-- /wp:audio -->
+
+						<!-- wp:paragraph {"align":"center","fontSize":"tiny"} -->
+						<p class="has-text-align-center has-tiny-font-size">' . sprintf( wp_kses( __( 'Listen on <a href="%1$s">Apple Podcasts</a>, <a href="%2$s">Spotify</a>.' ), array( 'a' => array( 'href' => array() ) ) ), 'https://podcasts.apple.com', 'https://spotify.com' ) . '</p>
+						<!-- /wp:paragraph -->',
+				)
+			);
 		}
 	}
 endif;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a listen pattern:

<img width="722" alt="Screenshot 2021-05-04 at 15 15 54" src="https://user-images.githubusercontent.com/275961/117017597-a0cccb00-aceb-11eb-910c-a94951fbb17c.png">

It's hard to style the audio player without custom JS. The alternative would be to use the Jetpack podcast player:

<img width="715" alt="Screenshot 2021-05-04 at 15 18 19" src="https://user-images.githubusercontent.com/275961/117017956-f73a0980-aceb-11eb-951b-14971371882b.png">

#### Related issue(s):
https://github.com/Automattic/themes/issues/3642