### PR TITLE
Quadrat: Update Pullquote styles

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -450,6 +450,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--pullquote--citation--typography--font-size);
 	font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 	font-style: var(--wp--custom--pullquote--citation--typography--font-style);
+	font-weight: var(--wp--custom--pullquote--citation--typography--font-weight);
 	margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);
 }
 

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -428,6 +428,12 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-align: var(--wp--custom--pullquote--typography--text-align);
 }
 
+.wp-block-pullquote.is-style-solid-color blockquote,
+.wp-block-pullquote blockquote {
+	padding: 0;
+	margin: 0;
+}
+
 .wp-block-pullquote.is-style-solid-color blockquote p,
 .wp-block-pullquote blockquote p {
 	font-size: 1em;
@@ -452,11 +458,6 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-pullquote.is-style-solid-color {
 	background-color: var(--wp--custom--color--foreground);
 	color: var(--wp--custom--color--background);
-}
-
-.wp-block-pullquote:not(.is-style-solid-color) blockquote {
-	padding: 0;
-	margin: 0;
 }
 
 .wp-block-quote.is-style-large p,

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -428,12 +428,6 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-align: var(--wp--custom--pullquote--typography--text-align);
 }
 
-.wp-block-pullquote.is-style-solid-color blockquote,
-.wp-block-pullquote blockquote {
-	padding: 0;
-	margin: 0;
-}
-
 .wp-block-pullquote.is-style-solid-color blockquote p,
 .wp-block-pullquote blockquote p {
 	font-size: 1em;
@@ -458,6 +452,11 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-pullquote.is-style-solid-color {
 	background-color: var(--wp--custom--color--foreground);
 	color: var(--wp--custom--color--background);
+}
+
+.wp-block-pullquote:not(.is-style-solid-color) blockquote {
+	padding: 0;
+	margin: 0;
 }
 
 .wp-block-quote.is-style-large p,

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -215,7 +215,8 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontStyle": "italic"
+						"fontStyle": "italic",
+						"fontWeight": "400"
 					}
 				},
 				"typography": {

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -2,8 +2,6 @@
 .wp-block-pullquote {
 	text-align: var(--wp--custom--pullquote--typography--text-align);
 	blockquote {
-		padding: 0;
-		margin: 0;
 		p {
 			font-size: 1em;
 			padding: 0;
@@ -25,5 +23,12 @@
 	&.is-style-solid-color {
 		background-color: var(--wp--custom--color--foreground);
 		color: var(--wp--custom--color--background);
+	}
+}
+
+.wp-block-pullquote:not(.is-style-solid-color) {
+	blockquote {
+		padding: 0;
+		margin: 0;
 	}
 }

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -2,6 +2,8 @@
 .wp-block-pullquote {
 	text-align: var(--wp--custom--pullquote--typography--text-align);
 	blockquote {
+		padding: 0;
+		margin: 0;
 		p {
 			font-size: 1em;
 			padding: 0;
@@ -26,9 +28,3 @@
 	}
 }
 
-.wp-block-pullquote:not(.is-style-solid-color) {
-	blockquote {
-		padding: 0;
-		margin: 0;
-	}
-}

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -17,6 +17,7 @@
 			font-size: var(--wp--custom--pullquote--citation--typography--font-size);
 			font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
+			font-weight: var(--wp--custom--pullquote--citation--typography--font-weight);
 			margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);
 		}
 	}

--- a/mayland-blocks/assets/theme.css
+++ b/mayland-blocks/assets/theme.css
@@ -5,6 +5,10 @@ body {
 }
 
 /* Adjust header spacing. */
+.site-header > .wp-block-columns {
+	padding: 0 var(--wp--custom--margin--horizontal);
+}
+
 .site-header .wp-block-site-title a {
 	text-decoration: none;
 }
@@ -31,9 +35,9 @@ h1, h2, h3 {
 	letter-spacing: -0.015em;
 }
 
-/* 
+/*
  * Preserve image ratios.
- * Needed until https://github.com/WordPress/gutenberg/pull/27518/ is merged. 
+ * Needed until https://github.com/WordPress/gutenberg/pull/27518/ is merged.
  */
 img {
 	height: auto;

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -219,7 +219,8 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontStyle": "italic"
+						"fontStyle": "italic",
+						"fontWeight": "400"
 					}
 				},
 				"typography": {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -154,11 +154,8 @@ ul ul {
 	border-bottom-width: 1px;
 }
 
-@media (max-width: 479px) {
-	.headlines-pattern {
-		padding-top: 50px !important;
-		padding-bottom: 50px !important;
-	}
+.wp-block-pullquote.is-style-solid-color {
+	padding: var(--wp--custom--margin--horizontal);
 }
 
 a:hover {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -238,6 +238,21 @@
 					"lineHeight": "40px"
 				}
 			},
+			"core/pullquote": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "600"
+				},
+				"spacing": {
+					"padding": {
+						"left": "0px",
+						"right": "0px"
+					}
+				},
+				"border": {
+					"width": "1px 0 0 0"
+				}
+			},
 			"core/site-title": {
 				"color": {
 					"link": "var(--wp--custom--color--primary)"
@@ -288,21 +303,6 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
-			"core/pullquote": {
-				"typography": {
-					"fontStyle": "normal",
-					"fontWeight": "600"
-				},
-				"spacing": {
-					"padding": {
-						"left": "0px",
-						"right": "0px"
-					}
-				},
-				"border": {
-					"width": "1px 0 0 0"
 				}
 			}
 		},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -241,7 +241,9 @@
 			"core/pullquote": {
 				"typography": {
 					"fontStyle": "normal",
-					"fontWeight": "500"
+					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontWeight": "500",
+					"lineHeight": "1.4"
 				},
 				"spacing": {
 					"padding": {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -103,6 +103,14 @@
 						"fontWeight": "300"
 					}
 				}
+			},
+			"pullquote": {
+				"citation": {
+					"typography": {
+						"fontStyle": "normal",
+						"fontWeight": 300
+					}
+				}
 			}
 		},
 		"layout": {
@@ -204,14 +212,6 @@
 					"lineHeight": "var(--wp--custom--line-height--headings--h2)"
 				}
 			},
-			"pullquote": {
-				"citation": {
-					"typography": {
-						"fontStyle": "normal",
-						"fontWeight": "400"
-					}
-				}
-			},
 			"list": {
 				"padding": {
 					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
@@ -241,7 +241,7 @@
 			"core/pullquote": {
 				"typography": {
 					"fontStyle": "normal",
-					"fontWeight": "600"
+					"fontWeight": "500"
 				},
 				"spacing": {
 					"padding": {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -204,6 +204,19 @@
 					"lineHeight": "var(--wp--custom--line-height--headings--h2)"
 				}
 			},
+			"pullquote": {
+				"citation": {
+					"typography": {
+						"fontStyle": "normal",
+						"fontWeight": "400"
+					}
+				}
+			},
+			"list": {
+				"padding": {
+					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				}
+			},
 			"core/quote": {
 				"border": {
 					"width": "0px"
@@ -275,6 +288,21 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
+				}
+			},
+			"core/pullquote": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "600"
+				},
+				"spacing": {
+					"padding": {
+						"left": "0px",
+						"right": "0px"
+					}
+				},
+				"border": {
+					"width": "1px 0 0 0"
 				}
 			}
 		},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -405,16 +405,17 @@
 			"core/pullquote": {
 				"border": {
 					"style": "solid",
-					"width": "1px 0"
+					"width": "1px 0 0 0"
 				},
 				"typography": {
-					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontStyle": "normal",
+					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontWeight": "600"
 				},
 				"spacing": {
 					"padding": {
-						"left": "var(--wp--custom--margin--horizontal)",
-						"right": "var(--wp--custom--margin--horizontal)",
+						"left": "0px",
+						"right": "0px",
 						"top": "var(--wp--custom--margin--horizontal)",
 						"bottom": "var(--wp--custom--margin--horizontal)"
 					}
@@ -521,21 +522,6 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
-			"core/pullquote": {
-				"typography": {
-					"fontStyle": "normal",
-					"fontWeight": "600"
-				},
-				"spacing": {
-					"padding": {
-						"left": "0px",
-						"right": "0px"
-					}
-				},
-				"border": {
-					"width": "1px 0 0 0"
 				}
 			}
 		},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -202,7 +202,8 @@
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
 						"fontFamily": "inherit",
-						"fontStyle": "italic"
+						"fontStyle": "normal",
+						"fontWeight": 300
 					},
 					"spacing": {
 						"margin": {
@@ -410,7 +411,7 @@
 				"typography": {
 					"fontStyle": "normal",
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "600"
+					"fontWeight": "500"
 				},
 				"spacing": {
 					"padding": {
@@ -461,14 +462,6 @@
 					"typography": {
 						"fontSize": "15px",
 						"fontWeight": "300"
-					}
-				}
-			},
-			"pullquote": {
-				"citation": {
-					"typography": {
-						"fontStyle": "normal",
-						"fontWeight": "400"
 					}
 				}
 			},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -462,6 +462,19 @@
 						"fontWeight": "300"
 					}
 				}
+			},
+			"pullquote": {
+				"citation": {
+					"typography": {
+						"fontStyle": "normal",
+						"fontWeight": "400"
+					}
+				}
+			},
+			"list": {
+				"padding": {
+					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				}
 			}
 		},
 		"color": {
@@ -508,6 +521,21 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
+				}
+			},
+			"core/pullquote": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "600"
+				},
+				"spacing": {
+					"padding": {
+						"left": "0px",
+						"right": "0px"
+					}
+				},
+				"border": {
+					"width": "1px 0 0 0"
 				}
 			}
 		},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -411,7 +411,8 @@
 				"typography": {
 					"fontStyle": "normal",
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "500"
+					"fontWeight": "500",
+					"lineHeight": "1.4"
 				},
 				"spacing": {
 					"padding": {

--- a/quadrat/sass/blocks/_pullquote.scss
+++ b/quadrat/sass/blocks/_pullquote.scss
@@ -1,0 +1,3 @@
+.wp-block-pullquote.is-style-solid-color {
+	padding: var(--wp--custom--margin--horizontal);
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -8,7 +8,7 @@
 @import "blocks/navigation";
 @import "blocks/post-navigation-link";
 @import "blocks/table";
-@import "block-patterns/headlines";
+@import "blocks/pullquote";
 @import "elements/links";
 @import "header";
 

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -176,6 +176,10 @@
 	}
 }
 
+.wp-block-pullquote.is-style-solid-color {
+	padding: var(--wp--custom--margin--horizontal);
+}
+
 /**
  * Author bio
  */

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -257,7 +257,8 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontStyle": "italic"
+						"fontStyle": "italic",
+						"fontWeight": "400"
 					}
 				},
 				"typography": {

--- a/seedlet-blocks/sass/blocks/_pullquote.scss
+++ b/seedlet-blocks/sass/blocks/_pullquote.scss
@@ -1,0 +1,3 @@
+.wp-block-pullquote.is-style-solid-color {
+	padding: var(--wp--custom--margin--horizontal);
+}

--- a/seedlet-blocks/sass/theme.scss
+++ b/seedlet-blocks/sass/theme.scss
@@ -1,6 +1,7 @@
 @import './blocks/site-title.scss';
 @import './blocks/links.scss';
 @import './blocks/latest-posts';
+@import './blocks/pullquote';
 
 /**
  * Author bio


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Updates pullquote styles to match https://github.com/Automattic/themes/issues/3743

Before:
<img width="714" alt="Screenshot 2021-05-07 at 11 18 26" src="https://user-images.githubusercontent.com/275961/117435610-f42a5d80-af25-11eb-9315-d1b66c62edcc.png">


After:
<img width="707" alt="Screenshot 2021-05-07 at 11 18 11" src="https://user-images.githubusercontent.com/275961/117435577-eaa0f580-af25-11eb-9150-2e6692b8c43f.png">

