### PR TITLE
Quadrat: fix mobile padding on query block

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -263,6 +263,12 @@ ul ul {
 	font-size: var(--wp--custom--heading--h3--font-size);
 }
 
+@media screen and (max-width: 704px) {
+	div[class^="wp-container-"] > .wp-block-query-loop {
+		padding: 0 var(--wp--custom--margin--horizontal);
+	}
+}
+
 .wp-block-query-pagination {
 	border-top: 1px solid var(--wp--custom--color--primary);
 	padding-top: 1.5em;

--- a/quadrat/sass/blocks/_query.scss
+++ b/quadrat/sass/blocks/_query.scss
@@ -3,3 +3,10 @@
 		font-size: var(--wp--custom--heading--h3--font-size);
 	}
 }
+
+// If a query block is a direct child of a container, it some padding on mobile
+div[class^="wp-container-"] > .wp-block-query-loop {
+	@media screen and ( max-width: 704px ){ // This is the default content width + padding
+		padding: 0 var(--wp--custom--margin--horizontal);
+	}
+}


### PR DESCRIPTION
This PR is an attempt at #3878.

![Kapture 2021-05-19 at 13 54 40](https://user-images.githubusercontent.com/5375500/118860787-a4865300-b890-11eb-9706-13698e735885.gif)

This is a prototype to demonstrate what I think the ideal behavior is, but I'm not sure about the approach using a media query. Do we think this is a use case Gutenberg alignment system should account for? If so, what kind of controls should be provided? 

