### PR TITLE
Added selectors for Quadrat navigation styles to support the current classes produced by the page-list block

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -176,7 +176,7 @@ ul ul {
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .submenu-container,
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link__container {
 	background-color: var(--wp--custom--color--background);
-	border-color: var(--wp--custom--color--foreground);
+	border-color: var(--wp--custom--color--secondary);
 }
 
 .wp-block-navigation .wp-block-navigation__mobile-menu-open-button {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -163,11 +163,17 @@ ul ul {
 	background: transparent;
 }
 
+.wp-block-navigation .wp-block-pages-list__item .wp-block-pages-list__item__link,
+.wp-block-navigation .wp-block-navigation-link__content {
+	color: var(--wp--custom--color--foreground);
+}
+
 .wp-block-navigation .wp-block-pages-list__item .wp-block-pages-list__item__link:hover,
 .wp-block-navigation .wp-block-navigation-link__content:hover {
 	text-decoration: underline;
 }
 
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container .submenu-container,
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link__container {
 	background-color: var(--wp--custom--color--background);
 	border-color: var(--wp--custom--color--foreground);
@@ -181,6 +187,7 @@ ul ul {
 	background-color: var(--wp--custom--color--secondary);
 }
 
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link {
 	font-size: 20px;
 	line-height: 50px;
@@ -188,16 +195,29 @@ ul ul {
 	align-items: flex-end;
 }
 
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-pages-list__item__link,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__content {
 	margin-right: 0;
 }
 
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container {
 	margin-right: -19px;
 	padding: 0 19px 0 0;
 	border-right: 1px solid var(--wp--custom--color--foreground);
 }
 
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-navigation-link__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-navigation-link__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
 	padding: 0;
 	font-size: 15px;

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -14,7 +14,7 @@
 			.submenu-container,
 			.wp-block-navigation-link__container {
 				background-color: var(--wp--custom--color--background);
-				border-color: var(--wp--custom--color--foreground);
+				border-color: var(--wp--custom--color--secondary);
 			}
 		}
 	}

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -4,12 +4,14 @@
 	}
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
 	.wp-block-navigation-link__content {
+		color: var(--wp--custom--color--foreground);
 		&:hover {
 			text-decoration: underline;
 		}
 	}
 	&:not(.has-background) { 
 		.wp-block-navigation__container { 
+			.submenu-container,
 			.wp-block-navigation-link__container {
 				background-color: var(--wp--custom--color--background);
 				border-color: var(--wp--custom--color--foreground);
@@ -24,19 +26,23 @@
 	&.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
 		background-color: var(--wp--custom--color--secondary);
 		&.has-modal-open {
+			.wp-block-pages-list__item,
 			.wp-block-navigation-link {
 				font-size: 20px;
 				line-height: 50px;
 				margin: 0;
 				align-items: flex-end;
 				&.has-child {
+					.wp-block-pages-list__item__link,
 					.wp-block-navigation-link__content {
 						margin-right: 0;
 					}
+					.submenu-container,
 					.wp-block-navigation-link__container{
 						margin-right: -19px;
 						padding: 0 19px 0 0;
 						border-right: 1px solid var(--wp--custom--color--foreground);
+						.wp-block-pages-list__item__link,
 						.wp-block-navigation-link__content {
 							padding: 0;
 							font-size: 15px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Because the Navigation Block currently produces DIFFERENT markup for `page-list` block and `page-link` blocks the `navigation` block has to have styles for both scenarios.

This change adds the necessary selectors to apply the same styles to both scenarios.

Before:
<img src="https://user-images.githubusercontent.com/146530/124154109-27d7be80-da63-11eb-85e4-464e0c2bfc1f.png" width=400>
<img src="https://user-images.githubusercontent.com/146530/124154068-1bebfc80-da63-11eb-98c3-d0daacdee8ff.png" width=300>

After:
<img src="https://user-images.githubusercontent.com/146530/124153977-0676d280-da63-11eb-9199-2a3f5bef6bbd.png" width=400>
<img src="https://user-images.githubusercontent.com/146530/124154016-0f67a400-da63-11eb-863d-bc3f3e50a4ff.png" width=300>


#### Related issue(s):

This fixes: #4133
