### PR TITLE
Quadrat: Another fix for alignments

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -659,6 +659,18 @@ textarea:focus {
 	outline: 1px dotted currentColor;
 }
 
+.alignfull p {
+	padding-left: var(--wp--custom--margin--horizontal);
+	padding-right: var(--wp--custom--margin--horizontal);
+}
+
+@media (max-width: 704px) {
+	[class^="wp-container-"] p {
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+	}
+}
+
 .site-header {
 	position: relative;
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -664,6 +664,13 @@ textarea:focus {
 	padding-right: var(--wp--custom--margin--horizontal);
 }
 
+@media (max-width: 1168px) {
+	.alignwide p {
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+	}
+}
+
 @media (max-width: 704px) {
 	[class^="wp-container-"] p {
 		padding-left: var(--wp--custom--margin--horizontal);

--- a/quadrat/child-experimental-theme.json
+++ b/quadrat/child-experimental-theme.json
@@ -108,6 +108,12 @@
 					}
 				}
 			},
+			"post-content": {
+				"padding": {
+					"left": "0px",
+					"right": "0px"
+				}
+			},
 			"quote": {
 				"citation": {
 					"typography": {

--- a/quadrat/experimental-theme.json
+++ b/quadrat/experimental-theme.json
@@ -167,8 +167,8 @@
 			},
 			"post-content": {
 				"padding": {
-					"left": "var(--wp--custom--margin--horizontal)",
-					"right": "var(--wp--custom--margin--horizontal)"
+					"left": "0px",
+					"right": "0px"
 				}
 			},
 			"pullquote": {

--- a/quadrat/sass/elements/_paragraph.scss
+++ b/quadrat/sass/elements/_paragraph.scss
@@ -1,0 +1,18 @@
+.alignfull p {
+	padding-left: var(--wp--custom--margin--horizontal);
+	padding-right: var(--wp--custom--margin--horizontal);
+}
+
+@media (max-width: 1168px ) { // 1128 = the content width + 40 = the horizontal margin * 2
+	.alignwide p {
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+	}
+}
+
+@media (max-width: 704px ) { // 664 = the content width + 40 = the horizontal margin * 2
+	[class^="wp-container-"] p {
+		padding-left: var(--wp--custom--margin--horizontal);
+		padding-right: var(--wp--custom--margin--horizontal);
+	}
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -19,6 +19,7 @@
 @import "colors";
 @import "elements/links";
 @import "elements/forms";
+@import "elements/paragraph";
 @import "header";
 @import "meta";
 @import "post-header";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is another attempt at https://github.com/Automattic/themes/issues/3747

The approach is to add left and right padding to paragraph blocks when they are inside a full width container, or when they are inside a container which inherits layout and the screen is smaller than the container.

To test:
- Add a paragraph block inside the post and check that when the page is narrow the content doesn't touch the sides
- Add a paragraph block inside a wide block and check that when the page is narrower than the wide width, the content doesn't touch the sides
- Add a paragraph block inside a full block and check that the content doesn't touch the sides

#### Related issue(s):
#3747