### PR TITLE
added tagline to header templates

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -486,7 +486,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	grid-template-columns: 1fr 2fr 1fr;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.wp-block-query-pagination {
 		grid-template-areas: "prev next";
 		grid-template-columns: 1fr 1fr;
@@ -512,7 +512,7 @@ p.has-drop-cap:not(:focus):first-letter {
 	text-decoration: underline;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.wp-block-query-pagination .wp-block-query-pagination-numbers {
 		display: none;
 	}

--- a/blockbase/sass/base/_breakpoints.scss
+++ b/blockbase/sass/base/_breakpoints.scss
@@ -1,8 +1,8 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
- @mixin break-mobile-only() {
-	@media (max-width: #{ ($break-mobile - 1) }) {
+@mixin break-small-only() {
+	@media (max-width: #{ ($break-small - 1) }) {
 		@content;
 	}
 }

--- a/blockbase/sass/blocks/_query-pagination.scss
+++ b/blockbase/sass/blocks/_query-pagination.scss
@@ -5,7 +5,7 @@
 	grid-template-areas: "prev numbers next";
 	grid-template-columns: 1fr 2fr 1fr;
 
-	@include break-mobile-only(){
+	@include break-small-only(){
 		grid-template-areas: "prev next";
 		grid-template-columns: 1fr 1fr;
 	}
@@ -26,7 +26,7 @@
 		.current {
 			text-decoration: underline;
 		}
-		@include break-mobile-only(){
+		@include break-small-only(){
 			display: none;
 		}
 	}

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -30,7 +30,7 @@
 /**
  * Reset the WP Admin page styles for Gutenberg-like pages.
  */
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.headlines-pattern {
 		padding-top: 50px !important;
 		padding-bottom: 50px !important;
@@ -153,7 +153,7 @@ ul ul {
 	list-style-type: disc;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.wp-block-media-text:not(.has-background) .wp-block-media-text__content {
 		padding: 0;
 	}
@@ -536,7 +536,7 @@ textarea:focus {
 	padding: 10px var(--wp--custom--post-content--padding--left) 60px;
 }
 
-@media (min-width: 480px) {
+@media (min-width: 600px) {
 	.site-header {
 		padding: var(--wp--custom--post-content--padding--left);
 	}
@@ -546,7 +546,7 @@ textarea:focus {
 	margin-right: var(--wp--custom--margin--horizontal);
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.site-header .wp-block-site-logo {
 		flex-basis: 100%;
 		margin: 20px 0;
@@ -572,7 +572,7 @@ textarea:focus {
 	margin: 0;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.site-header .wp-block-site-tagline {
 		padding-left: 0 !important;
 		flex-basis: 100%;
@@ -591,14 +591,14 @@ textarea:focus {
 	z-index: -1;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.site-header:before {
 		-webkit-clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
 		        clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
 	}
 }
 
-@media (min-width: 480px) {
+@media (min-width: 600px) {
 	.site-header:before {
 		-webkit-clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
 		        clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
@@ -626,7 +626,7 @@ textarea:focus {
 	justify-content: center;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 599px) {
 	.post-meta {
 		padding-top: 0 !important;
 		margin-bottom: -20px;

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -568,6 +568,18 @@ textarea:focus {
 	padding-right: 0;
 }
 
+.site-header .wp-block-site-tagline {
+	margin: 0;
+}
+
+@media (max-width: 479px) {
+	.site-header .wp-block-site-tagline {
+		padding-left: 0 !important;
+		flex-basis: 100%;
+		order: 10;
+	}
+}
+
 .site-header:before {
 	content: "";
 	background-color: var(--wp--custom--color--secondary);

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"tagName":"header","className":"site-header"} -->
-<header class="wp-block-group site-header"><!-- wp:site-title /-->
+<div class="wp-block-group site-header"><!-- wp:site-logo /--><!-- wp:site-title /--><!-- wp:site-tagline {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"20px"}}},"fontSize":"tiny"} /-->
 
 <!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation --></header>

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,6 +1,8 @@
 <!-- wp:group {"tagName":"header","className":"site-header"} -->
-<div class="wp-block-group site-header"><!-- wp:site-logo /--><!-- wp:site-title /--><!-- wp:site-tagline {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"20px"}}},"fontSize":"tiny"} /-->
-
-<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} -->
-<!-- /wp:navigation --></header>
+<div class="wp-block-group site-header">
+	<!-- wp:site-logo /-->
+	<!-- wp:site-title /-->
+	<!-- wp:site-tagline {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"20px"},"margin":{"right":"auto"}}},"fontSize":"tiny"} /-->
+	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+</div>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,8 +1,8 @@
 <!-- wp:group {"tagName":"header","className":"site-header"} -->
-<div class="wp-block-group site-header">
+<header class="wp-block-group site-header">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"20px"},"margin":{"right":"auto"}}},"fontSize":"tiny"} /-->
 	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
-</div>
+</header>
 <!-- /wp:group -->

--- a/quadrat/sass/block-patterns/_headlines.scss
+++ b/quadrat/sass/block-patterns/_headlines.scss
@@ -1,5 +1,5 @@
 .headlines-pattern {
-	@include break-mobile-only(){
+	@include break-small-only(){
 		padding-top: 50px !important;
 		padding-bottom: 50px !important;
 	}

--- a/quadrat/sass/blocks/_media-text.scss
+++ b/quadrat/sass/blocks/_media-text.scss
@@ -1,5 +1,5 @@
 .wp-block-media-text:not(.has-background) .wp-block-media-text__content {
-	@include break-mobile-only(){
+	@include break-small-only(){
 		padding: 0;
 	}
 }

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -31,6 +31,15 @@
 		padding-right: 0;
 	}
 
+	.wp-block-site-tagline {
+		margin: 0;
+		@include break-mobile-only() {
+			padding-left: 0 !important;
+			flex-basis: 100%;
+			order: 10;
+		}
+	}
+
 	&:before {
 		content: "";
 		background-color: var(--wp--custom--color--secondary);

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -3,14 +3,14 @@
 	overflow: inherit;
 	padding: 10px var(--wp--custom--post-content--padding--left) 60px; // TODO: Maybe replace with a responsive custom variable?
 
-	@include break-mobile() {
+	@include break-small() {
 		padding: var(--wp--custom--post-content--padding--left);
 	}
 
 	.wp-block-site-logo {
 		margin-right: var(--wp--custom--margin--horizontal);
 
-		@include break-mobile-only(){
+		@include break-small-only(){
 			flex-basis: 100%;
 			margin: 20px 0;
 			text-align: center;
@@ -33,7 +33,7 @@
 
 	.wp-block-site-tagline {
 		margin: 0;
-		@include break-mobile-only() {
+		@include break-small-only() {
 			padding-left: 0 !important;
 			flex-basis: 100%;
 			order: 10;
@@ -49,10 +49,10 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
-		@include break-mobile-only() {
+		@include break-small-only() {
 			clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
 		}
-		@include break-mobile() {
+		@include break-small() {
 			clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
 		}
 		@include break-large() {

--- a/quadrat/sass/templates/_meta.scss
+++ b/quadrat/sass/templates/_meta.scss
@@ -1,7 +1,7 @@
 .post-meta {
 	align-items: center;
 	justify-content: center;
-	@include break-mobile-only() {
+	@include break-small-only() {
 		padding-top: 0 !important;
 		margin-bottom: -20px;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Added tagline to the header of Quadrat.

With logo:

Desktop | Mobile
--- | ---
<img width="1607" alt="Screenshot 2021-06-18 at 10 45 59" src="https://user-images.githubusercontent.com/3593343/122542356-e559bf00-d02a-11eb-8f46-b5a045d28669.png"> | <img width="387" alt="Screenshot 2021-06-18 at 10 45 49" src="https://user-images.githubusercontent.com/3593343/122542352-e4289200-d02a-11eb-9556-f3d80b782238.png">


Without logo:

Desktop | Mobile
--- | ---
<img width="1612" alt="Screenshot 2021-06-18 at 10 46 17" src="https://user-images.githubusercontent.com/3593343/122542417-f1458100-d02a-11eb-8c4b-474f12ce9f06.png"> | <img width="372" alt="Screenshot 2021-06-18 at 10 46 26" src="https://user-images.githubusercontent.com/3593343/122542422-f276ae00-d02a-11eb-8452-73fa05d3ca2e.png">


#### Related issue(s):

Closes #4059