### PR TITLE
Fix group block padding when alignfull in varia

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/alves/style.css
+++ b/alves/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1704,6 +1704,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1704,6 +1704,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -1706,6 +1706,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1706,6 +1706,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/exford/style.css
+++ b/exford/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/hever/style.css
+++ b/hever/style.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/leven/style.css
+++ b/leven/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -1706,6 +1706,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1706,6 +1706,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/morden/style.css
+++ b/morden/style.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1707,6 +1707,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1730,6 +1730,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1730,6 +1730,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1735,6 +1735,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1735,6 +1735,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/stow/style.css
+++ b/stow/style.css
@@ -1734,6 +1734,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1733,6 +1733,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1733,6 +1733,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/varia/sass/blocks/group/_style.scss
+++ b/varia/sass/blocks/group/_style.scss
@@ -30,4 +30,10 @@
 			padding: #{map-deep-get($config-global, "spacing", "vertical")};
 		}
 	}
+
+	&.alignfull {
+		padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
+		padding-right: #{map-deep-get($config-global, "spacing", "horizontal")};
+	}
+
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1740,6 +1740,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-right: 16px;
+	padding-left: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,

--- a/varia/style.css
+++ b/varia/style.css
@@ -1740,6 +1740,11 @@ button[data-load-more-btn], .button {
 	}
 }
 
+.wp-block-group.alignfull {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
 h1, .h1,
 h2, .h2,
 h3, .h3,


### PR DESCRIPTION
In the same way that the COLUMNS block is already adding padding when
configured as alignwide the GROUP block is now doing the same.

Fixes #3733 

Before:
<img src="https://user-images.githubusercontent.com/146530/120543944-e0ee9e80-c3ba-11eb-804f-aa4ed009d2e6.png" width="300px">

<img src="https://user-images.githubusercontent.com/146530/120543983-eb109d00-c3ba-11eb-9b16-586060afe38e.png" width="300px">

After:
<img src="https://user-images.githubusercontent.com/146530/120543737-a6850180-c3ba-11eb-96c2-35735a547aec.png" width="300px">
<img src="https://user-images.githubusercontent.com/146530/120543898-d46a4600-c3ba-11eb-94af-710c98455d8d.png" width="300px">

All varia children have been compiled and verified with these changes (screenshots not included).