### PR TITLE
Seedlet: Update text and link when there are no published posts

### DIFF
--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -12,24 +12,29 @@
 
 <section class="no-results not-found">
 	<header class="page-header default-max-width">
-		<h1 class="page-title"><?php _e( 'Nothing Found', 'seedlet' ); ?></h1>
+		<h1 class="page-title"><?php _e( 'No posts published yet!', 'seedlet' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content default-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			printf(
+			<p><?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
+
+			<?php printf(
 				'<p>' . wp_kses(
-					/* translators: 1: link to WP admin new post page. */
-					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'seedlet' ),
+					/* translators: 1: link to WP admin new post page. 2: class for anchor */
+					__( '<a href="%1$s" class="%2$s">Add or publish Posts</a>', 'seedlet' ),
 					array(
 						'a' => array(
 							'href' => array(),
+							'class' => 'button',
 						),
 					)
 				) . '</p>',
-				esc_url( admin_url( 'post-new.php' ) )
+				esc_url( admin_url( 'edit.php' ) ),
+				'button',
+
 			);
 
 		elseif ( is_search() ) :

--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -19,25 +19,28 @@
 		<?php
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
+			<p>
+			<?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
 
 			<?php printf(
-				'<p>' . wp_kses(
-					/* translators: 1: link to WP admin new post page. 2: class for anchor */
-					__( '<a href="%1$s" class="%2$s">Add or publish Posts</a>', 'seedlet' ),
+				'<p>' 
+				. wp_kses('<a href="%1$s" class="button">',
 					array(
 						'a' => array(
 							'href' => array(),
-							'class' => 'button',
-						),
-					)
-				) . '</p>',
-				esc_url( admin_url( 'edit.php' ) ),
-				'button',
-
+							'class' => 'button'
+						)
+					)					
+				) ,
+				esc_url( admin_url( 'edit.php' ) )
 			);
+			
+			/* translators: 1: link to WP admin new post page. 2: class for anchor */
+			 _e( 'Add or publish Posts', 'seedlet' ); ?>
+			
+			</a></p>
 
-		elseif ( is_search() ) :
+		<?php elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'seedlet' ); ?></p>

--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -22,23 +22,12 @@
 			<p>
 			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
 
-			<?php printf(
-				'<p>' 
-				. wp_kses('<a href="%1$s" class="button">',
-					array(
-						'a' => array(
-							'href' => array(),
-							'class' => 'button'
-						)
-					)					
-				) ,
-				esc_url( admin_url( 'edit.php' ) )
-			);
-			
-			/* translators: 1: link to WP admin new post page. 2: class for anchor */
+			<p>
+				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
+			<?php /* translators: 1: link to WP admin new post page. */
 			 _e( 'Add or publish Posts', 'seedlet' ); ?>
-			
-			</a></p>
+				</a>
+			</p>
 
 		<?php elseif ( is_search() ) :
 			?>

--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -17,19 +17,22 @@
 
 	<div class="page-content default-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+			?>
 
 			<p>
 			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
-
 			<p>
-				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
-			<?php /* translators: 1: link to WP admin new post page. */
-			 _e( 'Add or publish Posts', 'seedlet' ); ?>
+				<a href="<?php echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
+					<?php
+					/* translators: 1: link to WP admin new post page. */
+					_e( 'Add or publish Posts', 'seedlet' );
+					?>
 				</a>
 			</p>
 
-		<?php elseif ( is_search() ) :
+			<?php
+		elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'seedlet' ); ?></p>

--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -20,7 +20,7 @@
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
 			<p>
-			<?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
+			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
 
 			<?php printf(
 				'<p>' 

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -18,19 +18,22 @@
 
 	<div class="page-content responsive-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
 
-			<p>
-			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
+			printf(
+				'<p>' . wp_kses(
+					/* translators: 1: link to WP admin new post page. */
+					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'varia' ),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				) . '</p>',
+				esc_url( admin_url( 'post-new.php' ) )
+			);
 
-			<p>
-				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
-			<?php /* translators: 1: link to WP admin new post page. */
-			 _e( 'Add or publish Posts', 'seedlet' ); ?>
-				</a>
-			</p>
-
-		<?php elseif ( is_search() ) :
+		elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'varia' ); ?></p>

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -18,22 +18,19 @@
 
 	<div class="page-content responsive-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			printf(
-				'<p>' . wp_kses(
-					/* translators: 1: link to WP admin new post page. */
-					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'varia' ),
-					array(
-						'a' => array(
-							'href' => array(),
-						),
-					)
-				) . '</p>',
-				esc_url( admin_url( 'post-new.php' ) )
-			);
+			<p>
+			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
 
-		elseif ( is_search() ) :
+			<p>
+				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
+			<?php /* translators: 1: link to WP admin new post page. */
+			 _e( 'Add or publish Posts', 'seedlet' ); ?>
+				</a>
+			</p>
+
+		<?php elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'varia' ); ?></p>


### PR DESCRIPTION
Addressing #3874

This PR changes the content shown when a user has 'Latest Posts' selected for their front page but no public posts. This affects only the logged-in view.

### Updated appearance

<img width="904" alt="Screen Shot 2021-05-18 at 3 14 09 pm" src="https://user-images.githubusercontent.com/1842363/118593925-e4472f00-b7eb-11eb-9223-d2fc43ac165d.png">

## Testing Instructions

1. Ensure site has no public posts (set them to be draft or remove them).
2. Use the Customizer to set the 'Home Page Settings' to show latest posts
3. Visit the home page of the site.
