### PR TITLE
Changes to quadrat table styles to match design and ensure editor and view are the same.

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -617,12 +617,21 @@ p.has-drop-cap:not(:focus):first-letter {
 	fill: var(--wp--custom--button--color--text);
 }
 
+.wp-block-table.is-style-stripes,
+.wp-block-table {
+	margin-bottom: 1em;
+	border-bottom: none;
+}
+
+.wp-block-table.is-style-stripes figcaption,
 .wp-block-table figcaption {
 	font-size: var(--wp--custom--table--figcaption--typography--font-size);
 	text-align: center;
 }
 
-.wp-block-table td, .wp-block-table th {
+.wp-block-table.is-style-stripes td, .wp-block-table.is-style-stripes th,
+.wp-block-table td,
+.wp-block-table th {
 	border: 1px solid;
 	padding: calc(0.5*var(--wp--custom--margin--vertical)) calc(0.5*var(--wp--custom--margin--horizontal));
 }

--- a/blockbase/sass/blocks/_table.scss
+++ b/blockbase/sass/blocks/_table.scss
@@ -1,3 +1,4 @@
+.wp-block-table.is-style-stripes,
 .wp-block-table {
 	figcaption {
 		font-size: var(--wp--custom--table--figcaption--typography--font-size);
@@ -8,4 +9,7 @@
 		border: 1px solid;
 		padding: calc(0.5*var(--wp--custom--margin--vertical)) calc(0.5*var(--wp--custom--margin--horizontal));
 	}
+
+	margin-bottom: 1em;
+	border-bottom: none;
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -424,11 +424,6 @@ ul ul {
 	border: none;
 }
 
-.wp-block-table.is-style-stripes,
-.wp-block-table {
-	margin-bottom: 1em;
-}
-
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;
@@ -455,10 +450,6 @@ ul ul {
 .wp-block-table.is-style-stripes figcaption,
 .wp-block-table figcaption {
 	color: var(--wp--preset--color--primary);
-}
-
-.wp-block-table.is-style-stripes {
-	border-bottom: none;
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -424,22 +424,45 @@ ul ul {
 	border: none;
 }
 
+.wp-block-table.is-style-stripes,
+.wp-block-table {
+	margin-bottom: 1em;
+}
+
+.wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;
 }
 
+.wp-block-table.is-style-stripes tbody td,
 .wp-block-table tbody td {
 	border-bottom-width: 0;
 	border-top-width: 0;
 	vertical-align: top;
+	border-color: var(--wp--preset--color--primary);
 }
 
+.wp-block-table.is-style-stripes tr:first-child td,
 .wp-block-table tr:first-child td {
 	border-top-width: 1px;
 }
 
+.wp-block-table.is-style-stripes tr:last-child td,
 .wp-block-table tr:last-child td {
 	border-bottom-width: 1px;
+}
+
+.wp-block-table.is-style-stripes figcaption,
+.wp-block-table figcaption {
+	color: var(--wp--preset--color--primary);
+}
+
+.wp-block-table.is-style-stripes {
+	border-bottom: none;
+}
+
+.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: var(--wp--preset--color--secondary);
 }
 
 .wp-block-pullquote.is-style-solid-color {

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -1,4 +1,6 @@
+.wp-block-table.is-style-stripes,
 .wp-block-table {
+
 	th {
 		font-weight: 400;
 	}
@@ -7,6 +9,7 @@
 		border-bottom-width: 0;
 		border-top-width: 0;
 		vertical-align: top;
+		border-color: var(--wp--preset--color--primary);
 	}
 
 	tr:first-child td {
@@ -16,4 +19,19 @@
 	tr:last-child td {
 		border-bottom-width: 1px;
 	}
+
+	figcaption {
+		color: var(--wp--preset--color--primary);
+	}
+
+	margin-bottom: 1em;
+}
+
+.wp-block-table.is-style-stripes {
+	tbody {
+		tr:nth-child(odd) {
+			background-color: var(--wp--preset--color--secondary);
+		}
+	}
+	border-bottom: none;
 }

--- a/quadrat/sass/blocks/_table.scss
+++ b/quadrat/sass/blocks/_table.scss
@@ -24,7 +24,6 @@
 		color: var(--wp--preset--color--primary);
 	}
 
-	margin-bottom: 1em;
 }
 
 .wp-block-table.is-style-stripes {
@@ -33,5 +32,4 @@
 			background-color: var(--wp--preset--color--secondary);
 		}
 	}
-	border-bottom: none;
 }


### PR DESCRIPTION
Before:

Quadrat Editor:
<img src="https://user-images.githubusercontent.com/146530/124018587-0076e800-d9b6-11eb-93d4-fb7ee6df23d7.png" width="400">
Quadrat View:
<img src="https://user-images.githubusercontent.com/146530/124018616-0a005000-d9b6-11eb-8fe2-433ff9f1c2c5.png" width="400">

Blockbase Editor:
<img src="https://user-images.githubusercontent.com/146530/124018472-e210ec80-d9b5-11eb-91c0-23e2a9b3e0f0.png" width="400">
Blockbase View:
<img src="https://user-images.githubusercontent.com/146530/124018493-e9d09100-d9b5-11eb-813d-78df540fc032.png" width="400">


After:

Quadrat Editor:
<img src="https://user-images.githubusercontent.com/146530/124018244-a7a74f80-d9b5-11eb-8538-892b947a3950.png" width="400">
Quadrat View:
<img src="https://user-images.githubusercontent.com/146530/124018286-b1c94e00-d9b5-11eb-90d2-2c2f58631c51.png" width="400">

Blockbase Editor:
<img src="https://user-images.githubusercontent.com/146530/124018379-c7d70e80-d9b5-11eb-9a10-c0360bf71019.png" width="400">
Blockbase View:
<img src="https://user-images.githubusercontent.com/146530/124018406-cf96b300-d9b5-11eb-9051-04f6fb00eb83.png" width="400">

PARTIALLY address (one of the items in) 
#4048