### PR TITLE
Block Patterns: Load before core

### DIFF
--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -41,4 +41,4 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 	}
 endif;
 
-add_action( 'init', 'quadrat_register_block_patterns' );
+add_action( 'init', 'quadrat_register_block_patterns', 9 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Updates the priority of the block patterns so they load before core:

<img width="160" alt="Screenshot 2021-05-06 at 16 40 21" src="https://user-images.githubusercontent.com/275961/117326632-c263b900-ae89-11eb-9773-66a7e3607179.png">

Requires this Jetpack PR: https://github.com/Automattic/jetpack/pull/19760
