### PR TITLE
Quadrat: use semantic colors + classes in block patterns

### DIFF
--- a/quadrat/inc/patterns/cover-with-heading.php
+++ b/quadrat/inc/patterns/cover-with-heading.php
@@ -8,9 +8,9 @@
 return array(
 	'title'      => __( 'Cover block with heading', 'quadrat' ),
 	'categories' => array( 'quadrat' ),
-	'content'    => '<!-- wp:cover {"overlayColor":"blue","minHeight":700,"align":"wide","className":"is-style-quadrat-cover-diamond"} -->
-	<div class="wp-block-cover alignwide has-blue-background-color has-background-dim is-style-quadrat-cover-diamond" style="min-height:700px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","textColor":"pink"} -->
-	<h2 class="has-text-align-center has-pink-color has-text-color">' . esc_html__( 'Episode 3: A Cycle of Emotions', 'quadrat' ) . '</h2>
+	'content'    => '<!-- wp:cover {"overlayColor":"background","minHeight":700,"align":"wide","className":"is-style-quadrat-cover-diamond"} -->
+	<div class="wp-block-cover alignwide has-background-background-color has-background-dim is-style-quadrat-cover-diamond" style="min-height:700px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","textColor":"primary"} -->
+	<h2 class="has-text-align-center has-primary-color has-text-color">' . esc_html__( 'Episode 3: A Cycle of Emotions', 'quadrat' ) . '</h2>
 	<!-- /wp:heading --></div></div>
 	<!-- /wp:cover -->',
 );

--- a/quadrat/inc/patterns/episode.php
+++ b/quadrat/inc/patterns/episode.php
@@ -8,8 +8,8 @@
 return array(
 	'title'      => __( 'Episode', 'quadrat' ),
 	'categories' => array( 'quadrat' ),
-	'content'    => '<!-- wp:media-text {"mediaId":1497,"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg","mediaType":"image","mediaWidth":40,"mediaSizeSlug":"large","imageFill":false,"className":"has-pink-color has-darker-blue-background-color has-text-color has-background is-style-default"} -->
-	<div class="wp-block-media-text alignwide is-stacked-on-mobile has-pink-color has-darker-blue-background-color has-text-color has-background is-style-default" style="grid-template-columns:40% auto"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg" alt="' . esc_attr__( 'Illustration of an introspective woman.', 'quadrat') . '" class="wp-image-1497 size-large"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"level":3} -->
+	'content'    => '<!-- wp:media-text {"mediaId":1497,"mediaLink":"https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg","mediaType":"image","mediaWidth":40,"mediaSizeSlug":"large","imageFill":false,"className":"has-primary-color has-secondary-background-color has-text-color has-background is-style-default"} -->
+	<div class="wp-block-media-text alignwide is-stacked-on-mobile has-primary-color has-secondary-background-color has-text-color has-background is-style-default" style="grid-template-columns:40% auto"><figure class="wp-block-media-text__media"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Introspection-scaled.jpg" alt="' . esc_attr__( 'Illustration of an introspective woman.', 'quadrat') . '" class="wp-image-1497 size-large"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"level":3} -->
 	<h3>' . esc_html__( 'Episode 3: A Cycle of Emotions', 'quadrat' ) . '</h3>
 	<!-- /wp:heading -->
 	

--- a/quadrat/inc/patterns/latest-episodes.php
+++ b/quadrat/inc/patterns/latest-episodes.php
@@ -15,13 +15,13 @@ return array(
 	<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Screen-usage-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman working on a laptop.', 'quadrat' ) . '" class="wp-image-1438"/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:cover {"overlayColor":"darker-blue","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
-	<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 1: How Screens Affect Hormones', 'quadrat' ) . '</h3>
+	<!-- wp:cover {"overlayColor":"secondary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-secondary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
+	<h3 class="has-primary-color has-text-color">' . esc_html__( 'Episode 1: How Screens Affect Hormones', 'quadrat' ) . '</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"textColor":"pink","fontSize":"small"} -->
-	<p class="has-pink-color has-text-color has-small-font-size">' . esc_html__( 'In this episode, Sarah and Olivia talk with female hormone specialist Diana Roth about the impact that gadgets and technology have on hormone and fertility health.', 'quadrat' ) . '</p>
+	<!-- wp:paragraph {"textColor":"primary","fontSize":"small"} -->
+	<p class="has-primary-color has-text-color has-small-font-size">' . esc_html__( 'In this episode, Sarah and Olivia talk with female hormone specialist Diana Roth about the impact that gadgets and technology have on hormone and fertility health.', 'quadrat' ) . '</p>
 	<!-- /wp:paragraph --></div></div>
 	<!-- /wp:cover --></div>
 	<!-- /wp:group --></div>
@@ -33,13 +33,13 @@ return array(
 	<figure class="wp-block-image size-large image-no-margin mb-0"><img src="https://quadrat.mystagingwebsite.com/wp-content/uploads/2021/04/Leadership-1024x623.jpg" alt="' . esc_attr__( 'Illustration of a woman climbing steps.', 'quadrat' ) . '" class="wp-image-1439"/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:cover {"overlayColor":"darker-blue","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-darker-blue-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"pink"} -->
-	<h3 class="has-pink-color has-text-color">' . esc_html__( 'Episode 2: Female Leaders, Where Are They?', 'quadrat' ) . '</h3>
+	<!-- wp:cover {"overlayColor":"secondary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-secondary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
+	<h3 class="has-primary-color has-text-color">' . esc_html__( 'Episode 2: Female Leaders, Where Are They?', 'quadrat' ) . '</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"textColor":"pink","fontSize":"small"} -->
-	<p class="has-pink-color has-text-color has-small-font-size">' . esc_html__( 'After years of revolution, the big question remains: why aren’t there more women in leadership? Sarah and Olivia get deep into the subject.', 'quadrat' ) . '</p>
+	<!-- wp:paragraph {"textColor":"primary","fontSize":"small"} -->
+	<p class="has-primary-color has-text-color has-small-font-size">' . esc_html__( 'After years of revolution, the big question remains: why aren’t there more women in leadership? Sarah and Olivia get deep into the subject.', 'quadrat' ) . '</p>
 	<!-- /wp:paragraph --></div></div>
 	<!-- /wp:cover --></div>
 	<!-- /wp:column --></div>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Some block patterns referenced non-existing color classes. This PR updates them to use the new semantic ones.

Before | After
-------- | -------
<img width="350" alt="Screen Shot 2021-06-30 at 2 08 00 PM" src="https://user-images.githubusercontent.com/5375500/124010261-7584f600-d993-11eb-9d92-231d716e15aa.png"> | <img width="353" alt="Screen Shot 2021-06-30 at 2 04 02 PM" src="https://user-images.githubusercontent.com/5375500/124010189-6140f900-d993-11eb-8506-193238cd1c92.png">

#### Related issue(s):

Fixes #4119 