### PR TITLE
Quadrat: Make Site Title uppercase by default

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -533,6 +533,7 @@ textarea:focus {
 
 .site-header .wp-block-site-title {
 	margin: 0;
+	text-transform: uppercase;
 }
 
 .site-header .wp-block-navigation {

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -24,6 +24,7 @@
 
 	.wp-block-site-title {
 		margin: 0;
+		text-transform: uppercase;
 	}
 
 	.wp-block-navigation {


### PR DESCRIPTION
Before:
<img width="325" alt="before-3" src="https://user-images.githubusercontent.com/905781/123836560-221a9580-d90a-11eb-9b62-5b94ddbb5d3a.png">

After:
<img width="373" alt="themes" src="https://user-images.githubusercontent.com/905781/123836588-2941a380-d90a-11eb-890a-91681859d28a.png">

Closes: #4064