### PR TITLE
Blockbase: Update header font size

### DIFF
--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"align":"full","tagName":"header","style":{"spacing":{"padding":{"right":"35px","left":"35px"}}},"className":"site-header"} -->
 <header class="wp-block-group alignfull site-header" style="padding-right:35px;padding-left:35px">
-	<!-- wp:site-title /-->
+	<!-- wp:site-title {"fontSize":"normal"} /-->
 	<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small"} /-->
 </header>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"align":"full","tagName":"header","style":{"spacing":{"padding":{"right":"35px","left":"35px"}}},"className":"site-header"} -->
 <header class="wp-block-group alignfull site-header" style="padding-right:35px;padding-left:35px">
-	<!-- wp:site-title {"fontSize":"normal"} /-->
+	<!-- wp:site-title /-->
 	<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small"} /-->
 </header>
 <!-- /wp:group -->

--- a/blockbase/experimental-theme.json
+++ b/blockbase/experimental-theme.json
@@ -373,7 +373,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontSize": "60px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": 700
 				}
 			},


### PR DESCRIPTION
The header font size should be the same size as the menu text: 


Before:
<img width="1286" alt="Screen Shot 2021-05-25 at 11 52 12 AM" src="https://user-images.githubusercontent.com/1202812/119528962-a7c98500-bd4f-11eb-9dc9-82740799c494.png">

After:
<img width="1286" alt="Screen Shot 2021-05-25 at 11 51 34 AM" src="https://user-images.githubusercontent.com/1202812/119528967-a8621b80-bd4f-11eb-9bc7-48659f0dce5c.png">
