### PR TITLE
Spearhead: add `blog-homepage` tag

### DIFF
--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, blog-homepage, jetpack-global-styles
 */
 /**
  * Required Variables


### PR DESCRIPTION
This add a `blog-homepage` tag to Spearhead in order to test some new functionality around theme switching (see Automattic/wp-calypso#52799).

Syncs the change made in D61383-code