### PR TITLE
Quadrat: Simplify templates

### DIFF
--- a/quadrat/404.php
+++ b/quadrat/404.php
@@ -14,12 +14,6 @@
  */
 get_header();
 
-	// the header
-	get_template_part( 'template-parts/header' );
-
 	echo gutenberg_block_template_part( '404' );
-
-	// the footer
-	echo gutenberg_block_template_part( 'footer' );
 
 get_footer();

--- a/quadrat/block-template-parts/404.html
+++ b/quadrat/block-template-parts/404.html
@@ -1,3 +1,5 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
 <!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
 <div class="wp-block-group page-content">
 
@@ -12,3 +14,5 @@
 <!-- wp:search {"label":"","buttonText":"Search"} /-->
 </div>
 <!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"tagName":"header","className":"site-header"} -->
 <header class="wp-block-group site-header"><!-- wp:site-title /-->
 
-<!-- wp:navigation {"isResponsive":true,"__unstable__location":"primary"} -->
+<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation --></header>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"tagName":"header","className":"site-header"} -->
-<div class="wp-block-group site-header"><!-- wp:site-logo /--><!-- wp:site-title /-->
+<header class="wp-block-group site-header"><!-- wp:site-title /-->
 
-<!-- wp:navigation {"isResponsive":true} -->
-<!-- /wp:navigation --></div>
+<!-- wp:navigation {"isResponsive":true,"__unstable__location":"primary"} -->
+<!-- /wp:navigation --></header>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/index.html
+++ b/quadrat/block-template-parts/index.html
@@ -1,3 +1,5 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
 <!-- wp:query {"className":"page-content","layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <div class="wp-block-query page-content">
 <!-- wp:query-loop -->
@@ -20,3 +22,5 @@
 
 </div>
 <!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-template-parts/page.html
+++ b/quadrat/block-template-parts/page.html
@@ -1,0 +1,5 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-template-parts/search.html
+++ b/quadrat/block-template-parts/search.html
@@ -1,3 +1,5 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
 <!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
 <div class="wp-block-group page-content">
 
@@ -16,3 +18,5 @@
 
 </div>
 <!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-template-parts/single.html
+++ b/quadrat/block-template-parts/single.html
@@ -1,3 +1,5 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
 <!-- wp:group {"className":"post-header"} -->
 <div class="wp-block-group post-header">
 
@@ -49,3 +51,5 @@
 	<!-- wp:post-comments /-->
 </div>
 <!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-templates/404.html
+++ b/quadrat/block-templates/404.html
@@ -1,5 +1,1 @@
-<!-- wp:template-part {"slug":"header"} /-->
-
 <!-- wp:template-part {"slug":"404"} /-->
-
-<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -1,6 +1,1 @@
-<!-- wp:template-part {"slug":"header"} /-->
-
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
-
-<!-- wp:template-part {"slug":"footer"} /-->
-
+<!-- wp:template-part {"slug":"page"} /-->

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -1,5 +1,1 @@
-<!-- wp:template-part {"slug":"header"} /-->
-
 <!-- wp:template-part {"slug":"search"} /-->
-
-<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -1,5 +1,1 @@
-<!-- wp:template-part {"slug":"header"} /-->
-
 <!-- wp:template-part {"slug":"single"} /-->
-
-<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/index.php
+++ b/quadrat/index.php
@@ -14,13 +14,7 @@
  */
 get_header();
 
-	// the header
-	get_template_part( 'template-parts/header' );
-
-	// the query
-	echo gutenberg_block_template_part( 'query' );
-
-	// the footer
-	echo gutenberg_block_template_part( 'footer' );
+// the query
+echo gutenberg_block_template_part( 'index' );
 
 get_footer();

--- a/quadrat/search.php
+++ b/quadrat/search.php
@@ -14,12 +14,6 @@
  */
 get_header();
 
-	// the header
-	get_template_part( 'template-parts/header' );
-
-	echo gutenberg_block_template_part( 'search' );
-
-	// the footer
-	echo gutenberg_block_template_part( 'footer' );
+echo gutenberg_block_template_part( 'search' );
 
 get_footer();

--- a/quadrat/single.php
+++ b/quadrat/single.php
@@ -9,12 +9,6 @@
  */
 get_header();
 
-	// the header
-	get_template_part( 'template-parts/header' );
-
-	echo gutenberg_block_template_part( 'single' );
-
-	// the footer
-	echo gutenberg_block_template_part( 'footer' );
+echo gutenberg_block_template_part( 'single' );
 
 get_footer();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This makes a few changes to our template files to simplify things.

Now each HTML template file is just a one liner that includes the corresponding template part. This means our PHP templates can be much simpler. It also means that we can modify the top level templates in the Site Editor and then switch back to classic mode and our edits will be kept.

It also implements the new `__unstable__location` attribute from Gutenberg so that we only need one header template part.

To test:
- Check that the site loads correctly still
- Try adding menu to the primary location and check that it shows up
- Add an index.html template file with this content: `<!-- wp:template-part {"slug":"index"} /-->` and check that everything works as expected in the site editor.