### PR TITLE
Quadrat: fix query block markup

### DIFF
--- a/quadrat/block-template-parts/index.html
+++ b/quadrat/block-template-parts/index.html
@@ -11,15 +11,11 @@
 		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 	<!-- /wp:post-template -->
-
 	<!-- wp:query-pagination {"align":"wide"} -->
 	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
-
 	<!-- wp:query-pagination-numbers /-->
-
 	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
 	<!-- /wp:query-pagination -->
-
 </main>
 <!-- /wp:query -->
 

--- a/quadrat/block-template-parts/index.html
+++ b/quadrat/block-template-parts/index.html
@@ -1,26 +1,26 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:query {"className":"page-content","layout":{"inherit":true},"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-<div class="wp-block-query page-content">
-<!-- wp:query-loop -->
-	<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
-	<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
-	<!-- wp:post-featured-image {"isLink":true} /-->
-	<!-- wp:post-excerpt /-->
-	<!-- wp:spacer {"height":60} -->
-	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-<!-- /wp:query-loop -->
+<!-- wp:query {"className":"page-content","tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<main class="wp-block-query page-content">
+	<!-- wp:post-template -->
+		<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
+		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+		<!-- wp:spacer {"height":60} -->
+		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+	<!-- /wp:post-template -->
 
-<!-- wp:query-pagination {"align":"wide"} -->
-<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+	<!-- wp:query-pagination {"align":"wide"} -->
+	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
 
 	<!-- wp:query-pagination-numbers /-->
 
 	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
-<!-- /wp:query-pagination -->
+	<!-- /wp:query-pagination -->
 
-</div>
+</main>
 <!-- /wp:query -->
 
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
While looking into #4060, I discovered that the query block was only showing one post per page. 

This PR fixes that by adding the `<!-- wp:post-template -->` wrapper to the query block in the index.html template and setting a `perPage` attribute to the query block.

Maybe fixes #4060.