### PR TITLE
Blockbase: Add post content to the blank template

### DIFF
--- a/blockbase/block-templates/blank.html
+++ b/blockbase/block-templates/blank.html
@@ -1,0 +1,1 @@
+<!-- wp:post-content {"layout":{"inherit":true}} /-->


### PR DESCRIPTION
Update to #4023. 

Prompted by @pbking's [comment](https://github.com/Automattic/themes/pull/4023#issuecomment-858031985), I realized that this template shouldn't actually be totally blank: it should display the post content. 😅 

This PR adds that in. 