### PR TITLE
Blockbase: Add template with just a header and footer

### DIFF
--- a/blockbase/block-templates/header-footer-only.html
+++ b/blockbase/block-templates/header-footer-only.html
@@ -1,0 +1,10 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group post-content">
+
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -18,6 +18,14 @@
 				"page",
 				"post"
 			]
+		},
+		{
+			"name": "header-footer-only",
+			"title": "Header and Footer Only",
+			"postTypes": [
+				"page",
+				"post"
+			]
 		}
 	],
 	"settings": {


### PR DESCRIPTION
@ianstewart Recommended having a set of three post/page templates bundled for block themes: 

Option A: Header and Footer Only|B: Blank|C: Default 
---|---|---
<img width="1440" alt="Option-A" src="https://user-images.githubusercontent.com/1202812/122568752-18df1e00-d018-11eb-8a75-713a1fda9d8c.png">|<img width="1440" alt="Option-B" src="https://user-images.githubusercontent.com/1202812/122568755-18df1e00-d018-11eb-9249-f5d6babcef5c.png">|<img width="1440" alt="Option-C" src="https://user-images.githubusercontent.com/1202812/122568759-1977b480-d018-11eb-95ef-6efcd928eee7.png">

Blockbase already has B and C, so this PR adds in that first one. I called it "Header and Footer Only" for now, but I'm definitely open to better names. 🤔 

## Screenshots

<img width="297" alt="Screen Shot 2021-06-18 at 9 28 53 AM" src="https://user-images.githubusercontent.com/1202812/122569037-5774d880-d018-11eb-8001-35d7de95dded.png">
<img width="295" alt="Screen Shot 2021-06-18 at 9 29 10 AM" src="https://user-images.githubusercontent.com/1202812/122569040-5774d880-d018-11eb-8777-9dec2ce32e69.png">
<img width="1435" alt="Screen Shot 2021-06-18 at 9 30 48 AM" src="https://user-images.githubusercontent.com/1202812/122569041-580d6f00-d018-11eb-8acd-f054dc58b404.png">

