### PR TITLE
Quadrat: changed the hover effect of text links

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -358,12 +358,13 @@ a {
 	        text-decoration-line: underline;
 }
 
-a:hover {
+p a:hover {
+	text-decoration: none;
 	background: var(--wp--custom--color--primary);
 	color: var(--wp--custom--color--background);
 }
 
-a:active, a:focus {
+p a:active, p a:focus {
 	background: var(--wp--custom--color--secondary);
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -231,6 +231,16 @@ ul ul {
 	grid-area: form-submit;
 }
 
+.wp-block-post-comments .comment-body > p > a,
+.wp-block-post-comments .comment-edit-link {
+	text-decoration: underline;
+}
+
+.wp-block-post-comments .comment-body > p > a:hover,
+.wp-block-post-comments .comment-edit-link:hover {
+	text-decoration: none;
+}
+
 .wp-block-post-navigation-link {
 	border-top: 1px solid;
 	display: flex;
@@ -313,6 +323,10 @@ ul ul {
 	justify-self: center;
 }
 
+.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
+	text-decoration: underline;
+}
+
 @media (max-width: 479px) {
 	.wp-block-query-pagination .wp-block-query-pagination-numbers {
 		display: none;
@@ -353,19 +367,13 @@ ul ul {
 	padding: var(--wp--custom--margin--horizontal);
 }
 
-a {
+.wp-block-post-content p a {
 	-webkit-text-decoration-line: underline;
 	        text-decoration-line: underline;
 }
 
-p a:hover {
+.wp-block-post-content p a:hover {
 	text-decoration: none;
-	background: var(--wp--custom--color--primary);
-	color: var(--wp--custom--color--background);
-}
-
-p a:active, p a:focus {
-	background: var(--wp--custom--color--secondary);
 }
 
 .site-header {
@@ -413,10 +421,6 @@ p a:active, p a:focus {
 .site-header .wp-block-group .wp-block-navigation {
 	margin-left: auto;
 	padding-right: 0;
-}
-
-.site-header .wp-block-site-title a {
-	text-decoration: none;
 }
 
 .site-header:before {

--- a/quadrat/sass/_header.scss
+++ b/quadrat/sass/_header.scss
@@ -38,10 +38,6 @@
 			padding-right: 0;
 		}
 	}
-
-	.wp-block-site-title a {
-		text-decoration: none;
-	}
 	
 	&:before {
 		content: "";

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -88,4 +88,14 @@
 			grid-area: form-submit;
 		}
 	}
+
+	// Target certain links within post comments to use the underline treatment.
+	.comment-body > p > a,
+	.comment-edit-link {
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
 }

--- a/quadrat/sass/blocks/_query-navigation.scss
+++ b/quadrat/sass/blocks/_query-navigation.scss
@@ -39,6 +39,9 @@
 	.wp-block-query-pagination-numbers{
 		grid-area: numbers;
 		justify-self: center;
+		.current {
+			text-decoration: underline;
+		}
 		@include break-mobile-only(){
 			display: none;
 		}

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,19 +1,7 @@
-a {
+.wp-block-post-content p a {
 	text-decoration-line: underline;
-}
 
-
-p {
-	a {	
-		&:hover {
-			text-decoration: none;
-			background: var(--wp--custom--color--primary);
-			color: var(--wp--custom--color--background);
-		}
-	
-		&:active,
-		&:focus {
-			background: var(--wp--custom--color--secondary);
-		}
+	&:hover {
+		text-decoration: none;
 	}
 }

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,13 +1,19 @@
 a {
 	text-decoration-line: underline;
+}
 
-	&:hover {
-		background: var(--wp--custom--color--primary);
-		color: var(--wp--custom--color--background);
-	}
 
-	&:active,
-	&:focus {
-		background: var(--wp--custom--color--secondary);
+p {
+	a {	
+		&:hover {
+			text-decoration: none;
+			background: var(--wp--custom--color--primary);
+			color: var(--wp--custom--color--background);
+		}
+	
+		&:active,
+		&:focus {
+			background: var(--wp--custom--color--secondary);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Following the design guidelines of #3782, this PR changes how links work on hover, having only links inside paragraph tags have the background change (without underline on them). I have a few questions about this:

- What happens to the hover effects of the rest of the links? right now they have none besides the cursor effect.
- Is it ok that we only target links inside paragraphs? or should we target post-content instead? Other small links like pagination blocks etc that are not paragraphs and are not part of the post content will not have the background hover effect either.

![Screen Capture on 2021-05-20 at 14-42-52](https://user-images.githubusercontent.com/3593343/118981327-839a2c80-b97a-11eb-8d4c-97ced1e8638b.gif)
![Screen Capture on 2021-05-20 at 14-44-33](https://user-images.githubusercontent.com/3593343/118981335-8563f000-b97a-11eb-98d8-cfdbaeb47260.gif)


#### Related issue(s):

Closes #3782
