### PR TITLE
Block themes: Update templates to include a Query block wrapper

### DIFF
--- a/blank-canvas-blocks/block-templates/index.html
+++ b/blank-canvas-blocks/block-templates/index.html
@@ -2,6 +2,7 @@
 <!-- wp:template-part {"slug":"navigation","tagName":"navigation","layout":{"inherit":true}} /-->
 
 <!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
 <!-- wp:query-loop -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
@@ -13,6 +14,7 @@
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- /wp:query-loop -->
+</div>
 <!-- /wp:query -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->

--- a/blank-canvas-blocks/block-templates/search.html
+++ b/blank-canvas-blocks/block-templates/search.html
@@ -9,12 +9,14 @@
 <!-- /wp:heading -->
 
 <!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+<div class="wp-block-query">
 <!-- wp:query-loop -->
 
 	<!-- wp:post-title {"level":5,"isLink":true} /-->
 	<!-- wp:post-excerpt /-->
 
 <!-- /wp:query-loop -->
+</div>
 <!-- /wp:query -->
 
 </div>

--- a/mayland-blocks/block-templates/index.html
+++ b/mayland-blocks/block-templates/index.html
@@ -4,6 +4,7 @@
 <div class="wp-block-group">
 
 <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
 <!-- wp:query-loop -->
 <!-- wp:post-title {"isLink":true} /-->
 
@@ -15,6 +16,7 @@
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:query-loop -->
+</div>
 <!-- /wp:query -->
 
 </div>

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -9,7 +9,7 @@
 	<!-- wp:post-date {"fontSize":"tiny"} /-->
 	<!-- wp:post-excerpt /-->
 
-	<!-- wp:spacer -->
+	<!-- wp:spacer {"height":30} -->
 	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 <!-- /wp:query-loop -->

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -1,7 +1,4 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<!-- wp:query {"layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <div class="wp-block-query">
 <!-- wp:query-loop -->
 	<!-- wp:post-featured-image {"isLink":true} /-->
@@ -24,6 +21,3 @@
 
 </div>
 <!-- /wp:query -->
-
-</div>
-<!-- /wp:group -->

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -2,6 +2,7 @@
 <div class="wp-block-group">
 
 <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<div class="wp-block-query">
 <!-- wp:query-loop -->
 	<!-- wp:post-featured-image {"isLink":true} /-->
 	<!-- wp:post-title {"isLink":true, "level": 3} /-->
@@ -21,6 +22,7 @@
 	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
 <!-- /wp:query-pagination -->
 
+</div>
 <!-- /wp:query -->
 
 </div>

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -1,6 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
 
 <!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
 <!-- wp:query-loop -->
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true} /--></div>
@@ -14,6 +15,7 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:query-loop -->
+</div>
 <!-- /wp:query -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->


### PR DESCRIPTION
WordPress/gutenberg#30804

I was able to observe the Alignment control for the Query block on the BCB Search template but not on the Index - not sure, what that is about.