### PR TITLE
Quadrat: changed border radius to file button block

### DIFF
--- a/blank-canvas-blocks/assets/ponyfill.css
+++ b/blank-canvas-blocks/assets/ponyfill.css
@@ -633,6 +633,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
+	border-radius: var(--wp--custom--button--border--radius);
 	display: inline-block;
 }
 

--- a/blank-canvas-blocks/sass/blocks/_file.scss
+++ b/blank-canvas-blocks/sass/blocks/_file.scss
@@ -4,5 +4,6 @@
 .wp-block-file .wp-block-file__button {
 	@include button-main-styles;
 	@include button-hover-styles;
+	border-radius: var(--wp--custom--button--border--radius);
 	display: inline-block;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds border radius styles to the file button block to override gutenberg styles.

<img width="569" alt="Screenshot 2021-05-19 at 16 52 24" src="https://user-images.githubusercontent.com/3593343/118834858-c993b980-b8c2-11eb-9b26-0e2630f5cee2.png">

#### Related issue(s):

Fixes #3811
