### PR TITLE
Quadrat: Add color customization

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -455,8 +455,8 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-pullquote.is-style-solid-color.is-style-solid-color,
 .wp-block-pullquote.is-style-solid-color {
-	background-color: var(--wp--custom--color--foreground);
-	color: var(--wp--custom--color--background);
+	background-color: var(--wp--custom--color--text);
+	color: var(--wp--style--color--background);
 }
 
 .wp-block-quote.is-style-large p,

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -64,7 +64,7 @@
 				},
 				"color": {
 					"background": "var(--wp--custom--color--secondary)",
-					"hoverText": "var(--wp--custom--color--background)",
+					"hoverText": "var(--wp--style--color--background)",
 					"hoverBackground": "#006ba1",
 					"text": "var(--wp--custom--color--background)"
 				},

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -66,7 +66,7 @@
 					"background": "var(--wp--custom--color--secondary)",
 					"hoverText": "var(--wp--style--color--background)",
 					"hoverBackground": "#006ba1",
-					"text": "var(--wp--custom--color--background)"
+					"text": "var(--wp--style--color--background)"
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
@@ -99,7 +99,7 @@
 				"color": {
 					"background": "transparent",
 					"boxShadow": "none",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--style--color--text)"
 				},
 				"label": {
 					"typography": {
@@ -136,7 +136,7 @@
 				"mobile": {
 					"menu": {
 						"color": {
-							"text": "var(--wp--custom--color--foreground)"
+							"text": "var(--wp--style--color--text)"
 						},
 						"closeLabel": "╳",
 						"openLabel": "☰",
@@ -158,10 +158,10 @@
 				"padding": "10px",
 				"submenu": {
 					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)",
+						"text": "var(--wp--style--color--text)",
+						"background": "var(--wp--style--color--background)",
 						"hoverText": "var(--wp--custom--color--secondary)",
-						"hoverBackground": "var(--wp--custom--color--background)"
+						"hoverBackground": "var(--wp--style--color--background)"
 					},
 					"border": {
 						"color": "0",
@@ -363,8 +363,8 @@
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--foreground)"
+					"link": "var(--wp--style--color--text)",
+					"text": "var(--wp--style--color--text)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -390,7 +390,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--style--color--text)"
 				},
 				"border": {
 					"color": "currentColor",
@@ -422,8 +422,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
+			"background": "var(--wp--style--color--background)",
+			"text": "var(--wp--style--color--text)"
 		},
 		"elements": {
 			"h1": {

--- a/blank-canvas-blocks/functions.php
+++ b/blank-canvas-blocks/functions.php
@@ -88,3 +88,8 @@ function blank_canvas_blocks_fonts_url() {
 if ( ! is_child_theme() ) {
 	require get_template_directory() . '/inc/block-patterns.php';
 }
+
+/**
+ * Add Global Styles Variables
+ */
+require get_template_directory() . '/inc/global-styles-variables.php';

--- a/blank-canvas-blocks/inc/global-styles-variables.php
+++ b/blank-canvas-blocks/inc/global-styles-variables.php
@@ -1,10 +1,8 @@
 <?php
 
-if ( function_exists( 'gutenberg_get_default_block_editor_settings' ) && class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
 	function global_styles_variables() {
-		$settings   = gutenberg_get_default_block_editor_settings();
-		$all        = WP_Theme_JSON_Resolver::get_merged_data( $settings );
-		$theme_json = $all->get_raw_data();
+		$theme_json = WP_Theme_JSON_Resolver::get_merged_data()->get_raw_data();
 		$stylesheet = 'body{';
 		foreach ( $theme_json['styles']['color'] as $key => $value ) {
 			$stylesheet .= '--wp--style--color--' . $key . ': ' . $value . ';';

--- a/blank-canvas-blocks/inc/global-styles-variables.php
+++ b/blank-canvas-blocks/inc/global-styles-variables.php
@@ -4,9 +4,22 @@ if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
 	function global_styles_variables() {
 		$theme_json = WP_Theme_JSON_Resolver::get_merged_data()->get_raw_data();
 		$stylesheet = 'body{';
-		foreach ( $theme_json['styles']['color'] as $key => $value ) {
-			$stylesheet .= '--wp--style--color--' . $key . ': ' . $value . ';';
+		if ( ! empty( $theme_json['styles']['color']['text'] ) ) {
+			$stylesheet .= '--wp--style--color--text: ' . $theme_json['styles']['color']['text'] . '; ';
 		}
+
+		if ( ! empty( $theme_json['styles']['color']['background'] ) ) {
+			$stylesheet .= '--wp--style--color--background: ' . $theme_json['styles']['color']['background'] . '; ';
+		}
+
+		if ( ! empty( $theme_json['styles']['border']['color'] ) ) {
+			$stylesheet .= '--wp--style--border--color: ' . $theme_json['styles']['border']['color'] . '; ';
+		}
+
+		if ( ! empty( $theme_json['styles']['elements']['link']['color']['text'] ) ) {
+			$stylesheet .= '--wp--style--link--color: ' . $theme_json['styles']['elements']['link']['color']['text'] . '; ';
+		}
+
 		$stylesheet .= '}';
 
 		wp_register_style( 'global-styles-variables', false, array( 'global-styles' ), true, true );

--- a/blank-canvas-blocks/inc/global-styles-variables.php
+++ b/blank-canvas-blocks/inc/global-styles-variables.php
@@ -1,0 +1,20 @@
+<?php
+
+if ( function_exists( 'gutenberg_get_default_block_editor_settings' ) && class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+	function global_styles_variables() {
+		$settings   = gutenberg_get_default_block_editor_settings();
+		$all        = WP_Theme_JSON_Resolver::get_merged_data( $settings );
+		$theme_json = $all->get_raw_data();
+		$stylesheet = 'body{';
+		foreach ( $theme_json['styles']['color'] as $key => $value ) {
+			$stylesheet .= '--wp--style--color--' . $key . ': ' . $value . ';';
+		}
+		$stylesheet .= '}';
+
+		wp_register_style( 'global-styles-variables', false, array( 'global-styles' ), true, true );
+		wp_add_inline_style( 'global-styles-variables', $stylesheet );
+		wp_enqueue_style( 'global-styles-variables' );
+	}
+
+	add_action( 'wp_enqueue_scripts', 'global_styles_variables' );
+}

--- a/blank-canvas-blocks/sass/blocks/_pullquote.scss
+++ b/blank-canvas-blocks/sass/blocks/_pullquote.scss
@@ -22,7 +22,7 @@
 	}
 
 	&.is-style-solid-color {
-		background-color: var(--wp--custom--color--foreground);
-		color: var(--wp--custom--color--background);
+		background-color: var(--wp--custom--color--text);
+		color: var(--wp--style--color--background);
 	}
 }

--- a/quadrat/assets/noop.css
+++ b/quadrat/assets/noop.css
@@ -1,0 +1,1 @@
+/* This page intentionally left blank. */

--- a/quadrat/assets/noop.css
+++ b/quadrat/assets/noop.css
@@ -1,1 +1,0 @@
-/* This page intentionally left blank. */

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -53,7 +53,7 @@
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	border: none;
-	color: var(--wp--custom--color--background);
+	color: var(--wp--style--color--background);
 	background: var(--wp--custom--color--primary);
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 }
@@ -163,7 +163,7 @@ ul ul {
 
 a:hover {
 	background: var(--wp--custom--color--primary);
-	color: var(--wp--custom--color--background);
+	color: var(--wp--style--color--background);
 }
 
 a:active,

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -162,7 +162,7 @@ ul ul {
 }
 
 a:hover {
-	background: var(--wp--custom--color--primary);
+	background: var(--wp--style--color--text);
 	color: var(--wp--style--color--background);
 }
 

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -116,25 +116,13 @@
 						"name": "Foreground Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "foreground"
+						"slug": "text"
 					},
 					{
 						"name": "Background Color",
 						"type": "color",
 						"default": "#292C6D",
 						"slug": "background"
-					},
-					{
-						"name": "Primary Color",
-						"type": "color",
-						"default": "#FFD1D1",
-						"slug": "primary"
-					},
-					{
-						"name": "Secondary Color",
-						"type": "color",
-						"default": "#151853",
-						"slug": "secondary"
 					}
 				]
 			}

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -116,28 +116,28 @@
 						"name": "Foreground Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "color--foreground"
+						"slug": "foreground"
 					},
 					{
 						"name": "Background Color",
 						"type": "color",
 						"default": "#292C6D",
-						"slug": "color--background"
+						"slug": "background"
 					},
 					{
 						"name": "Primary Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "color--primary"
+						"slug": "primary"
 					},
 					{
 						"name": "Secondary Color",
 						"type": "color",
 						"default": "#151853",
-						"slug": "color--secondary"
+						"slug": "secondary"
 					}
 				]
-			}	
+			}
 		],
 		"layout": {
 			"contentSize": "664px",

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -36,10 +36,10 @@
 					"radius": "0"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--foreground)",
-					"hoverText": "var(--wp--custom--color--foreground)",
+					"background": "var(--wp--style--color--text)",
+					"hoverText": "var(--wp--style--color--text)",
 					"hoverBackground": "transparent",
-					"text": "var(--wp--custom--color--background)"
+					"text": "var(--wp--style--color--background)"
 				},
 				"typography": {
 					"fontSize": "20px",
@@ -276,7 +276,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--syle--color--text)"
 				}
 			}
 		},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -105,28 +105,6 @@
 				}
 			}
 		},
-		"custom_meta": [
-			{
-				"name": "Colors",
-				"type": "section",
-				"slug": "colors",
-				"description": "Color Customization for Quadrat",
-				"controls": [
-					{
-						"name": "Foreground Color",
-						"type": "color",
-						"default": "#FFD1D1",
-						"slug": "text"
-					},
-					{
-						"name": "Background Color",
-						"type": "color",
-						"default": "#292C6D",
-						"slug": "background"
-					}
-				]
-			}
-		],
 		"layout": {
 			"contentSize": "664px",
 			"wideSize": "1128px"

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -46,11 +46,6 @@
 					"fontWeight": "600"
 				}
 			},
-			"color": {
-				"primary": "var(--wp--preset--color--pink)",
-				"secondary": "var(--wp--preset--color--darker-blue)",
-				"selection": "var(--wp--custom--color--secondary)"
-			},
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400"
 			],
@@ -81,7 +76,7 @@
 			},
 			"navigation": {
 				"color": {
-					"hoverText": "var(--wp--custom--color--primary)"
+					"hoverText": "var(--wp--style--color--link)"
 				}
 			},
 			"paragraph": {
@@ -182,7 +177,7 @@
 					"width": "0px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)"
+					"background": "var(--wp--style--border--color)"
 				},
 				"typography": {
 					"fontSize": "20px",
@@ -225,13 +220,16 @@
 			},
 			"core/site-title": {
 				"color": {
-					"link": "var(--wp--custom--color--primary)"
+					"link": "var(--wp--style--color--link)"
 				},
 				"typography": {
 					"fontSize": "20px",
 					"fontWeight": 800
 				}
 			}
+		},
+		"border": {
+			"color": "var(--wp--preset--color--darker-blue)"
 		},
 		"color": {
 			"background": "var(--wp--preset--color--blue)",
@@ -276,7 +274,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--style--color--text)"
+					"text": "var(--wp--preset--color--pink)"
 				}
 			}
 		},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -51,7 +51,7 @@
 				"secondary": "var(--wp--preset--color--darker-blue)",
 				"foreground": "var(--wp--preset--color--pink)",
 				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
+				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400"
@@ -105,6 +105,40 @@
 				}
 			}
 		},
+		"custom_meta": [
+			{
+				"name": "Colors",
+				"type": "section",
+				"slug": "colors",
+				"description": "Color Customization for Quadrat",
+				"controls": [
+					{
+						"name": "Foreground Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--foreground"
+					},
+					{
+						"name": "Background Color",
+						"type": "color",
+						"default": "#292C6D",
+						"slug": "color--background"
+					},
+					{
+						"name": "Primary Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--primary"
+					},
+					{
+						"name": "Secondary Color",
+						"type": "color",
+						"default": "#151853",
+						"slug": "color--secondary"
+					}
+				]
+			}	
+		],
 		"layout": {
 			"contentSize": "664px",
 			"wideSize": "1128px"

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -276,7 +276,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--syle--color--text)"
+					"text": "var(--wp--style--color--text)"
 				}
 			}
 		},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -49,8 +49,6 @@
 			"color": {
 				"primary": "var(--wp--preset--color--pink)",
 				"secondary": "var(--wp--preset--color--darker-blue)",
-				"foreground": "var(--wp--preset--color--pink)",
-				"background": "var(--wp--preset--color--blue)",
 				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"fontsToLoadFromGoogle": [
@@ -234,6 +232,10 @@
 					"fontWeight": 800
 				}
 			}
+		},
+		"color": {
+			"background": "var(--wp--preset--color--blue)",
+			"text": "var(--wp--preset--color--pink)"
 		},
 		"elements": {
 			"h1": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -332,25 +332,25 @@
 						"name": "Foreground Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "color--foreground"
+						"slug": "foreground"
 					},
 					{
 						"name": "Background Color",
 						"type": "color",
 						"default": "#292C6D",
-						"slug": "color--background"
+						"slug": "background"
 					},
 					{
 						"name": "Primary Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "color--primary"
+						"slug": "primary"
 					},
 					{
 						"name": "Secondary Color",
 						"type": "color",
 						"default": "#151853",
-						"slug": "color--secondary"
+						"slug": "secondary"
 					}
 				]
 			}

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -84,8 +84,8 @@
 				"primary": "var(--wp--preset--color--pink)",
 				"secondary": "var(--wp--preset--color--darker-blue)",
 				"tertiary": "var(--wp--preset--color--almost-white)",
-				"foreground": "var(--wp--preset--color--pink)",
-				"background": "var(--wp--preset--color--blue)",
+				"foreground": "var(--wp--preset--color--almost-black)",
+				"background": "var(--wp--preset--color--white)",
 				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"form": {
@@ -465,8 +465,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
+			"background": "var(--wp--preset--color--blue)",
+			"text": "var(--wp--preset--color--pink)"
 		},
 		"elements": {
 			"h1": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -332,25 +332,13 @@
 						"name": "Foreground Color",
 						"type": "color",
 						"default": "#FFD1D1",
-						"slug": "foreground"
+						"slug": "text"
 					},
 					{
 						"name": "Background Color",
 						"type": "color",
 						"default": "#292C6D",
 						"slug": "background"
-					},
-					{
-						"name": "Primary Color",
-						"type": "color",
-						"default": "#FFD1D1",
-						"slug": "primary"
-					},
-					{
-						"name": "Secondary Color",
-						"type": "color",
-						"default": "#151853",
-						"slug": "secondary"
 					}
 				]
 			}

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -320,29 +320,7 @@
 					"slug": "huge"
 				}
 			]
-		},
-		"custom_meta": [
-			{
-				"name": "Colors",
-				"type": "section",
-				"slug": "colors",
-				"description": "Color Customization for Quadrat",
-				"controls": [
-					{
-						"name": "Foreground Color",
-						"type": "color",
-						"default": "#FFD1D1",
-						"slug": "text"
-					},
-					{
-						"name": "Background Color",
-						"type": "color",
-						"default": "#292C6D",
-						"slug": "background"
-					}
-				]
-			}
-		]
+		}
 	},
 	"styles": {
 		"blocks": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -81,12 +81,12 @@
 				}
 			},
 			"color": {
-				"primary": "var(--wp--preset--color--pink)",
-				"secondary": "var(--wp--preset--color--darker-blue)",
+				"primary": "var(--wp--preset--color--black)",
+				"secondary": "var(--wp--preset--color--blue)",
 				"tertiary": "var(--wp--preset--color--almost-white)",
 				"foreground": "var(--wp--preset--color--almost-black)",
 				"background": "var(--wp--preset--color--white)",
-				"selection": "var(--wp--custom--color--secondary)"
+				"selection": "var(--wp--preset--color--almost-white)"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
@@ -99,7 +99,7 @@
 				"color": {
 					"background": "transparent",
 					"boxShadow": "none",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--style--color--text)"
 				},
 				"label": {
 					"typography": {
@@ -136,7 +136,7 @@
 				"mobile": {
 					"menu": {
 						"color": {
-							"text": "var(--wp--custom--color--foreground)"
+							"text": "var(--wp--style--color--text)"
 						},
 						"closeLabel": "╳",
 						"openLabel": "☰",
@@ -158,10 +158,10 @@
 				"padding": "10px",
 				"submenu": {
 					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)",
+						"text": "var(--wp--style--color--text)",
+						"background": "var(--wp--style--color--background)",
 						"hoverText": "var(--wp--custom--color--secondary)",
-						"hoverBackground": "var(--wp--custom--color--background)"
+						"hoverBackground": "var(--wp--style--color--background)"
 					},
 					"border": {
 						"color": "0",
@@ -173,7 +173,7 @@
 					"shadow": "1px 1px 3px 0px rgba(0,0,0,.2)"
 				},
 				"color": {
-					"hoverText": "var(--wp--custom--color--primary)"
+					"hoverText": "var(--wp--style--color--link)"
 				}
 			},
 			"paragraph": {
@@ -358,7 +358,7 @@
 					"width": "0px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)"
+					"background": "var(--wp--style--border--color)"
 				},
 				"typography": {
 					"fontSize": "20px",
@@ -395,8 +395,8 @@
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--foreground)"
+					"link": "var(--wp--style--color--text)",
+					"text": "var(--wp--style--color--text)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -422,7 +422,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--style--color--text)"
 				},
 				"border": {
 					"color": "currentColor",
@@ -436,7 +436,7 @@
 					"fontWeight": 800
 				},
 				"color": {
-					"link": "var(--wp--custom--color--primary)"
+					"link": "var(--wp--style--color--link)"
 				}
 			},
 			"core/quote": {
@@ -507,7 +507,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--style--color--text)"
+					"text": "var(--wp--preset--color--pink)"
 				}
 			}
 		},
@@ -516,6 +516,9 @@
 			"fontFamily": "var(--wp--preset--font-family--base)",
 			"fontSize": "20px",
 			"fontWeight": "300"
+		},
+		"border": {
+			"color": "var(--wp--preset--color--darker-blue)"
 		}
 	}
 }

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -63,10 +63,10 @@
 					"width": "0"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--foreground)",
-					"hoverText": "var(--wp--custom--color--foreground)",
+					"background": "var(--wp--style--color--text)",
+					"hoverText": "var(--wp--style--color--text)",
 					"hoverBackground": "transparent",
-					"text": "var(--wp--custom--color--background)"
+					"text": "var(--wp--style--color--background)"
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
@@ -507,7 +507,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--syle--color--text)"
 				}
 			}
 		},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -86,7 +86,7 @@
 				"tertiary": "var(--wp--preset--color--almost-white)",
 				"foreground": "var(--wp--preset--color--pink)",
 				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
+				"selection": "var(--wp--custom--color--secondary)"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
@@ -320,7 +320,41 @@
 					"slug": "huge"
 				}
 			]
-		}
+		},
+		"custom_meta": [
+			{
+				"name": "Colors",
+				"type": "section",
+				"slug": "colors",
+				"description": "Color Customization for Quadrat",
+				"controls": [
+					{
+						"name": "Foreground Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--foreground"
+					},
+					{
+						"name": "Background Color",
+						"type": "color",
+						"default": "#292C6D",
+						"slug": "color--background"
+					},
+					{
+						"name": "Primary Color",
+						"type": "color",
+						"default": "#FFD1D1",
+						"slug": "color--primary"
+					},
+					{
+						"name": "Secondary Color",
+						"type": "color",
+						"default": "#151853",
+						"slug": "color--secondary"
+					}
+				]
+			}
+		]
 	},
 	"styles": {
 		"blocks": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -507,7 +507,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--syle--color--text)"
+					"text": "var(--wp--style--color--text)"
 				}
 			}
 		},

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -49,4 +49,4 @@ require get_stylesheet_directory() . '/inc/block-styles.php';
 /**
  * Customizer Bridge
  */
-require get_template_directory() . '/inc/customization.php';
+require get_stylesheet_directory() . '/inc/customization.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -31,8 +31,6 @@ endif;
 function quadrat_scripts() {
 	// Enqueue front-end styles.
 	wp_enqueue_style( 'quadrat-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
-	// Enqueue customizer bridge styles
-	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array( 'quadrat-styles' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -31,6 +31,8 @@ endif;
 function quadrat_scripts() {
 	// Enqueue front-end styles.
 	wp_enqueue_style( 'quadrat-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
+	// Enqueue customizer bridge styles
+	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array( 'quadrat-styles' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 
@@ -43,3 +45,8 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
+
+/**
+ * Customizer Bridge
+ */
+require get_template_directory() . '/inc/customization.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -45,6 +45,6 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
 require get_stylesheet_directory() . '/inc/block-styles.php';
 
 /**
- * Customizer Bridge
+ * Customize Global Styles
  */
 require get_stylesheet_directory() . '/inc/customization.php';

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -5,7 +5,13 @@ class CustomizerBridge {
 
 	function __construct() {
 		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
+
+		//this is for the view
 		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
+
+		//this is for the editor
+		add_action( 'enqueue_block_editor_assets', array( $this, 'customizer_bridge_output_variables' ) );
+
 		$this->theme_customizations = $this->get_theme_customizations();
 	}
 
@@ -19,15 +25,20 @@ class CustomizerBridge {
 	 * Enqueue color variables for customizer & frontend.
 	 */
 	function customizer_bridge_output_variables() {
+		wp_register_style( 'customizer-style', false, array(), true, true );
+		wp_enqueue_style( 'customizer-style' );
 		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
 	}
 
 	/**
 	 * Render the customized variables.
+	 *
+	 * NOTE: Ideally this wouldn't happen at all and instead the theme.json would be filtered
+	 * and modified to reflect the users's choice.
 	 */
 	function customizer_bridge_generate_custom_color_variables( $context = null ) {
 
-		$css_variables = 'body {';
+		$css_variables = 'body, #editor {';
 		foreach ( $this->theme_customizations as $custom_section ) {
 			foreach ( $custom_section->controls as $custom_option ) {
 				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -1,144 +1,84 @@
 <?php
-class CustomizerBridge {
 
-	private $theme_customizations;
+require_once 'wp-customize-global-styles-setting.php';
+
+class GlobalStylesCustomizer {
+
+	private $custom_colors;
 
 	function __construct() {
-		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
-
-		//this is for the view
-		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
-
-		//this is for the editor
-		add_action( 'enqueue_block_editor_assets', array( $this, 'customizer_bridge_output_variables' ) );
-
-		add_action( 'customize_save_after', array( $this, 'save_to_global_styles' ) );
-
-		add_action( 'save_post_wp_global_styles', array( $this, 'update_from_global_styles' ), 3, 3 );
-
-		$this->theme_customizations = $this->get_theme_customizations();
-	}
-
-	function update_from_global_styles( $post_ID, $post, $update ) {
-		//var_dump( $post );
-	}
-
-	function save_to_global_styles( $manager ) {
-		//      var_dump( WP_Theme_JSON_Resolver::get_user_data() );
-		$user_custom_post_type_id     = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-		$user_theme_json_post         = get_post( $user_custom_post_type_id );
-		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
-		//var_dump( $user_theme_json_post_content );
-		$customizer_json = json_decode(
-			'{
-			"settings": {
-				"custom": {
-					"color": {
-
-					}
-				}
-			}
-		}'
+		$this->custom_colors = array(
+			'name'        => __( 'Colors' ),
+			'type'        => 'section',
+			'slug'        => 'customize-global-styles',
+			'description' => __( 'Color Customization for Quadrat' ),
+			'controls'    => array(
+				array(
+					'name'     => __( 'Foreground Color' ),
+					'type'     => 'color',
+					'default'  => '#FFD1D1', // TODO
+					'selector' => 'body',
+					'property' => 'color',
+					'slug'     => 'text',
+				),
+				array(
+					'name'     => __( 'Background Color' ),
+					'type'     => 'color',
+					'default'  => '#292C6D', //TOOD
+					'selector' => 'body',
+					'property' => 'background',
+					'slug'     => 'background',
+				),
+			),
 		);
-		foreach ( $this->theme_customizations as $custom_section ) {
-			foreach ( $custom_section->controls as $custom_option ) {
-				$slug_value = get_theme_mod( 'customizer-bridge-' . $custom_option->slug );
-				if ( $slug_value ) {
-					$customizer_json->settings->custom->color->{ $custom_option->slug } = $slug_value;
-				}
-			}
-		}
-		//var_dump( json_encode( $customizer_json ) );
 
-		$merged_settings                    = array_replace_recursive( (array) $user_theme_json_post_content, (array) $customizer_json );
-		$user_theme_json_post->post_content = json_encode( $merged_settings );
-		$result                             = wp_update_post( $user_theme_json_post );
+		add_action( 'customize_register', array( $this, 'register_section' ) );
+
+		/* Customizer Preview JS */
+		add_action( 'customize_preview_init', array( $this, 'customize_preview_js' ) );
 	}
 
-	function get_theme_customizations() {
-		$string  = file_get_contents( get_stylesheet_directory() . '/experimental-theme.json' );
-		$decoded = json_decode( $string );
-		return $decoded->settings->custom_meta;
+	/* Preview JS */
+	function customize_preview_js() {
+		wp_enqueue_script( 'customizer-preview-color', get_stylesheet_directory_uri() . '/inc/customizer-preview.js', array( 'customize-preview' ) );
+		wp_localize_script( 'customizer-preview-color', 'global_styles_settings', $this->custom_colors );
 	}
 
-	/**
-	 * Enqueue color variables for customizer & frontend.
-	 */
-	function customizer_bridge_output_variables() {
-		wp_register_style( 'customizer-style', false, array(), true, true );
-		wp_enqueue_style( 'customizer-style' );
-		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
-	}
-
-	/**
-	 * Render the customized variables.
-	 *
-	 * NOTE: Ideally this wouldn't happen at all and instead the theme.json would be filtered
-	 * and modified to reflect the users's choice.
-	 */
-	function customizer_bridge_generate_custom_color_variables( $context = null ) {
-
-		$css_variables = 'body, #editor {';
-		foreach ( $this->theme_customizations as $custom_section ) {
-			foreach ( $custom_section->controls as $custom_option ) {
-				$slug_value = get_theme_mod( 'customizer-bridge-' . $custom_option->slug );
-				if ( $slug_value ) {
-					$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . $slug_value . ';';
-				}
-			}
-		}
-		$css_variables = $css_variables . '}';
-
-		return $css_variables;
-	}
-
-	/**
-	 * Use theme.json to determine what variables to provide dials for.
-	 * Add those dials to the customizer interface.
-	 */
-	function customizer_bridge_register( $wp_customize ) {
-
-		foreach ( $this->theme_customizations as $custom_section ) {
-			$this->register_section( $custom_section, $wp_customize );
-		}
-
-	}
-
-	function register_section( $custom_section, $wp_customize ) {
-		if ( 'section' !== $custom_section->type ) {
+	function register_section( $wp_customize ) {
+		if ( 'section' !== $this->custom_colors['type'] ) {
 			return;
 		}
 
-		$section_key = 'customizer-bridge-' . $custom_section->slug;
+		$section_key = $this->custom_colors['slug'];
 
 		//Add a Section to the Customizer for these bits
 		$wp_customize->add_section(
 			$section_key,
 			array(
-				'capability' => 'edit_theme_options',
-				'title'      => esc_html__( $custom_section->name, 'customizer-bridge' ),
+				'capability'  => 'edit_theme_options',
+				'description' => $this->custom_colors['description'],
+				'title'       => $this->custom_colors['name'],
 			)
 		);
 
-		$wp_customize->get_section( $section_key )->description = __( $custom_section->description );
-
 		// Add Controls
-		foreach ( $custom_section->controls as $custom_option ) {
-			if ( 'color' === $custom_option->type ) {
-				$this->register_color_control( $custom_option, $section_key, $wp_customize );
+		foreach ( $this->custom_colors['controls'] as $custom_option ) {
+			if ( 'color' === $custom_option['type'] ) {
+				$this->register_color_control( $wp_customize, $custom_option, $section_key );
 			}
 		}
 	}
 
-	function register_color_control( $custom_option, $section_key, $wp_customize ) {
-		$setting_key           = 'customizer-bridge-' . $custom_option->slug;
+	function register_color_control( $wp_customize, $custom_option, $section_key ) {
+		$setting_key = $section_key . $custom_option['slug'];
+
 		$global_styles_setting = new WP_Customize_Global_Styles_Setting(
 			$wp_customize,
 			$setting_key,
 			array(
-				'default'           => esc_html( $custom_option->default ),
+				'default'           => esc_html( $custom_option['default'] ),
 				'sanitize_callback' => 'sanitize_hex_color',
-				'slug'              => $custom_option->slug,
+				'slug'              => $custom_option['slug'],
 			)
 		);
 
@@ -150,167 +90,10 @@ class CustomizerBridge {
 				$setting_key,
 				array(
 					'section' => $section_key,
-					'label'   => $custom_option->name,
+					'label'   => $custom_option['name'],
 				)
 			)
 		);
 	}
 }
-new CustomizerBridge;
-
-if ( class_exists( 'WP_Customize_Setting' ) ) {
-	/**
-	 * Customize API: WP_Customize_Global_Styles_Setting class
-	 *
-	 * This handles validation, sanitization and saving of the value.
-	 *
-	 * @package WordPress
-	 * @subpackage Customize
-	 * @since 4.7.0
-	 */
-
-	/**
-	 * Custom Setting to handle WP Global_Styles.
-	 *
-	 * @since 4.7.0
-	 *
-	 * @see WP_Customize_Setting
-	 */
-	final class WP_Customize_Global_Styles_Setting extends WP_Customize_Setting {
-
-		/**
-		 * The setting type.
-		 *
-		 * @since 4.7.0
-		 * @var string
-		 */
-		public $type = 'global_styles';
-
-		/**
-		 * Setting Transport
-		 *
-		 * @since 4.7.0
-		 * @var string
-		 */
-		public $transport = 'refresh'; // This is the default
-
-		/**
-		 * Capability required to edit this setting.
-		 *
-		 * @since 4.7.0
-		 * @var string
-		 */
-		public $capability = 'edit_css';
-
-		/**
-		 * Slug
-		 *
-		 * @var string
-		 */
-		public $slug = '';
-
-		/**
-		 * WP_Customize_Global_Styles_Setting constructor.
-		 *
-		 * @since 4.7.0
-		 *
-		 * @throws Exception If the setting ID does not match the pattern `custom_css[$stylesheet]`.
-		 *
-		 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
-		 * @param string               $id      A specific ID of the setting.
-		 *                                      Can be a theme mod or option name.
-		 * @param array                $args    Setting arguments.
-		 */
-		public function __construct( $manager, $id, $args = array() ) {
-			parent::__construct( $manager, $id, $args );
-			/*if ( 'customizer-bridge-foreground' !== $this->id_data['base'] ) {
-			throw new Exception( 'Expected customizer-bridge-foreground id_base.' );
-			}
-			if ( 1 !== count( $this->id_data['keys'] ) || empty( $this->id_data['keys'][0] ) ) {
-			throw new Exception( 'Expected customizer-bridge-foreground key.' );
-			}
-			$this->stylesheet = $this->id_data['keys'][0];*/
-		}
-
-		/**
-		 * Add filter to preview post value.
-		 *
-		 * @since 4.7.9
-		 *
-		 * @return bool False when preview short-circuits due no change needing to be previewed.
-		 */
-		public function preview() {
-			if ( $this->is_previewed ) {
-				return false;
-			}
-			$this->is_previewed = true;
-			return true;
-		}
-
-		/**
-		 * Fetch the value of the setting. Will return the previewed value when `preview()` is called.
-		 *
-		 * @since 4.7.0
-		 *
-		 * @see WP_Customize_Setting::value()
-		 *
-		 * @return string
-		 */
-		public function value() {
-			if ( $this->is_previewed ) {
-				$post_value = $this->post_value( null );
-				if ( null !== $post_value ) {
-					return $post_value;
-				}
-			}
-			$id_base = $this->id_data['base'];
-			$value   = '';
-
-			$user_custom_post_type_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-			$user_theme_json_post     = get_post( $user_custom_post_type_id );
-
-			if ( $user_theme_json_post ) {
-				$post_content = $user_theme_json_post->post_content;
-			}
-			if ( empty( $post_content ) ) {
-				$value = $this->default;
-			}
-
-			$post_json = json_decode( $post_content );
-			$value     = $post_json->styles->color->{$this->slug};
-
-			/** This filter is documented in wp-includes/class-wp-customize-setting.php */
-			$value = apply_filters( "customize_value_{$id_base}", $value, $this );
-
-			return $value;
-		}
-
-		/**
-		 * Store the color in the Global Styles custom post
-		 *
-		 * @since 4.7.0
-		 *
-		 * @param string $color The input color.
-		 * @return int|false The post ID or false if the value could not be saved.
-		 */
-		public function update( $color ) {
-			if ( empty( $color ) ) {
-				$color = '';
-			}
-
-			$user_custom_post_type_id                                   = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
-			$user_theme_json_post                                       = get_post( $user_custom_post_type_id );
-			$user_theme_json_post_content                               = json_decode( $user_theme_json_post->post_content );
-			$user_theme_json_post_content->styles->color->{$this->slug} = $color;
-
-			$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );
-			$result                             = wp_update_post( $user_theme_json_post );
-
-			if ( $r instanceof WP_Error ) {
-				return false;
-			}
-
-			return $r->ID;
-		}
-	}
-}
+new GlobalStylesCustomizer;

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -7,7 +7,7 @@ class GlobalStylesCustomizer {
 	private $custom_colors;
 
 	function __construct() {
-		$this->set_customizations();
+		add_action( 'customize_register', array( $this, 'set_customizations' ) );
 
 		add_action( 'customize_register', array( $this, 'register_section' ) );
 
@@ -37,9 +37,7 @@ class GlobalStylesCustomizer {
 	}
 
 	function set_customizations() {
-		$settings      = gutenberg_get_default_block_editor_settings();
-		$all           = WP_Theme_JSON_Resolver::get_merged_data( $settings, 'theme' );
-		$theme_json    = $all->get_raw_data();
+		$theme_json    = WP_Theme_JSON_Resolver::get_merged_data()->get_raw_data();
 		$color_palette = $theme_json['settings']['color']['palette'];
 
 		$this->custom_colors = array(
@@ -125,4 +123,5 @@ class GlobalStylesCustomizer {
 		);
 	}
 }
+
 new GlobalStylesCustomizer;

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -131,15 +131,18 @@ class CustomizerBridge {
 	}
 
 	function register_color_control( $custom_option, $section_key, $wp_customize ) {
-		$setting_key = 'customizer-bridge-' . $custom_option->slug;
-
-		$wp_customize->add_setting(
+		$setting_key           = 'customizer-bridge-' . $custom_option->slug;
+		$global_styles_setting = new WP_Customize_Global_Styles_Setting(
+			$wp_customize,
 			$setting_key,
 			array(
 				'default'           => esc_html( $custom_option->default ),
 				'sanitize_callback' => 'sanitize_hex_color',
+				'slug'              => $custom_option->slug,
 			)
 		);
+
+		$wp_customize->add_setting( $global_styles_setting );
 
 		$wp_customize->add_control(
 			new WP_Customize_Color_Control(
@@ -154,3 +157,160 @@ class CustomizerBridge {
 	}
 }
 new CustomizerBridge;
+
+if ( class_exists( 'WP_Customize_Setting' ) ) {
+	/**
+	 * Customize API: WP_Customize_Global_Styles_Setting class
+	 *
+	 * This handles validation, sanitization and saving of the value.
+	 *
+	 * @package WordPress
+	 * @subpackage Customize
+	 * @since 4.7.0
+	 */
+
+	/**
+	 * Custom Setting to handle WP Global_Styles.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @see WP_Customize_Setting
+	 */
+	final class WP_Customize_Global_Styles_Setting extends WP_Customize_Setting {
+
+		/**
+		 * The setting type.
+		 *
+		 * @since 4.7.0
+		 * @var string
+		 */
+		public $type = 'global_styles';
+
+		/**
+		 * Setting Transport
+		 *
+		 * @since 4.7.0
+		 * @var string
+		 */
+		public $transport = 'refresh'; // This is the default
+
+		/**
+		 * Capability required to edit this setting.
+		 *
+		 * @since 4.7.0
+		 * @var string
+		 */
+		public $capability = 'edit_css';
+
+		/**
+		 * Slug
+		 *
+		 * @var string
+		 */
+		public $slug = '';
+
+		/**
+		 * WP_Customize_Global_Styles_Setting constructor.
+		 *
+		 * @since 4.7.0
+		 *
+		 * @throws Exception If the setting ID does not match the pattern `custom_css[$stylesheet]`.
+		 *
+		 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
+		 * @param string               $id      A specific ID of the setting.
+		 *                                      Can be a theme mod or option name.
+		 * @param array                $args    Setting arguments.
+		 */
+		public function __construct( $manager, $id, $args = array() ) {
+			parent::__construct( $manager, $id, $args );
+			/*if ( 'customizer-bridge-foreground' !== $this->id_data['base'] ) {
+			throw new Exception( 'Expected customizer-bridge-foreground id_base.' );
+			}
+			if ( 1 !== count( $this->id_data['keys'] ) || empty( $this->id_data['keys'][0] ) ) {
+			throw new Exception( 'Expected customizer-bridge-foreground key.' );
+			}
+			$this->stylesheet = $this->id_data['keys'][0];*/
+		}
+
+		/**
+		 * Add filter to preview post value.
+		 *
+		 * @since 4.7.9
+		 *
+		 * @return bool False when preview short-circuits due no change needing to be previewed.
+		 */
+		public function preview() {
+			if ( $this->is_previewed ) {
+				return false;
+			}
+			$this->is_previewed = true;
+			return true;
+		}
+
+		/**
+		 * Fetch the value of the setting. Will return the previewed value when `preview()` is called.
+		 *
+		 * @since 4.7.0
+		 *
+		 * @see WP_Customize_Setting::value()
+		 *
+		 * @return string
+		 */
+		public function value() {
+			if ( $this->is_previewed ) {
+				$post_value = $this->post_value( null );
+				if ( null !== $post_value ) {
+					return $post_value;
+				}
+			}
+			$id_base = $this->id_data['base'];
+			$value   = '';
+
+			$user_custom_post_type_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+			$user_theme_json_post     = get_post( $user_custom_post_type_id );
+
+			if ( $user_theme_json_post ) {
+				$post_content = $user_theme_json_post->post_content;
+			}
+			if ( empty( $post_content ) ) {
+				$value = $this->default;
+			}
+
+			$post_json = json_decode( $post_content );
+			$value     = $post_json->styles->color->{$this->slug};
+
+			/** This filter is documented in wp-includes/class-wp-customize-setting.php */
+			$value = apply_filters( "customize_value_{$id_base}", $value, $this );
+
+			return $value;
+		}
+
+		/**
+		 * Store the color in the Global Styles custom post
+		 *
+		 * @since 4.7.0
+		 *
+		 * @param string $color The input color.
+		 * @return int|false The post ID or false if the value could not be saved.
+		 */
+		public function update( $color ) {
+			if ( empty( $color ) ) {
+				$color = '';
+			}
+
+			$user_custom_post_type_id                                   = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+			$user_theme_json_post                                       = get_post( $user_custom_post_type_id );
+			$user_theme_json_post_content                               = json_decode( $user_theme_json_post->post_content );
+			$user_theme_json_post_content->styles->color->{$this->slug} = $color;
+
+			$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );
+			$result                             = wp_update_post( $user_theme_json_post );
+
+			if ( $r instanceof WP_Error ) {
+				return false;
+			}
+
+			return $r->ID;
+		}
+	}
+}

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -1,0 +1,112 @@
+<?php
+class CustomizerBridge {
+
+	private $theme_customizations;
+
+	function __construct() {
+		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
+		$this->theme_customizations = $this->get_theme_customizations();
+	}
+
+	function get_theme_customizations() {
+		$string  = file_get_contents( get_stylesheet_directory() . '/experimental-theme.json' );
+		$decoded = json_decode( $string );
+		return $decoded->settings->defaults->custom_meta;
+	}
+
+	/**
+	 * Enqueue color variables for customizer & frontend.
+	 */
+	function customizer_bridge_output_variables() {
+		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
+	}
+
+	/**
+	 * Render the customized variables.
+	 */
+	function customizer_bridge_generate_custom_color_variables( $context = null ) {
+
+		$css_variables = ':root {';
+		foreach ( $this->theme_customizations as $custom_section ) {
+			foreach ( $custom_section->controls as $custom_option ) {
+				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';
+			}
+		}
+		$css_variables = $css_variables . '}';
+
+		return $css_variables;
+	}
+
+	/**
+	 * Use theme.json to determine what variables to provide dials for.
+	 * Add those dials to the customizer interface.
+	 */
+	function customizer_bridge_register( $wp_customize ) {
+
+		// Add Color Controls
+		foreach ( $this->theme_customizations as $custom_section ) {
+
+			if ( 'section' === $custom_section->type ) {
+
+				$section_key = 'customizer-bridge-' . $custom_section->slug;
+
+				//Add a Section to the Customizer for these bits
+				$wp_customize->add_section(
+					$section_key,
+					array(
+						'capability' => 'edit_theme_options',
+						'title'      => esc_html__( $custom_section->name, 'customizer-bridge' ),
+					)
+				);
+
+				$wp_customize->get_section( $section_key )->description = __( $custom_section->description );
+
+				// Add Controls
+				foreach ( $custom_section->controls as $custom_option ) {
+
+					$setting_key = 'customizer-bridge-' . $custom_option->slug;
+
+					if ( 'color' === $custom_option->type ) {
+
+						$wp_customize->add_setting(
+							$setting_key,
+							array(
+								'default'           => esc_html( $custom_option->default ),
+								'sanitize_callback' => 'sanitize_hex_color',
+							)
+						);
+
+						$wp_customize->add_control(
+							new WP_Customize_Color_Control(
+								$wp_customize,
+								$setting_key,
+								array(
+									'section' => $section_key,
+									'label'   => $custom_option->name,
+								)
+							)
+						);
+					} elseif ( 'boolean' === $custom_option->type ) {
+
+						$wp_customize->add_setting( $setting_key );
+						$wp_customize->add_control(
+							$setting_key,
+							array(
+								'label'       => esc_html__( $custom_option->name ),
+								'description' => $custom_option->description,
+								'section'     => $section_key,
+								'type'        => 'checkbox',
+								'settings'    => $setting_key,
+							)
+						);
+
+					}
+				}
+			}
+		}
+
+	}
+
+}
+new CustomizerBridge;

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -27,20 +27,20 @@ class GlobalStylesCustomizer {
 			return $color;
 		}
 
-		// Is this a preset?
+		// Is this a variable?
 		if ( 0 === strpos( $color, 'var(--wp--preset--color--' ) ) {
 			// If so just return the palette
 			$color_slug = preg_replace( '/var\(--wp--preset--color--(.*)\)/', '$1', $color );
 			$key        = array_search( $color_slug, array_column( $palette, 'slug' ), true );
-			return $palette[ $key ]->color;
+			return $palette[ $key ]['color'];
 		}
-
 	}
 
 	function set_customizations() {
-		$default_theme_json = file_get_contents( get_stylesheet_directory() . '/experimental-theme.json' );
-		$decoded_theme_json = json_decode( $default_theme_json );
-		$color_palette      = $decoded_theme_json->settings->color->palette;
+		$settings      = gutenberg_get_default_block_editor_settings();
+		$all           = WP_Theme_JSON_Resolver::get_merged_data( $settings, 'theme' );
+		$theme_json    = $all->get_raw_data();
+		$color_palette = $theme_json['settings']['color']['palette'];
 
 		$this->custom_colors = array(
 			'name'        => __( 'Colors' ),
@@ -51,7 +51,7 @@ class GlobalStylesCustomizer {
 				array(
 					'name'     => __( 'Foreground Color' ),
 					'type'     => 'color',
-					'default'  => $this->get_color( $decoded_theme_json->styles->color->text, $color_palette ),
+					'default'  => $this->get_color( $theme_json['styles']['color']['text'], $color_palette ),
 					'selector' => 'body',
 					'property' => 'color',
 					'slug'     => 'text',
@@ -59,7 +59,7 @@ class GlobalStylesCustomizer {
 				array(
 					'name'     => __( 'Background Color' ),
 					'type'     => 'color',
-					'default'  => $this->get_color( $decoded_theme_json->styles->color->background, $color_palette ),
+					'default'  => $this->get_color( $theme_json['styles']['color']['background'], $color_palette ),
 					'selector' => 'body',
 					'property' => 'background',
 					'slug'     => 'background',
@@ -111,7 +111,6 @@ class GlobalStylesCustomizer {
 				'slug'              => $custom_option['slug'],
 			)
 		);
-
 		$wp_customize->add_setting( $global_styles_setting );
 
 		$wp_customize->add_control(

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -41,7 +41,11 @@ class CustomizerBridge {
 		$css_variables = 'body, #editor {';
 		foreach ( $this->theme_customizations as $custom_section ) {
 			foreach ( $custom_section->controls as $custom_option ) {
-				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';
+				$slug_value = get_theme_mod( 'customizer-bridge-' . $custom_option->slug );
+				if ( $slug_value ) {
+					var_dump( $slug_value );
+					$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . $slug_value . ';';
+				}
 			}
 		}
 		$css_variables = $css_variables . '}';

--- a/quadrat/inc/customization.php
+++ b/quadrat/inc/customization.php
@@ -47,20 +47,48 @@ class GlobalStylesCustomizer {
 			'description' => __( 'Color Customization for Quadrat' ),
 			'controls'    => array(
 				array(
-					'name'     => __( 'Foreground Color' ),
-					'type'     => 'color',
-					'default'  => $this->get_color( $theme_json['styles']['color']['text'], $color_palette ),
-					'selector' => 'body',
-					'property' => 'color',
-					'slug'     => 'text',
+					'name'           => __( 'Foreground Color' ),
+					'type'           => 'color',
+					'default'        => $this->get_color( $theme_json['styles']['color']['text'], $color_palette ),
+					'selector'       => 'body',
+					'property'       => 'color',
+					'declaration'    => 'color',
+					'slug'           => 'text',
+					'json_structure' => array( 'styles', 'color', 'text' ),
+					'variable'       => '--wp--style--color--text',
 				),
 				array(
-					'name'     => __( 'Background Color' ),
-					'type'     => 'color',
-					'default'  => $this->get_color( $theme_json['styles']['color']['background'], $color_palette ),
-					'selector' => 'body',
-					'property' => 'background',
-					'slug'     => 'background',
+					'name'           => __( 'Background Color' ),
+					'type'           => 'color',
+					'default'        => $this->get_color( $theme_json['styles']['color']['background'], $color_palette ),
+					'selector'       => 'body',
+					'property'       => 'color',
+					'declaration'    => 'background-color',
+					'slug'           => 'background',
+					'json_structure' => array( 'styles', 'color', 'background' ),
+					'variable'       => '--wp--style--color--background',
+				),
+				array(
+					'name'           => __( 'Link Color' ),
+					'type'           => 'color',
+					'default'        => $this->get_color( $theme_json['styles']['elements']['link']['color']['text'], $color_palette ),
+					'selector'       => 'a',
+					'declaration'    => 'color',
+					'property'       => 'text',
+					'slug'           => 'color',
+					'json_structure' => array( 'styles', 'elements', 'link', 'color', 'text' ),
+					'variable'       => '--wp--style--link--color',
+				),
+				array(
+					'name'           => __( 'Border Color' ),
+					'type'           => 'color',
+					'default'        => $this->get_color( $theme_json['styles']['border']['color'], $color_palette ),
+					'selector'       => 'body',
+					'declaration'    => 'border-color',
+					'property'       => 'border',
+					'slug'           => 'color',
+					'json_structure' => array( 'styles', 'border', 'color' ),
+					'variable'       => '--wp--style--border--color',
 				),
 			),
 		);
@@ -98,15 +126,15 @@ class GlobalStylesCustomizer {
 	}
 
 	function register_color_control( $wp_customize, $custom_option, $section_key ) {
-		$setting_key = $section_key . $custom_option['slug'];
+		$setting_key = $section_key . $custom_option['variable'];
 
 		$global_styles_setting = new WP_Customize_Global_Styles_Setting(
 			$wp_customize,
 			$setting_key,
 			array(
 				'default'           => esc_html( $custom_option['default'] ),
+				'json_structure'    => $custom_option['json_structure'],
 				'sanitize_callback' => 'sanitize_hex_color',
-				'slug'              => $custom_option['slug'],
 			)
 		);
 		$wp_customize->add_setting( $global_styles_setting );

--- a/quadrat/inc/customizer-preview.js
+++ b/quadrat/inc/customizer-preview.js
@@ -11,7 +11,17 @@ if ( global_styles_settings ) {
 			value.bind( function ( to ) {
 				// Build the CSS based on the settings
 				styleElement.innerHTML =
-					control.selector + '{' + control.property + ':' + to + '}';
+					control.selector +
+					'{' +
+					'--wp--style--color--' +
+					control.slug +
+					': ' +
+					to +
+					';' +
+					control.property +
+					':' +
+					to +
+					'}';
 			} );
 		} );
 	} );

--- a/quadrat/inc/customizer-preview.js
+++ b/quadrat/inc/customizer-preview.js
@@ -1,0 +1,18 @@
+// Check that the settings object exists
+if ( global_styles_settings ) {
+	// For each of the controls add a listener
+	global_styles_settings.controls.forEach( function ( control ) {
+		var setting_name = global_styles_settings.slug + control.slug;
+		wp.customize( setting_name, function ( value ) {
+			// Get a style element to inject the setting
+			var styleElement = document.getElementById(
+				setting_name + '-inline-css'
+			);
+			value.bind( function ( to ) {
+				// Build the CSS based on the settings
+				styleElement.innerHTML =
+					control.selector + '{' + control.property + ':' + to + '}';
+			} );
+		} );
+	} );
+}

--- a/quadrat/inc/customizer-preview.js
+++ b/quadrat/inc/customizer-preview.js
@@ -2,28 +2,34 @@
 if ( global_styles_settings ) {
 	// For each of the controls add a listener
 	global_styles_settings.controls.forEach( function ( control ) {
-		var setting_name = global_styles_settings.slug + control.slug;
+		var setting_name = global_styles_settings.slug + control.variable;
 		wp.customize( setting_name, function ( value ) {
 			// Get a style element to inject the setting
 			var styleElement = document.getElementById(
 				setting_name + '-inline-css'
 			);
+
 			value.bind( function ( to ) {
 				// Build the CSS based on the settings
-				styleElement.innerHTML =
+				var css =
 					// Build the variable.
-					control.selector +
-					'{' +
-					'--wp--style--color--' +
-					control.slug +
+					'body{' +
+					control.variable +
 					': ' +
 					to +
-					';' +
+					';}' +
 					// Build the selector.
-					control.property +
+					control.selector +
+					'{' +
+					control.declaration +
 					':' +
 					to +
 					'}';
+
+				console.log( setting_name );
+				console.log( styleElement );
+
+				styleElement.innerHTML = css;
 			} );
 		} );
 	} );

--- a/quadrat/inc/customizer-preview.js
+++ b/quadrat/inc/customizer-preview.js
@@ -11,6 +11,7 @@ if ( global_styles_settings ) {
 			value.bind( function ( to ) {
 				// Build the CSS based on the settings
 				styleElement.innerHTML =
+					// Build the variable.
 					control.selector +
 					'{' +
 					'--wp--style--color--' +
@@ -18,6 +19,7 @@ if ( global_styles_settings ) {
 					': ' +
 					to +
 					';' +
+					// Build the selector.
 					control.property +
 					':' +
 					to +

--- a/quadrat/inc/wp-customize-global-styles-setting.php
+++ b/quadrat/inc/wp-customize-global-styles-setting.php
@@ -82,6 +82,14 @@ if ( class_exists( 'WP_Customize_Setting' ) && ! class_exists( 'WP_Customize_Glo
 				return $this->default;
 			}
 
+			if ( ! property_exists( $post_json->styles, 'color' ) ) {
+				return $this->default;
+			}
+
+			if ( ! property_exists( $post_json->styles->color, $this->slug ) ) {
+				return $this->default;
+			}
+
 			return $post_json->styles->color->{$this->slug};
 		}
 

--- a/quadrat/inc/wp-customize-global-styles-setting.php
+++ b/quadrat/inc/wp-customize-global-styles-setting.php
@@ -1,0 +1,111 @@
+<?php
+
+if ( class_exists( 'WP_Customize_Setting' ) && ! class_exists( 'WP_Customize_Global_Styles_Setting' ) ) {
+	/**
+	 * Customize API: WP_Customize_Global_Styles_Setting class
+	 *
+	 * This handles saving and retrieving of the value.
+	 *
+	 */
+
+	/**
+	 * Custom Setting to handle WP Global_Styles.
+	 *
+	 * @see WP_Customize_Setting
+	 */
+	final class WP_Customize_Global_Styles_Setting extends WP_Customize_Setting {
+
+		/**
+		 * The setting type.
+		 *
+		 * @var string
+		 */
+		public $type = 'global_styles';
+
+		/**
+		 * Setting Transport
+		 *
+		 * @var string
+		 */
+		public $transport = 'postMessage';
+
+		/**
+		 * Slug
+		 *
+		 * @var string
+		 */
+		public $slug = '';
+
+		/**
+		 * WP_Customize_Global_Styles_Setting constructor.
+		 *
+		 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
+		 * @param string               $id      A specific ID of the setting.
+		 *                                      Can be a theme mod or option name.
+		 * @param array                $args    Setting arguments.
+		 */
+		public function __construct( $manager, $id, $args = array() ) {
+			parent::__construct( $manager, $id, $args );
+			$this->print_empty_style_elements( $id );
+		}
+
+		/**
+		 * Print Empty Color CSS
+		 * This is used to update the preview
+		 */
+		public function print_empty_style_elements( $id ) {
+			wp_register_style( $id, false, array( 'global-styles' ), true, true ); // This needs to load after global_styles, hence the dependency
+			wp_enqueue_style( $id );
+			wp_add_inline_style( $id, ' ' ); // This has to have content otherwise nothing is output
+		}
+
+		/**
+		 * Fetch the value of the setting.
+		 *
+		 * @see WP_Customize_Setting::value()
+		 *
+		 * @return string
+		 */
+		public function value() {
+			$user_custom_post_type_id = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+			$user_theme_json_post     = get_post( $user_custom_post_type_id );
+
+			if ( $user_theme_json_post ) {
+				$post_content = $user_theme_json_post->post_content;
+			}
+			if ( empty( $post_content ) ) {
+				return $this->default;
+			}
+
+			$post_json = json_decode( $post_content );
+			if ( ! property_exists( $post_json, 'styles' ) ) {
+				return $this->default;
+			}
+
+			return $post_json->styles->color->{$this->slug};
+		}
+
+		/**
+		 * Store the color in the Global Styles custom post
+		 *
+		 * @param string $color The input color.
+		 * @return WP_Post|WP_Error The post or a WP_Error if the value could not be saved.
+		 */
+		public function update( $color ) {
+			if ( empty( $color ) ) {
+				return;
+			}
+
+			// Get the user's theme.json from the CPT
+			$user_custom_post_type_id     = WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+			$user_theme_json_post         = get_post( $user_custom_post_type_id );
+			$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
+
+			// Upate the theme.json with the new color
+			$user_theme_json_post_content->styles->color->{$this->slug} = $color;
+			$user_theme_json_post->post_content                         = json_encode( $user_theme_json_post_content );
+
+			return wp_update_post( $user_theme_json_post );
+		}
+	}
+}

--- a/quadrat/inc/wp-customize-global-styles-setting.php
+++ b/quadrat/inc/wp-customize-global-styles-setting.php
@@ -54,7 +54,7 @@ if ( class_exists( 'WP_Customize_Setting' ) && ! class_exists( 'WP_Customize_Glo
 		 * This is used to update the preview
 		 */
 		public function print_empty_style_elements( $id ) {
-			wp_register_style( $id, false, array( 'global-styles' ), true, true ); // This needs to load after global_styles, hence the dependency
+			wp_register_style( $id, false, array( 'global-styles-variables' ), true, true ); // This needs to load after global_styles, hence the dependency
 			wp_enqueue_style( $id );
 			wp_add_inline_style( $id, ' ' ); // This has to have content otherwise nothing is output
 		}

--- a/quadrat/inc/wp-customize-global-styles-setting.php
+++ b/quadrat/inc/wp-customize-global-styles-setting.php
@@ -73,6 +73,7 @@ if ( class_exists( 'WP_Customize_Setting' ) && ! class_exists( 'WP_Customize_Glo
 			if ( $user_theme_json_post ) {
 				$post_content = $user_theme_json_post->post_content;
 			}
+
 			if ( empty( $post_content ) ) {
 				return $this->default;
 			}
@@ -90,7 +91,29 @@ if ( class_exists( 'WP_Customize_Setting' ) && ! class_exists( 'WP_Customize_Glo
 				return $this->default;
 			}
 
-			return $post_json->styles->color->{$this->slug};
+			$color_string = $post_json->styles->color->{$this->slug};
+			return $this->get_color( $color_string );
+		}
+
+		// There is a similar but different version of this in customization.php
+		function get_color( $color ) {
+			$all        = WP_Theme_JSON_Resolver::get_merged_data();
+			$theme_json = $all->get_raw_data();
+			$palette    = $theme_json['settings']['color']['palette'];
+
+			// Is this a HEX?
+			if ( 0 === strpos( $color, '#' ) ) {
+				// If so just return.
+				return $color;
+			}
+
+			// Is this a variable?
+			if ( 0 === strpos( $color, 'var:preset|color|' ) ) {
+				// If so just return the palette
+				$color_slug = preg_replace( '/var:preset\|color\|(.*)/', '$1', $color );
+				$key        = array_search( $color_slug, array_column( $palette, 'slug' ), true );
+				return $palette[ $key ]['color'];
+			}
 		}
 
 		/**

--- a/quadrat/sass/blocks/_buttons.scss
+++ b/quadrat/sass/blocks/_buttons.scss
@@ -20,7 +20,7 @@
 			&:focus,
 			&.has-focus {
 				border: none;
-				color: var(--wp--custom--color--background);
+				color: var(--wp--style--color--background);
 				background: var(--wp--custom--color--primary);
 				padding: calc(0.667em + 2px) calc(1.333em + 2px);
 			}

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,5 +1,5 @@
 a:hover {
-	background: var(--wp--custom--color--primary);
+	background: var(--wp--style--color--text);
 	color: var(--wp--style--color--background);
 }
 

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,6 +1,6 @@
 a:hover {
 	background: var(--wp--custom--color--primary);
-	color: var(--wp--custom--color--background);
+	color: var(--wp--style--color--background);
 }
 
 a:active,


### PR DESCRIPTION
This is a different approach to https://github.com/Automattic/themes/pull/3817.

The general approach is to replicate the functionality of Global Styles in the Customizer. This means that we modify the custom post type, so that the data can be shared between both environments.

To simplify this I have also removed the custom background and custom foreground colors and implemented new variables for these, which can be referenced in the CSS.

I have also added a preview to the Customizer which just injects some CSS to target the relevant selectors and also modifies the variables.

The code is written to be extendable so it should be trivial to add support for custom link colors too.