### PR TITLE
Provide reasonable color defaults when palette background color is selected

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -406,6 +406,11 @@ ul ul {
 	padding: var(--wp--custom--margin--horizontal);
 }
 
+.has-pink-background-color,
+.has-white-background-color {
+	color: var(--wp--preset--color--blue);
+}
+
 .wp-block-post-content p a {
 	-webkit-text-decoration-line: underline;
 	        text-decoration-line: underline;

--- a/quadrat/sass/_colors.scss
+++ b/quadrat/sass/_colors.scss
@@ -1,0 +1,6 @@
+// Provide reasonable default colors when a background color is chosen 
+// that doesn't work with the default foreground color
+.has-pink-background-color,
+.has-white-background-color {
+	color: var(--wp--preset--color--blue);
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -16,6 +16,7 @@
 @import "blocks/search";
 @import "blocks/table";
 @import "blocks/pullquote";
+@import "colors";
 @import "elements/links";
 @import "elements/forms";
 @import "header";


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/146530/119152023-ec86b080-ba1d-11eb-8f39-152aa8a18729.png)

#### Changes proposed in this Pull Request:

Sets the color for any element that expresses a background color who's foreground color doesn't work as the default.

#### Related issue(s):

Fixes #3814 