### PR TITLE
Independent Publisher 2: Adds two tags to style.css

### DIFF
--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -8,7 +8,7 @@ Author URI: http://raamdev.com/
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Text Domain: independent-publisher-2
-Tags: accessibility-ready, author-bio, classic-menu, custom-background, custom-colors, custom-header, custom-menu, featured-image-header, featured-images, flexible-header, blue, right-sidebar, light, one-column, responsive-layout, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, white, minimal, modern, conservative, blog, journal
+Tags: accessibility-ready, author-bio, auto-loading-homepage, classic-menu, custom-background, custom-colors, custom-header, custom-menu, featured-image-header, featured-images, flexible-header, blue, right-sidebar, light, one-column, responsive-layout, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, white, minimal, modern, conservative, blog, journal, blog-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.


### PR DESCRIPTION
Sync with r58961-wpcom-themes by adding two new tags, `auto-loading-homepage` and `blog-homepage` to style.css
