### PR TITLE
Quadrat: outline button in the editor

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -41,6 +41,11 @@
 	text-align: right;
 }
 
+.wp-block-button.is-style-outline.wp-block-button__link,
+.wp-block-button.is-style-outline .wp-block-button__link {
+	border: 2px solid currentColor;
+}
+
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,

--- a/quadrat/sass/blocks/_buttons.scss
+++ b/quadrat/sass/blocks/_buttons.scss
@@ -1,6 +1,7 @@
 .wp-block-button.is-style-outline {
 	&.wp-block-button__link,
 	.wp-block-button__link {
+		border: 2px solid currentColor; // The priority of global styles in the post editor overrides the outline style variation, so this line is needed.
 		&:not(.has-background):not(.has-text-color) {
 			&:hover,
 			&:focus,


### PR DESCRIPTION
This PR addresses #3806.

Before | After
------ | -------
<img width="1279" alt="Screen Shot 2021-05-17 at 12 44 45 PM" src="https://user-images.githubusercontent.com/5375500/118525891-884daf00-b6f4-11eb-83d1-12d67657b699.png"> | <img width="1275" alt="Screen Shot 2021-05-17 at 12 42 51 PM" src="https://user-images.githubusercontent.com/5375500/118525808-73711b80-b6f4-11eb-9259-b87e20b6538d.png">
