### PR TITLE
Varia: Fix cover text color over clear backgrounds.

### DIFF
--- a/alves/package-lock.json
+++ b/alves/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/alves/package.json
+++ b/alves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alves",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Alves",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/alves/sass/style-child-theme.scss
+++ b/alves/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #3E7D98;
+	color: #ffffff;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #394d55;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: calc( 17 * 32px);
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #394d55;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #394d55;
 }
 
 .is-small-text,

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #394d55;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/alves/style.css
+++ b/alves/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #394d55;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #394d55;
 }
 
 .is-small-text,

--- a/alves/style.css
+++ b/alves/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/alves/style.css
+++ b/alves/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #394d55;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/balasana/package-lock.json
+++ b/balasana/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/balasana/package.json
+++ b/balasana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balasana",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Balasana",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/balasana/sass/style-child-theme.scss
+++ b/balasana/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: 576px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #19744C;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #303030;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #303030;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #303030;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #303030;
 }
 
 .is-small-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #303030;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #303030;
 }
 
 .is-small-text,

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #303030;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/barnsbury/package-lock.json
+++ b/barnsbury/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/barnsbury/package.json
+++ b/barnsbury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barnsbury",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Barnsbury",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/barnsbury/sass/style-child-theme.scss
+++ b/barnsbury/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #20603C;
+	color: #FFFDF6;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
+	color: #3C2323;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: calc( 15 * 32px);
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: #FDF9EC;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #FDF9EC;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
+	color: #3C2323;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #3C2323;
 }
 
 .is-small-text,

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #3C2323;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #3C2323;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
+	color: #3C2323;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #3C2323;
 }
 
 .is-small-text,

--- a/brompton/package-lock.json
+++ b/brompton/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/brompton/package.json
+++ b/brompton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brompton",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Brompton",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: 576px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: #E8E4DD;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #E8E4DD;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #C04239;
+	color: #E8E4DD;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
+	color: #252E36;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2600,7 +2600,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #252E36;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2596,11 +2596,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
+	color: #252E36;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #252E36;
 }
 
 .is-small-text,

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1560,6 +1560,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1560,6 +1560,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2607,7 +2607,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #252E36;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2603,11 +2603,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
+	color: #252E36;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #252E36;
 }
 
 .is-small-text,

--- a/coutoire/package-lock.json
+++ b/coutoire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/coutoire/package.json
+++ b/coutoire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coutoire",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Coutoire",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/coutoire/sass/style-child-theme.scss
+++ b/coutoire/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -624,7 +624,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -634,15 +633,15 @@ object {
 	color: #FFFFFF;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #FFFFFF;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1132,6 +1131,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -1133,19 +1133,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1218,6 +1209,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1556,6 +1556,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2596,7 +2596,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #444444;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2592,11 +2592,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #444444;
 }
 
 .is-small-text,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2599,11 +2599,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #444444;
 }
 
 .is-small-text,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1556,6 +1556,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2603,7 +2603,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #444444;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/dalston/package-lock.json
+++ b/dalston/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/dalston/sass/style-child-theme.scss
+++ b/dalston/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.9
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #0073AA;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #1e1e1e;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2598,7 +2598,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #1e1e1e;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1558,6 +1558,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2594,11 +2594,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #1e1e1e;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #1e1e1e;
 }
 
 .is-small-text,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2605,7 +2605,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #1e1e1e;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1558,6 +1558,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2601,11 +2601,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #1e1e1e;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #1e1e1e;
 }
 
 .is-small-text,

--- a/exford/package-lock.json
+++ b/exford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/exford/package.json
+++ b/exford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exford",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Exford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/exford/sass/style-child-theme.scss
+++ b/exford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: #FFFFFF;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #FFFFFF;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #23883D;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #111111;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #111111;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #111111;
 }
 
 .is-small-text,

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #111111;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/exford/style.css
+++ b/exford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/exford/style.css
+++ b/exford/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #111111;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #111111;
 }
 
 .is-small-text,

--- a/exford/style.css
+++ b/exford/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #111111;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/package.json
+++ b/hever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Hever",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/hever/sass/style-child-theme.scss
+++ b/hever/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -654,7 +654,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -664,15 +663,15 @@ object {
 	color: var(--wp--preset--color--background);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--background);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1162,6 +1161,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1163,19 +1163,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1248,6 +1239,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2626,7 +2626,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2622,11 +2622,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/hever/style.css
+++ b/hever/style.css
@@ -2629,11 +2629,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/hever/style.css
+++ b/hever/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/hever/style.css
+++ b/hever/style.css
@@ -2633,7 +2633,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/leven/package-lock.json
+++ b/leven/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/leven/package.json
+++ b/leven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leven",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Leven",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #ff302c;
+	color: #f7f7f6;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: #f7f7f6;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #f7f7f6;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #444444;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #444444;
 }
 
 .is-small-text,

--- a/leven/style.css
+++ b/leven/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #444444;
 }
 
 .is-small-text,

--- a/leven/style.css
+++ b/leven/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #444444;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/leven/style.css
+++ b/leven/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/mayland/package-lock.json
+++ b/mayland/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mayland/package.json
+++ b/mayland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mayland",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "mayland",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/mayland/sass/style-child-theme.scss
+++ b/mayland/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -626,7 +626,6 @@ object {
 	color: white;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -636,15 +635,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1134,6 +1133,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -1135,19 +1135,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #000000;
+	color: #ffffff;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1220,6 +1211,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #010101;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1558,6 +1558,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2594,11 +2594,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #010101;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #010101;
 }
 
 .is-small-text,

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2598,7 +2598,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #010101;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1558,6 +1558,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2601,11 +2601,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
+	color: #010101;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #010101;
 }
 
 .is-small-text,

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2605,7 +2605,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #010101;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/maywood/package-lock.json
+++ b/maywood/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/maywood/package.json
+++ b/maywood/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maywood",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Maywood",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/maywood/sass/style-child-theme.scss
+++ b/maywood/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1151,19 +1151,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #897248;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1236,6 +1227,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #181818;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -642,7 +642,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -652,15 +651,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1150,6 +1149,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #181818;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #181818;
 }
 
 .is-small-text,

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #181818;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #181818;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #181818;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #181818;
 }
 
 .is-small-text,

--- a/morden/package-lock.json
+++ b/morden/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.6.7",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/morden/sass/style-child-theme.scss
+++ b/morden/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.9
+Version: 1.6.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -654,7 +654,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -664,15 +663,15 @@ object {
 	color: var(--wp--preset--color--background);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--background);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1162,6 +1161,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1163,19 +1163,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1248,6 +1239,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2626,7 +2626,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2622,11 +2622,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.8
+Version: 1.6.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/morden/style.css
+++ b/morden/style.css
@@ -2629,11 +2629,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/morden/style.css
+++ b/morden/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.8
+Version: 1.6.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/morden/style.css
+++ b/morden/style.css
@@ -2633,7 +2633,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/redhill/package-lock.json
+++ b/redhill/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/redhill/package.json
+++ b/redhill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhill",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "redhill",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -639,7 +639,6 @@ object {
 	min-height: 576px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -649,15 +648,15 @@ object {
 	color: #FFFFFF;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: #FFFFFF;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1147,6 +1146,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -1148,19 +1148,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CA2017;
+	color: #FFFFFF;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1233,6 +1224,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #222222;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2600,7 +2600,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #222222;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2596,11 +2596,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #222222;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #222222;
 }
 
 .is-small-text,

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1560,6 +1560,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2603,11 +2603,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
+	color: #222222;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #222222;
 }
 
 .is-small-text,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1560,6 +1560,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2607,7 +2607,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #222222;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/rivington/package-lock.json
+++ b/rivington/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rivington/package.json
+++ b/rivington/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivington",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Rivington",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rivington/sass/_extra-child-theme.scss
+++ b/rivington/sass/_extra-child-theme.scss
@@ -470,3 +470,21 @@ a {
 		}
 	}
 }
+
+/**
+ * Search block
+ */
+.wp-block-search {
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper{
+			border-radius: #{map-deep-get($config-button, "border-radius")};
+		}
+		.wp-block-search__input {
+			background: transparent;
+		}
+	}
+	.wp-block-search__input {
+		margin-right: calc( .1 * #{map-deep-get($config-button, "padding", "horizontal")} );
+		border-radius: #{map-deep-get($config-button, "border-radius")};
+	}
+}

--- a/rivington/sass/style-child-theme.scss
+++ b/rivington/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.8
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -627,7 +627,6 @@ object {
 	min-height: calc( 15 * 32px);
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -637,15 +636,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1135,6 +1134,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -1136,19 +1136,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #CAAB57;
+	color: #060f29;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1221,6 +1212,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2595,11 +2595,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -4647,20 +4648,4 @@ p:not(.site-title) a:hover {
 	.mobile-nav-side .site-header.has-menu .site-branding {
 		display: contents;
 	}
-}
-
-/**
- * Search block
- */
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-	border-radius: 3px;
-}
-
-.wp-block-search.wp-block-search__button-inside .wp-block-search__input {
-	background: transparent;
-}
-
-.wp-block-search .wp-block-search__input {
-	margin-left: calc( .1 * 16px);
-	border-radius: 3px;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2599,7 +2599,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #f2f2f2;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -4650,3 +4650,19 @@ p:not(.site-title) a:hover {
 		display: contents;
 	}
 }
+
+/**
+ * Search block
+ */
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	border-radius: 3px;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__input {
+	background: transparent;
+}
+
+.wp-block-search .wp-block-search__input {
+	margin-left: calc( .1 * 16px);
+	border-radius: 3px;
+}

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.7
+Version: 1.3.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1559,6 +1559,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -4676,20 +4677,4 @@ p:not(.site-title) a:hover {
 	.mobile-nav-side .site-header.has-menu .site-branding {
 		display: contents;
 	}
-}
-
-/**
- * Search block
- */
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-	border-radius: 3px;
-}
-
-.wp-block-search.wp-block-search__button-inside .wp-block-search__input {
-	background: transparent;
-}
-
-.wp-block-search .wp-block-search__input {
-	margin-right: calc( .1 * 16px);
-	border-radius: 3px;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2606,7 +2606,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #f2f2f2;
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4679,3 +4679,19 @@ p:not(.site-title) a:hover {
 		display: contents;
 	}
 }
+
+/**
+ * Search block
+ */
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	border-radius: 3px;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__input {
+	background: transparent;
+}
+
+.wp-block-search .wp-block-search__input {
+	margin-right: calc( .1 * 16px);
+	border-radius: 3px;
+}

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2602,11 +2602,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
+	color: #f2f2f2;
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: #f2f2f2;
 }
 
 .is-small-text,

--- a/rockfield/package-lock.json
+++ b/rockfield/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rockfield/package.json
+++ b/rockfield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockfield",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Rockfield",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/rockfield/sass/style-child-theme.scss
+++ b/rockfield/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -651,7 +651,6 @@ object {
 	min-height: 90vh;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -661,15 +660,15 @@ object {
 	color: var(--wp--preset--color--background);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--background);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1159,6 +1158,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -1160,19 +1160,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1245,6 +1236,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1582,6 +1582,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2622,7 +2622,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2618,11 +2618,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1582,6 +1582,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2625,11 +2625,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2629,7 +2629,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/shawburn/package-lock.json
+++ b/shawburn/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shawburn/package.json
+++ b/shawburn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shawburn",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Shawburn",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1164,19 +1164,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1249,6 +1240,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -655,7 +655,6 @@ object {
 	min-height: 576px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -665,15 +664,15 @@ object {
 	color: var(--wp--preset--color--white);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--white);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1163,6 +1162,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1587,6 +1587,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2627,7 +2627,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2623,11 +2623,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2630,11 +2630,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.7
+Version: 1.4.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1587,6 +1587,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2634,7 +2634,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/stow/package-lock.json
+++ b/stow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.5.7",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stow/package.json
+++ b/stow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stow",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Stow",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stow/sass/style-child-theme.scss
+++ b/stow/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.8
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -654,7 +654,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -664,15 +663,15 @@ object {
 	color: var(--wp--preset--color--background);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--background);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1162,6 +1161,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -1163,19 +1163,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1248,6 +1239,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -2626,7 +2626,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -2622,11 +2622,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/stow/style.css
+++ b/stow/style.css
@@ -2629,11 +2629,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.7
+Version: 1.5.9
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1586,6 +1586,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/stow/style.css
+++ b/stow/style.css
@@ -2633,7 +2633,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/stratford/package-lock.json
+++ b/stratford/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.9
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -654,7 +654,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -664,15 +663,15 @@ object {
 	color: var(--wp--preset--color--background);
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: var(--wp--preset--color--background);
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1162,6 +1161,16 @@ pre.wp-block-verse {
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
 	color: currentColor;
+}
+
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
 }
 
 .has-primary-background-color,

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -1163,19 +1163,10 @@ pre.wp-block-verse {
 	color: currentColor;
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1248,6 +1239,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1585,6 +1585,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2621,11 +2621,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2625,7 +2625,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.8
+Version: 1.4.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1585,6 +1585,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2628,11 +2628,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var-(--global-color-foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 .is-small-text,

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2632,7 +2632,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: var(--wp--preset--color--foreground);
+	color: var-(--global-color-foreground);
 }
 
 .is-small-text,

--- a/varia/package-lock.json
+++ b/varia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "varia",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/varia/sass/blocks/cover/_editor.scss
+++ b/varia/sass/blocks/cover/_editor.scss
@@ -12,15 +12,12 @@
 		color: #{map-deep-get($config-cover, "color", "foreground")};
 	}
 
-	/* default & custom background-color */
-	&:not([class*='background-color']){
-		.wp-block-cover__inner-container,
-		.wp-block-cover-image-text,
-		.wp-block-cover-text,
-		.block-editor-block-list__block {
-			color: #{map-deep-get($config-cover, "color", "foreground")};
-		}
-	}
+    .wp-block-cover__inner-container,
+    .wp-block-cover-image-text,
+    .wp-block-cover-text,
+    .block-editor-block-list__block {
+        color: currentColor;
+    }
 
 	/* Treating H2 separately to account for legacy /core styles */
 	h2 {

--- a/varia/sass/blocks/cover/_style.scss
+++ b/varia/sass/blocks/cover/_style.scss
@@ -16,6 +16,7 @@
 	.wp-block-cover-text {
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
+        color: currentColor;
 	}
 
 	/* Treating H2 separately to account for legacy /core styles */

--- a/varia/sass/blocks/utilities/_editor.scss
+++ b/varia/sass/blocks/utilities/_editor.scss
@@ -68,19 +68,10 @@
 	}
 }
 
-.has-primary-background-color[class] {
-	background-color: var(--global--color-primary);
-	color: var(--global--color-background);
-}
-
-.has-background-background-color[class] {
-	background-color: var(--global--color-background);
-	color: var(--global--color-foreground);
-}
-
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "primary", "default")};
+	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -152,6 +143,7 @@
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
+	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/varia/sass/blocks/utilities/_editor.scss
+++ b/varia/sass/blocks/utilities/_editor.scss
@@ -68,6 +68,16 @@
 	}
 }
 
+.has-primary-background-color[class] {
+	background-color: var(--global--color-primary);
+	color: var(--global--color-background);
+}
+
+.has-background-background-color[class] {
+	background-color: var(--global--color-background);
+	color: var(--global--color-foreground);
+}
+
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "primary", "default")};

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -238,7 +238,8 @@
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
+	//color: #{map-deep-get($config-global, "color", "foreground", "default")};
+	color: var-(--global-color-foreground);
 }
 
 // Gutenberg Font-size options

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -234,12 +234,12 @@
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
+	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .has-background-background-color:not(.has-text-color),
 .has-background-background-color.has-background-dim:not(.has-text-color) {
-	//color: #{map-deep-get($config-global, "color", "foreground", "default")};
-	color: var-(--global-color-foreground);
+	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 // Gutenberg Font-size options

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -641,7 +641,6 @@ object {
 	min-height: 480px;
 	margin-top: inherit;
 	margin-bottom: inherit;
-	/* default & custom background-color */
 	/* Treating H2 separately to account for legacy /core styles */
 }
 
@@ -651,15 +650,15 @@ object {
 	color: white;
 }
 
-.wp-block-cover:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover:not([class*='background-color']) .block-editor-block-list__block,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover__inner-container,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-image-text,
-.wp-block-cover-image:not([class*='background-color']) .wp-block-cover-text,
-.wp-block-cover-image:not([class*='background-color']) .block-editor-block-list__block {
-	color: white;
+.wp-block-cover .wp-block-cover__inner-container,
+.wp-block-cover .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text,
+.wp-block-cover .block-editor-block-list__block,
+.wp-block-cover-image .wp-block-cover__inner-container,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover-image .wp-block-cover-text,
+.wp-block-cover-image .block-editor-block-list__block {
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -1154,6 +1153,7 @@ pre.wp-block-verse {
 .has-primary-background-color,
 .has-primary-background-color.has-background-dim {
 	background-color: blue;
+	color: white;
 }
 
 .has-primary-background-color:not(.has-text-color),
@@ -1226,6 +1226,7 @@ pre.wp-block-verse {
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -1592,6 +1592,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -2627,6 +2628,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/varia/style.css
+++ b/varia/style.css
@@ -1592,6 +1592,7 @@ button[data-load-more-btn], .button {
 .wp-block-cover-image .wp-block-cover-text {
 	margin-top: 32px;
 	margin-bottom: 32px;
+	color: currentColor;
 }
 
 .wp-block-cover h2,
@@ -2634,6 +2635,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
+	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 When you add a cover block with a white (or clear) background the font color is also white and you cannot see what you write. 

This change makes the necessary changes so that the cover font colors are picked up from the customizer palette in `Colors & Backgrounds > Text Color`. 

This fix applies to Varia and all its child themes.

| Before | After |
|-------|-------|
|![image](https://user-images.githubusercontent.com/375980/122973327-7f8d7000-d367-11eb-82b3-4deea83eabb7.png)|![image](https://user-images.githubusercontent.com/375980/122973628-d2672780-d367-11eb-8eb4-4d31e69826bf.png)|

The changes are in the sass files in the Varia template:
* `varia/sass/blocks/utilities/_style.scss`
* `varia/sass/blocks/utilities/_editor.scss`
* `varia/sass/blocks/cover/_style.scss`
* `varia/sass/blocks/cover/_editor.scss`

All the other changes are auto-generated following this instructions: pNEWy-daO-p2

**This also fixes the alignment of the search block on the Rivington theme**. In this commit:  https://github.com/Automattic/themes/commit/87dbce487c959e4d701234be220777247fcfe350 changes where added directly to the css files instead of the corresponding sass file. When I rebuilt Varia children the changed got removed.

SVN: D63216-code

#### Testing instructions
 1. Clone this repo `git@github.com:Automattic/themes.git`
 2. Push this repo to your sandbox using `./sandbox.sh push` (more instructions in README.md https://github.com/Automattic/themes)
 3. Verify on your sandbox that when you add a cover block with a light background-color the paragraph inside is visible. This only applies to Varia and its child themes. Here is a list of the themes affected:
```
Barnsbury
Dalston
Mayland
Rivington
Maywood
Balasana
Shawburn
Alves
Exford
Rockfield
Stratford
Coutoire
Morden
Stow
Hever
Leven
Varia
```
 
#### Related issue(s):
https://github.com/Automattic/themes/issues/3483