### PR TITLE
Quadrat Body font size fix

### DIFF
--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -279,7 +279,7 @@
 			}
 		},
 		"typography": {
-			"fontSize": "20px",
+			"fontSize": "18px",
 			"fontWeight": "300",
 			"lineHeight": "var(--wp--custom--line-height--body)"
 		}

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -514,7 +514,7 @@
 		"typography": {
 			"lineHeight": "var(--wp--custom--line-height--body)",
 			"fontFamily": "var(--wp--preset--font-family--base)",
-			"fontSize": "20px",
+			"fontSize": "18px",
 			"fontWeight": "300"
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR sets the body font size to 18px for Quadrat (the line height is already 1.7).

#### Related issue(s):

Fixes #3785