### PR TITLE
Blockbase: Fix alignment styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -57,7 +57,12 @@ img {
 .wp-block-post-content > .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left));
 	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right));
-	width: unset;
+	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
+}
+
+.alignfull p {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
 @media (min-width: 480px) {

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,11 +1,16 @@
 .wp-block-post-content > .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left));
 	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right));
-	width: unset;
+	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) )
+}
+
+.alignfull p {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
 @include break-mobile {
-	// limit size of any element that is aligned left/right 
+	// limit size of any element that is aligned left/right
 	.wp-block[data-align="left"], // This is for the editor
 	.wp-block[data-align="right"], // This is for the editor
 	.wp-site-blocks .alignleft,
@@ -15,9 +20,9 @@
 }
 
 // When content is aligned left/right (particularly inside of a container) it is floated left/right
-// and needs something to ensure that the content follows the block rather than nestling up beside the floated element.  
+// and needs something to ensure that the content follows the block rather than nestling up beside the floated element.
 // The issue should be resolved upstream: https://github.com/WordPress/gutenberg/issues/10299
-.wp-block-group:not(.site-header) { 
+.wp-block-group:not(.site-header) {
 	overflow: auto;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This works with https://github.com/WordPress/gutenberg/pull/32231 and also resolves #3747 to fix alignments on Blockbase.

To test:
- Add align full blocks without a background color and check that paragraph blocks have some space around them
- Also check for space at the side of paragraph blocks on mobile

#### Related issue(s):
