### PR TITLE
Blank Canvas: Improve user experience when adding logo if headers are disabled. (D62950-code)

### DIFF
--- a/blank-canvas/assets/js/disabled-site-header-custom-logo-notification.js
+++ b/blank-canvas/assets/js/disabled-site-header-custom-logo-notification.js
@@ -1,0 +1,62 @@
+/**
+ * @author danielsmithmichigan
+ * global wp
+**/
+
+var blankCanvasDisabledSiteHeaderCustomLogoNotification = ( function( wp ) {
+	var notification_code = 'BLANK_CANVAS_DISABLED_SITE_HEADER_CUSTOM_LOGO_NOTIFICATION';
+	var self = {};
+	wp.customize.bind( 'ready', function() {
+		self.maybeAddCustomLogoNotification = function() {
+			// Exit if one of the controls doesn't exist just to be safe.
+			var showSiteHeaderControl = wp.customize.control('show_site_header')
+			var customLogoControl = wp.customize.control('custom_logo');
+			if ( !showSiteHeaderControl || !customLogoControl ) {
+				return;
+			}
+
+			// Check if the notification has already been added to the custom logo control
+			var notification_is_present = false;
+			var all_notifications = customLogoControl.notifications.get() || [];
+			for (var i = 0; i < all_notifications.length; i++) {
+				if( 'object' !== typeof all_notifications[i] ) continue;
+				if( all_notifications[i].code === notification_code ) {
+					notification_is_present = true;
+					break;
+				}
+			}
+
+			// The notification is necessary if show_site_header is not enabled, and a logo has been uploaded
+			var notification_is_necessary = false === showSiteHeaderControl.setting.get() &&
+				'' !== customLogoControl.setting.get();
+
+			// Add or remove the notification
+			if ( ! notification_is_present && notification_is_necessary ) {
+				customLogoControl.notifications.add(
+					notification_code,
+					new wp.customize.Notification(
+						notification_code,
+						{
+							message: disabled_site_header_custom_logo_notification_translations.custom_logo_notification_content,
+							type: 'warning'
+						}
+					)
+				)
+			} else if ( notification_is_present && ! notification_is_necessary ) {
+				customLogoControl.notifications.remove( notification_code );
+			}
+		};
+		wp.customize('custom_logo', function(setting) {
+			setting.bind(function(value) {
+				self.maybeAddCustomLogoNotification();
+			});
+		});
+		wp.customize('show_site_header', function(setting) {
+			setting.bind(function(value) {
+				self.maybeAddCustomLogoNotification();
+			});
+		}); 
+		self.maybeAddCustomLogoNotification();
+	});
+	return self;
+} )( wp );

--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -129,8 +129,11 @@ function blank_canvas_add_customizer_settings( $wp_customize ) {
 	// Cast the widgets panel as an object.
 	$customizer_widgets_panel = (object) $wp_customize->get_panel( 'widgets' );
 
+	$content_options_link = "wp.customize.control('show_site_header').focus(); return false;";
+
 	// Add a Customizer message about the site title & tagline options.
-	$wp_customize->get_section( 'title_tagline' )->description  = __( 'The site logo, title, and tagline will only appear on single posts and pages if the “Site header and top menu" option is enabled in the Content Options section.', 'blank-canvas' );
+	// translators: %s is an action which opens the "Content Options" section of customizer
+	$wp_customize->get_section( 'title_tagline' )->description  = sprintf( __( 'The site logo, title, and tagline will only appear on all posts and pages if the "Site header and top menu" option is enabled in the <a href="#" onClick="%s">Content Options</a> section.', 'blank-canvas' ), $content_options_link );
 	$wp_customize->get_section( 'menu_locations' )->description = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
 	$wp_customize->get_panel( 'nav_menus' )->description        = __( 'This theme will only display Menus if they are enabled in the Content Options section.', 'blank-canvas' );
 	$customizer_widgets_panel->description                      = __( 'This theme will only display Widgets if they are enabled in the Content Options section.', 'blank-canvas' );

--- a/blank-canvas/inc/customizer.php
+++ b/blank-canvas/inc/customizer.php
@@ -23,6 +23,7 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 		 */
 		public function __construct() {
 			add_action( 'customize_register', array( $this, 'register' ) );
+			add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_disabled_header_custom_logo_notification_script') );
 		}
 
 		/**
@@ -140,6 +141,30 @@ if ( ! class_exists( 'Blank_Canvas_Customize' ) ) {
 					'priority'    => 10,
 					'type'        => 'checkbox',
 					'settings'    => 'show_comments',
+				)
+			);
+		}
+		
+		/**
+		 * Displays a notification above the custom logo control when you have set a logo,
+		 * but it's not visible since the site header is disabled.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+
+		public function enqueue_disabled_header_custom_logo_notification_script() {
+			$handle = 'disabled-site-header-custom-logo-notification';
+			$src    = get_stylesheet_directory_uri() . '/assets/js/disabled-site-header-custom-logo-notification.js';
+			$deps   = array( 'customize-controls' );
+			wp_enqueue_script( $handle, $src, $deps );
+
+			wp_localize_script(
+				$handle,
+				'disabled_site_header_custom_logo_notification_translations',
+				array(
+					'custom_logo_notification_content' => __( 'Your logo will not be shown on all posts and pages. To display your logo, follow the instructions above to enable your site header.', 'blank-canvas'),
 				)
 			);
 		}


### PR DESCRIPTION
Blank canvas has a setting: 'show_site_header.' When this setting is false (the default), then the logo is not shown on single posts or pages (as opposed to archives). This is confusing when users add a logo, but can't see it.

This differential adds a pop-up notification after adding a logo, instructing the users how to enable this setting. This notification will only show when show_site_header is false.

https://github.com/Automattic/themes/issues/4036

[Preview](https://user-images.githubusercontent.com/10274366/123276468-32c6a800-d4d3-11eb-857d-9f100e523451.png)

## Testing Instructions

```
1. Push this repo to your sandbox using ./sandbox.sh push (more instructions in README.md https://github.com/Automattic/themes)
2. Switch your theme to blank canvas. Go to the "Content Options" section in customizer. Make sure the "Enable site header and top menu" option is disabled.
3. Go to customizer, to the "Site Identity" section. Add a logo. Your logo should not be visible, and you should see the notification (shown above) under the "Logo" header.
4. The notification should have a link in it. Click the link. It should focus the "Enable site header and top menu" option.
5. Check the option. Your logo should now be visible.
6. Return to the "Site Identity" section in customizer. The notification should be gone.
7. Try all 4 combinations:
Custom Logo + DONT Enable site header and top menu: You should see the notification
Custom Logo + Enable site header and top menu: You should NOT see the notification
NO Logo + DONT Enable site header and top menu: You should NOT see the notification
NO Logo + Enable site header and top menu: You should NOT see the notification
8. Refresh the page while each of these 4 combinations is present. The notification should still function according to the rules above.
```

