### PR TITLE
Refactor/theme heading styles json

### DIFF
--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -336,54 +336,6 @@
 					"color": "var(--wp--custom--button--border--color)"
 				}
 			},
-			"core/heading/h1": {
-				"typography": {
-					"fontSize": "48px",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h2": {
-				"typography": {
-					"fontSize": "32px",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h3": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h4": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h5": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h6": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
 			"core/post-title/h1": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
@@ -469,12 +421,49 @@
 					"style": "solid",
 					"width": "0 0 1px 0"
 				}
+			},
+			"core/heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--headings)",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
+					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
+				}
 			}
 		},
 		"elements": {
 			"link": {
 				"color": {
-					"link": "var(--wp--custom--color--secondary)"
+					"text": "var(--wp--custom--color--secondary)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "48px"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "32px"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			}
 		}

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -336,7 +336,7 @@
 					"color": "var(--wp--custom--button--border--color)"
 				}
 			},
-			"core/post-title/h1": {
+			"core/post-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"

--- a/mayland-blocks/child-experimental-theme.json
+++ b/mayland-blocks/child-experimental-theme.json
@@ -157,45 +157,9 @@
 			"fontFamily": "var(--wp--preset--font-family--base)"
 		},
 		"blocks": {
-			"core/heading/h1": {
+			"core/heading": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "41.47px",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
-			"core/heading/h2": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
-			"core/heading/h3": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
-			"core/heading/h4": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "24px",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
-			"core/heading/h5": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
-			"core/heading/h6": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": "var(--wp--custom--line-height--headings)"
 				}
 			},
@@ -233,7 +197,37 @@
 		"elements": {
 			"link": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--custom--color--foreground)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "41.47px"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "24px"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			}
 		}

--- a/mayland-blocks/child-experimental-theme.json
+++ b/mayland-blocks/child-experimental-theme.json
@@ -1,5 +1,4 @@
 {
-	"version:": 1,
 	"templateParts": [
 		{
 			"name": "header",
@@ -163,7 +162,7 @@
 					"lineHeight": "var(--wp--custom--line-height--headings)"
 				}
 			},
-			"core/post-title/h1": {
+			"core/post-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--line-height--headings)"

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -362,55 +362,7 @@
 					"color": "var(--wp--custom--button--border--color)"
 				}
 			},
-			"core/heading/h1": {
-				"typography": {
-					"fontSize": "41.47px",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h2": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h3": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h4": {
-				"typography": {
-					"fontSize": "24px",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h5": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h6": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/post-title/h1": {
+			"core/post-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--line-height--headings)"
@@ -495,6 +447,13 @@
 					"style": "solid",
 					"width": "0 0 1px 0"
 				}
+			},
+			"core/heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--base)",
+					"lineHeight": "var(--wp--custom--line-height--headings)",
+					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
+				}
 			}
 		},
 		"elements": {
@@ -502,8 +461,37 @@
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
 				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "41.47px"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "24px"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
 			}
 		}
-	},
-	"version:": 1
+	}
 }

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -500,7 +500,7 @@
 		"elements": {
 			"link": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
 		}

--- a/mayland-blocks/package.json
+++ b/mayland-blocks/package.json
@@ -13,7 +13,7 @@
 	"scripts": {
 		"start": "chokidar \"**/*.scss\" child-experimental-theme.json ../blank-canvas-blocks/experimental-theme.json -c \"npm run build\" --initial",
 		"build": "npm run build:theme && npm run build:scss",
-		"build:theme": "node ../blank-canvas-blocks/build.js seedlet-blocks",
+		"build:theme": "node ../blank-canvas-blocks/build.js mayland-blocks",
 		"build:scss": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js sass/theme.scss assets/theme.css --output-style expanded --indent-type tab --indent-width 1 --source-map true"
 	},
 	"author": "",

--- a/seedlet-blocks/child-experimental-theme.json
+++ b/seedlet-blocks/child-experimental-theme.json
@@ -1,5 +1,4 @@
 {
-	"version": 1,
 	"templateParts": [
 		{
 			"name": "header",

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -392,54 +392,6 @@
 					"color": "var(--wp--custom--button--border--color)"
 				}
 			},
-			"core/heading/h1": {
-				"typography": {
-					"fontSize": "48px",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h2": {
-				"typography": {
-					"fontSize": "32px",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h3": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h4": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h5": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
-			"core/heading/h6": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontFamily": "var(--wp--preset--font-family--headings)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
-				}
-			},
 			"core/post-title/h1": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
@@ -530,12 +482,49 @@
 					"style": "solid",
 					"width": "0 0 1px 0"
 				}
+			},
+			"core/heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--headings)",
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
+					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
+				}
 			}
 		},
 		"elements": {
 			"link": {
 				"color": {
-					"link": "var(--wp--custom--color--secondary)"
+					"text": "var(--wp--custom--color--secondary)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "48px"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "32px"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			}
 		}

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -392,7 +392,7 @@
 					"color": "var(--wp--custom--button--border--color)"
 				}
 			},
-			"core/post-title/h1": {
+			"core/post-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"


### PR DESCRIPTION
The change: 
* moves the header styles from "blocks" to "elements"
* moves common header styles (family/height/weight) from h?-specific blocks to a common 'core/header' location
* Refactors BCB, Mayland-blocks and Seedlet-Blocks
* Fixes Mayland's theme build script
* Fixes block styles of post-title
