### PR TITLE
Add a sandbox pull command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,10 @@ vendor/
 .sandbox-config
 .wp-env.override.json
 
-#Ignoring headstart and language files
+#Ignoring headstart files
+*/inc/headstart/*
 */languages/*
 !*/languages/*.pot
-*/inc/headstart/*
 
 #Retired themes we do not track in git
 able/
@@ -210,13 +210,16 @@ origin/
 orvis/
 oulipo/
 oxygen/
-p2-breathe/
 p2/
+p2-breathe/
+p2-hub/
 p2020/
 pachyderm/
 panel/
 paperpunch/
 parament/
+partner-annotum-base/
+partner-annotum-sans/
 penscratch/
 piano-black/
 pictorico/
@@ -308,6 +311,7 @@ treba/
 triton-lite/
 truly-minimal/
 trvl/
+tt1-blocks/
 twenty-eight/
 twentyeleven/
 twentyfifteen/
@@ -319,6 +323,7 @@ twentyten/
 twentythirteen/
 twentytwelve/
 twentytwenty/
+twentytwentyone/
 twentytwentyone-blocks/
 typo/
 under-the-influence/

--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -3,6 +3,7 @@
 .gitignore
 .sandbox-config
 .sandbox-ignore
+.svn
 package-lock.json
 sandbox.sh
 vendor

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"prettier": "@wordpress/prettier-config",
 	"scripts": {
 		"sandbox:clean": "./sandbox.sh clean",
+		"sandbox:pull": "./sandbox.sh pull",
 		"sandbox:push": "./sandbox.sh push",
 		"sandbox:push:ignore": "./sandbox.sh push --ignore",
 		"sandbox:push:force": "./sandbox.sh push --force",

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -38,6 +38,11 @@ ssh -T $SANDBOX_USER@$SANDBOX_LOCATION << EOF
   svn up;
 EOF
 
+elif [[ $1 == "pull" ]]; then
+
+  cmd="rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude=$ignore_string $SANDBOX_USER@$SANDBOX_LOCATION:$SANDBOX_PUBLIC_THEMES_FOLDER/ ./ "
+  eval $cmd
+
 elif [[ $1 == "push" ]]; then
 
   git remote update


### PR DESCRIPTION
This change:

* Adds a simple command to pull content from sandbox to local: `./sandbox.sh pull`
* Ignores .svn files during rsync 
* Ignores a few additional themes that aren't currently tracked in github

Related to (and created for) #4031 