### PR TITLE
Mayland Blocks: fix header template part

### DIFF
--- a/mayland-blocks/assets/theme.css
+++ b/mayland-blocks/assets/theme.css
@@ -5,16 +5,13 @@ body {
 }
 
 /* Adjust header spacing. */
-.site-header > .wp-block-columns {
-	padding: 0 var(--wp--custom--margin--horizontal);
-}
-
 .site-header .wp-block-site-title a {
 	text-decoration: none;
 }
 
 .site-header .wp-block-navigation {
 	margin-bottom: 0;
+	margin-left: auto;
 }
 
 .site-header .wp-block-social-links.alignright {

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,10 +1,4 @@
-<!-- wp:columns {"verticalAlignment":null, "align":"full"} -->
-<div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title /--></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true} -->
-<!-- /wp:navigation --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
+<!-- wp:site-logo /-->
+<!-- wp:site-title /-->
+<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true} -->
+<!-- /wp:navigation -->

--- a/mayland-blocks/functions.php
+++ b/mayland-blocks/functions.php
@@ -18,6 +18,6 @@ endif;
  */
 function mayland_blocks_scripts() {
 	// Enqueue front-end styles.
-	wp_enqueue_style( 'mayland-blocks-styles', get_stylesheet_uri(), array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'mayland-blocks-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blank_canvas_blocks-ponyfill' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'mayland_blocks_scripts' );

--- a/mayland-blocks/sass/theme.scss
+++ b/mayland-blocks/sass/theme.scss
@@ -6,16 +6,13 @@ body {
 }
 
 /* Adjust header spacing. */
-.site-header > .wp-block-columns {
-	padding: 0 var(--wp--custom--margin--horizontal);
-}
-
 .site-header .wp-block-site-title a {
 	text-decoration: none;
 }
 
 .site-header .wp-block-navigation {
 	margin-bottom: 0;
+	margin-left: auto;
 }
 
 .site-header .wp-block-social-links.alignright {


### PR DESCRIPTION
This PR makes a few changes to Mayland Blocks:

- Fixes a bug where the wrong stylesheet was being enqueued 
- Simplifies the header template to match BCB + Quadrat