### PR TITLE
Quadrat: Add wp.com Font Picker support [Refactor Blockbase Font Family handling to support]

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -176,7 +176,7 @@ textarea {
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
 	color: var(--wp--custom--form--color--text);
-	font-family: var(--wp--preset--font-family--base);
+	font-family: var(--wp--custom--body--typography--font-family);
 	padding: var(--wp--custom--form--padding);
 }
 
@@ -334,8 +334,8 @@ input[type=checkbox] + label {
 
 ul,
 ol {
-	font-family: var(--wp--custom--list--font-family);
-	padding-left: var(--wp--custom--list--padding--left);
+	font-family: var(--wp--custom--list--typography--font-family);
+	padding-left: var(--wp--custom--list--spacing--padding--left);
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open {

--- a/blockbase/sass/blocks/_list.scss
+++ b/blockbase/sass/blocks/_list.scss
@@ -1,5 +1,5 @@
 ul,
 ol {
-	font-family: var(--wp--custom--list--font-family);
-	padding-left: var(--wp--custom--list--padding--left);
+	font-family: var(--wp--custom--list--typography--font-family);
+	padding-left: var(--wp--custom--list--spacing--padding--left);
 }

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -19,7 +19,7 @@ textarea {
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
 	color: var(--wp--custom--form--color--text);
-	font-family: var(--wp--preset--font-family--base);
+	font-family: var(--wp--custom--body--typography--font-family);
 	padding: var(--wp--custom--form--padding);
 
 	&:focus {

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -90,7 +90,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
@@ -136,16 +136,26 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"body": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--segoe-ui)"
+				}
+			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--segoe-ui)",
 					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
 			},
 			"list": {
-				"fontFamily": "var(--wp--custom--font-family--base)",
-				"padding": {
-					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				"typography": {
+					"fontFamily": "var(--wp--custom--body--typography--font-family)"
+				},
+				"spacing": {
+					"padding": {
+						"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+					}
 				}
 			},
 			"margin": {
@@ -157,7 +167,7 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--base)",
+						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -241,14 +251,9 @@
 			"customLineHeight": true,
 			"fontFamilies": [
 				{
-					"fontFamily": "var(--font-base, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
-					"slug": "base",
-					"name": "Base"
-				},
-				{
-					"fontFamily": "var(--font-headings, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
-					"slug": "headings",
-					"name": "Headings"
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "segoe-ui",
+					"name": "Segoe UI"
 				}
 			],
 			"fontSizes": [
@@ -315,7 +320,7 @@
 			},
 			"core/heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--headings)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -340,6 +345,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -447,7 +453,7 @@
 		},
 		"typography": {
 			"lineHeight": 1.6,
-			"fontFamily": "var(--wp--preset--font-family--base)",
+			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -138,7 +138,8 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--segoe-ui)"
+					"fontFamily": "var(--wp--preset--font-family--segoe-ui)",
+					"lineHeight": 1.6
 				}
 			},
 			"heading": {
@@ -452,7 +453,7 @@
 			}
 		},
 		"typography": {
-			"lineHeight": 1.6,
+			"lineHeight": "var(--wp--custom--body--typography--line-height)",
 			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -55,7 +55,7 @@
 				},
 				"color": {
 					"text": "var(--wp--custom--color--background)",
-					"background": "var(--wp--custom--color--foreground)"
+					"background": "var(--wp--custom--color--primary)"
 				},
 				"hover": {
 					"color": {
@@ -89,14 +89,16 @@
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,400;0,600;1,400"
 			],
-			"heading": {
+			"body": {
 				"typography": {
-					"fontWeight": 600
+					"fontFamily": "var(--wp--preset--font-family--poppins)"
 				}
 			},
-			"line-height": {
-				"body": 1.6,
-				"headings": 1.125
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
+					"fontWeight": 600
+				}
 			},
 			"margin": {
 				"horizontal": "32px"
@@ -120,7 +122,7 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Poppins\", sans-serif",
-					"slug": "base",
+					"slug": "poppins",
 					"name": "Poppins"
 				},
 				{
@@ -171,27 +173,12 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"color": {
-					"background": "var(--wp--custom--color--primary)"
-				}
-			},
-			"core/heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/post-date": {
-				"color": {
-					"link": "var(--wp--custom--color--foreground-light)",
-					"text": "var(--wp--custom--color--foreground-light)"
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
@@ -199,7 +186,7 @@
 			"core/post-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},
 			"core/site-title": {
@@ -248,11 +235,6 @@
 					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--base)",
-			"fontSize": "var(--wp--preset--font-size--normal)",
-			"lineHeight": "var(--wp--custom--line-height--body)"
 		}
 	}
 }

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -179,6 +179,10 @@
 				}
 			},
 			"core/post-date": {
+				"color": {
+					"link": null,
+					"text": null 
+				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -18,6 +18,16 @@
 			"area": "Post Meta"
 		}
 	],
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
 	"settings": {
 		"border": {
 			"customColor": true,
@@ -88,7 +98,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": 600,
 					"lineHeight": 2
@@ -134,16 +144,27 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"body": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
+					"lineHeight": 1.6
+				}
+			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": 600,
 					"lineHeight": 1.125
 				}
 			},
 			"list": {
-				"fontFamily": "var(--wp--custom--font-family--base)",
-				"padding": {
-					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				"typography": {
+					"fontFamily": "var(--wp--custom--body--typography--font-family)"
+				},
+				"spacing": {
+					"padding": {
+						"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+					}
 				}
 			},
 			"margin": {
@@ -155,7 +176,7 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--base)",
+						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -222,10 +243,6 @@
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,400;0,600;1,400"
 			],
-			"line-height": {
-				"body": 1.6,
-				"headings": 1.125
-			},
 			"width": {
 				"default": "750px",
 				"wide": "1022px"
@@ -251,7 +268,7 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Poppins\", sans-serif",
-					"slug": "base",
+					"slug": "poppins",
 					"name": "Poppins"
 				},
 				{
@@ -335,7 +352,7 @@
 			},
 			"core/heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--line-height--headings)"
 				}
@@ -360,6 +377,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--line-height--headings)"
 				}
@@ -466,8 +484,8 @@
 			}
 		},
 		"typography": {
-			"lineHeight": "var(--wp--custom--line-height--body)",
-			"fontFamily": "var(--wp--preset--font-family--base)",
+			"lineHeight": "var(--wp--custom--body--typography--line-height)",
+			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -77,7 +77,7 @@
 					"width": "2px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--foreground)",
+					"background": "var(--wp--custom--color--primary)",
 					"text": "var(--wp--custom--color--background)"
 				},
 				"hover": {
@@ -324,7 +324,7 @@
 					"radius": "var(--wp--custom--button--border--radius)"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--primary)",
+					"background": "var(--wp--custom--button--color--background)",
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
@@ -354,7 +354,7 @@
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},
 			"core/navigation": {
@@ -379,13 +379,13 @@
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"lineHeight": "var(--wp--custom--line-height--headings)"
+					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground-light)",
-					"text": "var(--wp--custom--color--foreground-light)"
+					"link": null,
+					"text": null
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -211,7 +211,7 @@ ul ul {
 
 .wp-block-post-comments {
 	font-size: var(--wp--preset--font-size--normal);
-	line-height: var(--wp--custom--line-height--body);
+	line-height: var(--wp--custom--body--typography--line-height);
 }
 
 .wp-block-post-comments .reply a {
@@ -344,7 +344,7 @@ ul ul {
 
 .wp-block-post-comments .commentlist .comment p {
 	font-size: var(--wp--preset--font-size--normal);
-	line-height: var(--wp--custom--line-height--body);
+	line-height: var(--wp--custom--body--typography--line-height);
 }
 
 .wp-block-post-comments .comment-body > p > a,

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -71,8 +71,14 @@
 				},
 				"padding": "20px"
 			},
+			"body": {
+				"typography": {
+					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))"
+				}
+			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--font-headings, var(--wp--preset--font-family--dm-sans))",
 					"fontWeight": "500"
 				},
 				"h1": {
@@ -91,11 +97,6 @@
 					"h4": 1.4,
 					"h5": 1.4,
 					"h6": 1.4
-				}
-			},
-			"list": {
-				"padding": {
-					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
 				}
 			},
 			"margin": {
@@ -155,13 +156,8 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "\"DM Sans\", sans-serif",
-					"slug": "base",
+					"slug": "dm-sans",
 					"name": "DM Sans"
-				},
-				{
-					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-					"slug": "system-font",
-					"name": "System Font"
 				}
 			],
 			"fontSizes": [
@@ -221,11 +217,6 @@
 					"fontSize": "20px",
 					"fontWeight": "400",
 					"lineHeight": "1.6"
-				}
-			},
-			"core/heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)"
 				}
 			},
 			"core/navigation": {

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -73,7 +73,8 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))"
+					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))",
+					"lineHeight": 1.7
 				}
 			},
 			"heading": {
@@ -89,15 +90,7 @@
 				}
 			},
 			"line-height": {
-				"body": 1.7,
-				"headings": {
-					"h1": 1.2,
-					"h2": 1.2,
-					"h3": 1.2,
-					"h4": 1.4,
-					"h5": 1.4,
-					"h6": 1.4
-				}
+				"body": 1.7
 			},
 			"margin": {
 				"horizontal": "20px",
@@ -234,7 +227,7 @@
 				"typography": {
 					"fontSize": "var(--wp--custom--heading--h1--font-size)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
+					"lineHeight": 1.2
 				}
 			},
 			"list": {
@@ -300,37 +293,37 @@
 			"h1": {
 				"typography": {
 					"fontSize": "var(--wp--custom--heading--h1--font-size)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
+					"lineHeight": 1.2
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontSize": "min(max(36px, 6vw), 65px)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h2)"
+					"lineHeight": 1.2
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontSize": "var(--wp--custom--heading--h3--font-size)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h3)"
+					"lineHeight": 1.2
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontSize": "20px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h4)"
+					"lineHeight": 1.4
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontSize": "18px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h5)"
+					"lineHeight": 1.4
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontSize": "16px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h6)"
+					"lineHeight": 1.4
 				}
 			},
 			"link": {
@@ -340,9 +333,7 @@
 			}
 		},
 		"typography": {
-			"fontSize": "var(--wp--preset--font-size--normal)",
-			"fontWeight": "400",
-			"lineHeight": "var(--wp--custom--line-height--body)"
+			"fontWeight": "400"
 		},
 		"core/site-logo": {
 			"spacing": {

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -32,6 +32,14 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 			)
 		);
 
+		// Add support for WordPress.com Global Styles.
+		add_theme_support(
+			'jetpack-global-styles',
+			array(
+				'enable_theme_default' => true,
+			)
+		);
+
 		remove_theme_support( 'block-templates' );
 	}
 	add_action( 'after_setup_theme', 'quadrat_support' );

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -3,7 +3,7 @@
 .wp-block-post-comments {
 
 	font-size: var(--wp--preset--font-size--normal);
-	line-height: var(--wp--custom--line-height--body);
+	line-height: var(--wp--custom--body--typography--line-height);
 
 	.reply a {
 		--wp--custom--button--typography--font-size: var(--wp--preset--font-size--normal);
@@ -127,7 +127,7 @@
 		.comment {
 			p {
 				font-size: var(--wp--preset--font-size--normal);
-				line-height: var(--wp--custom--line-height--body);
+				line-height: var(--wp--custom--body--typography--line-height);
 			}
 		}
 	}

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -138,7 +138,8 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))"
+					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))",
+					"lineHeight": 1.7
 				}
 			},
 			"heading": {
@@ -242,15 +243,7 @@
 				"family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
 			],
 			"line-height": {
-				"body": 1.7,
-				"headings": {
-					"h1": 1.2,
-					"h2": 1.2,
-					"h3": 1.2,
-					"h4": 1.4,
-					"h5": 1.4,
-					"h6": 1.4
-				}
+				"body": 1.7
 			}
 		},
 		"layout": {
@@ -382,7 +375,7 @@
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--heading--h1--font-size)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h1)",
+					"lineHeight": 1.2,
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
 				}
 			},
@@ -478,37 +471,37 @@
 			"h1": {
 				"typography": {
 					"fontSize": "var(--wp--custom--heading--h1--font-size)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h1)"
+					"lineHeight": 1.2
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontSize": "min(max(36px, 6vw), 65px)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h2)"
+					"lineHeight": 1.2
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontSize": "var(--wp--custom--heading--h3--font-size)",
-					"lineHeight": "var(--wp--custom--line-height--headings--h3)"
+					"lineHeight": 1.2
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontSize": "20px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h4)"
+					"lineHeight": 1.4
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontSize": "18px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h5)"
+					"lineHeight": 1.4
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontSize": "16px",
-					"lineHeight": "var(--wp--custom--line-height--headings--h6)"
+					"lineHeight": 1.4
 				}
 			},
 			"link": {
@@ -518,7 +511,7 @@
 			}
 		},
 		"typography": {
-			"lineHeight": "var(--wp--custom--line-height--body)",
+			"lineHeight": "var(--wp--custom--body--typography--line-height)",
 			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -10,6 +10,16 @@
 			"area": "footer"
 		}
 	],
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
 	"settings": {
 		"border": {
 			"customColor": true,
@@ -80,7 +90,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "20px",
 					"fontWeight": "700",
 					"lineHeight": 2
@@ -126,8 +136,14 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"body": {
+				"typography": {
+					"fontFamily": "var(--font-base, var(--wp--preset--font-family--dm-sans))"
+				}
+			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--font-headings, var(--wp--preset--font-family--dm-sans))",
 					"fontWeight": "500",
 					"lineHeight": 1.125
 				},
@@ -139,9 +155,13 @@
 				}
 			},
 			"list": {
-				"fontFamily": "var(--wp--custom--font-family--base)",
-				"padding": {
-					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				"typography": {
+					"fontFamily": "var(--wp--custom--body--typography--font-family)"
+				},
+				"spacing": {
+					"padding": {
+						"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+					}
 				}
 			},
 			"margin": {
@@ -153,7 +173,7 @@
 				"dropcap": {
 					"margin": "0 .2em .2em 0",
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--base)",
+						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "var(--wp--preset--font-size--huge)",
 						"fontWeight": "400"
 					}
@@ -253,13 +273,8 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "\"DM Sans\", sans-serif",
-					"slug": "base",
+					"slug": "dm-sans",
 					"name": "DM Sans"
-				},
-				{
-					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-					"slug": "system-font",
-					"name": "System Font"
 				}
 			],
 			"fontSizes": [
@@ -339,7 +354,7 @@
 			},
 			"core/heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -365,6 +380,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--custom--heading--h1--font-size)",
 					"lineHeight": "var(--wp--custom--line-height--headings--h1)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
@@ -503,7 +519,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--line-height--body)",
-			"fontFamily": "var(--wp--preset--font-family--base)",
+			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
 		},

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -88,6 +88,11 @@
 			]
 		},
 		"custom": {
+			"body": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fira-sans)"
+				}
+			},
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--color--secondary)"
@@ -113,6 +118,11 @@
 				"family=Fira+Sans:ital,wght@0,400;0,500;1,400",
 				"family=Playfair+Display:ital,wght@0,400;0,700;1,400"
 			],
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}	
+			},
 			"margin": {
 				"horizontal": "25px",
 				"vertical": "30px"
@@ -120,7 +130,7 @@
 			"pullquote": {
 				"citation": {
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--base)"
+						"fontFamily": "var(--wp--custom--body--typography--font-family)"
 					},
 					"spacing": {
 						"margin": {
@@ -142,14 +152,14 @@
 			"customLineHeight": true,
 			"fontFamilies": [
 				{
-					"fontFamily": "var(--font-base, 'Fira Sans', Helvetica, Arial, sans-serif)",
-					"slug": "base",
-					"name": "Base"
+					"fontFamily": "'Fira Sans', Helvetica, Arial, sans-serif",
+					"slug": "fira-sans",
+					"name": "Fira Sans"
 				},
 				{
-					"fontFamily": "var(--font-headings, 'Playfair Display', Georgia, Times, serif)",
-					"slug": "headings",
-					"name": "Headings"
+					"fontFamily": "'Playfair Display', Georgia, Times, serif",
+					"slug": "playfair-display",
+					"name": "Playfair Display"
 				}
 			],
 			"fontSizes": [
@@ -203,7 +213,7 @@
 					"fontSize": "32px",
 					"fontStyle": "italic",
 					"lineHeight": "1.3",
-					"fontFamily": "var(--wp--preset--font-family--headings)"
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)"
 				}
 			},
 			"core/separator": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -14,6 +14,16 @@
 			"area": "Post Meta"
 		}
 	],
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
 	"settings": {
 		"border": {
 			"customColor": true,
@@ -126,7 +136,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--base)",
+					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
@@ -172,16 +182,27 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"body": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fira-sans)",
+					"lineHeight": 1.6
+				}
+			},
 			"heading": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
 			},
 			"list": {
-				"fontFamily": "var(--wp--custom--font-family--base)",
-				"padding": {
-					"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+				"typography": {
+					"fontFamily": "var(--wp--custom--body--typography--font-family)"
+				},
+				"spacing": {
+					"padding": {
+						"left": "calc( 2 * var(--wp--custom--margin--horizontal) )"
+					}
 				}
 			},
 			"margin": {
@@ -193,7 +214,7 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--base)",
+						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -214,7 +235,7 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontFamily": "var(--wp--preset--font-family--base)",
+						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontStyle": "italic"
 					},
 					"spacing": {
@@ -281,14 +302,14 @@
 			"customLineHeight": true,
 			"fontFamilies": [
 				{
-					"fontFamily": "var(--font-base, 'Fira Sans', Helvetica, Arial, sans-serif)",
-					"slug": "base",
-					"name": "Base"
+					"fontFamily": "'Fira Sans', Helvetica, Arial, sans-serif",
+					"slug": "fira-sans",
+					"name": "Fira Sans"
 				},
 				{
-					"fontFamily": "var(--font-headings, 'Playfair Display', Georgia, Times, serif)",
-					"slug": "headings",
-					"name": "Headings"
+					"fontFamily": "'Playfair Display', Georgia, Times, serif",
+					"slug": "playfair-display",
+					"name": "Playfair Display"
 				}
 			],
 			"fontSizes": [
@@ -365,7 +386,7 @@
 			},
 			"core/heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--headings)",
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -390,6 +411,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -412,7 +434,7 @@
 					"fontStyle": "italic",
 					"fontSize": "32px",
 					"lineHeight": "1.3",
-					"fontFamily": "var(--wp--preset--font-family--headings)"
+					"fontFamily": "var(--wp--custom--heading--typography--font-family)"
 				},
 				"spacing": {
 					"padding": {
@@ -501,8 +523,8 @@
 			}
 		},
 		"typography": {
-			"lineHeight": 1.6,
-			"fontFamily": "var(--wp--preset--font-family--base)",
+			"lineHeight": "var(--wp--custom--body--typography--line-height)",
+			"fontFamily": "var(--wp--custom--body--typography--font-family)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}


### PR DESCRIPTION
### Details

This change allows the wp.com Font Picker to work with the Quadrat theme.  

Additionally it refactors Blockbase and children in order to simplify the handling of Font Faces in the configurations.  Some font-related housekeeping was also done.

#### Known Issues

Editor does NOT SHOW updated font choices (either upon load or in real time). In order for variables to flow to enable this functionality one of two things will need to happen:

* The Font Picker will need to target body instead of .editor-styles-wrapper in the editor
OR
* The Global Styles variables will need to target .editor-styles-wrapper instead of body

This is because at the level at which the font family variable is first consumed (body) the value of --font-face isn’t defined so the  browser moves on to the alternate value provided. Even though the variable IS defined further down the stack, it’s not defined THERE so it’s ignored in that context henceforth.  Even though the value of --font-face IS defined in the context in which it’s used (any text element in the .editor-styles-wrapper element) it’s still ignored.

I’m not sure which of these to further explore or recommend.   I don’t believe any themes leveraging Global Styles to define fonts will be able to use the .com Font Picker until that’s resolved in some way.  There may be other situations where other plugins or tools are trying to make use of Global Styles variables so this situation seems likely to happen in other scenarios.  

#### Refactor Details

Prior to this change there was a bit of a mix between "semantic" and "descriptive" font faces in the Blockbase & Co. themes.  This change standardizes on BOTH concepts with "descriptive" font families being supplied in the --preset (and thus provided to the user with meaningful names) and "semantic" font families being defined in the "custom" block and distributed to the blocks (or CSS).

In this way a theme (such as Quadrat) can tap into those two locations to introduce the `var(--font-base)` and `var(--font-headings)` variable usage for the Font Picker (which it does in this change).

A number of other font-related house cleaning was done as well eliminating any duplicate/redundant settings.

Note that prior to this change Seedlet-blocks DID have SOME (-ish) support for the Font Picker in that it would consume the font values assigned (though with no way to change it).  This change REMOVES the usage of the Font Picker `var(--font-base/--font-headings)` from Seedlet (though adding FULL support for the Font Picker for any of the Blockbase children would be a simple thing... though [at least for now] I suggest ONLY supporting that in "Universal" themes such as Quadrat.

### Testing

Either test these changes on a sandbox or install the Editing Toolkit plugin.  
Activate Quadrat and edit any post or page.
Note that the Font Picker icon is active.  Select it.
Change the BASE and HEADER font families and publish the changes.
(Note the bug noted above; currently you will NOT see those changes in the Editor).
View the site.  Note that the headings and body font families match the selections made in the editor.
Activate Blockbase, Seedlet-Blocks and Mayland-blocks
Ensure that the default font-faces show as expected and are not influenced by the typeface selection in the Font Picker.

### Screenshots

Editor:
![image](https://user-images.githubusercontent.com/146530/121950714-fe5f2900-cd27-11eb-8dbb-eb26b8b36cbd.png)

View:
![image](https://user-images.githubusercontent.com/146530/121950805-19319d80-cd28-11eb-967e-068a06deb772.png)
