### PR TITLE
Blockbase + children: Add footer credits for wordpress.com 

### DIFF
--- a/mayland-blocks/block-template-parts/footer.html
+++ b/mayland-blocks/block-template-parts/footer.html
@@ -19,3 +19,7 @@
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+<!-- /wp:paragraph -->

--- a/quadrat/block-template-parts/footer.html
+++ b/quadrat/block-template-parts/footer.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
 
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Powered by WordPress</p>
+<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
 <!-- /wp:paragraph -->
 
 </div>

--- a/seedlet-blocks/block-template-parts/footer.html
+++ b/seedlet-blocks/block-template-parts/footer.html
@@ -10,7 +10,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-<p class="has-text-align-left has-small-font-size">Proudly powered by <a href="https://wordpress.org">WordPress</a></p>
+<p class="has-text-align-left has-small-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
WordPress.com looks for footer credits that contain a link to wordpress.org (or .com). This adds consistent footer credits to the three child themes (this was done for Blockbase in https://github.com/Automattic/themes/pull/4076) so that they don't get extra credits when on WordPress.com

To test:
- Put this code on wpcom (npm run sandbox:push)
- Switch to a child of blockbase
- Check that the footer credit only appears once

#### Related issue(s):
Fixes #4047