### PR TITLE
Blockbase: Add theme support for block templates

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -24,6 +24,9 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		// Experimental support for adding blocks inside nav menus
 		add_theme_support( 'block-nav-menus' );
 
+		// Add support for block templates, so that user Global Styles settings load in the editor.
+		add_theme_support( 'block-templates' );
+
 		// Enqueue editor styles.
 		add_editor_style(
 			array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Classic themes need to declare support for block templates to ensure that theme.json loads in the block editor (see https://github.com/WordPress/gutenberg/blob/f1aacbbe451d39a4aee40bff329100b77d2fe2fb/lib/global-styles.php#L107)

This adds a theme_support for block templates to Blockbase so that it gets passed on to all of the child themes.

#### Related issue(s):
Fixes #4111
