### PR TITLE
Quadrat: fix single post title when a custom logo is present

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -457,7 +457,7 @@ a:active, a:focus {
 
 @media (max-width: 479px) {
 	.post-meta {
-		padding-top: 120px !important;
+		padding-top: 0 !important;
 	}
 }
 
@@ -506,6 +506,9 @@ a:active, a:focus {
 		bottom: 1.5rem;
 		left: 50%;
 	}
+	.post-header .wp-block-spacer {
+		display: none;
+	}
 }
 
 @media (max-width: 479px) {
@@ -514,6 +517,9 @@ a:active, a:focus {
 	}
 	.single.admin-bar .site-header {
 		top: 46px;
+	}
+	.single.wp-custom-logo .post-header {
+		padding-top: 150px !important;
 	}
 	.single .site-header {
 		position: absolute;

--- a/quadrat/sass/_meta.scss
+++ b/quadrat/sass/_meta.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	justify-content: center;
 	@include break-mobile-only() {
-		padding-top: 120px !important;
+		padding-top: 0 !important;
 	}
 
 	.wp-block-post-date::before {

--- a/quadrat/sass/_post-header.scss
+++ b/quadrat/sass/_post-header.scss
@@ -17,6 +17,10 @@
 			bottom: 1.5rem;
 			left: 50%;
 		}
+
+		.wp-block-spacer {
+			display: none;
+		}
 	}
 }
 
@@ -28,6 +32,12 @@
 			}
 			.site-header{
 				top: 46px;
+			}
+		}
+
+		&.wp-custom-logo {
+			.post-header {
+				padding-top: 150px !important;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

When a custom logo is active and the post title is long the post meta was moving on top of the menu.

<img width="382" alt="Screenshot 2021-05-20 at 17 43 32" src="https://user-images.githubusercontent.com/3593343/119009246-38404800-b993-11eb-8e91-7e9d57b6f98d.png">
<img width="371" alt="Screenshot 2021-05-20 at 17 43 47" src="https://user-images.githubusercontent.com/3593343/119009249-38d8de80-b993-11eb-91dc-050d83d83c13.png">


