### PR TITLE
Quadrat: add custom logo support (rebase)

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -302,11 +302,18 @@ a:active, a:focus {
 	background: var(--wp--custom--color--secondary);
 }
 
-.site-header .wp-block-group {
+.site-header > .wp-block-group {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
 	overflow: inherit;
+}
+
+.site-header > .wp-block-group .wp-block-site-logo {
+	margin-bottom: var(--wp--custom--margin--vertical);
+}
+
+.site-header > .wp-block-group .wp-block-site-title {
+	margin-top: 0;
 }
 
 .site-header .wp-block-site-title a {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -312,7 +312,7 @@ a:active, a:focus {
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	overflow: inherit;
-	padding: 20px 20px 60px;
+	padding: 10px 20px 60px;
 }
 
 @media (min-width: 480px) {
@@ -328,7 +328,7 @@ a:active, a:focus {
 @media (max-width: 479px) {
 	.site-header > .wp-block-group .wp-block-site-logo {
 		flex-basis: 100%;
-		margin: 0 0 10px;
+		margin: 20px 0;
 		text-align: center;
 	}
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -124,6 +124,10 @@ ul ul {
 	text-decoration: underline;
 }
 
+.wp-block-navigation__mobile-menu-open-button {
+	color: var(--wp--custom--color--primary);
+}
+
 .wp-block-post-comments .reply a {
 	font-size: 1em;
 	line-height: 1.2;
@@ -302,18 +306,36 @@ a:active, a:focus {
 	background: var(--wp--custom--color--secondary);
 }
 
-.site-header > .wp-block-group {
-	display: flex;
-	justify-content: space-between;
-	overflow: inherit;
-}
-
-.site-header > .wp-block-group .wp-block-site-logo {
+.site-header {
 	margin-bottom: var(--wp--custom--margin--vertical);
 }
 
+.site-header > .wp-block-group {
+	align-items: center;
+	display: flex;
+	justify-content: flex-start;
+	overflow: inherit;
+	flex-wrap: wrap;
+}
+
+.site-header > .wp-block-group .wp-block-site-logo {
+	margin-right: var(--wp--custom--margin--horizontal);
+}
+
+@media (max-width: 479px) {
+	.site-header > .wp-block-group .wp-block-site-logo {
+		margin: 0 0 var(--wp--custom--margin--vertical);
+		flex-basis: 100%;
+	}
+}
+
 .site-header > .wp-block-group .wp-block-site-title {
-	margin-top: 0;
+	margin: 0;
+}
+
+.site-header > .wp-block-group .wp-block-navigation {
+	margin-left: auto;
+	padding-right: 0;
 }
 
 .site-header .wp-block-site-title a {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -337,7 +337,7 @@ a:active, a:focus {
 }
 
 .site-header > .wp-block-group .wp-block-site-logo a > img {
-	height: 35px;
+	height: 64px;
 	width: auto;
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -306,22 +306,18 @@ a:active, a:focus {
 	background: var(--wp--custom--color--secondary);
 }
 
-.site-header {
-	margin-bottom: var(--wp--custom--margin--vertical);
-}
-
 .site-header > .wp-block-group {
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	overflow: inherit;
-	padding: 60px 20px;
+	padding: 20px 20px 60px;
 }
 
 @media (min-width: 480px) {
 	.site-header > .wp-block-group {
-		padding: 35px 35px;
+		padding: var(--wp--custom--margin--vertical);
 	}
 }
 
@@ -332,7 +328,8 @@ a:active, a:focus {
 @media (max-width: 479px) {
 	.site-header > .wp-block-group .wp-block-site-logo {
 		flex-basis: 100%;
-		margin-bottom: 20px;
+		margin: 0 0 10px;
+		text-align: center;
 	}
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -313,9 +313,16 @@ a:active, a:focus {
 .site-header > .wp-block-group {
 	align-items: center;
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: flex-start;
 	overflow: inherit;
-	flex-wrap: wrap;
+	padding: 60px 20px;
+}
+
+@media (min-width: 480px) {
+	.site-header > .wp-block-group {
+		padding: 35px 35px;
+	}
 }
 
 .site-header > .wp-block-group .wp-block-site-logo {
@@ -324,9 +331,14 @@ a:active, a:focus {
 
 @media (max-width: 479px) {
 	.site-header > .wp-block-group .wp-block-site-logo {
-		margin: 0 0 var(--wp--custom--margin--vertical);
 		flex-basis: 100%;
+		margin-bottom: 20px;
 	}
+}
+
+.site-header > .wp-block-group .wp-block-site-logo a > img {
+	height: 35px;
+	width: auto;
 }
 
 .site-header > .wp-block-group .wp-block-site-title {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -332,6 +332,13 @@
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400",
 			"lineHeight": "var(--wp--custom--line-height--body)"
+		},
+		"core/site-logo": {
+			"spacing": {
+				"padding": {
+					"left": "35px"
+				}
+			}
 		}
 	}
 }

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -533,6 +533,13 @@
 			"fontFamily": "var(--wp--preset--font-family--base)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
+		},
+		"core/site-logo": {
+			"spacing": {
+				"padding": {
+					"left": "35px"
+				}
+			}
 		}
 	}
 }

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -10,7 +10,19 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 			)
 		);
 
+		// Experimental support for adding blocks inside nav menus
 		add_theme_support( 'block-nav-menus' );
+
+		// Add support for core custom logo.
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 240,
+				'width'       => 240,
+				'flex-width'  => false,
+				'flex-height' => false,
+			)
+		);
 
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -17,10 +17,10 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 240,
-				'width'       => 240,
-				'flex-width'  => false,
-				'flex-height' => false,
+				'height'      => 35,
+				'width'       => 150,
+				'flex-width'  => true,
+				'flex-height' => true,
 			)
 		);
 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -1,16 +1,14 @@
 .site-header {
-	margin-bottom: var(--wp--custom--margin--vertical);
-
 	> .wp-block-group {
 		align-items: center;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		overflow: inherit;
-		padding: 60px 20px;
+		padding: 20px 20px 60px; // TODO: Maybe replace with a responsive custom variable?
 
 		@include break-mobile() {
-			padding: 35px 35px;
+			padding: var(--wp--custom--margin--vertical);
 		}
 
 		.wp-block-site-logo {
@@ -18,7 +16,8 @@
 
 			@include break-mobile-only(){
 				flex-basis: 100%;
-				margin-bottom: 20px;
+				margin: 0 0 10px;
+				text-align: center;
 			}
 
 			a > img {

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -1,14 +1,28 @@
 .site-header {
+	margin-bottom: var(--wp--custom--margin--vertical);
+
 	> .wp-block-group {
+		align-items: center;
 		display: flex;
-		justify-content: space-between;
+		justify-content: flex-start;
 		overflow: inherit;
+		flex-wrap: wrap;
+
 		.wp-block-site-logo {
-			margin-bottom: var(--wp--custom--margin--vertical);
+			margin-right: var(--wp--custom--margin--horizontal);
+			@include break-mobile-only(){
+				margin: 0 0 var(--wp--custom--margin--vertical);
+				flex-basis: 100%;
+			}
 		}
 		
 		.wp-block-site-title {
-			margin-top: 0;
+			margin: 0;
+		}
+
+		.wp-block-navigation {
+			margin-left: auto;
+			padding-right: 0;
 		}
 	}
 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -22,7 +22,7 @@
 			}
 
 			a > img {
-				height: 35px;
+				height: 64px;
 				width: auto;
 			}
 		}

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -5,7 +5,7 @@
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		overflow: inherit;
-		padding: 20px 20px 60px; // TODO: Maybe replace with a responsive custom variable?
+		padding: 10px 20px 60px; // TODO: Maybe replace with a responsive custom variable?
 
 		@include break-mobile() {
 			padding: var(--wp--custom--margin--vertical);
@@ -16,7 +16,7 @@
 
 			@include break-mobile-only(){
 				flex-basis: 100%;
-				margin: 0 0 10px;
+				margin: 20px 0;
 				text-align: center;
 			}
 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -4,15 +4,26 @@
 	> .wp-block-group {
 		align-items: center;
 		display: flex;
+		flex-wrap: wrap;
 		justify-content: flex-start;
 		overflow: inherit;
-		flex-wrap: wrap;
+		padding: 60px 20px;
+
+		@include break-mobile() {
+			padding: 35px 35px;
+		}
 
 		.wp-block-site-logo {
 			margin-right: var(--wp--custom--margin--horizontal);
+
 			@include break-mobile-only(){
-				margin: 0 0 var(--wp--custom--margin--vertical);
 				flex-basis: 100%;
+				margin-bottom: 20px;
+			}
+
+			a > img {
+				height: 35px;
+				width: auto;
 			}
 		}
 		

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -1,9 +1,15 @@
 .site-header {
-	.wp-block-group {
+	> .wp-block-group {
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
 		overflow: inherit;
+		.wp-block-site-logo {
+			margin-bottom: var(--wp--custom--margin--vertical);
+		}
+		
+		.wp-block-site-title {
+			margin-top: 0;
+		}
 	}
 
 	.wp-block-site-title a {

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -8,3 +8,7 @@
 		text-decoration: underline;
 	}
 }
+
+.wp-block-navigation__mobile-menu-open-button {
+	color: var(--wp--custom--color--primary);
+}

--- a/quadrat/template-parts/header.php
+++ b/quadrat/template-parts/header.php
@@ -14,13 +14,13 @@ require get_stylesheet_directory() . '/inc/render-navigation-block.php';
 <header class="site-header" role="banner">
 	<?php
 	echo do_blocks(
-		'<!-- wp:group {"style":{"spacing":{"padding":{"right":"35px","left":"35px"}}}} --><div class="wp-block-group" style="padding-right:35px;padding-left:35px">
+		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"35px","right":"35px","left":"35px"}}}} --><div class="wp-block-group" style="padding-top:35px;padding-right:35px;padding-left:35px">
 		<!-- wp:group --><div class="wp-block-group">
+		<!-- wp:site-logo {"width":100} /-->
 		<!-- wp:site-title /-->
 		</div><!-- /wp:group -->' .
 		render_navigation_block( 'primary' ) .
-		'</div><!-- /wp:group -->
-		<!-- wp:site-logo {"width":100} /-->'
+		'</div><!-- /wp:group -->'
 	);
 	?>
 </header>

--- a/quadrat/template-parts/header.php
+++ b/quadrat/template-parts/header.php
@@ -15,10 +15,8 @@ require get_stylesheet_directory() . '/inc/render-navigation-block.php';
 	<?php
 	echo do_blocks(
 		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"35px","right":"35px","left":"35px"}}}} --><div class="wp-block-group" style="padding-top:35px;padding-right:35px;padding-left:35px">
-		<!-- wp:group --><div class="wp-block-group">
-		<!-- wp:site-logo {"width":100} /-->
-		<!-- wp:site-title /-->
-		</div><!-- /wp:group -->' .
+		<!-- wp:site-logo {"width":150} /-->
+		<!-- wp:site-title /-->' .
 		render_navigation_block( 'primary' ) .
 		'</div><!-- /wp:group -->'
 	);

--- a/quadrat/template-parts/header.php
+++ b/quadrat/template-parts/header.php
@@ -15,9 +15,12 @@ require get_stylesheet_directory() . '/inc/render-navigation-block.php';
 	<?php
 	echo do_blocks(
 		'<!-- wp:group {"style":{"spacing":{"padding":{"right":"35px","left":"35px"}}}} --><div class="wp-block-group" style="padding-right:35px;padding-left:35px">
-		<!-- wp:site-title /-->' .
+		<!-- wp:group --><div class="wp-block-group">
+		<!-- wp:site-title /-->
+		</div><!-- /wp:group -->' .
 		render_navigation_block( 'primary' ) .
-		'</div><!-- /wp:group -->'
+		'</div><!-- /wp:group -->
+		<!-- wp:site-logo {"width":100} /-->'
 	);
 	?>
 </header>

--- a/quadrat/template-parts/header.php
+++ b/quadrat/template-parts/header.php
@@ -14,8 +14,8 @@ require get_stylesheet_directory() . '/inc/render-navigation-block.php';
 <header class="site-header" role="banner">
 	<?php
 	echo do_blocks(
-		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"35px","right":"35px","left":"35px"}}}} --><div class="wp-block-group" style="padding-top:35px;padding-right:35px;padding-left:35px">
-		<!-- wp:site-logo {"width":150} /-->
+		'<!-- wp:group --><div class="wp-block-group">
+		<!-- wp:site-logo /-->
 		<!-- wp:site-title /-->' .
 		render_navigation_block( 'primary' ) .
 		'</div><!-- /wp:group -->'


### PR DESCRIPTION
Clean version of #3761.

Desktop | Mobile
------- | --------
<img width="1228" alt="Screen Shot 2021-05-06 at 2 47 45 PM" src="https://user-images.githubusercontent.com/5375500/117350106-04c4d000-ae61-11eb-9db5-a19e776789d4.png">|<img width="380" alt="Screen Shot 2021-05-06 at 2 47 39 PM" src="https://user-images.githubusercontent.com/5375500/117350113-05f5fd00-ae61-11eb-92c8-5de838a7526d.png">
