### PR TITLE
Add generated title tag support to BB&Co themes

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -18,6 +18,9 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		// Add support for post thumbnails.
 		add_theme_support( 'post-thumbnails' );
 
+		// Declare that there are no <title> tags and allow WordPress to provide them
+		add_theme_support( 'title-tag' );
+
 		// Experimental support for adding blocks inside nav menus
 		add_theme_support( 'block-nav-menus' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds theme support for 'title_tags' prompting WordPress to generate the necessary `<title>` tags for the site.

Effects all BB&Co themes.

Before:
<img src="https://user-images.githubusercontent.com/146530/123812235-ebb92800-d8c1-11eb-8af7-735b551831cd.png" width="400px">
<img src="https://user-images.githubusercontent.com/146530/123812197-e360ed00-d8c1-11eb-84fc-d9d41c3219db.png" width="400px">

After:
<img src="https://user-images.githubusercontent.com/146530/123812091-cd532c80-d8c1-11eb-9225-74b6262d0efd.png" width="400px">
<img src="https://user-images.githubusercontent.com/146530/123812137-d6dc9480-d8c1-11eb-9532-782a3bf0421a.png" width="400px">

#### Related issue(s):

Fixes: #4084 