### PR TITLE
Quadrat: fix site title and post title styles

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -236,6 +236,10 @@ ul ul {
 	margin-left: 20%;
 }
 
+.wp-block-query-loop .wp-block-post-title {
+	font-size: var(--wp--custom--heading--h3--font-size);
+}
+
 .wp-block-quote.is-style-large p {
 	line-height: 1.4;
 }
@@ -289,6 +293,10 @@ a:active, a:focus {
 	justify-content: space-between;
 	align-items: center;
 	overflow: inherit;
+}
+
+.site-header .wp-block-site-title a {
+	text-decoration: none;
 }
 
 .post-meta {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -70,7 +70,10 @@
 					"fontWeight": "500"
 				},
 				"h1": {
-					"fontSize":"min(max(48px, 7vw), 80px)"
+					"fontSize": "min(max(48px, 7vw), 80px)"
+				},
+				"h3": {
+					"fontSize": "min(max(28px, 5vw), 38px)"
 				}
 			},
 			"line-height": {
@@ -297,7 +300,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "min(max(28px, 5vw), 38px)",
+					"fontSize": "var(--wp--custom--heading--h3--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h3)"
 				}
 			},

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -125,6 +125,9 @@
 				},
 				"h1": {
 					"fontSize": "min(max(48px, 7vw), 80px)"
+				},
+				"h3": {
+					"fontSize": "min(max(28px, 5vw), 38px)"
 				}
 			},
 			"list": {
@@ -497,7 +500,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "min(max(28px, 5vw), 38px)",
+					"fontSize": "var(--wp--custom--heading--h3--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h3)"
 				}
 			},

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -5,4 +5,8 @@
 		align-items: center;
 		overflow: inherit;
 	}
+
+	.wp-block-site-title a {
+		text-decoration: none;
+	}
 } 

--- a/quadrat/sass/blocks/_query.scss
+++ b/quadrat/sass/blocks/_query.scss
@@ -1,0 +1,5 @@
+.wp-block-query-loop {
+	.wp-block-post-title {
+		font-size: var(--wp--custom--heading--h3--font-size);
+	}
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -9,6 +9,7 @@
 @import "blocks/navigation";
 @import "blocks/post-comments";
 @import "blocks/post-navigation-link";
+@import "blocks/query";
 @import "blocks/quote";
 @import "blocks/search";
 @import "blocks/table";


### PR DESCRIPTION
This PR fixes some styling on the site title block in the header and post title blocks that appear in a query loop.

Before | After
------- | -------
<img width="1261" alt="Screen Shot 2021-05-14 at 2 08 32 PM" src="https://user-images.githubusercontent.com/5375500/118311504-d8cecd80-b4a4-11eb-9dd9-bfc291074096.png"> | <img width="1258" alt="Screen Shot 2021-05-14 at 2 07 19 PM" src="https://user-images.githubusercontent.com/5375500/118311511-da989100-b4a4-11eb-95b0-00892f30298b.png">

