### PR TITLE
Removed Quadrat's social menu location as it wasn't actually defined anywhere

### DIFF
--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -25,7 +25,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'quadrat' ),
-				'social'  => __( 'Social Links Navigation', 'quadrat' ),
 			)
 		);
 


### PR DESCRIPTION
The user was able to assign a social menu but there were no blocks configured to accept it so it wasn't showing up anywhere.  This change just removes so a user doesn't see it as a target.

Fixes #4080 (kind of)