### PR TITLE
Quadrat: added space after navigation arrows

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -126,6 +126,14 @@ ul ul {
 	flex-direction: row-reverse;
 }
 
+.post-navigation-link-next a {
+	margin-right: 0.5em;
+}
+
+.post-navigation-link-previous a {
+	margin-left: 0.5em;
+}
+
 .next-prev-links .wp-block-column,
 .next-prev-links .wp-block-column:not(:only-child) {
 	flex-basis: 40% !important;

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -172,6 +172,7 @@ ul ul {
 a:hover {
 	background: var(--wp--custom--color--primary);
 	color: var(--wp--custom--color--background);
+	text-decoration: none;
 }
 
 a:active,

--- a/quadrat/sass/blocks/_post-navigation-link.scss
+++ b/quadrat/sass/blocks/_post-navigation-link.scss
@@ -5,6 +5,14 @@
 }
 .post-navigation-link-next {
 	flex-direction: row-reverse;
+	a {
+		margin-right: 0.5em;
+	}
+}
+.post-navigation-link-previous {
+	a {
+		margin-left: 0.5em;
+	}
 }
 
 .next-prev-links {

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,6 +1,7 @@
 a:hover {
 	background: var(--wp--custom--color--primary);
 	color: var(--wp--custom--color--background);
+	text-decoration: none;
 }
 
 a:active,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a space between the arrows and the title of the posts for the post navigation block.

Before | After
--- | ---
<img width="1590" alt="Screenshot 2021-05-11 at 17 32 10" src="https://user-images.githubusercontent.com/3593343/117843289-f9b5d980-b27e-11eb-90bc-f724d5370bd8.png"> | <img width="1272" alt="Screenshot 2021-05-11 at 17 31 54" src="https://user-images.githubusercontent.com/3593343/117843295-fae70680-b27e-11eb-9bb3-7449138eae53.png">


#### Related issue(s):

Fixes #3783
