### PR TITLE
Quadrat: Add an index template

### DIFF
--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -1,0 +1,1 @@
+<!-- wp:template-part {"slug":"index"} /-->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Global Styles only load in the editor when a theme is a block theme. This adds an index.html file to Quadrat so that the colors and fonts load correctly:

Before:
<img width="1440" alt="Screenshot 2021-06-30 at 17 47 33" src="https://user-images.githubusercontent.com/275961/124000370-64f07200-d9cb-11eb-9c4f-9f3ebafafb8d.png">

After:
<img width="1440" alt="Screenshot 2021-06-30 at 17 47 14" src="https://user-images.githubusercontent.com/275961/124000376-6752cc00-d9cb-11eb-867d-dbb6cc8e45a6.png">


