### PR TITLE
Quadrat: revise focus states

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -376,6 +376,31 @@ ul ul {
 	text-decoration: none;
 }
 
+a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
+	outline: 1px dotted currentColor;
+	text-decoration: none;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="submit"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+	outline: 1px dotted currentColor;
+}
+
 .site-header {
 	position: relative;
 }

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -1,0 +1,21 @@
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="submit"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
+textarea {
+	&:focus {
+		outline: 1px dotted currentColor;
+	}
+}

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -5,3 +5,13 @@
 		text-decoration: none;
 	}
 }
+
+
+// Select the focus states of all non-wpadmin and screen reader links
+a:not(.ab-item):not(.screen-reader-shortcut) {
+	&:active,
+	&:focus {
+		outline: 1px dotted currentColor;
+		text-decoration: none;
+	}
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -17,6 +17,7 @@
 @import "blocks/table";
 @import "blocks/pullquote";
 @import "elements/links";
+@import "elements/forms";
 @import "header";
 @import "meta";
 @import "post-header";


### PR DESCRIPTION
Closes #3868. It adds an `outline` to all links that are not wp-admin related, and form fields. 

Before | After
------- | -------
<img width="421" alt="Screen Shot 2021-05-20 at 3 39 37 PM" src="https://user-images.githubusercontent.com/5375500/119038844-77a56f00-b968-11eb-9dfc-47a3ccbaf5c0.png"> | <img width="419" alt="Screen Shot 2021-05-20 at 3 36 39 PM" src="https://user-images.githubusercontent.com/5375500/119038850-7a07c900-b968-11eb-85bb-b8aedd5e6a38.png">

cc @beafialho — I am using `outline` here instead of `border` because a border will grow the size of the element on focus, and I don't think that's what we want. The downside is we have a little less control over the style of the outline.