### PR TITLE
Change meta icons to use mask

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -663,18 +663,27 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin-right: calc(0.5 * var(--wp--custom--margin--baseline));
 	height: 16px;
 	width: 16px;
+	background-color: currentColor;
 }
 
 .post-meta .wp-block-post-author:before {
-	background: url(svg/post-author.svg) no-repeat;
+	-webkit-mask-image: url(svg/post-author.svg);
+	mask-image: url(svg/post-author.svg);
 }
 
 .post-meta .wp-block-post-date:before {
-	background: url(svg/post-date.svg) no-repeat;
+	-webkit-mask-image: url(svg/post-date.svg);
+	mask-image: url(svg/post-date.svg);
 }
 
 .post-meta .wp-block-post-hierarchical-terms:before {
-	background: url(svg/post-category.svg) no-repeat;
+	-webkit-mask-image: url(svg/post-category.svg);
+	mask-image: url(svg/post-category.svg);
+}
+
+.post-meta .wp-block-post-tags:before {
+	-webkit-mask-image: url(svg/post-tag.svg);
+	mask-image: url(svg/post-tag.svg);
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blockbase/sass/post/_meta.scss
+++ b/blockbase/sass/post/_meta.scss
@@ -20,17 +20,26 @@
 		margin-right: calc(0.5 * var(--wp--custom--margin--baseline) );
 		height: 16px;
 		width: 16px;
+		background-color: currentColor;
 	}
 
 	.wp-block-post-author:before {
-		background: url(svg/post-author.svg) no-repeat;
+		-webkit-mask-image: url(svg/post-author.svg);
+		mask-image: url(svg/post-author.svg);
 	}
 
 	.wp-block-post-date:before {
-		background: url(svg/post-date.svg) no-repeat;
+		-webkit-mask-image: url(svg/post-date.svg);
+		mask-image: url(svg/post-date.svg);
 	}
 
-	.wp-block-post-hierarchical-terms:before {
-		background: url(svg/post-category.svg) no-repeat;
+	.wp-block-post-hierarchical-terms:before  {
+		-webkit-mask-image: url(svg/post-category.svg);
+		mask-image: url(svg/post-category.svg);
+	}
+
+	.wp-block-post-tags:before {
+		-webkit-mask-image: url(svg/post-tag.svg);
+		mask-image: url(svg/post-tag.svg);
 	}
 }

--- a/mayland-blocks/assets/theme.css
+++ b/mayland-blocks/assets/theme.css
@@ -46,4 +46,24 @@ img {
 	color: currentColor;
 }
 
+.post-meta .wp-block-post-author:before {
+	-webkit-mask-image: url(svg/post-author.svg);
+	mask-image: url(svg/post-author.svg);
+}
+
+.post-meta .wp-block-post-date:before {
+	-webkit-mask-image: url(svg/post-date.svg);
+	mask-image: url(svg/post-date.svg);
+}
+
+.post-meta .wp-block-post-hierarchical-terms:before {
+	-webkit-mask-image: url(svg/post-category.svg);
+	mask-image: url(svg/post-category.svg);
+}
+
+.post-meta .wp-block-post-tags:before {
+	-webkit-mask-image: url(svg/post-tag.svg);
+	mask-image: url(svg/post-tag.svg);
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/mayland-blocks/assets/theme.css
+++ b/mayland-blocks/assets/theme.css
@@ -46,20 +46,4 @@ img {
 	color: currentColor;
 }
 
-.post-meta .wp-block-post-author:before {
-	background: url(svg/post-author.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-date:before {
-	background: url(svg/post-date.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-hierarchical-terms:before {
-	background: url(svg/post-category.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-tags:before {
-	background: url(svg/post-tag.svg) no-repeat;
-}
-
 /*# sourceMappingURL=theme.css.map */

--- a/mayland-blocks/sass/theme.scss
+++ b/mayland-blocks/sass/theme.scss
@@ -48,19 +48,3 @@ img {
 .post-meta a {
 	color: currentColor;
 }
-
-.post-meta .wp-block-post-author:before {
-	background: url(svg/post-author.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-date:before {
-	background: url(svg/post-date.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-hierarchical-terms:before {
-	background: url(svg/post-category.svg) no-repeat;
-}
-
-.post-meta .wp-block-post-tags:before {
-	background: url(svg/post-tag.svg) no-repeat;
-}

--- a/mayland-blocks/sass/theme.scss
+++ b/mayland-blocks/sass/theme.scss
@@ -48,3 +48,23 @@ img {
 .post-meta a {
 	color: currentColor;
 }
+
+.post-meta .wp-block-post-author:before {
+	-webkit-mask-image: url(svg/post-author.svg);
+	mask-image: url(svg/post-author.svg);
+}
+
+.post-meta .wp-block-post-date:before {
+	-webkit-mask-image: url(svg/post-date.svg);
+	mask-image: url(svg/post-date.svg);
+}
+
+.post-meta .wp-block-post-hierarchical-terms:before {
+	-webkit-mask-image: url(svg/post-category.svg);
+	mask-image: url(svg/post-category.svg);
+}
+
+.post-meta .wp-block-post-tags:before {
+	-webkit-mask-image: url(svg/post-tag.svg);
+	mask-image: url(svg/post-tag.svg);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change uses `mask-image` to set the colour of the post meta icons to the text colour (`currentColor`) set by the user. The approach is based on [this CodePen](https://codepen.io/joen/pen/poRwpPj?editors=1100).

Before:
![image](https://user-images.githubusercontent.com/1645628/124119616-a5eb9380-da6a-11eb-891e-97a5be99f258.png)

After:
![image](https://user-images.githubusercontent.com/1645628/124119685-b8fe6380-da6a-11eb-930b-6eb91159e1db.png)

#### Related issue(s):
Fixes #3615