### PR TITLE
Removed top padding from quote blocks's paragraph element

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -635,6 +635,7 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-quote.is-style-large p,
 .wp-block-quote p {
 	font-style: unset;
+	margin-top: 0px;
 }
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,

--- a/blockbase/sass/blocks/_quote.scss
+++ b/blockbase/sass/blocks/_quote.scss
@@ -2,6 +2,7 @@
 .wp-block-quote {
 	p {
 		font-style: unset;
+		margin-top: 0px;
 	}
 	.wp-block-quote__citation, // For the editor
 	cite {


### PR DESCRIPTION
This effects all child themes as well.

BB Before:
![image](https://user-images.githubusercontent.com/146530/119882901-f10b0780-befc-11eb-99dc-6283e1230837.png)

BB After:
![image](https://user-images.githubusercontent.com/146530/119882840-dd5fa100-befc-11eb-8d17-b3afe4f3c206.png)

Seedlet-Blocks before:
![image](https://user-images.githubusercontent.com/146530/119882950-fe27f680-befc-11eb-85db-e6f0ef020d86.png)

Seedlet-Blocks after:
![image](https://user-images.githubusercontent.com/146530/119883010-0b44e580-befd-11eb-9ba1-9a54cae313d2.png)

Mayland-Blocks before:
![image](https://user-images.githubusercontent.com/146530/119883109-27488700-befd-11eb-8893-5a6d48fc7831.png)

Mayland-Blocks after:
![image](https://user-images.githubusercontent.com/146530/119883079-1dbf1f00-befd-11eb-91fd-b7eb58e68a15.png)

Quadrat before:
![image](https://user-images.githubusercontent.com/146530/119883166-39c2c080-befd-11eb-9c96-4ac78343f006.png)

Quadrat after:
![image](https://user-images.githubusercontent.com/146530/119883218-4a733680-befd-11eb-9913-3aa790c2b9fc.png)

Fixes #3969 