### PR TITLE
Themes: Fix anchor link behavior on Varia/Seedlet child themes

### DIFF
--- a/seedlet/assets/js/primary-navigation.js
+++ b/seedlet/assets/js/primary-navigation.js
@@ -28,6 +28,19 @@
 			};
 		}
 
+		document.addEventListener( 'click', function( event ) {
+			// If target onclick is <a> with # within the href attribute
+			if ( event.target.hash && event.target.hash.includes( '#' ) ) {
+				wrapper.classList.remove( id + '-navigation-open' );
+				wrapper.classList.remove( 'lock-scrolling' );
+				// Wait 550 and scroll to the anchor.
+				setTimeout(function () {
+					var anchor = document.getElementById(event.target.hash.slice(1));
+					anchor.scrollIntoView();
+				}, 550);
+			}
+		} );
+
 		/**
 		 * Trap keyboard navigation in the menu modal.
 		 * Adapted from TwentyTwenty

--- a/varia/js/primary-navigation.js
+++ b/varia/js/primary-navigation.js
@@ -27,6 +27,21 @@
 				toggleButton.focus();
 			}
 		}
+
+		document.addEventListener( 'click', function( event ) {
+			// If target onclick is <a> with # within the href attribute
+			if ( event.target.hash && event.target.hash.includes( '#' ) ) {
+				wrapper.classList.remove( 'lock-scrolling' );
+				if (toggleInput) {
+					toggleInput.checked = false;
+				}
+				// Wait 550 and scroll to the anchor.
+				setTimeout(function () {
+					var anchor = document.getElementById(event.target.hash.slice(1));
+					anchor.scrollIntoView();
+				}, 550);
+			}
+		} );
 	}
 
 	window.addEventListener( 'load', function() {


### PR DESCRIPTION
## Changes

As described in https://github.com/Automattic/themes/issues/3520,
certain child themes of Varia and Seedlet were not handling menu links
correctly when they were navigating to anchor IDs on the page the user
was currently on. An existing bit of logic was already implemented in
the twentytwentyone theme to address this use case, so this diff ports
it into the asset scripts for Varia and Seedlet as well.

## Ported

Ported from D62296-code

## Testing Instructions

- Check out this diff to your sandbox.
- On a sandboxed test site, set your theme to Seedlet (or Spearhead, which is a Seedlet child theme and uses the same navigation script).
- Create a page on your test site with a large amount of content. Somewhere down the page (far enough down that you would have to scroll to it), add a header block with an anchor tag (i.e. `<h3 id="my-anchor-tag">Header Content</h3>`)
In the Customizer, add a custom menu item to the main site navigation which links to the anchor hash.
- Resize your browser to trigger mobile styling on your test site (or make use of Chrome dev tools mobile view.
- Navigate to your test page, then open the menu and click the menu item linking to the anchor hash.
- Verify that the menu closes and the page scrolls to the expected place.
- Repeat the above with any or all of the following themes, which use the equivalent change made to the Varia parent theme: Hever, Barnsbury, Dalston, Mayland, Rivington, Alves, Morde