### PR TITLE
Adjusted large blockquote style per design

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -150,6 +150,10 @@ ul ul {
 	line-height: 1.4;
 }
 
+.wp-block-quote.is-style-large cite {
+	text-align: unset;
+}
+
 .wp-block-table th {
 	font-weight: 500;
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -146,6 +146,10 @@ ul ul {
 	margin-left: 20%;
 }
 
+.wp-block-quote.is-style-large p {
+	line-height: 1.4;
+}
+
 .wp-block-table th {
 	font-weight: 500;
 }

--- a/quadrat/sass/blocks/_quote.scss
+++ b/quadrat/sass/blocks/_quote.scss
@@ -1,0 +1,3 @@
+.wp-block-quote.is-style-large p {
+	line-height: 1.4;
+}

--- a/quadrat/sass/blocks/_quote.scss
+++ b/quadrat/sass/blocks/_quote.scss
@@ -1,3 +1,9 @@
-.wp-block-quote.is-style-large p {
-	line-height: 1.4;
+.wp-block-quote.is-style-large {
+	p {
+		line-height: 1.4;
+	}
+
+	cite {
+		text-align: unset;
+	}
 }

--- a/quadrat/sass/blocks/_quote.scss
+++ b/quadrat/sass/blocks/_quote.scss
@@ -4,6 +4,6 @@
 	}
 
 	cite {
-		text-align: unset;
+		text-align: unset; // Gutenberg adds a text-align: right to the cite, we don't want this. 
 	}
 }

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -7,6 +7,7 @@
 @import "blocks/media-text";
 @import "blocks/navigation";
 @import "blocks/post-navigation-link";
+@import "blocks/quote";
 @import "blocks/table";
 @import "block-patterns/headlines";
 @import "elements/links";


### PR DESCRIPTION
Added a rule for that scenario via CSS.

Before:

![image](https://user-images.githubusercontent.com/146530/117885619-0c7adf00-b27c-11eb-8c8d-ffdb875d18f0.png)

After:

![image](https://user-images.githubusercontent.com/146530/117885659-16044700-b27c-11eb-953f-46fc320e4f61.png)

#### Related issue(s):

Fixes #3812 