### PR TITLE
Quadrat: Fix mobile spacing

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -662,12 +662,12 @@ textarea:focus {
 .site-header {
 	position: relative;
 	overflow: inherit;
-	padding: 10px 20px 60px;
+	padding: 10px var(--wp--custom--post-content--padding--left) 60px;
 }
 
 @media (min-width: 480px) {
 	.site-header {
-		padding: var(--wp--custom--margin--vertical);
+		padding: var(--wp--custom--post-content--padding--left);
 	}
 }
 
@@ -846,6 +846,11 @@ textarea:focus {
 
 .wp-block-post-featured-image {
 	margin-top: 0;
+}
+
+.page-content {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -659,6 +659,24 @@ textarea:focus {
 	outline: 1px dotted currentColor;
 }
 
+.home .site-footer.wp-block-group {
+	position: relative;
+	overflow: visible;
+}
+
+.home .site-footer.wp-block-group:before {
+	content: "";
+	background-color: var(--wp--custom--color--secondary);
+	-webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+	        clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+	position: absolute;
+	height: 100vw;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: -1;
+}
+
 .site-header {
 	position: relative;
 	overflow: inherit;
@@ -729,22 +747,13 @@ textarea:focus {
 	}
 }
 
-.home .site-footer.wp-block-group {
-	position: relative;
-	overflow: visible;
+.wp-block-post-featured-image {
+	margin-top: 0;
 }
 
-.home .site-footer.wp-block-group:before {
-	content: "";
-	background-color: var(--wp--custom--color--secondary);
-	-webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
-	        clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
-	position: absolute;
-	height: 100vw;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	z-index: -1;
+.page-content {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
 .post-meta {
@@ -842,15 +851,6 @@ textarea:focus {
 
 .wp-block-query .wp-block-post-featured-image {
 	margin-top: calc( var(--wp--custom--margin--vertical) / 2);
-}
-
-.wp-block-post-featured-image {
-	margin-top: 0;
-}
-
-.page-content {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/block-template-parts/404.html
+++ b/quadrat/block-template-parts/404.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
+<!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
+<div class="wp-block-group page-content">
 
 <!-- wp:heading {"textAlign":"center","level":1,"fontSize":"large"} -->
 <h1 class="has-text-align-center has-large-font-size">Oops! That page can’t be found.</h1>

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -1,17 +1,17 @@
-<!-- wp:query {"layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-<div class="wp-block-query">
-<!-- wp:query-loop -->
-	<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
-	<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
-	<!-- wp:post-featured-image {"isLink":true} /-->
-	<!-- wp:post-excerpt /-->
-	<!-- wp:spacer {"height":60} -->
-	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-<!-- /wp:query-loop -->
+<!-- wp:query {"className":"page-content","layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<div class="wp-block-query page-content">
+		<!-- wp:query-loop -->
+		<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
+		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+		<!-- wp:spacer {"height":60} -->
+		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+		<!-- /wp:query-loop -->
 
-<!-- wp:query-pagination {"align":"wide"} -->
-<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+	<!-- wp:query-pagination {"align":"wide"} -->
+	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
 
 	<!-- wp:query-pagination-numbers /-->
 

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -1,6 +1,6 @@
 <!-- wp:query {"className":"page-content","layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <div class="wp-block-query page-content">
-	<!-- wp:query-loop -->
+<!-- wp:query-loop -->
 	<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
 	<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
 	<!-- wp:post-featured-image {"isLink":true} /-->
@@ -8,14 +8,14 @@
 	<!-- wp:spacer {"height":60} -->
 	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
-	<!-- /wp:query-loop -->
+<!-- /wp:query-loop -->
 
 <!-- wp:query-pagination {"align":"wide"} -->
 <div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
 
-<!-- wp:query-pagination-numbers /-->
+	<!-- wp:query-pagination-numbers /-->
 
-<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
 <!-- /wp:query-pagination -->
 
 </div>

--- a/quadrat/block-template-parts/query.html
+++ b/quadrat/block-template-parts/query.html
@@ -1,21 +1,21 @@
 <!-- wp:query {"className":"page-content","layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <div class="wp-block-query page-content">
-		<!-- wp:query-loop -->
-		<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
-		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
-		<!-- wp:post-featured-image {"isLink":true} /-->
-		<!-- wp:post-excerpt /-->
-		<!-- wp:spacer {"height":60} -->
-		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-		<!-- /wp:query-loop -->
+	<!-- wp:query-loop -->
+	<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
+	<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
+	<!-- wp:post-featured-image {"isLink":true} /-->
+	<!-- wp:post-excerpt /-->
+	<!-- wp:spacer {"height":60} -->
+	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- /wp:query-loop -->
 
-	<!-- wp:query-pagination {"align":"wide"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+<!-- wp:query-pagination {"align":"wide"} -->
+<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
 
-	<!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
 <!-- /wp:query-pagination -->
 
 </div>

--- a/quadrat/block-template-parts/search.html
+++ b/quadrat/block-template-parts/search.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
+<!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
+<div class="wp-block-group page-content">
 
 <!-- wp:heading -->
 <h2>Results:</h2>

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -108,6 +108,12 @@
 					}
 				}
 			},
+			"post-content": {
+				"padding": {
+					"left": "min( var(--wp--custom--margin--horizontal), 5vw)",
+					"right": "min( var(--wp--custom--margin--horizontal), 5vw)"
+				}
+			},
 			"quote": {
 				"citation": {
 					"typography": {

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -1,10 +1,10 @@
 .site-header {
 	position: relative;
 	overflow: inherit;
-	padding: 10px 20px 60px; // TODO: Maybe replace with a responsive custom variable?
+	padding: 10px var(--wp--custom--post-content--padding--left) 60px; // TODO: Maybe replace with a responsive custom variable?
 
 	@include break-mobile() {
-		padding: var(--wp--custom--margin--vertical);
+		padding: var(--wp--custom--post-content--padding--left);
 	}
 
 	.wp-block-site-logo {
@@ -21,7 +21,7 @@
 			width: auto;
 		}
 	}
-	
+
 	.wp-block-site-title {
 		margin: 0;
 	}
@@ -30,7 +30,7 @@
 		margin-left: auto;
 		padding-right: 0;
 	}
-	
+
 	&:before {
 		content: "";
 		background-color: var(--wp--custom--color--secondary);
@@ -50,4 +50,4 @@
 			clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
 		}
 	}
-} 
+}

--- a/quadrat/sass/templates/_index.scss
+++ b/quadrat/sass/templates/_index.scss
@@ -1,0 +1,8 @@
+.wp-block-post-featured-image {
+	margin-top: 0;
+}
+
+.page-content {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -19,17 +19,9 @@
 @import "colors";
 @import "elements/links";
 @import "elements/forms";
-@import "templates/header";
 @import "templates/footer";
+@import "templates/header";
+@import "templates/index";
 @import "templates/meta";
 @import "templates/post-header";
 @import "templates/query";
-
-.wp-block-post-featured-image {
-	margin-top: 0;
-}
-
-.page-content {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -28,3 +28,8 @@
 .wp-block-post-featured-image {
 	margin-top: 0;
 }
+
+.page-content {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+}

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -167,8 +167,8 @@
 			},
 			"post-content": {
 				"padding": {
-					"left": "var(--wp--custom--margin--horizontal)",
-					"right": "var(--wp--custom--margin--horizontal)"
+					"left": "min( var(--wp--custom--margin--horizontal), 5vw)",
+					"right": "min( var(--wp--custom--margin--horizontal), 5vw)"
 				}
 			},
 			"pullquote": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This introduces space around the page content on all templates in Quadrat:

<img width="462" alt="Screenshot 2021-05-27 at 15 01 42" src="https://user-images.githubusercontent.com/275961/119839953-75a95600-befc-11eb-93ff-cc0fe37b87d5.png">

I have changed from a px value to a vw value, so that it is intrinsically responsive. It was also necessary to update the header so the two values match.

#### Related issue(s):
#3878
