### PR TITLE
Align the featured image to center, not full.

### DIFF
--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -15,7 +15,7 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:post-featured-image {"align":"full"} /-->
+<!-- wp:post-featured-image {"align":"center"} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
Fixes #3805.

Before | After
------- | ------
<img width="2672" alt="Screen Shot 2021-05-17 at 12 24 29 PM" src="https://user-images.githubusercontent.com/5375500/118523169-bbdb0a00-b6f1-11eb-8a49-99e7890185e3.png"> | <img width="2672" alt="Screen Shot 2021-05-17 at 12 24 10 PM" src="https://user-images.githubusercontent.com/5375500/118523176-be3d6400-b6f1-11eb-9ba5-430301873abb.png">
