### PR TITLE
Adds Custom Color Controls to Customizer for Quadrat

### DIFF
--- a/quadrat/assets/noop.css
+++ b/quadrat/assets/noop.css
@@ -1,0 +1,1 @@
+/* This page intentionally left blank. */

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -51,7 +51,7 @@
 				"secondary": "var(--wp--preset--color--darker-blue)",
 				"foreground": "var(--wp--preset--color--pink)",
 				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
+				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400"
@@ -105,6 +105,40 @@
 				}
 			}
 		},
+		"custom_meta": [
+			{
+				"name": "Colors",
+				"type": "section",
+				"slug": "colors",
+				"description": "Color Customization for Quadrat",
+				"controls": [
+					{
+						"name": "Foreground Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--foreground"
+					},
+					{
+						"name": "Background Color",
+						"type": "color",
+						"default": "#292C6D",
+						"slug": "color--background"
+					},
+					{
+						"name": "Primary Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--primary"
+					},
+					{
+						"name": "Secondary Color",
+						"type": "color",
+						"default": "#151853",
+						"slug": "color--secondary"
+					}
+				]
+			}	
+		],
 		"layout": {
 			"contentSize": "664px",
 			"wideSize": "1128px"

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -86,7 +86,7 @@
 				"tertiary": "var(--wp--preset--color--almost-white)",
 				"foreground": "var(--wp--preset--color--pink)",
 				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
+				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
@@ -320,7 +320,41 @@
 					"slug": "huge"
 				}
 			]
-		}
+		},
+		"custom_meta": [
+			{
+				"name": "Colors",
+				"type": "section",
+				"slug": "colors",
+				"description": "Color Customization for Quadrat",
+				"controls": [
+					{
+						"name": "Foreground Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--foreground"
+					},
+					{
+						"name": "Background Color",
+						"type": "color",
+						"default": "#292C6D",
+						"slug": "color--background"
+					},
+					{
+						"name": "Primary Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--primary"
+					},
+					{
+						"name": "Secondary Color",
+						"type": "color",
+						"default": "#151853",
+						"slug": "color--secondary"
+					}
+				]
+			}
+		]
 	},
 	"styles": {
 		"blocks": {

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -49,4 +49,4 @@ require get_stylesheet_directory() . '/inc/block-styles.php';
 /**
  * Customizer Bridge
  */
-require get_template_directory() . '/inc/customization.php';
+require get_stylesheet_directory() . '/inc/customization.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -31,8 +31,6 @@ endif;
 function quadrat_scripts() {
 	// Enqueue front-end styles.
 	wp_enqueue_style( 'quadrat-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
-	// Enqueue customizer bridge styles
-	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array( 'quadrat-styles' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -31,6 +31,8 @@ endif;
 function quadrat_scripts() {
 	// Enqueue front-end styles.
 	wp_enqueue_style( 'quadrat-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
+	// Enqueue customizer bridge styles
+	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array( 'quadrat-styles' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 
@@ -43,3 +45,8 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
+
+/**
+ * Customizer Bridge
+ */
+require get_template_directory() . '/inc/customization.php';

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -5,7 +5,13 @@ class CustomizerBridge {
 
 	function __construct() {
 		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
+
+		//this is for the view
 		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
+
+		//this is for the editor
+		add_action( 'enqueue_block_editor_assets', array( $this, 'customizer_bridge_output_variables' ) );
+
 		$this->theme_customizations = $this->get_theme_customizations();
 	}
 
@@ -19,15 +25,20 @@ class CustomizerBridge {
 	 * Enqueue color variables for customizer & frontend.
 	 */
 	function customizer_bridge_output_variables() {
+		wp_register_style( 'customizer-style', false, array(), true, true );
+		wp_enqueue_style( 'customizer-style' );
 		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
 	}
 
 	/**
 	 * Render the customized variables.
+	 *
+	 * NOTE: Ideally this wouldn't happen at all and instead the theme.json would be filtered
+	 * and modified to reflect the users's choice.
 	 */
 	function customizer_bridge_generate_custom_color_variables( $context = null ) {
 
-		$css_variables = 'body {';
+		$css_variables = 'body, #editor {';
 		foreach ( $this->theme_customizations as $custom_section ) {
 			foreach ( $custom_section->controls as $custom_option ) {
 				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -1,0 +1,112 @@
+<?php
+class CustomizerBridge {
+
+	private $theme_customizations;
+
+	function __construct() {
+		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
+		$this->theme_customizations = $this->get_theme_customizations();
+	}
+
+	function get_theme_customizations() {
+		$string  = file_get_contents( get_stylesheet_directory() . '/experimental-theme.json' );
+		$decoded = json_decode( $string );
+		return $decoded->settings->defaults->custom_meta;
+	}
+
+	/**
+	 * Enqueue color variables for customizer & frontend.
+	 */
+	function customizer_bridge_output_variables() {
+		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
+	}
+
+	/**
+	 * Render the customized variables.
+	 */
+	function customizer_bridge_generate_custom_color_variables( $context = null ) {
+
+		$css_variables = ':root {';
+		foreach ( $this->theme_customizations as $custom_section ) {
+			foreach ( $custom_section->controls as $custom_option ) {
+				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';
+			}
+		}
+		$css_variables = $css_variables . '}';
+
+		return $css_variables;
+	}
+
+	/**
+	 * Use theme.json to determine what variables to provide dials for.
+	 * Add those dials to the customizer interface.
+	 */
+	function customizer_bridge_register( $wp_customize ) {
+
+		// Add Color Controls
+		foreach ( $this->theme_customizations as $custom_section ) {
+
+			if ( 'section' === $custom_section->type ) {
+
+				$section_key = 'customizer-bridge-' . $custom_section->slug;
+
+				//Add a Section to the Customizer for these bits
+				$wp_customize->add_section(
+					$section_key,
+					array(
+						'capability' => 'edit_theme_options',
+						'title'      => esc_html__( $custom_section->name, 'customizer-bridge' ),
+					)
+				);
+
+				$wp_customize->get_section( $section_key )->description = __( $custom_section->description );
+
+				// Add Controls
+				foreach ( $custom_section->controls as $custom_option ) {
+
+					$setting_key = 'customizer-bridge-' . $custom_option->slug;
+
+					if ( 'color' === $custom_option->type ) {
+
+						$wp_customize->add_setting(
+							$setting_key,
+							array(
+								'default'           => esc_html( $custom_option->default ),
+								'sanitize_callback' => 'sanitize_hex_color',
+							)
+						);
+
+						$wp_customize->add_control(
+							new WP_Customize_Color_Control(
+								$wp_customize,
+								$setting_key,
+								array(
+									'section' => $section_key,
+									'label'   => $custom_option->name,
+								)
+							)
+						);
+					} elseif ( 'boolean' === $custom_option->type ) {
+
+						$wp_customize->add_setting( $setting_key );
+						$wp_customize->add_control(
+							$setting_key,
+							array(
+								'label'       => esc_html__( $custom_option->name ),
+								'description' => $custom_option->description,
+								'section'     => $section_key,
+								'type'        => 'checkbox',
+								'settings'    => $setting_key,
+							)
+						);
+
+					}
+				}
+			}
+		}
+
+	}
+
+}
+new CustomizerBridge;

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -41,7 +41,11 @@ class CustomizerBridge {
 		$css_variables = 'body, #editor {';
 		foreach ( $this->theme_customizations as $custom_section ) {
 			foreach ( $custom_section->controls as $custom_option ) {
-				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';
+				$slug_value = get_theme_mod( 'customizer-bridge-' . $custom_option->slug );
+				if ( $slug_value ) {
+					var_dump( $slug_value );
+					$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . $slug_value . ';';
+				}
 			}
 		}
 		$css_variables = $css_variables . '}';


### PR DESCRIPTION
Accomplishes the color customization of #3661 

This uses the 'overwrite CSS variables' method to customize values.

These customizations are ONLY available in the Customizer.

The things to be customized are defined in the theme.json's 'custom_meta' block.  

The 'Customizer Bridge' presents controls to the user based on that JSON and renders the stored values as Global Styles CSS variables.

The user DOES NOT have access to the selected colors via the block editor panel.  

![image](https://user-images.githubusercontent.com/146530/117720904-3dd8a980-b1ad-11eb-8961-e01166f1b83c.png)

![image](https://user-images.githubusercontent.com/146530/117721614-159d7a80-b1ae-11eb-9b78-adfe0672d570.png)
