### PR TITLE
Styled color to HTML block in editor (overriding Gutenberg's styles)

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -321,6 +321,11 @@ input[type=checkbox] + label {
 	font-size: var(--wp--custom--gallery--caption--font-size);
 }
 
+.block-library-html__edit .block-editor-plain-text {
+	color: var(--wp--custom--form--color--text);
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+}
+
 .wp-block-image {
 	/* 
 	From what I can tell the below are styles regularly used by themes

--- a/blockbase/sass/blocks/_html.scss
+++ b/blockbase/sass/blocks/_html.scss
@@ -1,0 +1,6 @@
+.block-library-html__edit {
+	.block-editor-plain-text {
+		color: var(--wp--custom--form--color--text);
+		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	}
+}

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -12,6 +12,7 @@
 @import "blocks/button";
 @import "blocks/code";
 @import "blocks/gallery";
+@import "blocks/html";
 @import "blocks/image";
 @import "blocks/list";
 @import "blocks/navigation";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This change uses the 'form color' for the HTML block when NOT selected (in the same way as it had already applied that color when UNSELECTED).

Before:
![image](https://user-images.githubusercontent.com/146530/123810479-6d0fbb00-d8c0-11eb-9ba9-bb8bc940ff12.png)
![image](https://user-images.githubusercontent.com/146530/123810506-7436c900-d8c0-11eb-8baf-0b9f0b590873.png)

After:
![image](https://user-images.githubusercontent.com/146530/123810351-523d4680-d8c0-11eb-8433-e095945d5492.png)
![image](https://user-images.githubusercontent.com/146530/123810394-58cbbe00-d8c0-11eb-9646-0b77515e6d21.png)

Note that this change effects the editor only.  The view remains unchanged.

#### Related issue(s):

Fixes #4093 