### PR TITLE
Blockbase: Add a link to WordPress.com to the blockbase theme footer credits.

### DIFF
--- a/blockbase/block-template-parts/footer.html
+++ b/blockbase/block-template-parts/footer.html
@@ -1,7 +1,7 @@
 <!-- wp:group -->
 <div class="wp-block-group">
 	<!-- wp:paragraph {"align":"center","fontSize":"tiny"} -->
-	<p class="has-text-align-center has-tiny-font-size">Proudly Powered by <a href="https://wordpress.com" rel="nofollow">WordPress</a></p>
+	<p class="has-text-align-center has-tiny-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/footer.html
+++ b/blockbase/block-template-parts/footer.html
@@ -1,7 +1,7 @@
 <!-- wp:group -->
 <div class="wp-block-group">
 	<!-- wp:paragraph {"align":"center","fontSize":"tiny"} -->
-	<p class="has-text-align-center has-tiny-font-size">Proudly Powered by WordPress</p>
+	<p class="has-text-align-center has-tiny-font-size">Proudly Powered by <a href="https://wordpress.com" rel="nofollow">WordPress</a></p>
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We append WPCOM footer credits to block-based site frontends for free accounts.

See D59022-code for where we introduced this.

If the site already **has a link** to WordPress.com or WordPress.org however we won't append the footer.

This PR adds a link to the default theme footer template so new sites created using this theme won't show the additional footer.

#### Before
<img width="700" alt="Screen Shot 2021-06-21 at 10 20 04 am" src="https://user-images.githubusercontent.com/6458278/122692956-14ff0600-d27b-11eb-96d7-3e29e9cd964c.png">


#### After
<img width="700" alt="Screen Shot 2021-06-21 at 10 21 34 am" src="https://user-images.githubusercontent.com/6458278/122692958-17616000-d27b-11eb-93c7-052c43568007.png">


### Related issue(s):

See pbAok1-2d9-p2#comment-4500 for context.
