### PR TITLE
Remove dark mode theme supports

### DIFF
--- a/rivington/functions.php
+++ b/rivington/functions.php
@@ -21,10 +21,7 @@ if ( ! function_exists( 'rivington_setup' ) ) :
 		// Add child theme editor styles, compiled from `style-child-theme-editor.scss`.
 		add_editor_style( 'style-editor.css' );
 
-		// Dark backgrounds
-		// - See: https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds
 		add_theme_support( 'editor-styles' );
-		add_theme_support( 'dark-editor-style' );
 
 		// Add child theme editor font sizes to match Sass-map variables in `_config-child-theme-deep.scss`.
 		add_theme_support(
@@ -148,7 +145,7 @@ function rivington_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/sophisticated-business/functions.php
+++ b/sophisticated-business/functions.php
@@ -16,9 +16,6 @@ if ( ! function_exists( 'sophisticated_business_setup' ) ) :
 	 * as indicating support for post thumbnails.
 	 */
 	function sophisticated_business_setup() {
-		// Switches Gutenberg controls to work against a dark background.
-		add_theme_support( 'dark-editor-style' );
-
 		/**
 		 * Add support for core custom logo.
 		 *
@@ -89,7 +86,7 @@ function sophisticated_business_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/pull/28233 merged we don't need these theme supports. We should merge this after 5.8 ships.

#### Related issue(s):
