### PR TITLE
Refactored blockbase color configuration from 'descriptive' to 'semantic

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -106,11 +106,11 @@ img {
 }
 
 ::selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--selection);
 }
 
 ::-moz-selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--selection);
 }
 
 p, h1, h2, h3, h4, h5, h6 {
@@ -339,12 +339,12 @@ ol {
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
-	background-color: var(--wp--custom--color--background);
-	color: var(--wp--custom--color--foreground);
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation-link__content {
-	color: var(--wp--custom--color--foreground) !important;
+	color: var(--wp--preset--color--foreground) !important;
 }
 
 .wp-block-navigation.is-responsive .has-child .wp-block-navigation-link__container {
@@ -352,7 +352,7 @@ ol {
 }
 
 p.has-text-color a {
-	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
+	color: var(--wp--style--color--link, var(--wp--preset--color--primary));
 }
 
 p.has-drop-cap:not(:focus):first-letter {
@@ -448,8 +448,8 @@ p.has-drop-cap:not(:focus):first-letter {
 
 .wp-block-pullquote.is-style-solid-color.is-style-solid-color,
 .wp-block-pullquote.is-style-solid-color {
-	background-color: var(--wp--custom--color--foreground);
-	color: var(--wp--custom--color--background);
+	background-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
 }
 
 .wp-block-query-pagination {

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,10 +1,10 @@
 // Text selection background color
 
 ::selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--selection);
 }
 ::-moz-selection {
-	background-color: var(--wp--custom--color--selection);
+	background-color: var(--wp--preset--color--selection);
 }
 
 p, h1, h2, h3, h4, h5, h6 {

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -1,10 +1,10 @@
 .wp-block-navigation.is-responsive {
 	.wp-block-navigation__responsive-container.is-menu-open {
-		background-color: var(--wp--custom--color--background);
-		color: var(--wp--custom--color--foreground);
+		background-color: var(--wp--preset--color--background);
+		color: var(--wp--preset--color--foreground);
 	}
 	.wp-block-navigation-link__content {
-		color: var(--wp--custom--color--foreground) !important;
+		color: var(--wp--preset--color--foreground) !important;
 	}
 	.has-child .wp-block-navigation-link__container{
 		display: revert;

--- a/blockbase/sass/blocks/_paragraph.scss
+++ b/blockbase/sass/blocks/_paragraph.scss
@@ -3,7 +3,7 @@ p {
 
 	// Override `color: inherit` from Core styles.
 	&.has-text-color a {
-		color: var( --wp--style--color--link, var(--wp--custom--color--primary) );
+		color: var( --wp--style--color--link, var(--wp--preset--color--primary) );
 	}
 
 	&.has-drop-cap:not(:focus):first-letter {

--- a/blockbase/sass/blocks/_pullquote.scss
+++ b/blockbase/sass/blocks/_pullquote.scss
@@ -23,8 +23,8 @@
 	}
 
 	&.is-style-solid-color {
-		background-color: var(--wp--custom--color--foreground);
-		color: var(--wp--custom--color--background);
+		background-color: var(--wp--preset--color--foreground);
+		color: var(--wp--preset--color--background);
 	}
 }
 

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -43,12 +43,6 @@
 					"name": "Secondary"
 				},
 				{
-					"slug": "tertiary",
-					"color": "#FFFFFF",
-					"color-value-i-would-like-to-use": "var(--wp--custom--color--white)",
-					"name": "Tertiary"
-				},
-				{
 					"slug": "foreground",
 					"color": "#333333",
 					"color-value-i-would-like-to-use": "var(--wp--custom--color--almost-black)",

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -31,29 +31,40 @@
 			"gradients": [],
 			"palette": [
 				{
-					"slug": "black",
+					"slug": "primary",
 					"color": "#000000",
-					"name": "Black"
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--black)",
+					"name": "Primary"
 				},
 				{
-					"slug": "white",
-					"color": "#ffffff",
-					"name": "White"
-				},
-				{
-					"slug": "blue",
+					"slug": "secondary",
 					"color": "#007cba",
-					"name": "Blue"
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--blue)",
+					"name": "Secondary"
 				},
 				{
-					"slug": "almost-black",
+					"slug": "tertiary",
+					"color": "#FFFFFF",
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--white)",
+					"name": "Tertiary"
+				},
+				{
+					"slug": "foreground",
 					"color": "#333333",
-					"name": "Almost Black"
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--almost-black)",
+					"name": "Foreground"
 				},
 				{
-					"slug": "almost-white",
-					"color": "#FAFAFA",
-					"name": "Almost White"
+					"slug": "background",
+					"color": "#ffffff",
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--white)",
+					"name": "Background"
+				},
+				{
+					"slug": "selection",
+					"color": "#c2c2c2",
+					"color-value-i-would-like-to-use": "var(--wp--custom--color--gray)",
+					"name": "Selection"
 				}
 			]
 		},
@@ -63,18 +74,18 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--color--secondary)",
+					"color": "var(--wp--preset--color--secondary)",
 					"radius": "4px",
 					"style": "solid",
 					"width": "2px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)",
-					"text": "var(--wp--custom--color--background)"
+					"background": "var(--wp--preset--color--secondary)",
+					"text": "var(--wp--preset--color--background)"
 				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--custom--color--background)",
+						"text": "var(--wp--preset--color--background)",
 						"background": "#006ba1"
 					},
 					"border": {
@@ -102,12 +113,12 @@
 				}
 			},
 			"color": {
-				"primary": "var(--wp--preset--color--black)",
-				"secondary": "var(--wp--preset--color--blue)",
-				"tertiary": "var(--wp--preset--color--almost-white)",
-				"foreground": "var(--wp--preset--color--almost-black)",
-				"background": "var(--wp--preset--color--white)",
-				"selection": "var(--wp--preset--color--almost-white)"
+				"black": "#000000",
+				"white": "#FFFFFF",
+				"gray": "#C2C2C2",
+				"blue": "#007cba",
+				"almost-black": "#333333",
+				"almost-white": "#FAFAFA"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
@@ -120,7 +131,7 @@
 				"color": {
 					"background": "transparent",
 					"boxShadow": "none",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"label": {
 					"typography": {
@@ -327,7 +338,7 @@
 			},
 			"core/navigation-link": {
 				"color": {
-					"background": "var(--wp--custom--color--background)"
+					"background": "var(--wp--preset--color--background)"
 				}
 			},
 			"core/post-content": {
@@ -346,8 +357,8 @@
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--foreground)"
+					"link": "var(--wp--preset--color--foreground)",
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -373,7 +384,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"border": {
 					"color": "currentColor",
@@ -389,7 +400,7 @@
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--custom--color--secondary)",
+					"color": "var(--wp--preset--color--secondary)",
 					"style": "solid",
 					"width": "0 0 0 1px"
 				},
@@ -405,8 +416,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
@@ -441,7 +452,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--custom--color--secondary)"
+					"text": "var(--wp--preset--color--secondary)"
 				}
 			}
 		},

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -96,17 +96,17 @@
 }
 
 .wp-block-calendar table caption {
-	color: var(--wp--custom--color--primary);
+	color: var(--wp--preset--color--primary);
 }
 
 .wp-block-calendar table th {
-	background-color: var(--wp--custom--color--secondary);
-	border-color: var(--wp--custom--color--secondary);
+	background-color: var(--wp--preset--color--secondary);
+	border-color: var(--wp--preset--color--secondary);
 }
 
 .wp-block-calendar table td {
-	color: var(--wp--custom--color--primary);
-	border-color: var(--wp--custom--color--secondary);
+	color: var(--wp--preset--color--primary);
+	border-color: var(--wp--preset--color--secondary);
 }
 
 .wp-block-cover.is-style-quadrat-cover-diamond::after {
@@ -169,16 +169,16 @@ ul ul {
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link__container {
-	background-color: var(--wp--custom--color--background);
-	border-color: var(--wp--custom--color--foreground);
+	background-color: var(--wp--preset--color--background);
+	border-color: var(--wp--preset--color--foreground);
 }
 
 .wp-block-navigation .wp-block-navigation__mobile-menu-open-button {
-	color: var(--wp--custom--color--primary);
+	color: var(--wp--preset--color--primary);
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
-	background-color: var(--wp--custom--color--secondary);
+	background-color: var(--wp--preset--color--secondary);
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link {
@@ -195,7 +195,7 @@ ul ul {
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container {
 	margin-right: -19px;
 	padding: 0 19px 0 0;
-	border-right: 1px solid var(--wp--custom--color--foreground);
+	border-right: 1px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
@@ -248,7 +248,7 @@ ul ul {
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),
 .wp-block-post-comments form textarea {
 	border: none;
-	background: var(--wp--custom--color--secondary);
+	background: var(--wp--preset--color--secondary);
 	font-size: var(--wp--preset--font-size--normal);
 	width: 100%;
 }
@@ -313,7 +313,7 @@ ul ul {
 	left: 0;
 	width: 16px;
 	height: 16px;
-	border: 1px solid var(--wp--custom--color--foreground);
+	border: 1px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-post-comments form .comment-form-cookies-consent input[type="checkbox"]:checked + ::after {
@@ -390,7 +390,7 @@ ul ul {
 }
 
 .wp-block-query-pagination {
-	border-top: 1px solid var(--wp--custom--color--primary);
+	border-top: 1px solid var(--wp--preset--color--primary);
 }
 
 .wp-block-query-pagination .wp-block-query-pagination-previous::before {
@@ -492,7 +492,7 @@ textarea:focus {
 
 .home .site-footer.wp-block-group:before {
 	content: "";
-	background-color: var(--wp--custom--color--secondary);
+	background-color: var(--wp--preset--color--secondary);
 	-webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
 	        clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
 	position: absolute;
@@ -543,7 +543,7 @@ textarea:focus {
 
 .site-header:before {
 	content: "";
-	background-color: var(--wp--custom--color--secondary);
+	background-color: var(--wp--preset--color--secondary);
 	position: absolute;
 	height: 100vw;
 	top: 0;
@@ -609,13 +609,13 @@ textarea:focus {
 }
 
 .post-meta .wp-block-post-terms::before {
-	color: var(--wp--custom--color--foreground);
+	color: var(--wp--preset--color--foreground);
 	content: "·";
 	margin-right: 8px;
 }
 
 .post-meta .wp-block-post-terms a {
-	color: var(--wp--custom--color--foreground);
+	color: var(--wp--preset--color--foreground);
 }
 
 @media (max-width: 479px) {
@@ -633,7 +633,7 @@ textarea:focus {
 		        mask-image: url(arrow.svg);
 		-webkit-mask-repeat: no-repeat;
 		        mask-repeat: no-repeat;
-		background-color: var(--wp--custom--color--foreground);
+		background-color: var(--wp--preset--color--foreground);
 		transform: translateX(-50%);
 		position: absolute;
 		bottom: 1.5rem;

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -4,50 +4,51 @@
 			"gradients": [],
 			"palette": [
 				{
-					"slug": "black",
-					"color": "#000000",
-					"name": "Black"
-				},
-				{
-					"slug": "white",
-					"color": "#ffffff",
-					"name": "White"
-				},
-				{
-					"slug": "pink",
+					"slug": "primary",
 					"color": "#FFD1D1",
-					"name": "Pink"
+					"name": "Primary"
 				},
 				{
-					"slug": "blue",
-					"color": "#292C6D",
-					"name": "Blue"
-				},
-				{
-					"slug": "darker-blue",
+					"slug": "secondary",
 					"color": "#151853",
-					"name": "Darker Blue"
+					"name": "Secondary"
+				},
+				{
+					"slug": "foreground",
+					"color": "#FFD1D1",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#292C6D",
+					"name": "Background"
+				},
+				{
+					"slug": "selection",
+					"color": "#151853",
+					"name": "Selection"
 				}
+
 			]
 		},
 		"custom": {
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--color--foreground)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0",
 					"width": "3px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--background)"
+					"background": "var(--wp--preset--color--foreground)",
+					"text": "var(--wp--preset--color--background)"
 				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)"
+						"text": "var(--wp--preset--color--foreground)",
+						"background": "var(--wp--preset--color--background)"
 					},
 					"border": {
-						"color": "var(--wp--custom--color--foreground)"
+						"color": "var(--wp--preset--color--foreground)"
 					}
 				},
 				"typography": {
@@ -55,19 +56,12 @@
 					"fontWeight": "700"
 				}
 			},
-			"color": {
-				"primary": "var(--wp--preset--color--pink)",
-				"secondary": "var(--wp--preset--color--darker-blue)",
-				"foreground": "var(--wp--preset--color--pink)",
-				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
-			},
 			"fontsToLoadFromGoogle": [
 				"family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
 			],
 			"form": {
 				"border": {
-					"color": "var(--wp--custom--color--foreground)"
+					"color": "var(--wp--preset--color--foreground)"
 				},
 				"padding": "20px"
 			},
@@ -215,7 +209,7 @@
 					"width": "0px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)"
+					"background": "var(--wp--preset--color--secondary)"
 				},
 				"typography": {
 					"fontSize": "20px",
@@ -236,7 +230,7 @@
 			"core/navigation-link": {
 				"color": {
 					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/post-title": {
@@ -297,7 +291,7 @@
 			},
 			"core/site-title": {
 				"color": {
-					"link": "var(--wp--custom--color--primary)"
+					"link": "var(--wp--preset--color--primary)"
 				},
 				"typography": {
 					"fontSize": "18px",
@@ -344,7 +338,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			}
 		},

--- a/quadrat/sass/blocks/_calendar.scss
+++ b/quadrat/sass/blocks/_calendar.scss
@@ -1,15 +1,15 @@
 .wp-block-calendar {
 	table {
 		caption {
-			color: var(--wp--custom--color--primary);
+			color: var(--wp--preset--color--primary);
 		}
 		th {
-			background-color: var(--wp--custom--color--secondary);
-			border-color: var(--wp--custom--color--secondary);
+			background-color: var(--wp--preset--color--secondary);
+			border-color: var(--wp--preset--color--secondary);
 		}
 		td {
-			color: var(--wp--custom--color--primary);
-			border-color: var(--wp--custom--color--secondary);
+			color: var(--wp--preset--color--primary);
+			border-color: var(--wp--preset--color--secondary);
 		}
 	}
 }

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -11,18 +11,18 @@
 	&:not(.has-background) { 
 		.wp-block-navigation__container { 
 			.wp-block-navigation-link__container {
-				background-color: var(--wp--custom--color--background);
-				border-color: var(--wp--custom--color--foreground);
+				background-color: var(--wp--preset--color--background);
+				border-color: var(--wp--preset--color--foreground);
 			}
 		}
 	}
 
 	.wp-block-navigation__mobile-menu-open-button {
-		color: var(--wp--custom--color--primary);
+		color: var(--wp--preset--color--primary);
 	}
 
 	&.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
-		background-color: var(--wp--custom--color--secondary);
+		background-color: var(--wp--preset--color--secondary);
 		&.has-modal-open {
 			.wp-block-navigation-link {
 				font-size: 20px;
@@ -36,7 +36,7 @@
 					.wp-block-navigation-link__container{
 						margin-right: -19px;
 						padding: 0 19px 0 0;
-						border-right: 1px solid var(--wp--custom--color--foreground);
+						border-right: 1px solid var(--wp--preset--color--foreground);
 						.wp-block-navigation-link__content {
 							padding: 0;
 							font-size: 15px;

--- a/quadrat/sass/blocks/_post-comments.scss
+++ b/quadrat/sass/blocks/_post-comments.scss
@@ -44,7 +44,7 @@
 		input:not([type=submit]):not([type=checkbox]),
 		textarea {
 			border: none;
-			background: var(--wp--custom--color--secondary);
+			background: var(--wp--preset--color--secondary);
 			font-size: var(--wp--preset--font-size--normal);
 			width: 100%;
 		}
@@ -94,7 +94,7 @@
 					left: 0;
 					width: 16px;
 					height: 16px;
-					border: 1px solid var(--wp--custom--color--foreground);
+					border: 1px solid var(--wp--preset--color--foreground);
 				}
 				&:checked + ::after {
 					content: "\2715";

--- a/quadrat/sass/blocks/_query-pagination.scss
+++ b/quadrat/sass/blocks/_query-pagination.scss
@@ -1,5 +1,5 @@
 .wp-block-query-pagination {
-	border-top: 1px solid var(--wp--custom--color--primary);
+	border-top: 1px solid var(--wp--preset--color--primary);
 
 	.wp-block-query-pagination-previous {
 		&::before{

--- a/quadrat/sass/templates/_footer.scss
+++ b/quadrat/sass/templates/_footer.scss
@@ -4,7 +4,7 @@
 		overflow: visible;
 		&:before {
 			content: "";
-			background-color: var(--wp--custom--color--secondary);
+			background-color: var(--wp--preset--color--secondary);
 			clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
 			position: absolute;
 			height: 100vw;

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -33,7 +33,7 @@
 
 	&:before {
 		content: "";
-		background-color: var(--wp--custom--color--secondary);
+		background-color: var(--wp--preset--color--secondary);
 		position: absolute;
 		height: 100vw;
 		top: 0;

--- a/quadrat/sass/templates/_meta.scss
+++ b/quadrat/sass/templates/_meta.scss
@@ -18,7 +18,7 @@
 	.wp-block-post-terms {
 		margin-left: 0;
 		&::before {
-			color: var(--wp--custom--color--foreground);
+			color: var(--wp--preset--color--foreground);
 			content: "·";
 			margin-right: 8px;
 		}
@@ -26,7 +26,7 @@
 		// Needed while https://github.com/WordPress/gutenberg/issues/31710 is sorted.
 		color: transparent;
 		a {
-			color: var(--wp--custom--color--foreground);
+			color: var(--wp--preset--color--foreground);
 		}
 	}
 }

--- a/quadrat/sass/templates/_post-header.scss
+++ b/quadrat/sass/templates/_post-header.scss
@@ -13,7 +13,7 @@ $admin-bar: 46px;
 			width: 23px;
 			mask-image: url(arrow.svg);
 			mask-repeat: no-repeat;
-			background-color: var(--wp--custom--color--foreground);
+			background-color: var(--wp--preset--color--foreground);
 			transform: translateX(-50%);
 			position: absolute;
 			bottom: 1.5rem;

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -10,6 +10,16 @@
 			"area": "footer"
 		}
 	],
+	"customTemplates": [
+		{
+			"name": "blank",
+			"title": "Blank",
+			"postTypes": [
+				"page",
+				"post"
+			]
+		}
+	],
 	"settings": {
 		"border": {
 			"customColor": true,
@@ -21,29 +31,29 @@
 			"gradients": [],
 			"palette": [
 				{
-					"slug": "black",
-					"color": "#000000",
-					"name": "Black"
-				},
-				{
-					"slug": "white",
-					"color": "#ffffff",
-					"name": "White"
-				},
-				{
-					"slug": "pink",
+					"slug": "primary",
 					"color": "#FFD1D1",
-					"name": "Pink"
+					"name": "Primary"
 				},
 				{
-					"slug": "blue",
-					"color": "#292C6D",
-					"name": "Blue"
-				},
-				{
-					"slug": "darker-blue",
+					"slug": "secondary",
 					"color": "#151853",
-					"name": "Darker Blue"
+					"name": "Secondary"
+				},
+				{
+					"slug": "foreground",
+					"color": "#FFD1D1",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#292C6D",
+					"name": "Background"
+				},
+				{
+					"slug": "selection",
+					"color": "#151853",
+					"name": "Selection"
 				}
 			]
 		},
@@ -53,22 +63,22 @@
 			},
 			"button": {
 				"border": {
-					"color": "var(--wp--custom--color--foreground)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0",
 					"style": "solid",
 					"width": "3px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--background)"
+					"background": "var(--wp--preset--color--foreground)",
+					"text": "var(--wp--preset--color--background)"
 				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--custom--color--foreground)",
-						"background": "var(--wp--custom--color--background)"
+						"text": "var(--wp--preset--color--foreground)",
+						"background": "var(--wp--preset--color--background)"
 					},
 					"border": {
-						"color": "var(--wp--custom--color--foreground)"
+						"color": "var(--wp--preset--color--foreground)"
 					}
 				},
 				"spacing": {
@@ -92,17 +102,17 @@
 				}
 			},
 			"color": {
-				"primary": "var(--wp--preset--color--pink)",
-				"secondary": "var(--wp--preset--color--darker-blue)",
-				"tertiary": "var(--wp--preset--color--almost-white)",
-				"foreground": "var(--wp--preset--color--pink)",
-				"background": "var(--wp--preset--color--blue)",
-				"selection": "var(--wp--preset--color--darker-blue)"
+				"black": "#000000",
+				"white": "#FFFFFF",
+				"gray": "#C2C2C2",
+				"blue": "#007cba",
+				"almost-black": "#333333",
+				"almost-white": "#FAFAFA"
 			},
 			"form": {
 				"padding": "20px",
 				"border": {
-					"color": "var(--wp--custom--color--foreground)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0",
 					"style": "solid",
 					"width": "2px"
@@ -110,7 +120,7 @@
 				"color": {
 					"background": "transparent",
 					"boxShadow": "none",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"label": {
 					"typography": {
@@ -329,7 +339,7 @@
 					"width": "0px"
 				},
 				"color": {
-					"background": "var(--wp--custom--color--secondary)"
+					"background": "var(--wp--preset--color--secondary)"
 				},
 				"typography": {
 					"fontSize": "20px",
@@ -352,7 +362,7 @@
 			"core/navigation-link": {
 				"color": {
 					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/post-content": {
@@ -372,8 +382,8 @@
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)",
-					"text": "var(--wp--custom--color--foreground)"
+					"link": "var(--wp--preset--color--foreground)",
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -401,7 +411,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"border": {
 					"color": "currentColor",
@@ -415,12 +425,12 @@
 					"fontWeight": 700
 				},
 				"color": {
-					"link": "var(--wp--custom--color--primary)"
+					"link": "var(--wp--preset--color--primary)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--custom--color--secondary)",
+					"color": "var(--wp--preset--color--secondary)",
 					"style": "solid",
 					"width": "0px"
 				},
@@ -455,8 +465,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
@@ -497,7 +507,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--custom--color--foreground)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			}
 		},


### PR DESCRIPTION
NOTE: Child themes have NOT YET been refactored to support this change.  Currently it's blockbase only.

UPDATE: Quadrat has been updated.  (And has a continued experiment with editing these semantic colors and storing them in the CPT [here](https://github.com/Automattic/themes/pull/4090).)

Before:
![image](https://user-images.githubusercontent.com/146530/123116376-dbf79a80-d40e-11eb-9c8f-3dc7e869a0ab.png)

After:
![image](https://user-images.githubusercontent.com/146530/123116312-cb472480-d40e-11eb-9970-2a601be0a25a.png)

