### PR TITLE
Canard: Set a high z-index on the menu to avoid it being obscured

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -3616,9 +3616,7 @@ a {
 	}
 	.main-navigation {
 		float: left;
-	}
-	.main-navigation {
-		z-index: 1;
+		z-index: 99;
 	}
 	.main-navigation > div {
 		display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Set a z-index of 99 on the main navigation menu to ensure longer submenus do not get overlapped by post/page content. 

**Before**

<img width="657" alt="Screen Shot 2021-05-12 at 12 47 42 PM" src="https://user-images.githubusercontent.com/2124984/118013595-456c8f80-b320-11eb-910e-c86a87d64ee3.png">

**After**

<img width="720" alt="Screen Shot 2021-05-12 at 12 47 28 PM" src="https://user-images.githubusercontent.com/2124984/118013611-4a314380-b320-11eb-8a9a-c89fad47ece0.png">

#### Testing instructions:

* Apply these changes to your sandbox manually and sandbox your test site, and sandbox the site demo at canarddemo.wordpress.com
* Activate the Canard theme on your test site and make sure nothing looks broken
* Go through the demo site and make sure nothing there is broken

#### Related issue(s):

Fixes #682 