### PR TITLE
Quadrat: cover block pattern hover bug

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -70,6 +70,7 @@
 	left: 0;
 	bottom: 0;
 	right: 0;
+	z-index: 0 !important;
 }
 
 .wp-block-cover.is-style-quadrat-cover-diamond.has-white-background-color.wp-block-cover.has-background-dim:not(.has-background-gradient)::before, .wp-block-cover.is-style-quadrat-cover-diamond.has-black-background-color.wp-block-cover.has-background-dim:not(.has-background-gradient)::before {

--- a/quadrat/inc/patterns/cover-with-heading.php
+++ b/quadrat/inc/patterns/cover-with-heading.php
@@ -8,8 +8,8 @@
 return array(
 	'title'      => __( 'Cover block with heading', 'quadrat' ),
 	'categories' => array( 'quadrat' ),
-	'content'    => '<!-- wp:cover {"overlayColor":"darker-blue","minHeight":700,"align":"wide","className":"is-style-quadrat-cover-diamond"} -->
-	<div class="wp-block-cover alignwide has-darker-blue-background-color has-background-dim is-style-quadrat-cover-diamond" style="min-height:700px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","textColor":"pink"} -->
+	'content'    => '<!-- wp:cover {"overlayColor":"blue","minHeight":700,"align":"wide","className":"is-style-quadrat-cover-diamond"} -->
+	<div class="wp-block-cover alignwide has-blue-background-color has-background-dim is-style-quadrat-cover-diamond" style="min-height:700px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","textColor":"pink"} -->
 	<h2 class="has-text-align-center has-pink-color has-text-color">' . esc_html__( 'Episode 3: A Cycle of Emotions', 'quadrat' ) . '</h2>
 	<!-- /wp:heading --></div></div>
 	<!-- /wp:cover -->',

--- a/quadrat/sass/blocks/_cover.scss
+++ b/quadrat/sass/blocks/_cover.scss
@@ -12,6 +12,7 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
+		z-index: 0 !important; 
 	}
 
 	&.has-white-background-color,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR changes the default color for the cover pattern to blue from dark blue and fixes the weird bug that was changing the color of the text when the cover is selected in the editor.

#### Related issue(s):

Fixes #3738
