### PR TITLE
Quadrat: revise post header and meta

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -179,8 +179,8 @@ a:focus {
 }
 
 .post-meta {
-	justify-content: center;
 	align-items: center;
+	justify-content: center;
 }
 
 .post-meta .wp-block-post-date::before {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -178,6 +178,20 @@ a:focus {
 	overflow: inherit;
 }
 
+.post-meta {
+	justify-content: center;
+	align-items: center;
+}
+
+.post-meta .wp-block-post-date::before {
+	background: none;
+}
+
+.post-meta > *,
+.post-meta .wp-block-post-date {
+	margin: 0 8px;
+}
+
 .wp-block-post-featured-image {
 	margin-top: 0;
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -195,11 +195,17 @@ a:focus {
 
 .post-meta .wp-block-post-terms {
 	margin-left: 0;
+	color: transparent;
 }
 
 .post-meta .wp-block-post-terms::before {
+	color: var(--wp--custom--color--foreground);
 	content: "·";
 	margin-right: 8px;
+}
+
+.post-meta .wp-block-post-terms a {
+	color: var(--wp--custom--color--foreground);
 }
 
 .wp-block-post-featured-image {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -190,6 +191,15 @@ a:focus {
 .post-meta > *,
 .post-meta .wp-block-post-date {
 	margin: 0 8px;
+}
+
+.post-meta .wp-block-post-terms {
+	margin-left: 0;
+}
+
+.post-meta .wp-block-post-terms::before {
+	content: "·";
+	margin-right: 8px;
 }
 
 .wp-block-post-featured-image {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -185,7 +185,7 @@ a:focus {
 }
 
 .post-meta .wp-block-post-date::before {
-	background: none;
+	display: none;
 }
 
 .post-meta > *,

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -9,7 +9,7 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"30px","left":"20px"}}}} -->
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"60px","left":"20px"}}}} -->
 <div class="wp-block-group" style="padding-top:30px;padding-right:20px;padding-bottom:30px;padding-left:20px">
 	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
 </div>

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -18,7 +18,7 @@
 <!-- wp:post-featured-image {"align":"full"} /-->
 
 <!-- wp:spacer {"height":60} -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -1,14 +1,26 @@
-<!-- wp:post-date {"textAlign":"center","fontSize":"tiny"} /-->
-<!-- wp:post-tags {"textAlign":"center","fontSize":"tiny"} /-->
+<!-- wp:spacer -->
+<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"className":"post-meta"} -->
+<div class="wp-block-group post-meta">
+	<!-- wp:post-date {"textAlign":"center","fontSize":"tiny"} /-->
+	· 
+	<!-- wp:post-terms {"term":"category","textAlign":"center","fontSize":"tiny"} /-->
+</div>
+<!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"30px","left":"20px"}}}} -->
 <div class="wp-block-group" style="padding-top:30px;padding-right:20px;padding-bottom:30px;padding-left:20px">
-
-	<!-- wp:post-title {"textAlign":"center","level":1} /-->
+	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
 </div>
 <!-- /wp:group -->
 
 <!-- wp:post-featured-image {"align":"full"} /-->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -5,7 +5,6 @@
 <!-- wp:group {"className":"post-meta"} -->
 <div class="wp-block-group post-meta">
 	<!-- wp:post-date {"textAlign":"center","fontSize":"tiny"} /-->
-	· 
 	<!-- wp:post-terms {"term":"category","textAlign":"center","fontSize":"tiny"} /-->
 </div>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -17,7 +17,7 @@
 
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:spacer -->
+<!-- wp:spacer {"height":60} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -91,7 +91,7 @@
 					"margin": "0 .2em .2em 0",
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--huge)",
-						"fontWeight": "300"
+						"fontWeight": "400"
 					}
 				}
 			},
@@ -199,9 +199,9 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(36px, 5vw), 65px)",
+					"fontSize": "min(max(48px, 7vw), 80px)",
 					"fontWeight": "500",
-					"lineHeight": "var(--wp--custom--line-height--headings--h2)"
+					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},
 			"core/quote": {
@@ -279,8 +279,8 @@
 			}
 		},
 		"typography": {
-			"fontSize": "18px",
-			"fontWeight": "300",
+			"fontSize": "20px",
+			"fontWeight": "400",
 			"lineHeight": "var(--wp--custom--line-height--body)"
 		}
 	}

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -241,7 +241,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--custom--heading--h1--font-size",
+					"fontSize": "var(--wp--custom--heading--h1--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -236,6 +236,11 @@
 					"fontSize": "20px",
 					"fontWeight": 800
 				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "20px"
+				}
 			}
 		},
 		"elements": {
@@ -282,7 +287,7 @@
 			}
 		},
 		"typography": {
-			"fontSize": "20px",
+			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400",
 			"lineHeight": "var(--wp--custom--line-height--body)"
 		}

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -59,6 +59,9 @@
 			"heading": {
 				"typography": {
 					"fontWeight": "500"
+				},
+				"h1": {
+					"fontSize":"min(max(48px, 7vw), 80px)"
 				}
 			},
 			"line-height": {
@@ -199,8 +202,8 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(48px, 7vw), 80px)",
-					"fontWeight": "500",
+					"fontSize": "var(--wp--custom--heading--h1--font-size)",
+					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},
@@ -238,7 +241,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "min(max(48px, 7vw), 80px)",
+					"fontSize": "var(--wp--custom--heading--h1--font-size",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -378,7 +378,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "20px"
 				}
 			},
 			"core/post-content": {
@@ -517,7 +517,7 @@
 		"typography": {
 			"lineHeight": "var(--wp--custom--line-height--body)",
 			"fontFamily": "var(--wp--preset--font-family--base)",
-			"fontSize": "20px",
+			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
 		}
 	}

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -474,7 +474,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "var(--wp--custom--heading--h1--font-size",
+					"fontSize": "var(--wp--custom--heading--h1--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -119,6 +119,9 @@
 				"typography": {
 					"fontWeight": "500",
 					"lineHeight": 1.125
+				},
+				"h1": {
+					"fontSize": "min(max(48px, 7vw), 80px)"
 				}
 			},
 			"list": {
@@ -388,9 +391,9 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(48px, 7vw), 80px)",
+					"fontSize": "var(--wp--custom--heading--h1--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)",
-					"fontWeight": "500"
+					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
 				}
 			},
 			"core/post-date": {
@@ -471,7 +474,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "min(max(48px, 7vw), 80px)",
+					"fontSize": "var(--wp--custom--heading--h1--font-size",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
 				}
 			},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -182,7 +182,7 @@
 					"typography": {
 						"fontFamily": "var(--wp--preset--font-family--base)",
 						"fontSize": "var(--wp--preset--font-size--huge)",
-						"fontWeight": "300"
+						"fontWeight": "400"
 					}
 				}
 			},
@@ -388,8 +388,8 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(36px, 5vw), 65px)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h2)",
+					"fontSize": "min(max(48px, 7vw), 80px)",
+					"lineHeight": "var(--wp--custom--line-height--headings--h1)",
 					"fontWeight": "500"
 				}
 			},
@@ -514,8 +514,8 @@
 		"typography": {
 			"lineHeight": "var(--wp--custom--line-height--body)",
 			"fontFamily": "var(--wp--preset--font-family--base)",
-			"fontSize": "18px",
-			"fontWeight": "300"
+			"fontSize": "20px",
+			"fontWeight": "400"
 		}
 	}
 }

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -10,4 +10,12 @@
 	.wp-block-post-date {
 		margin: 0 8px;
 	}
+
+	.wp-block-post-terms {
+		margin-left: 0;
+		&::before {
+			content: "·";
+			margin-right: 8px;
+		}
+	}
 }

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -1,7 +1,7 @@
 .post-meta {
-	justify-content: center;
 	align-items: center;
-	
+	justify-content: center;
+
 	.wp-block-post-date::before {
 		background: none;
 	}

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -1,0 +1,13 @@
+.post-meta {
+	justify-content: center;
+	align-items: center;
+	
+	.wp-block-post-date::before {
+		background: none;
+	}
+
+	> *,
+	.wp-block-post-date {
+		margin: 0 8px;
+	}
+}

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -3,7 +3,7 @@
 	justify-content: center;
 
 	.wp-block-post-date::before {
-		background: none;
+		display: none;
 	}
 
 	> *,

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -14,8 +14,15 @@
 	.wp-block-post-terms {
 		margin-left: 0;
 		&::before {
+			color: var(--wp--custom--color--foreground);
 			content: "·";
 			margin-right: 8px;
+		}
+
+		// Needed while https://github.com/WordPress/gutenberg/issues/31710 is sorted.
+		color: transparent;
+		a {
+			color: var(--wp--custom--color--foreground);
 		}
 	}
 }

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -11,6 +11,7 @@
 @import "block-patterns/headlines";
 @import "elements/links";
 @import "header";
+@import "meta";
 
 .wp-block-post-featured-image {
 	margin-top: 0;


### PR DESCRIPTION
This PR addresses #3784.

Before | After
-------- | -------
<img width="1904" alt="Screen Shot 2021-05-10 at 8 32 56 PM" src="https://user-images.githubusercontent.com/5375500/117740691-d2470a00-b1b5-11eb-8f55-30a8771a581b.png"> | <img width="1904" alt="Screen Shot 2021-05-10 at 8 31 59 PM" src="https://user-images.githubusercontent.com/5375500/117740700-d4a96400-b1b5-11eb-8aa4-4055310487fd.png">

One thing I wasn't able to address is changing the divider between categories. This is baked into the block at the moment.
