### PR TITLE
BCB: Only show patterns on the parent theme

### DIFF
--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -85,4 +85,6 @@ function blank_canvas_blocks_fonts_url() {
 /**
  * Block Patterns.
  */
-require get_template_directory() . '/inc/block-patterns.php';
+if ( ! is_child_theme() ) {
+	require get_template_directory() . '/inc/block-patterns.php';
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We shouldn't show Blank Canvas patterns on the child themes.

To test, make sure that the Blank Canvas patterns don't show on Seedlet Blocks, but they do when you are on BCB.
