### PR TITLE
Dalston: Separate script and style enqueues for better performance

### DIFF
--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -216,7 +216,7 @@ function dalston_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'dalston_editor_styles' );
 
 /**
- * Enqueue Custom Cover Block Styles and Scripts
+ * Enqueue Custom Cover Block Scripts
  */
 function dalston_block_extends() {
 
@@ -232,11 +232,6 @@ function dalston_block_extends() {
 		array( 'wp-blocks' )
 	);
 
-	wp_enqueue_style(
-		'dalston-extend-cover-block-style',
-		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'
-	);
-
 	// Columns Block Tweaks
 	wp_enqueue_script(
 		'dalston-extend-columns-block',
@@ -244,16 +239,33 @@ function dalston_block_extends() {
 		array( 'wp-blocks' )
 	);
 
-	wp_enqueue_style(
-		'dalston-extend-cover-columns-style',
-		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.css'
-	);
-
-	// Columns Block Tweaks
+	// Media & Text Block Tweaks
 	wp_enqueue_script(
 		'dalston-extend-media-text-block',
 		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.js',
 		array( 'wp-blocks' )
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'dalston_block_extends' );
+
+/**
+ * Enqueue Custom Cover Block Styles
+ */
+function dalston_block_extends_styles() {
+
+	// Bail out early while in AMP endpoint.
+	if ( dalston_is_amp() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'dalston-extend-cover-block-style',
+		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'
+	);
+
+	wp_enqueue_style(
+		'dalston-extend-cover-columns-style',
+		get_stylesheet_directory_uri() . '/block-extends/extend-columns-block.css'
 	);
 
 	wp_enqueue_style(
@@ -261,7 +273,7 @@ function dalston_block_extends() {
 		get_stylesheet_directory_uri() . '/block-extends/extend-media-text-block.css'
 	);
 }
-add_action( 'enqueue_block_assets', 'dalston_block_extends' );
+add_action( 'enqueue_block_assets', 'dalston_block_extends_styles' );
 
 /**
  * Whether this is an AMP endpoint.

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -253,11 +253,6 @@ add_action( 'enqueue_block_editor_assets', 'dalston_block_extends' );
  */
 function dalston_block_extends_styles() {
 
-	// Bail out early while in AMP endpoint.
-	if ( dalston_is_amp() ) {
-		return;
-	}
-
 	wp_enqueue_style(
 		'dalston-extend-cover-block-style',
 		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block.css'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Use separate functions with separate hooks for enqueuing styles and scripts in Dalston to avoid unnecessary enqueues on the front end.
* Props to @westonruter for the bug report and original fix in #1652 

This doesn't appear to break anything in my testing, but I could use a Theam review to confirm things are still working as expected. I'm not sure what the block customizations are supposed to add/change based on the code. :)

#### Testing instructions

* Check out this PR theme to your local install, or sync it to your sandbox, and activate Dalston.
* Check the source and ensure the scripts and styles located in functions.php are being enqueued in the appropriate locations:
* Everything in `dalston_block_extends_styles()` should be enqueued on both the front end and the block editor
* Everything in `dalston_block_extends()` should only be enqueued in the block editor