### PR TITLE
Blockbase: Add all fonts

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -65,16 +65,17 @@ function blockbase_fonts_url() {
 	}
 
 	$theme_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
-	if ( empty( $theme_data ) || empty( $theme_data['custom'] ) ) {
+	if ( empty( $theme_data ) || empty( $theme_data['typography'] ) || empty( $theme_data['typography']['fontFamilies'] ) || empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
 		return '';
 	}
 
-	$custom_data = $theme_data['custom'];
-	if ( ! array_key_exists( 'fontsToLoadFromGoogle', $custom_data ) ) {
-		return '';
+	$font_list = $theme_data['typography']['fontFamilies']['theme'];
+	$font_families = [];
+	foreach( $font_list as $font ) {
+		if ( 'system-font' !== $font['slug'] ) {
+			$font_families[] = 'family=' . str_replace( ' ', '+', $font['name'] ) . ':ital,wght@0,400;0,500;0,700;1,400;1,500;1,700';
+		}
 	}
-
-	$font_families   = $theme_data['custom']['fontsToLoadFromGoogle'];
 	$font_families[] = 'display=swap';
 
 	// Make a single request for the theme fonts.

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -241,14 +241,154 @@
 			"customLineHeight": true,
 			"fontFamilies": [
 				{
-					"fontFamily": "var(--font-base, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
-					"slug": "base",
-					"name": "Base"
+					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+					"slug": "system-font",
+					"name": "System Font"
 				},
 				{
-					"fontFamily": "var(--font-headings, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
-					"slug": "headings",
-					"name": "Headings"
+					"fontFamily": "\"Arvo\", serif",
+					"slug": "arvo",
+					"name": "Arvo"
+				},
+				{
+					"fontFamily": "\"Bodoni Moda\", serif",
+					"slug": "bodoni-moda",
+					"name": "Bodoni Moda"
+				},
+				{
+					"fontFamily": "\"Cabin\", sans-serif",
+					"slug": "cabin",
+					"name": "Cabin"
+				},
+				{
+					"fontFamily": "\"Chivo\", sans-serif",
+					"slug": "chivo",
+					"name": "Chivo"
+				},
+				{
+					"fontFamily": "\"Courier Prime\", serif",
+					"slug": "courier-prime",
+					"name": "Courier Prime"
+				},
+				{
+					"fontFamily": "\"DM Sans\", sans-serif",
+					"slug": "dm-sans",
+					"name": "DM Sans"
+				},
+				{
+					"fontFamily": "\"Domine\", serif",
+					"slug": "domine",
+					"name": "Domine"
+				},
+				{
+					"fontFamily": "\"EB Garamond\", serif",
+					"slug": "eb-garamond",
+					"name": "EB Garamond"
+				},
+				{
+					"fontFamily": "\"Fira Sans\", sans-serif",
+					"slug": "fira-sans",
+					"name": "Fira Sans"
+				},
+				{
+					"fontFamily": "\"Inter\", sans-serif",
+					"slug": "inter",
+					"name": "Inter"
+				},
+				{
+					"fontFamily": "\"Josefin Sans\", sans-serif",
+					"slug": "josefin-sans",
+					"name": "Josefin Sans"
+				},
+				{
+					"fontFamily": "\"Libre Baskerville\", serif",
+					"slug": "libre-baskerville",
+					"name": "Libre Baskerville"
+				},
+				{
+					"fontFamily": "\"Libre Franklin\", sans-serif",
+					"slug": "libre-franklin",
+					"name": "Libre Franklin"
+				},
+				{
+					"fontFamily": "\"Lora\", serif",
+					"slug": "lora",
+					"name": "Lora"
+				},
+				{
+					"fontFamily": "\"Merriweather\", serif",
+					"slug": "merriweather",
+					"name": "Merriweather"
+				},
+				{
+					"fontFamily": "\"Montserrat\", sans-serif",
+					"slug": "montserrat",
+					"name": "Montserrat"
+				},
+				{
+					"fontFamily": "\"Nunito\", sans-serif",
+					"slug": "nunito",
+					"name": "Nunito"
+				},
+				{
+					"fontFamily": "\"Open Sans\", sans-serif",
+					"slug": "open-sans",
+					"name": "Open Sans"
+				},
+				{
+					"fontFamily": "\"Overpass\", sans-serif",
+					"slug": "overpass",
+					"name": "Overpass"
+				},
+				{
+					"fontFamily": "\"Playfair Display\", serif",
+					"slug": "playfair-display",
+					"name": "Playfair Display"
+				},
+				{
+					"fontFamily": "\"Poppins\", sans-serif",
+					"slug": "poppins",
+					"name": "Poppins"
+				},
+				{
+					"fontFamily": "\"Raleway\", sans-serif",
+					"slug": "raleway",
+					"name": "Raleway"
+				},
+				{
+					"fontFamily": "\"Roboto\", sans-serif",
+					"slug": "roboto",
+					"name": "Roboto"
+				},
+				{
+					"fontFamily": "\"Roboto Slab\", sans-serif",
+					"slug": "roboto-slab",
+					"name": "Roboto Slab"
+				},
+				{
+					"fontFamily": "\"Rubik\", sans-serif",
+					"slug": "rubik",
+					"name": "Rubik"
+				},
+				{
+					"fontFamily": "\"Source Sans Pro\", sans-serif",
+					"slug": "source-sans-pro",
+					"name": "Source Sans Pro"
+				},
+				{
+					"fontFamily": "\"Source Serif Pro\", serif",
+					"slug": "source-sans-pro",
+					"name": "Source Sans Pro"
+				},
+				{
+					"fontFamily": "\"Space Mono\", sans-serif",
+					"slug": "space-mono",
+					"name": "Space Mono"
+				},
+				{
+					"fontFamily": "\"Work Sans\", sans-serif",
+					"slug": "work-sans",
+					"name": "Work Sans"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This is an alternative approach to https://github.com/Automattic/themes/issues/4051

By loading a large selection of fonts into Blockbase we make all these available to the child themes too.

One problem with this approach is that we load all fonts regardless of which ones you use. The request is pretty small so maybe this is ok. In some ways this could be better as if we always load the same URL for fonts on all themes, it will be cached so it will be faster across sites than having different font packages per theme/site and loading different ones each time.

We should make it possible for child themes to add additional fonts.

To test, load the site editor and change fonts.


#### Related issue(s):
#4051