### PR TITLE
Quadrat: footer and single post spacing

### DIFF
--- a/quadrat/block-template-parts/footer.html
+++ b/quadrat/block-template-parts/footer.html
@@ -1,11 +1,9 @@
-<!-- wp:spacer {"height":30} -->
-<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+<div class="wp-block-group" style="padding-top:150px;padding-bottom: 150px">
 
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">Powered by WordPress</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:spacer {"height":30} -->
-<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+</div>
+<!-- /wp:group -->

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -12,6 +12,10 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
+<!-- wp:spacer {"height":150} -->
+<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"0px","left":"20px"}}}} -->
 <div class="wp-block-group" style="padding-top:30px;padding-right:20px;padding-bottom:0px;padding-left:20px">
 	<!-- wp:columns {"align":"wide","className":"next-prev-links"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adapts the spacing on the footer and after the post content to better fit the designs:

Before | After
--- | ---
<img width="1511" alt="Screenshot 2021-05-11 at 11 55 11" src="https://user-images.githubusercontent.com/3593343/117796879-c3149a80-b24f-11eb-9645-2025298424b6.png"> | <img width="1605" alt="Screenshot 2021-05-11 at 11 52 30" src="https://user-images.githubusercontent.com/3593343/117796796-af693400-b24f-11eb-9d86-2ee359b08686.png">


#### Related issue(s):

Fixes #3788
