### PR TITLE
Refactor button hover styles into its own custom object tree

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -204,6 +204,7 @@ input[type=checkbox] + label {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -217,6 +218,7 @@ input[type=checkbox] + label {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -265,6 +267,7 @@ input[type=checkbox] + label {
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -277,6 +280,7 @@ input[type=checkbox] + label {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -475,6 +479,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -488,6 +493,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -536,6 +542,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -548,6 +555,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -607,6 +615,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -621,6 +630,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -724,6 +734,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -737,6 +748,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -785,6 +797,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -797,6 +810,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -864,6 +878,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -882,6 +897,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -945,6 +961,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -958,6 +975,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -1006,6 +1024,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -1018,6 +1037,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -1069,6 +1089,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);
@@ -1084,6 +1105,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -239,7 +239,7 @@ input[type=checkbox] + label {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -299,7 +299,7 @@ input[type=checkbox] + label {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -510,7 +510,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -570,7 +570,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -637,7 +637,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -759,7 +759,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -819,7 +819,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -904,7 +904,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -980,7 +980,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -1040,7 +1040,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);
@@ -1100,7 +1100,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
 	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
 	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
 	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
 	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
 	font-weight: var(--wp--custom--button--typography--font-weight);

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -206,6 +206,7 @@ input[type=checkbox] + label {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -215,9 +216,10 @@ input[type=checkbox] + label {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -265,6 +267,7 @@ input[type=checkbox] + label {
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
@@ -273,9 +276,10 @@ input[type=checkbox] + label {
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -473,6 +477,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -482,9 +487,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -532,6 +538,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
@@ -540,9 +547,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -601,6 +609,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -611,9 +620,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus svg {
@@ -716,6 +726,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -725,9 +736,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -775,6 +787,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
@@ -783,9 +796,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -852,6 +866,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -866,9 +881,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
@@ -931,6 +947,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 }
 
@@ -940,9 +957,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -990,6 +1008,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
@@ -998,9 +1017,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
@@ -1051,6 +1071,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	border-radius: var(--wp--custom--button--border--radius);
 	display: inline-block;
 }
@@ -1062,9 +1083,10 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	border-color: var(--wp--custom--button--border--color);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 }
 
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus svg {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -195,34 +195,119 @@ input[type=checkbox] + label {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.wp-block-button__link svg,
+.wp-block-button .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link,
+.wp-block-button.is-style-outline .wp-block-button__link {
+	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	--wp--custom--button--color--background: transparent;
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link svg,
+.wp-block-button.is-style-outline .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -377,34 +462,119 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.wp-block-button__link svg,
+.wp-block-button .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link,
+.wp-block-button.is-style-outline .wp-block-button__link {
+	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	--wp--custom--button--color--background: transparent;
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link svg,
+.wp-block-button.is-style-outline .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -420,6 +590,10 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments input[type="submit"], .wp-block-post-comments .reply a {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
@@ -427,14 +601,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding-top: var(--wp--custom--button--spacing--padding--top);
-	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-	padding-left: var(--wp--custom--button--spacing--padding--left);
-	padding-right: var(--wp--custom--button--spacing--padding--right);
-	border-color: var(--wp--custom--button--border--color);
-	border-width: var(--wp--custom--button--border--width);
 	border-radius: var(--wp--custom--button--border--radius);
-	border-style: var(--wp--custom--button--border--style);
 }
 
 .wp-block-post-comments input[type="submit"] svg, .wp-block-post-comments .reply a svg {
@@ -442,24 +609,32 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-post-comments input[type="submit"]:hover, .wp-block-post-comments input[type="submit"]:focus, .wp-block-post-comments input[type="submit"].has-focus, .wp-block-post-comments .reply a:hover, .wp-block-post-comments .reply a:focus, .wp-block-post-comments .reply a.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
 }
 
 .wp-block-post-comments input[type="submit"] {
@@ -530,34 +705,119 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.wp-block-button__link svg,
+.wp-block-button .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link,
+.wp-block-button.is-style-outline .wp-block-button__link {
+	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	--wp--custom--button--color--background: transparent;
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link svg,
+.wp-block-button.is-style-outline .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -581,6 +841,10 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 .wp-block-search .wp-block-search__button {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
@@ -588,14 +852,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding-top: var(--wp--custom--button--spacing--padding--top);
-	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-	padding-left: var(--wp--custom--button--spacing--padding--left);
-	padding-right: var(--wp--custom--button--spacing--padding--right);
-	border-color: var(--wp--custom--button--border--color);
-	border-width: var(--wp--custom--button--border--width);
 	border-radius: var(--wp--custom--button--border--radius);
-	border-style: var(--wp--custom--button--border--style);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
@@ -607,27 +864,38 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus,
+.wp-block-search .wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
@@ -652,41 +920,10 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
-	text-decoration: none;
-}
-
-.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
-}
-
-.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-}
-
-.wp-block-buttons .wp-block-button:last-child {
-	margin-bottom: 0;
-}
-
-.wp-block-file .wp-block-file__button {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
@@ -694,14 +931,127 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-radius: var(--wp--custom--button--border--radius);
+}
+
+.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.wp-block-button__link:hover, .wp-block-button.wp-block-button__link:focus, .wp-block-button.wp-block-button__link.has-focus,
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.wp-block-button__link svg,
+.wp-block-button .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link,
+.wp-block-button.is-style-outline .wp-block-button__link {
+	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	--wp--custom--button--color--background: transparent;
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
 	padding-top: var(--wp--custom--button--spacing--padding--top);
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	border-color: var(--wp--custom--button--border--color);
-	border-width: var(--wp--custom--button--border--width);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline .wp-block-button__link:hover,
+.wp-block-button.is-style-outline .wp-block-button__link:focus,
+.wp-block-button.is-style-outline .wp-block-button__link.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+}
+
+.wp-block-button.is-style-outline.wp-block-button__link svg,
+.wp-block-button.is-style-outline .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-buttons .wp-block-button:last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-file .wp-block-file__button {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 	border-radius: var(--wp--custom--button--border--radius);
-	border-style: var(--wp--custom--button--border--style);
 	display: inline-block;
 }
 
@@ -710,24 +1060,32 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus {
-	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
 }
 
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
+	--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+	--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+	--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+	--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+	--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+	--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+	--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+	--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-family: var(--wp--custom--button--typography--font-family);
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--button--typography--line-height);
+	text-decoration: none;
 }
 
 .wp-block-table figcaption {

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -195,6 +195,7 @@ input[type=checkbox] + label {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -470,6 +471,7 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -606,6 +608,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments input[type="submit"], .wp-block-post-comments .reply a {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -655,12 +658,6 @@ p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
-}
-
-.wp-block-post-comments input[type="submit"] {
-	border-color: var(--wp--custom--button--border--color);
-	border-style: var(--wp--custom--button--border--style);
-	border-width: var(--wp--custom--button--border--width);
 }
 
 .wp-block-post-comments .reply a {
@@ -725,6 +722,7 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -869,6 +867,7 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 .wp-block-search .wp-block-search__button {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -952,6 +951,7 @@ p.has-drop-cap:not(:focus):first-letter {
  */
 .wp-block-button.wp-block-button__link,
 .wp-block-button .wp-block-button__link {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
@@ -1080,6 +1080,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-file .wp-block-file__button {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));

--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -202,19 +202,27 @@ input[type=checkbox] + label {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -376,19 +384,27 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -411,7 +427,14 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding: calc(.667em + 2px) calc(1.333em + 2px);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	border-color: var(--wp--custom--button--border--color);
+	border-width: var(--wp--custom--button--border--width);
+	border-radius: var(--wp--custom--button--border--radius);
+	border-style: var(--wp--custom--button--border--style);
 }
 
 .wp-block-post-comments input[type="submit"] svg, .wp-block-post-comments .reply a svg {
@@ -419,16 +442,24 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments input[type="submit"]:not(.has-background):not(.has-text-color).has-focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):hover svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color):focus svg, .wp-block-post-comments .reply a:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-post-comments input[type="submit"] {
@@ -506,19 +537,27 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -549,7 +588,14 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding: calc(.667em + 2px) calc(1.333em + 2px);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	border-color: var(--wp--custom--button--border--color);
+	border-width: var(--wp--custom--button--border--width);
+	border-radius: var(--wp--custom--button--border--radius);
+	border-style: var(--wp--custom--button--border--style);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
@@ -561,19 +607,27 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
@@ -605,19 +659,27 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-buttons .wp-block-button:last-child {
@@ -632,7 +694,14 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: none;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding: calc(.667em + 2px) calc(1.333em + 2px);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	border-color: var(--wp--custom--button--border--color);
+	border-width: var(--wp--custom--button--border--width);
+	border-radius: var(--wp--custom--button--border--radius);
+	border-style: var(--wp--custom--button--border--style);
 	display: inline-block;
 }
 
@@ -641,16 +710,24 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus {
-	color: var(--wp--custom--button--color--hover-text);
-	background-color: var(--wp--custom--button--color--hover-background);
-	border-color: var(--wp--custom--button--border--hover-color);
-	border-style: var(--wp--custom--button--border--hover-style);
-	border-width: var(--wp--custom--button--border--hover-width);
-	padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width));
+	font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+	font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+	font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+	line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+	color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+	background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+	padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+	padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+	padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+	padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+	border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+	border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+	border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+	border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 }
 
 .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-file .wp-block-file__button:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--hover-text);
+	fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 }
 
 .wp-block-table figcaption {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -57,17 +57,17 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--button--color--text)",
+					"color": "var(--wp--custom--color--foreground)",
 					"radius": "4px",
 					"style": "solid",
-					"width": "0"
+					"width": "2px"
 				},
 				"spacing": {
 					"padding": {
-						"top": "calc(.667em + 2px)",
-						"bottom": "calc(.667em + 2px)",
-						"left": "calc(1.333em + 2px)",
-						"right": "calc(1.333em + 2px)"
+						"top": "0.667em",
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em"
 					}
 				},
 				"color": {
@@ -81,9 +81,6 @@
 					"lineHeight": 2
 				},
 				"hover": {
-					"border": {
-						"color": "transparent"
-					},
 					"color": {
 						"background": "#006ba1"
 					}
@@ -317,19 +314,8 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--button--spacing--padding--top)",
-						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
-						"left": "var(--wp--custom--button--spacing--padding--left)",
-						"right": "var(--wp--custom--button--spacing--padding--right)"
-					}
-				},
 				"border": {
-					"color": "var(--wp--custom--button--border--color)",
-					"radius": "var(--wp--custom--button--border--radius)",
-					"style": "var(--wp--custom--button--border--style)",
-					"width": "var(--wp--custom--button--border--width)"
+					"radius": "var(--wp--custom--button--border--radius)"
 				},
 				"color": {
 					"background": "var(--wp--custom--button--color--background)",

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -62,6 +62,15 @@
 					"style": "solid",
 					"width": "2px"
 				},
+				"color": {
+					"background": "var(--wp--custom--color--secondary)",
+					"text": "var(--wp--custom--color--background)"
+				},
+				"hover": {
+					"color": {
+						"background": "#006ba1"
+					}
+				},
 				"spacing": {
 					"padding": {
 						"top": "0.667em",
@@ -70,20 +79,11 @@
 						"right": "1.333em"
 					}
 				},
-				"color": {
-					"background": "var(--wp--custom--color--secondary)",
-					"text": "var(--wp--custom--color--background)"
-				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
-				},
-				"hover": {
-					"color": {
-						"background": "#006ba1"
-					}
 				}
 			},
 			"code": {

--- a/blank-canvas-blocks/experimental-theme.json
+++ b/blank-canvas-blocks/experimental-theme.json
@@ -58,17 +58,20 @@
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--button--color--text)",
-					"hoverColor": "transparent",
 					"radius": "4px",
 					"style": "solid",
-					"hoverStyle": "solid",
-					"width": "0",
-					"hoverWidth": "0"
+					"width": "0"
+				},
+				"spacing": {
+					"padding": {
+						"top": "calc(.667em + 2px)",
+						"bottom": "calc(.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
 				},
 				"color": {
 					"background": "var(--wp--custom--color--secondary)",
-					"hoverText": "var(--wp--custom--color--background)",
-					"hoverBackground": "#006ba1",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"typography": {
@@ -76,6 +79,14 @@
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
+				},
+				"hover": {
+					"border": {
+						"color": "transparent"
+					},
+					"color": {
+						"background": "#006ba1"
+					}
 				}
 			},
 			"code": {
@@ -306,6 +317,14 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--button--spacing--padding--top)",
+						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
+						"left": "var(--wp--custom--button--spacing--padding--left)",
+						"right": "var(--wp--custom--button--spacing--padding--right)"
+					}
+				},
 				"border": {
 					"color": "var(--wp--custom--button--border--color)",
 					"radius": "var(--wp--custom--button--border--radius)",

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -4,25 +4,45 @@
 
 // NOTE: These remain for the styling of buttons that are NOT blocks and is used elsewhere.  This can be removed when those no longer exist.
 @mixin button-main-styles {
+	@include button-padding-styles;
+	@include button-typography-styles;
+	@include button-color-styles;
+	border-radius: var(--wp--custom--button--border--radius);
+}
+
+@mixin button-color-styles {
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	svg {
+		fill: var(--wp--custom--button--color--text);
+	}
+}
+
+@mixin button-padding-styles {
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width) );
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width) );
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width) );
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width) );
+}
+
+@mixin button-typography-styles {
  	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
+}
+
+@mixin button-border-styles {
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
 	padding-top: var(--wp--custom--button--spacing--padding--top);
 	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
 	padding-left: var(--wp--custom--button--spacing--padding--left);
 	padding-right: var(--wp--custom--button--spacing--padding--right);
-	border-color: var(--wp--custom--button--border--color);
-	border-width: var(--wp--custom--button--border--width);
-	border-radius: var(--wp--custom--button--border--radius);
-	border-style: var(--wp--custom--button--border--style);
-	svg {
-		fill: var(--wp--custom--button--color--text);
-	}
 }
+
 
 // NOTE: These remain for the hover styling of blocks.  This can be removed when the button block has configurable hover states.
 @mixin button-hover-styles {
@@ -30,25 +50,26 @@
 		&:hover,
 		&:focus,
 		&.has-focus {
- 			font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
-			font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
-			font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
-			line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
-			color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-			background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
-			padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
-			padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
-			padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
-			padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
-			border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
-			border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
-			border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
-			border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
-			svg {
-				fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
-			}
+			--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+			--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+			border-color: var(--wp--custom--button--border--color);
+			@include button-color-styles;
 		}
 	}
+		&:hover,
+		&:focus,
+		&.has-focus {
+			--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+			--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+			--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+			--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+			--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+ 			--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+			--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+			--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+			@include button-typography-styles;
+		}
 }
 
 /**
@@ -58,7 +79,17 @@
 	&.wp-block-button__link,
 	.wp-block-button__link {
 		@include button-hover-styles;
-		text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
+		@include button-main-styles;
+	}
+	&.is-style-outline {
+		&.wp-block-button__link,
+		.wp-block-button__link {
+			--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+			--wp--custom--button--color--background : transparent;
+			@include button-border-styles;
+			@include button-hover-styles;
+			@include button-color-styles;
+		}
 	}
 }
 

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -29,7 +29,7 @@
 }
 
 @mixin button-typography-styles {
- 	font-weight: var(--wp--custom--button--typography--font-weight);
+	font-weight: var(--wp--custom--button--typography--font-weight);
 	font-family: var(--wp--custom--button--typography--font-family);
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
@@ -93,7 +93,7 @@
 		&.wp-block-button__link,
 		.wp-block-button__link {
 			--wp--custom--button--color--text: var(--wp--custom--button--border--color);
-			--wp--custom--button--color--background : transparent;
+			--wp--custom--button--color--background: transparent;
 			@include button-border-styles;
 			@include button-hover-styles;
 			@include button-color-styles;

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -11,6 +11,7 @@
 }
 
 @mixin button-color-styles {
+	opacity: 1;
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border-color: var(--wp--custom--button--border--color);

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -13,11 +13,14 @@
 @mixin button-color-styles {
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
 	svg {
 		fill: var(--wp--custom--button--color--text);
 	}
 }
 
+//standard Button padding.  Account for desired padding size and the size of the border width (so that the total height of
+//standard and outline buttons are equal.
 @mixin button-padding-styles {
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width) );
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width) );
@@ -33,6 +36,7 @@
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
 }
 
+//apply outline styles. apply padding that does NOT account for border width (as the border width is applied here).
 @mixin button-border-styles {
 	border-style: var(--wp--custom--button--border--style);
 	border-color: currentColor;
@@ -45,31 +49,35 @@
 
 
 // NOTE: These remain for the hover styling of blocks.  This can be removed when the button block has configurable hover states.
+// The mechanism below ONLY CHANGES CSS VARIABLES that are already applied to properties (above)
 @mixin button-hover-styles {
+	//The following changes should ONLY be changed if the user has NOT set a custom color
 	&:not(.has-background):not(.has-text-color) {
 		&:hover,
 		&:focus,
 		&.has-focus {
+			//change the color variables to the hover equivalent
 			--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 			--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-			border-color: var(--wp--custom--button--border--color);
+			--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
 			@include button-color-styles;
 		}
 	}
-		&:hover,
-		&:focus,
-		&.has-focus {
-			--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
-			--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
-			--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
-			--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
-			--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
- 			--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
-			--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
-			--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
-			--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
-			@include button-typography-styles;
-		}
+	//The following styles can ALWAYS be changed, even if the user has set a custom color.
+	&:hover,
+	&:focus,
+	&.has-focus {
+		--wp--custom--button--border--radius: var(--wp--custom--button--hover--border--radius);
+		--wp--custom--button--spacing--padding--top: var(--wp--custom--button--hover--spacing--padding--top);
+		--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--hover--spacing--padding--bottom);
+		--wp--custom--button--spacing--padding--left: var(--wp--custom--button--hover--spacing--padding--left);
+		--wp--custom--button--spacing--padding--right: var(--wp--custom--button--hover--spacing--padding--right);
+ 		--wp--custom--button--typography--font-weight: var(--wp--custom--button--hover--typography--font-weight)
+		--wp--custom--button--typography--font-family: var(--wp--custom--button--hover--typography--font-family);
+		--wp--custom--button--typography--font-size: var(--wp--custom--button--hover--typography--font-size);
+		--wp--custom--button--typography--line-height: var(--wp--custom--button--hover--typography--line-height);
+		@include button-typography-styles;
+	}
 }
 
 /**

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -11,7 +11,14 @@
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
-	padding: calc(.667em + 2px) calc(1.333em + 2px); //The padding found on an unmodified Button Block
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	border-color: var(--wp--custom--button--border--color);
+	border-width: var(--wp--custom--button--border--width);
+	border-radius: var(--wp--custom--button--border--radius);
+	border-style: var(--wp--custom--button--border--style);
 	svg {
 		fill: var(--wp--custom--button--color--text);
 	}
@@ -23,14 +30,22 @@
 		&:hover,
 		&:focus,
 		&.has-focus {
-			color: var(--wp--custom--button--color--hover-text);
-			background-color: var(--wp--custom--button--color--hover-background);
-			border-color: var(--wp--custom--button--border--hover-color);
-			border-style: var(--wp--custom--button--border--hover-style);
-			border-width: var(--wp--custom--button--border--hover-width);
-			padding: calc(.667em + 2px - var(--wp--custom--button--border--hover-width)) calc(1.333em + 2px - var(--wp--custom--button--border--hover-width)); //The padding found on an unmodified Button Block
+ 			font-weight: var(--wp--custom--button--hover--typography--font-weight, var(--wp--custom--button--typography--font-weight));
+			font-family: var(--wp--custom--button--hover--typography--font-family, var(--wp--custom--button--typography--font-family));
+			font-size: var(--wp--custom--button--hover--typography--font-size, var(--wp--custom--button--typography--font-size));
+			line-height: var(--wp--custom--button--hover--typography--line-height, var(--wp--custom--button--typography--line-height));
+			color: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
+			background-color: var(--wp--custom--button--hover--color--background, var(--wp--custom--button--color--background));
+			padding-top: var(--wp--custom--button--hover--spacing--padding--top, var(--wp--custom--button--spacing--padding--top));
+			padding-bottom: var(--wp--custom--button--hover--spacing--padding--bottom, var(--wp--custom--button--spacing--padding--bottom));
+			padding-left: var(--wp--custom--button--hover--spacing--padding--left, var(--wp--custom--button--spacing--padding--left));
+			padding-right: var(--wp--custom--button--hover--spacing--padding--right, var(--wp--custom--button--spacing--padding--right));
+			border-color: var(--wp--custom--button--hover--border--color, var(--wp--custom--button--border--color));
+			border-width: var(--wp--custom--button--hover--border--width, var(--wp--custom--button--border--width));
+			border-radius: var(--wp--custom--button--hover--border--radius, var(--wp--custom--button--border--radius));
+			border-style: var(--wp--custom--button--hover--border--style, var(--wp--custom--button--border--style));
 			svg {
-				fill: var(--wp--custom--button--color--hover-text);
+				fill: var(--wp--custom--button--hover--color--text, var(--wp--custom--button--color--text));
 			}
 		}
 	}

--- a/blank-canvas-blocks/sass/blocks/_button.scss
+++ b/blank-canvas-blocks/sass/blocks/_button.scss
@@ -23,6 +23,7 @@
 //standard Button padding.  Account for desired padding size and the size of the border width (so that the total height of
 //standard and outline buttons are equal.
 @mixin button-padding-styles {
+	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width) );
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width) );
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width) );

--- a/blank-canvas-blocks/sass/blocks/_post-comments.scss
+++ b/blank-canvas-blocks/sass/blocks/_post-comments.scss
@@ -14,12 +14,6 @@
 		@include button-hover-styles;
 	}
 
-	input[type="submit"] {
-		border-color: var(--wp--custom--button--border--color);
-		border-style: var(--wp--custom--button--border--style);
-		border-width: var(--wp--custom--button--border--width);
-	}
-
 	.reply a {
 		display: inline-block;
 	}

--- a/mayland-blocks/child-experimental-theme.json
+++ b/mayland-blocks/child-experimental-theme.json
@@ -50,8 +50,10 @@
 		},
 		"custom": {
 			"button": {
-				"color": {
-					"hoverBackground": "var(--wp--custom--color--tertiary)"
+				"hover": {
+					"color": {
+						"background": "var(--wp--custom--color--tertiary)"
+					}
 				}
 			},
 			"color": {

--- a/mayland-blocks/child-experimental-theme.json
+++ b/mayland-blocks/child-experimental-theme.json
@@ -50,10 +50,32 @@
 		},
 		"custom": {
 			"button": {
+				"border": {
+					"radius": "5px"
+				},
+				"color": {
+					"text": "var(--wp--custom--color--background)",
+					"background": "var(--wp--custom--color--foreground)"
+				},
 				"hover": {
 					"color": {
 						"background": "var(--wp--custom--color--tertiary)"
+					},
+					"border": {
+						"color": "var(--wp--custom--color--tertiary)"
 					}
+				},
+				"spacing": {
+					"padding": {
+						"top": "4px",
+						"bottom": "4px",
+						"left": "14px",
+						"right": "14px"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": 600
 				}
 			},
 			"color": {

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -62,31 +62,34 @@
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--color--foreground)",
-					"radius": "4px",
+					"radius": "5px",
 					"style": "solid",
 					"width": "2px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)",
+					"background": "var(--wp--custom--color--foreground)",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"hover": {
 					"color": {
 						"background": "var(--wp--custom--color--tertiary)"
+					},
+					"border": {
+						"color": "var(--wp--custom--color--tertiary)"
 					}
 				},
 				"spacing": {
 					"padding": {
-						"top": "0.667em",
-						"bottom": "0.667em",
-						"left": "1.333em",
-						"right": "1.333em"
+						"top": "4px",
+						"bottom": "4px",
+						"left": "14px",
+						"right": "14px"
 					}
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": "normal",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": 600,
 					"lineHeight": 2
 				}
 			},

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -66,6 +66,15 @@
 					"style": "solid",
 					"width": "2px"
 				},
+				"color": {
+					"background": "var(--wp--custom--color--secondary)",
+					"text": "var(--wp--custom--color--background)"
+				},
+				"hover": {
+					"color": {
+						"background": "var(--wp--custom--color--tertiary)"
+					}
+				},
 				"spacing": {
 					"padding": {
 						"top": "0.667em",
@@ -74,20 +83,11 @@
 						"right": "1.333em"
 					}
 				},
-				"color": {
-					"background": "var(--wp--custom--color--secondary)",
-					"text": "var(--wp--custom--color--background)"
-				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
-				},
-				"hover": {
-					"color": {
-						"background": "var(--wp--custom--color--tertiary)"
-					}
 				}
 			},
 			"code": {

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -69,10 +69,16 @@
 					"width": "0",
 					"hoverWidth": "0"
 				},
+				"spacing": {
+					"padding": {
+						"top": "calc(.667em + 2px)",
+						"bottom": "calc(.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
+				},
 				"color": {
 					"background": "var(--wp--custom--color--secondary)",
-					"hoverText": "var(--wp--custom--color--background)",
-					"hoverBackground": "var(--wp--custom--color--tertiary)",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"typography": {
@@ -80,6 +86,14 @@
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
+				},
+				"hover": {
+					"border": {
+						"color": "transparent"
+					},
+					"color": {
+						"background": "var(--wp--custom--color--tertiary)"
+					}
 				}
 			},
 			"code": {
@@ -332,6 +346,14 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--button--spacing--padding--top)",
+						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
+						"left": "var(--wp--custom--button--spacing--padding--left)",
+						"right": "var(--wp--custom--button--spacing--padding--right)"
+					}
+				},
 				"border": {
 					"color": "var(--wp--custom--button--border--color)",
 					"radius": "var(--wp--custom--button--border--radius)",

--- a/mayland-blocks/experimental-theme.json
+++ b/mayland-blocks/experimental-theme.json
@@ -61,20 +61,17 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--button--color--text)",
-					"hoverColor": "transparent",
+					"color": "var(--wp--custom--color--foreground)",
 					"radius": "4px",
 					"style": "solid",
-					"hoverStyle": "solid",
-					"width": "0",
-					"hoverWidth": "0"
+					"width": "2px"
 				},
 				"spacing": {
 					"padding": {
-						"top": "calc(.667em + 2px)",
-						"bottom": "calc(.667em + 2px)",
-						"left": "calc(1.333em + 2px)",
-						"right": "calc(1.333em + 2px)"
+						"top": "0.667em",
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em"
 					}
 				},
 				"color": {
@@ -88,9 +85,6 @@
 					"lineHeight": 2
 				},
 				"hover": {
-					"border": {
-						"color": "transparent"
-					},
 					"color": {
 						"background": "var(--wp--custom--color--tertiary)"
 					}
@@ -346,19 +340,8 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--button--spacing--padding--top)",
-						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
-						"left": "var(--wp--custom--button--spacing--padding--left)",
-						"right": "var(--wp--custom--button--spacing--padding--right)"
-					}
-				},
 				"border": {
-					"color": "var(--wp--custom--button--border--color)",
-					"radius": "var(--wp--custom--button--border--radius)",
-					"style": "var(--wp--custom--button--border--style)",
-					"width": "var(--wp--custom--button--border--width)"
+					"radius": "var(--wp--custom--button--border--radius)"
 				},
 				"color": {
 					"background": "var(--wp--custom--color--primary)",

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -172,9 +172,9 @@ ul ul {
 	color: var(--wp--custom--color--primary);
 }
 
-.wp-block-post-comments .reply a {
-	font-size: 1em;
-	line-height: 1.2;
+.wp-block-post-comments .reply a, .wp-block-post-comments .reply a:hover {
+	--wp--custom--button--typography--font-size: 1em;
+	--wp--custom--button--typography--line-height: 1.2;
 }
 
 .wp-block-post-comments form {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -77,6 +77,16 @@
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 }
 
+.wp-block-post-comments input[type="submit"]:hover, .wp-block-post-comments input[type="submit"]:focus, .wp-block-post-comments input[type="submit"].has-focus, .wp-block-post-comments .reply a:hover, .wp-block-post-comments .reply a:focus, .wp-block-post-comments .reply a.has-focus {
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+}
+
 .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -41,19 +41,25 @@
 	text-align: right;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link,
-.wp-block-button.is-style-outline .wp-block-button__link {
-	border: 2px solid currentColor;
+.wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	border: none;
-	color: var(--wp--custom--color--background);
-	background: var(--wp--custom--color--primary);
-	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+.wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	color: var(--wp--custom--button--color--background);
+	background-color: var(--wp--custom--button--color--text);
 }
 
 .wp-block-calendar table caption {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -172,9 +172,9 @@ ul ul {
 	color: var(--wp--custom--color--primary);
 }
 
-.wp-block-post-comments .reply a, .wp-block-post-comments .reply a:hover {
-	--wp--custom--button--typography--font-size: 1em;
-	--wp--custom--button--typography--line-height: 1.2;
+.wp-block-post-comments .reply a, .wp-block-post-comments .reply a:hover, .wp-block-post-comments .reply a:focus, .wp-block-post-comments .reply a:active {
+	font-size: 1em;
+	line-height: 1.2;
 }
 
 .wp-block-post-comments form {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -54,6 +54,29 @@
 	padding-right: var(--wp--custom--button--spacing--padding--right);
 }
 
+.wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus,
+.wp-block-search .wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button.has-focus {
+	border-style: var(--wp--custom--button--border--style);
+	border-color: currentColor;
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+}
+
 .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -33,8 +33,9 @@
 		"custom": {
 			"button": {
 				"border": {
-					"color": "transparent",
-					"radius": "0"
+					"color": "var(--wp--custom--color--foreground)",
+					"radius": "0",
+					"width": "3px"
 				},
 				"color": {
 					"background": "var(--wp--custom--color--foreground)",
@@ -45,21 +46,9 @@
 					"fontWeight": "700"
 				},
 				"hover": {
-					"spacing": {
-						"padding": {
-							"top": "0.667em",
-							"bottom": "0.667em",
-							"left": "1.333em",
-							"right": "1.333em"
-						}
-					},
 					"color": {
 						"text": "var(--wp--custom--color--foreground)",
-						"background": "transparent"
-					},
-					"border": {
-						"color": "var(--wp--custom--color--foreground)",
-						"width": "2px"
+						"background": "var(--wp--custom--color--background)"
 					}
 				}
 			},

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -41,15 +41,15 @@
 					"background": "var(--wp--custom--color--foreground)",
 					"text": "var(--wp--custom--color--background)"
 				},
-				"typography": {
-					"fontSize": "20px",
-					"fontWeight": "700"
-				},
 				"hover": {
 					"color": {
 						"text": "var(--wp--custom--color--foreground)",
 						"background": "var(--wp--custom--color--background)"
 					}
+				},
+				"typography": {
+					"fontSize": "20px",
+					"fontWeight": "700"
 				}
 			},
 			"color": {

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -34,19 +34,33 @@
 			"button": {
 				"border": {
 					"color": "transparent",
-					"hoverColor": "var(--wp--custom--color--foreground)",
-					"radius": "0",
-					"hoverWidth": "2px"
+					"radius": "0"
 				},
 				"color": {
 					"background": "var(--wp--custom--color--foreground)",
-					"hoverText": "var(--wp--custom--color--foreground)",
-					"hoverBackground": "transparent",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"typography": {
 					"fontSize": "20px",
 					"fontWeight": "700"
+				},
+				"hover": {
+					"spacing": {
+						"padding": {
+							"top": "0.667em",
+							"bottom": "0.667em",
+							"left": "1.333em",
+							"right": "1.333em"
+						}
+					},
+					"color": {
+						"text": "var(--wp--custom--color--foreground)",
+						"background": "transparent"
+					},
+					"border": {
+						"color": "var(--wp--custom--color--foreground)",
+						"width": "2px"
+					}
 				}
 			},
 			"color": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -58,17 +58,20 @@
 			"button": {
 				"border": {
 					"color": "transparent",
-					"hoverColor": "var(--wp--custom--color--foreground)",
 					"radius": "0",
 					"style": "solid",
-					"hoverStyle": "solid",
-					"width": "0",
-					"hoverWidth": "2px"
+					"width": "0"
+				},
+				"spacing": {
+					"padding": {
+						"top": "calc(.667em + 2px)",
+						"bottom": "calc(.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
 				},
 				"color": {
 					"background": "var(--wp--custom--color--foreground)",
-					"hoverText": "var(--wp--custom--color--foreground)",
-					"hoverBackground": "transparent",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"typography": {
@@ -76,6 +79,24 @@
 					"fontSize": "20px",
 					"fontWeight": "700",
 					"lineHeight": 2
+				},
+				"hover": {
+					"border": {
+						"color": "var(--wp--custom--color--foreground)",
+						"width": "2px"
+					},
+					"color": {
+						"background": "transparent",
+						"text": "var(--wp--custom--color--foreground)"
+					},
+					"spacing": {
+						"padding": {
+							"top": "0.667em",
+							"bottom": "0.667em",
+							"left": "1.333em",
+							"right": "1.333em"
+						}
+					}
 				}
 			},
 			"code": {
@@ -335,6 +356,14 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--button--spacing--padding--top)",
+						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
+						"left": "var(--wp--custom--button--spacing--padding--left)",
+						"right": "var(--wp--custom--button--spacing--padding--right)"
+					}
+				},
 				"border": {
 					"color": "var(--wp--custom--button--border--color)",
 					"radius": "var(--wp--custom--button--border--radius)",

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -57,17 +57,17 @@
 			},
 			"button": {
 				"border": {
-					"color": "transparent",
+					"color": "var(--wp--custom--color--foreground)",
 					"radius": "0",
 					"style": "solid",
-					"width": "0"
+					"width": "3px"
 				},
 				"spacing": {
 					"padding": {
-						"top": "calc(.667em + 2px)",
-						"bottom": "calc(.667em + 2px)",
-						"left": "calc(1.333em + 2px)",
-						"right": "calc(1.333em + 2px)"
+						"top": "0.667em",
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em"
 					}
 				},
 				"color": {
@@ -81,21 +81,9 @@
 					"lineHeight": 2
 				},
 				"hover": {
-					"border": {
-						"color": "var(--wp--custom--color--foreground)",
-						"width": "2px"
-					},
 					"color": {
-						"background": "transparent",
+						"background": "var(--wp--custom--color--background)",
 						"text": "var(--wp--custom--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"top": "0.667em",
-							"bottom": "0.667em",
-							"left": "1.333em",
-							"right": "1.333em"
-						}
 					}
 				}
 			},
@@ -356,19 +344,8 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--button--spacing--padding--top)",
-						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
-						"left": "var(--wp--custom--button--spacing--padding--left)",
-						"right": "var(--wp--custom--button--spacing--padding--right)"
-					}
-				},
 				"border": {
-					"color": "var(--wp--custom--button--border--color)",
-					"radius": "var(--wp--custom--button--border--radius)",
-					"style": "var(--wp--custom--button--border--style)",
-					"width": "var(--wp--custom--button--border--width)"
+					"radius": "var(--wp--custom--button--border--radius)"
 				},
 				"color": {
 					"background": "var(--wp--custom--button--color--background)",

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -62,6 +62,16 @@
 					"style": "solid",
 					"width": "3px"
 				},
+				"color": {
+					"background": "var(--wp--custom--color--foreground)",
+					"text": "var(--wp--custom--color--background)"
+				},
+				"hover": {
+					"color": {
+						"background": "var(--wp--custom--color--background)",
+						"text": "var(--wp--custom--color--foreground)"
+					}
+				},
 				"spacing": {
 					"padding": {
 						"top": "0.667em",
@@ -70,21 +80,11 @@
 						"right": "1.333em"
 					}
 				},
-				"color": {
-					"background": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--background)"
-				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
 					"fontSize": "20px",
 					"fontWeight": "700",
 					"lineHeight": 2
-				},
-				"hover": {
-					"color": {
-						"background": "var(--wp--custom--color--background)",
-						"text": "var(--wp--custom--color--foreground)"
-					}
 				}
 			},
 			"code": {

--- a/quadrat/sass/blocks/_buttons.scss
+++ b/quadrat/sass/blocks/_buttons.scss
@@ -1,15 +1,33 @@
-.wp-block-button.is-style-outline {
-	&.wp-block-button__link,
-	.wp-block-button__link {
-		border: 2px solid currentColor; // The priority of global styles in the post editor overrides the outline style variation, so this line is needed.
+.wp-block-button {
+ 	&.wp-block-button__link,
+ 	.wp-block-button__link {
 		&:not(.has-background):not(.has-text-color) {
 			&:hover,
 			&:focus,
 			&.has-focus {
-				border: none;
-				color: var(--wp--custom--color--background);
-				background: var(--wp--custom--color--primary);
-				padding: calc(0.667em + 2px) calc(1.333em + 2px);
+				border-style: var(--wp--custom--button--border--style);
+				border-color: currentColor;
+				border-width: var(--wp--custom--button--border--width);
+				padding-top: var(--wp--custom--button--spacing--padding--top);
+				padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+				padding-left: var(--wp--custom--button--spacing--padding--left);
+				padding-right: var(--wp--custom--button--spacing--padding--right);
+			}
+		}
+	}
+}
+
+//NOTE: Double-classed to raise specificity above parent theme's outline hover styles
+//as an alternative to !important.  Only needed for the editor.
+.wp-block-button.wp-block-button.is-style-outline {
+ 	&.wp-block-button__link,
+ 	.wp-block-button__link {
+		&:not(.has-background):not(.has-text-color) {
+			&:hover,
+			&:focus,
+			&.has-focus {
+				color: var(--wp--custom--button--color--background);
+				background-color: var(--wp--custom--button--color--text);
 			}
 		}
 	}

--- a/quadrat/sass/blocks/_buttons.scss
+++ b/quadrat/sass/blocks/_buttons.scss
@@ -30,6 +30,12 @@
 	}
 }
 
+.wp-block-post-comments {
+	input[type="submit"], .reply a {
+		@include quadrat_button_hover_styles;
+	}
+}
+
 //NOTE: Double-classed to raise specificity above parent theme's outline hover styles
 //as an alternative to !important.  Only needed for the editor.
 .wp-block-button.wp-block-button.is-style-outline {

--- a/quadrat/sass/blocks/_buttons.scss
+++ b/quadrat/sass/blocks/_buttons.scss
@@ -1,19 +1,32 @@
+@mixin quadrat_button_hover_styles {
+	&:hover,
+	&:focus,
+	&.has-focus {
+		border-style: var(--wp--custom--button--border--style);
+		border-color: currentColor;
+		border-width: var(--wp--custom--button--border--width);
+		padding-top: var(--wp--custom--button--spacing--padding--top);
+		padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+		padding-left: var(--wp--custom--button--spacing--padding--left);
+		padding-right: var(--wp--custom--button--spacing--padding--right);
+	}
+}
 .wp-block-button {
  	&.wp-block-button__link,
  	.wp-block-button__link {
 		&:not(.has-background):not(.has-text-color) {
-			&:hover,
-			&:focus,
-			&.has-focus {
-				border-style: var(--wp--custom--button--border--style);
-				border-color: currentColor;
-				border-width: var(--wp--custom--button--border--width);
-				padding-top: var(--wp--custom--button--spacing--padding--top);
-				padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-				padding-left: var(--wp--custom--button--spacing--padding--left);
-				padding-right: var(--wp--custom--button--spacing--padding--right);
-			}
+			@include quadrat_button_hover_styles;
 		}
+	}
+}
+.wp-block-file .wp-block-file__button {
+	@include quadrat_button_hover_styles;
+}	
+
+.wp-block-search {
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
+	.wp-block-search__button {
+		@include quadrat_button_hover_styles;
 	}
 }
 

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -1,9 +1,14 @@
 // @import '../../../blank-canvas-blocks/sass/blocks/button';
 
 .wp-block-post-comments {
-	.reply a, .reply a:hover {
-		--wp--custom--button--typography--font-size: 1em;
-		--wp--custom--button--typography--line-height: 1.2;
+	.reply a {
+		& ,
+		&:hover,
+		&:focus,
+		&:active {
+			font-size: 1em;
+			line-height: 1.2;
+		}
 	}
 
 	form {

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -1,5 +1,3 @@
-// @import '../../../blank-canvas-blocks/sass/blocks/button';
-
 .wp-block-post-comments {
 	.reply a {
 		& ,

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -1,7 +1,9 @@
+// @import '../../../blank-canvas-blocks/sass/blocks/button';
+
 .wp-block-post-comments {
-	.reply a {
-		font-size: 1em;
-		line-height: 1.2;
+	.reply a, .reply a:hover {
+		--wp--custom--button--typography--font-size: 1em;
+		--wp--custom--button--typography--line-height: 1.2;
 	}
 
 	form {

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -148,17 +148,17 @@
 /**
  * Links in Content
  */
-.is-root-container a:not(.wp-block-button__link),
-.wp-block-post-content a:not(.wp-block-button__link) {
+.is-root-container a:not(.wp-block-button__link):not([download]),
+.wp-block-post-content a:not(.wp-block-button__link):not([download]) {
 	color: var(--wp--custom--color--primary);
 	text-decoration-color: var(--wp--style--color--link);
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.2em;
 }
 
-.is-root-container a:not(.wp-block-button__link):focus, .is-root-container a:not(.wp-block-button__link):hover,
-.wp-block-post-content a:not(.wp-block-button__link):focus,
-.wp-block-post-content a:not(.wp-block-button__link):hover {
+.is-root-container a:not(.wp-block-button__link):not([download]):focus, .is-root-container a:not(.wp-block-button__link):not([download]):hover,
+.wp-block-post-content a:not(.wp-block-button__link):not([download]):focus,
+.wp-block-post-content a:not(.wp-block-button__link):not([download]):hover {
 	color: var(--wp--style--color--link);
 }
 

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -148,17 +148,17 @@
 /**
  * Links in Content
  */
-.is-root-container a,
-.wp-block-post-content a {
+.is-root-container a:not(.wp-block-button__link),
+.wp-block-post-content a:not(.wp-block-button__link) {
 	color: var(--wp--custom--color--primary);
 	text-decoration-color: var(--wp--style--color--link);
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.2em;
 }
 
-.is-root-container a:focus, .is-root-container a:hover,
-.wp-block-post-content a:focus,
-.wp-block-post-content a:hover {
+.is-root-container a:not(.wp-block-button__link):focus, .is-root-container a:not(.wp-block-button__link):hover,
+.wp-block-post-content a:not(.wp-block-button__link):focus,
+.wp-block-post-content a:not(.wp-block-button__link):hover {
 	color: var(--wp--style--color--link);
 }
 

--- a/seedlet-blocks/child-experimental-theme.json
+++ b/seedlet-blocks/child-experimental-theme.json
@@ -89,9 +89,15 @@
 		},
 		"custom": {
 			"button": {
+				"border": {
+					"color": "var(--wp--custom--color--secondary)"
+				},
 				"hover": {
 					"color": {
 						"background": "#336D58"
+					},
+					"border": {
+						"color": "#336D58"
 					}
 				}
 			},

--- a/seedlet-blocks/child-experimental-theme.json
+++ b/seedlet-blocks/child-experimental-theme.json
@@ -89,8 +89,10 @@
 		},
 		"custom": {
 			"button": {
-				"color": {
-					"hoverBackground": "#336D58"
+				"hover": {
+					"color": {
+						"background": "#336D58"
+					}
 				}
 			},
 			"color": {

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -99,17 +99,17 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--button--color--text)",
+					"color": "var(--wp--custom--color--foreground)",
 					"radius": "4px",
 					"style": "solid",
-					"width": "0"
+					"width": "2px"
 				},
 				"spacing": {
 					"padding": {
-						"top": "calc(.667em + 2px)",
-						"bottom": "calc(.667em + 2px)",
-						"left": "calc(1.333em + 2px)",
-						"right": "calc(1.333em + 2px)"
+						"top": "0.667em",
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em"
 					}
 				},
 				"color": {
@@ -123,9 +123,6 @@
 					"lineHeight": 2
 				},
 				"hover": {
-					"border": {
-						"color": "transparent"
-					},
 					"color": {
 						"background": "#336D58"
 					}
@@ -373,19 +370,8 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--button--spacing--padding--top)",
-						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
-						"left": "var(--wp--custom--button--spacing--padding--left)",
-						"right": "var(--wp--custom--button--spacing--padding--right)"
-					}
-				},
 				"border": {
-					"color": "var(--wp--custom--button--border--color)",
-					"radius": "var(--wp--custom--button--border--radius)",
-					"style": "var(--wp--custom--button--border--style)",
-					"width": "var(--wp--custom--button--border--width)"
+					"radius": "var(--wp--custom--button--border--radius)"
 				},
 				"color": {
 					"background": "var(--wp--custom--button--color--background)",

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -100,17 +100,20 @@
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--button--color--text)",
-					"hoverColor": "transparent",
 					"radius": "4px",
 					"style": "solid",
-					"hoverStyle": "solid",
-					"width": "0",
-					"hoverWidth": "0"
+					"width": "0"
+				},
+				"spacing": {
+					"padding": {
+						"top": "calc(.667em + 2px)",
+						"bottom": "calc(.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
 				},
 				"color": {
 					"background": "var(--wp--custom--color--secondary)",
-					"hoverText": "var(--wp--custom--color--background)",
-					"hoverBackground": "#336D58",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"typography": {
@@ -118,6 +121,14 @@
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
+				},
+				"hover": {
+					"border": {
+						"color": "transparent"
+					},
+					"color": {
+						"background": "#336D58"
+					}
 				}
 			},
 			"code": {
@@ -362,6 +373,14 @@
 	"styles": {
 		"blocks": {
 			"core/button": {
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--button--spacing--padding--top)",
+						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
+						"left": "var(--wp--custom--button--spacing--padding--left)",
+						"right": "var(--wp--custom--button--spacing--padding--right)"
+					}
+				},
 				"border": {
 					"color": "var(--wp--custom--button--border--color)",
 					"radius": "var(--wp--custom--button--border--radius)",

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -104,6 +104,15 @@
 					"style": "solid",
 					"width": "2px"
 				},
+				"color": {
+					"background": "var(--wp--custom--color--secondary)",
+					"text": "var(--wp--custom--color--background)"
+				},
+				"hover": {
+					"color": {
+						"background": "#336D58"
+					}
+				},
 				"spacing": {
 					"padding": {
 						"top": "0.667em",
@@ -112,20 +121,11 @@
 						"right": "1.333em"
 					}
 				},
-				"color": {
-					"background": "var(--wp--custom--color--secondary)",
-					"text": "var(--wp--custom--color--background)"
-				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--base)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
-				},
-				"hover": {
-					"color": {
-						"background": "#336D58"
-					}
 				}
 			},
 			"code": {

--- a/seedlet-blocks/experimental-theme.json
+++ b/seedlet-blocks/experimental-theme.json
@@ -99,7 +99,7 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--color--foreground)",
+					"color": "var(--wp--custom--color--secondary)",
 					"radius": "4px",
 					"style": "solid",
 					"width": "2px"
@@ -111,6 +111,9 @@
 				"hover": {
 					"color": {
 						"background": "#336D58"
+					},
+					"border": {
+						"color": "#336D58"
 					}
 				},
 				"spacing": {

--- a/seedlet-blocks/sass/blocks/_links.scss
+++ b/seedlet-blocks/sass/blocks/_links.scss
@@ -15,7 +15,7 @@
  */
 .is-root-container, // Editor class hack.
 .wp-block-post-content {
-	a:not(.wp-block-button__link) {
+	a:not(.wp-block-button__link):not([download]) {
 		color: var(--wp--custom--color--primary);
 		text-decoration-color: var(--wp--style--color--link);
 		text-decoration-thickness: 1px;

--- a/seedlet-blocks/sass/blocks/_links.scss
+++ b/seedlet-blocks/sass/blocks/_links.scss
@@ -15,7 +15,7 @@
  */
 .is-root-container, // Editor class hack.
 .wp-block-post-content {
-	a {
+	a:not(.wp-block-button__link) {
 		color: var(--wp--custom--color--primary);
 		text-decoration-color: var(--wp--style--color--link);
 		text-decoration-thickness: 1px;


### PR DESCRIPTION
A recent change for Quadrat caused non-quadrat button styles to break. Padding values for hover styles were lost.  The below is the hover state of a button in Blank-Canvas-Blocks.

![image](https://user-images.githubusercontent.com/146530/118701433-b78e1a00-b7e1-11eb-814e-6ce59277931d.png)

While looking into this issue I became very disillusioned by the mechanism by which BCB was handling the styles for the button hover state and took another stab at that.

This is the result.

#### Changes proposed in this Pull Request:

* Hover styles for the button are a mirror of all button styles, but housed in a "hover" object.  (I tried to make it ':hover' but a css variable like `--wp--button--:hover--color--text` didn't work out very well.) This definition was inspired by the recent "elements" addition to block styling.
* The default calculated padding value was set as the default button padding value and referenced by the button block styles.
* The button hover state styles reference the exact same styles as the button block if the --hover equivalent is absent.

Blank-Canvas-Blocks (of course), Seedlet-Blocks, Mayland-Blocks and Quadrat have been evaluated with this change.


