### PR TITLE
Varia: Update text and link when there are no published posts

### DIFF
--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -18,27 +18,23 @@
 
 	<div class="page-content responsive-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+			?>
 
-<p>
+			<p>
 			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
 
 			<p>
-				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
-			<?php /* translators: 1: link to WP admin new post page. */
-			 _e( 'Add or publish Posts', 'seedlet' ); ?>
+				<a href="<?php echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
+					<?php
+					/* translators: 1: link to WP admin new post page. */
+					_e( 'Add or publish Posts', 'seedlet' );
+					?>
 				</a>
-			</p>		)
-					)					
-				) ,
-				esc_url( admin_url( 'edit.php' ) )
-			);
-			/* translators: 1: link to WP admin new post page. 2: class for anchor */
-			 _e( 'Add or publish Posts', 'seedlet' ); ?>
-
-			</a></p>
+			</p>	
 			
-		<?php elseif ( is_search() ) :
+			<?php
+		elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'varia' ); ?></p>

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -18,22 +18,29 @@
 
 	<div class="page-content responsive-max-width">
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			printf(
-				'<p>' . wp_kses(
-					/* translators: 1: link to WP admin new post page. */
-					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'varia' ),
+			<p>
+			<?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
+
+			<?php printf(
+				'<p>' 
+				. wp_kses('<a href="%1$s" class="button">',
 					array(
 						'a' => array(
 							'href' => array(),
-						),
-					)
-				) . '</p>',
-				esc_url( admin_url( 'post-new.php' ) )
+							'class' => 'button'
+						)
+					)					
+				) ,
+				esc_url( admin_url( 'edit.php' ) )
 			);
+			/* translators: 1: link to WP admin new post page. 2: class for anchor */
+			 _e( 'Add or publish Posts', 'seedlet' ); ?>
 
-		elseif ( is_search() ) :
+			</a></p>
+			
+		<?php elseif ( is_search() ) :
 			?>
 
 			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'varia' ); ?></p>

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -20,17 +20,15 @@
 		<?php
 		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p>
-			<?php _e( 'Your site is set to show the the most recent posts on your homepage - but you don\'t have any Posts published.', 'seedlet' ); ?></p>
+<p>
+			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
 
-			<?php printf(
-				'<p>' 
-				. wp_kses('<a href="%1$s" class="button">',
-					array(
-						'a' => array(
-							'href' => array(),
-							'class' => 'button'
-						)
+			<p>
+				<a href="<?php  echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
+			<?php /* translators: 1: link to WP admin new post page. */
+			 _e( 'Add or publish Posts', 'seedlet' ); ?>
+				</a>
+			</p>		)
 					)					
 				) ,
 				esc_url( admin_url( 'edit.php' ) )

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -13,7 +13,7 @@
 
 <section class="no-results not-found">
 	<header class="page-header responsive-max-width">
-		<h1 class="page-title"><?php _e( 'Nothing Found', 'varia' ); ?></h1>
+		<h1 class="page-title"><?php _e( 'No Posts Found', 'varia' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content responsive-max-width">

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -22,13 +22,13 @@
 			?>
 
 			<p>
-			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'seedlet' ); ?></p>
+			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'varia' ); ?></p>
 
 			<p>
 				<a href="<?php echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
 					<?php
 					/* translators: 1: link to WP admin new post page. */
-					_e( 'Add or publish Posts', 'seedlet' );
+					_e( 'Add or publish Posts', 'varia' );
 					?>
 				</a>
 			</p>	


### PR DESCRIPTION
This PR uses the same fix used in #3875 to change the content shown when a user has 'Latest Posts' selected for their front page but no public posts. This affects only the logged-in view.

Addresses #3913.

<img width="801" alt="Screen Shot 2021-05-23 at 2 22 41 pm" src="https://user-images.githubusercontent.com/1842363/119248122-6eb7d600-bbd2-11eb-8ba8-cd95d952518c.png">

### Testing Instructions

1. Ensure site has no public posts (set them to be draft or remove them).
1. Use the Customizer to set the 'Home Page Settings' to show latest posts
1. Visit the home page of the site.