### PR TITLE
BB - Fix margin alignments in view and editor

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -4,6 +4,7 @@
  */
 body {
 	margin: 0;
+	padding: 0;
 }
 
 body {
@@ -54,15 +55,22 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
+.is-root-container {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+}
+
+.block-editor-block-list__layout.is-root-container > .wp-block[data-align=full],
 .wp-block-post-content > .alignfull {
-	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left));
-	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right));
-	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
+	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
+	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
+	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right)) !important;
 }
 
 .site-header,
 .post-header,
 .page-content,
+[data-align="full"] p,
 .alignfull p {
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,12 +1,19 @@
+.is-root-container {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+}
+
+.block-editor-block-list__layout.is-root-container>.wp-block[data-align=full],
 .wp-block-post-content > .alignfull {
-	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left));
-	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right));
-	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) )
+	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
+	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
+	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) ) !important;
 }
 
 .site-header,
 .post-header,
 .page-content,
+[data-align="full"] p,
 .alignfull p {
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,3 +1,5 @@
+// This targets the editor. It is the closest equivalent to .wp-block-post-content,
+// since the editor does not output that class. 
 .is-root-container {
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);

--- a/blockbase/sass/base/_normalize.scss
+++ b/blockbase/sass/base/_normalize.scss
@@ -2,6 +2,7 @@
 // Remove the margin in all browsers.
 body {
   margin: 0;
+  padding: 0;
 }
 
 // Smooth out the fonts


### PR DESCRIPTION
* Add selectors so that alignment utilities work in the editor.  
* Added `!important`s to utilities to overcome Gutenberg margin utilities.

This change adds a few selectors to the alignment classes to ensure that they work as expected in the editor.

It also adds !important to the alignwide alignment rules to ensure that they work despite Gutenberg's own addition of !important to the margins.

Before (view):
![image](https://user-images.githubusercontent.com/146530/120005446-d476da00-bfa5-11eb-86f4-921d42891a7c.png)

Before (editor):
![image](https://user-images.githubusercontent.com/146530/120005596-fbcda700-bfa5-11eb-8e19-ed3df8545df4.png)

After (view):
![image](https://user-images.githubusercontent.com/146530/120005349-bad59280-bfa5-11eb-97a3-98a2e0fb8070.png)

After (editor):
![image](https://user-images.githubusercontent.com/146530/120004522-de4c0d80-bfa4-11eb-8061-0a929d9444c4.png)
