### PR TITLE
Add a blank customTemplate to blockbase

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -10,6 +10,16 @@
 			"area": "footer"
 		}
 	],
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
 	"settings": {
 		"border": {
 			"customColor": true,


### PR DESCRIPTION
Will close #3895. 

This PR adds a blank [`customTemplate`](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#customtemplates) to blockbase. 

Once added, you'll see this as an option in the post/page editor like so: 

![templates-editor](https://user-images.githubusercontent.com/1202812/121185789-6e574600-c834-11eb-83ca-447f6e89c2a0.gif)

... and also in the site editor here: 

![templates](https://user-images.githubusercontent.com/1202812/121185818-73b49080-c834-11eb-8682-e2f93dbe7288.gif)

I can't figure out why the title is showing as lowercase — changing the `name` field doesn't seem to fix it, so maybe that's a Gutenberg bug?