### PR TITLE
Universal themes: Add a setting to disable the Site Editor

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -100,3 +100,5 @@ function blockbase_fonts_url() {
  */
 require get_template_directory() . '/inc/wp-customize-colors.php';
 require get_template_directory() . '/inc/wp-customize-color-palettes.php';
+
+require get_template_directory() . '/inc/disable-site-editor.php';

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -101,4 +101,5 @@ function blockbase_fonts_url() {
 require get_template_directory() . '/inc/wp-customize-colors.php';
 require get_template_directory() . '/inc/wp-customize-color-palettes.php';
 
+/** Add a checkbox to hide the Site Editor */
 require get_template_directory() . '/inc/disable-site-editor.php';

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
+ */
+function add_disable_site_editor_setting() {
+	add_settings_field(
+		'universal-theme-disable-site-editor',
+		__( 'Site Editor', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Disable Site Editor', 'gutenberg' ),
+			'id'    => 'universal-theme-disable-site-editor',
+		)
+	);
+
+	if ( get_option( 'gutenberg-experiments' ) ) {
+		if ( array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) ) ) {
+			readd_legacy_admin_links();
+			remove_site_editor_admin_link();
+		}
+	}
+}
+
+/**
+ * Adds the Customizer and Widgets menu links back to the Dashboard under themes.
+ */
+function readd_legacy_admin_links() {
+	global $submenu;
+	if ( isset( $submenu['themes.php'] ) ) {
+		// Add Customize back to the admin menu.
+		$customize_url            = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+		$submenu['themes.php'][6] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
+		ksort( $submenu['themes.php'] );
+
+		if (
+			gutenberg_use_widgets_block_editor() &&
+			! function_exists( 'wp_use_widgets_block_editor' ) &&
+			current_theme_supports( 'widgets' )
+		) {
+			// Add Widgets back to the admin menu.
+			add_theme_page(
+				__( 'Widgets', 'gutenberg' ),
+				__( 'Widgets', 'gutenberg' ),
+				'edit_theme_options',
+				'gutenberg-widgets',
+				'the_gutenberg_widgets',
+				2
+			);
+		}
+	}
+}
+
+/**
+ * Removes the Site Editor link from the admin.
+ */
+function remove_site_editor_admin_link() {
+	global $menu;
+	// Remove Site Editor.
+	foreach ( $menu as $index => $menu_item ) {
+		if ( ! empty( $menu_item[5] ) && false !== strpos( $menu_item[5], 'toplevel_page_gutenberg-edit-site' ) ) {
+			$site_editor_index = $index;
+		}
+	}
+
+	unset( $menu[ $site_editor_index ] );
+}
+
+add_action( 'admin_init', 'add_disable_site_editor_setting' );

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -4,6 +4,11 @@
  * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
  */
 function add_disable_site_editor_setting() {
+
+	if ( ! is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) ) {
+		return;
+	}
+
 	add_settings_field(
 		'universal-theme-disable-site-editor',
 		__( 'Site Editor', 'gutenberg' ),

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -4,7 +4,6 @@
  * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
  */
 function add_disable_site_editor_setting() {
-
 	if ( ! is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) ) {
 		return;
 	}
@@ -38,23 +37,39 @@ function readd_legacy_admin_links() {
 		// Add Customize back to the admin menu.
 		$customize_url            = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
 		$submenu['themes.php'][6] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
-		ksort( $submenu['themes.php'] );
 
 		if (
+			function_exists( 'gutenberg_use_widgets_block_editor') &&
 			gutenberg_use_widgets_block_editor() &&
 			! function_exists( 'wp_use_widgets_block_editor' ) &&
 			current_theme_supports( 'widgets' )
 		) {
+			// Find Widgets menu
+			$has_widgets_menu = false;
+			foreach ( $submenu['themes.php'] as $index => $menu_item ) {
+				if (
+					! empty( $menu_item[2] ) &&
+					( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ||
+					false !== strpos( $menu_item[2], 'widgets.php' ) )
+				) {
+					$has_widgets_menu = true;
+				}
+			}
+
 			// Add Widgets back to the admin menu.
-			add_theme_page(
-				__( 'Widgets', 'gutenberg' ),
-				__( 'Widgets', 'gutenberg' ),
-				'edit_theme_options',
-				'gutenberg-widgets',
-				'the_gutenberg_widgets',
-				2
-			);
+			if ( ! $has_widgets_menu ) {
+				add_theme_page(
+					__( 'Widgets', 'gutenberg' ),
+					__( 'Widgets', 'gutenberg' ),
+					'edit_theme_options',
+					'gutenberg-widgets',
+					'the_gutenberg_widgets',
+					2
+				);
+			}
 		}
+
+		ksort( $submenu['themes.php'] );
 	}
 }
 

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -1,0 +1,1 @@
+<!-- wp:template-part {"slug":"index"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a setting to the Gutenberg experiments page which allows users to disable the Site Editor for universal themes.

We talked about this being a separate plugin, but I think in some ways shipping it in the theme makes more sense.

<img width="1049" alt="Screenshot 2021-07-02 at 11 43 25" src="https://user-images.githubusercontent.com/275961/124263098-be22e780-db2a-11eb-846e-4b839a4b0691.png">

<img width="1050" alt="Screenshot 2021-07-02 at 11 43 14" src="https://user-images.githubusercontent.com/275961/124263103-bfecab00-db2a-11eb-86bc-8008d0ac8939.png">

