### PR TITLE
Quadrat: added polygons to header and footer

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -431,9 +431,22 @@ a:active, a:focus {
 	z-index: -1;
 }
 
+@media (max-width: 479px) {
+	.site-header:before {
+		-webkit-clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+		        clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+	}
+}
+
 .post-meta {
 	align-items: center;
 	justify-content: center;
+}
+
+@media (max-width: 479px) {
+	.post-meta {
+		padding-top: 120px !important;
+	}
 }
 
 .post-meta .wp-block-post-date::before {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -445,8 +445,8 @@ a:active, a:focus {
 
 @media (min-width: 960px) {
 	.site-header:before {
-		-webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
-		        clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+		-webkit-clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
+		        clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
 	}
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -445,8 +445,8 @@ a:active, a:focus {
 
 @media (min-width: 960px) {
 	.site-header:before {
-		-webkit-clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
-		        clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
+		-webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
+		        clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
 	}
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -367,7 +367,13 @@ a:active, a:focus {
 	background: var(--wp--custom--color--secondary);
 }
 
-.site-header > .wp-block-group {
+.site-header {
+	position: relative;
+}
+
+.site-header .wp-block-group {
+	display: flex;
+	justify-content: space-between;
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
@@ -377,39 +383,52 @@ a:active, a:focus {
 }
 
 @media (min-width: 480px) {
-	.site-header > .wp-block-group {
+	.site-header .wp-block-group {
 		padding: var(--wp--custom--margin--vertical);
 	}
 }
 
-.site-header > .wp-block-group .wp-block-site-logo {
+.site-header .wp-block-group .wp-block-site-logo {
 	margin-right: var(--wp--custom--margin--horizontal);
 }
 
 @media (max-width: 479px) {
-	.site-header > .wp-block-group .wp-block-site-logo {
+	.site-header .wp-block-group .wp-block-site-logo {
 		flex-basis: 100%;
 		margin: 20px 0;
 		text-align: center;
 	}
 }
 
-.site-header > .wp-block-group .wp-block-site-logo a > img {
+.site-header .wp-block-group .wp-block-site-logo a > img {
 	height: 64px;
 	width: auto;
 }
 
-.site-header > .wp-block-group .wp-block-site-title {
+.site-header .wp-block-group .wp-block-site-title {
 	margin: 0;
 }
 
-.site-header > .wp-block-group .wp-block-navigation {
+.site-header .wp-block-group .wp-block-navigation {
 	margin-left: auto;
 	padding-right: 0;
 }
 
 .site-header .wp-block-site-title a {
 	text-decoration: none;
+}
+
+.site-header:before {
+	content: "";
+	background-color: var(--wp--custom--color--secondary);
+	-webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+	        clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+	position: absolute;
+	height: 100vw;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: -1;
 }
 
 .post-meta {
@@ -439,6 +458,24 @@ a:active, a:focus {
 
 .post-meta .wp-block-post-terms a {
 	color: var(--wp--custom--color--foreground);
+}
+
+.site-footer.wp-block-group {
+	position: relative;
+	overflow: visible;
+}
+
+.site-footer.wp-block-group:before {
+	content: "";
+	background-color: var(--wp--custom--color--secondary);
+	-webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+	        clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+	position: absolute;
+	height: 100vw;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: -1;
 }
 
 .wp-block-post-featured-image {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -421,8 +421,6 @@ a:active, a:focus {
 .site-header:before {
 	content: "";
 	background-color: var(--wp--custom--color--secondary);
-	-webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
-	        clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
 	position: absolute;
 	height: 100vw;
 	top: 0;
@@ -435,6 +433,20 @@ a:active, a:focus {
 	.site-header:before {
 		-webkit-clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
 		        clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+	}
+}
+
+@media (min-width: 480px) {
+	.site-header:before {
+		-webkit-clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
+		        clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
+	}
+}
+
+@media (min-width: 960px) {
+	.site-header:before {
+		-webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+		        clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
 	}
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -445,8 +445,8 @@ a:active, a:focus {
 
 @media (min-width: 960px) {
 	.site-header:before {
-		-webkit-clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
-		        clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
+		-webkit-clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
+		        clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
 	}
 }
 

--- a/quadrat/block-template-parts/footer.html
+++ b/quadrat/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
-<div class="wp-block-group" style="padding-top:150px;padding-bottom: 150px">
+<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">Powered by WordPress</p>

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -1,9 +1,5 @@
-<!-- wp:spacer -->
-<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:group {"className":"post-meta"} -->
-<div class="wp-block-group post-meta">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"170px"}}},"className":"post-meta"} -->
+<div class="wp-block-group post-meta" style="padding-top:170px">
 	<!-- wp:post-date {"textAlign":"center","fontSize":"tiny"} /-->
 	<!-- wp:post-terms {"term":"category","textAlign":"center","fontSize":"tiny"} /-->
 </div>

--- a/quadrat/sass/_footer.scss
+++ b/quadrat/sass/_footer.scss
@@ -1,0 +1,15 @@
+.site-footer.wp-block-group {
+	position: relative;
+	overflow: visible;
+	&:before {
+		content: "";
+		background-color: var(--wp--custom--color--secondary);
+		clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+		position: absolute;
+		height: 100vw;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: -1;
+	}
+}

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -59,7 +59,7 @@
 			clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
 		}
 		@include break-large() {
-			clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
+			clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
 		}
 	}
 } 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -46,16 +46,20 @@
 	&:before {
 		content: "";
 		background-color: var(--wp--custom--color--secondary);
-		clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
 		position: absolute;
 		height: 100vw;
 		top: 0;
 		left: 0;
 		right: 0;
 		z-index: -1;
-
 		@include break-mobile-only() {
 			clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+		}
+		@include break-mobile() {
+			clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
+		}
+		@include break-large() {
+			clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
 		}
 	}
 } 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -59,7 +59,7 @@
 			clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
 		}
 		@include break-large() {
-			clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+			clip-path: polygon(20vw 0, 96vw 0, 100vw 7vw, 100vw 16vw, 50vw 46vw);
 		}
 	}
 } 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -53,5 +53,9 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
+
+		@include break-mobile-only() {
+			clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+		}
 	}
 } 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -1,5 +1,8 @@
 .site-header {
-	> .wp-block-group {
+	position: relative;
+	.wp-block-group {
+		display: flex;
+		justify-content: space-between;
 		align-items: center;
 		display: flex;
 		flex-wrap: wrap;
@@ -38,5 +41,17 @@
 
 	.wp-block-site-title a {
 		text-decoration: none;
+	}
+	
+	&:before {
+		content: "";
+		background-color: var(--wp--custom--color--secondary);
+		clip-path: polygon(13vw 0, 100vw 0, 100vw 28vw, 52vw 63vw, 9vw 3vw);
+		position: absolute;
+		height: 100vw;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: -1;
 	}
 } 

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -59,7 +59,7 @@
 			clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
 		}
 		@include break-large() {
-			clip-path: polygon(13vw 0, 95vw 0, 100vw 7vw, 100vw 16vw, 50vw 51vw);
+			clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
 		}
 	}
 } 

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -1,6 +1,9 @@
 .post-meta {
 	align-items: center;
 	justify-content: center;
+	@include break-mobile-only() {
+		padding-top: 120px !important;
+	}
 
 	.wp-block-post-date::before {
 		display: none;

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -19,6 +19,7 @@
 @import "elements/links";
 @import "header";
 @import "meta";
+@import "footer";
 
 .wp-block-post-featured-image {
 	margin-top: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds the squares from the design to the header and the footer. I tried using the group block as a control for the user to enable/disable/customize the color of the squares but it's not possible, since the background color is in the group block and we don't have access to a variable (in case the user uses a custom color). We could on the cover block because the color was actually on the before pseudoelement.

We could consider providing two different header/footer options for the user to use with or without the squares. I don't believe we can make a block style of the header/footer though.

I used clip-path instead of the square svgs because it was simpler to handle the overflow when the element was bigger than the viewport. The shapes are done "by eye" so they may need adjusting, but they are responsive and maintain aspect ratio no matter the screen size.

On big screens or posts with very little content, the top square and the bottom square are very close to one another. I'd love input from @beafialho and @kjellr about that. We could tweak with media queries so the proportions of the squares are different on some viewports (like forcing a max size of the squares for the bigger screens) or adapt the shapes so this issue is a little less prominent.

I've been headbutting a bit against this PR, so any new eyes that can point out other ways of achieving this or improving it are more than welcome.

Design:

<img width="396" alt="Screenshot 2021-05-10 at 14 53 56" src="https://user-images.githubusercontent.com/3593343/117663493-ffd58880-b1a0-11eb-8794-fc0383d26485.png">

Header | Footer
--- | ---
![ezgif-6-dc2d4b2b5081](https://user-images.githubusercontent.com/3593343/117664135-bb96b800-b1a1-11eb-825a-1599e86d0e27.gif) | ![ezgif-6-35f211ea3934](https://user-images.githubusercontent.com/3593343/117664140-bdf91200-b1a1-11eb-8371-dd386ae2390c.gif)



#### Related issue(s):
