### PR TITLE
Style Seedlet mobile navigation

### DIFF
--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -162,6 +162,19 @@
 	color: var(--wp--style--color--link);
 }
 
+.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link {
+	font-family: var(--font-headings, "Playfair Display", Georgia, Times, serif);
+	font-size: 32px;
+	font-weight: 400;
+	line-height: 60px;
+}
+
+.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link {
+	font-style: italic;
+	font-size: 24px;
+	line-height: 30px;
+}
+
 .wp-block-post-comments .reply a {
 	border-radius: var(--wp--custom--button--border--radius);
 	font-size: var(--wp--preset--font-size--small);

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -163,7 +163,7 @@
 }
 
 .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link {
-	font-family: var(--font-headings, "Playfair Display", Georgia, Times, serif);
+	font-family: var(--wp--preset--font-family--headings);
 	font-size: 32px;
 	font-weight: 400;
 	line-height: 60px;

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -1,0 +1,19 @@
+.wp-block-navigation__responsive-container {
+	&.has-modal-open {
+		.wp-block-navigation-link {
+			//NOTE: For reasons I cannot explain... if I set this to use the --wp--preset--font-family--headings
+			//these values (which are what are set) are not respected in the modal.
+			font-family: var(--font-headings, 'Playfair Display', Georgia, Times, serif);
+			font-size: 32px;
+			font-weight: 400;
+			line-height: 60px;
+			&.has-child {
+				.wp-block-navigation-link{
+					font-style: italic;
+					font-size: 24px;
+					line-height: 30px;
+				}
+			}
+		}
+	}
+}

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -3,7 +3,7 @@
 		.wp-block-navigation-link {
 			//NOTE: For reasons I cannot explain... if I set this to use the --wp--preset--font-family--headings
 			//these values (which are what are set) are not respected in the modal.
-			font-family: var(--font-headings, 'Playfair Display', Georgia, Times, serif);
+			font-family: var(--wp--preset--font-family--headings);
 			font-size: 32px;
 			font-weight: 400;
 			line-height: 60px;

--- a/seedlet-blocks/sass/theme.scss
+++ b/seedlet-blocks/sass/theme.scss
@@ -1,5 +1,6 @@
 @import 'blocks/latest-posts';
 @import 'blocks/links';
+@import 'blocks/navigation';
 @import 'blocks/post-comments';
 @import 'blocks/pullquote';
 @import 'blocks/site-title';


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This follows up on https://github.com/Automattic/themes/pull/3870 and styles the Navigation Block's mobile menu.

Turns out there's no need for breakpoints after all...

Before:
![image](https://user-images.githubusercontent.com/146530/119186129-a6454780-ba45-11eb-8330-f72e1a52da32.png)

After:
![image](https://user-images.githubusercontent.com/146530/119186040-8a41a600-ba45-11eb-8de1-3c21ba6851a2.png)

Design Target:
![image](https://user-images.githubusercontent.com/146530/119186081-9594d180-ba45-11eb-996d-30141a01c166.png)
