### PR TITLE
Lodestar: update site_logo for compatibility with Jetpack 9.9

### DIFF
--- a/lodestar/inc/wpcom.php
+++ b/lodestar/inc/wpcom.php
@@ -35,7 +35,7 @@ add_action( 'after_setup_theme', 'lodestar_wpcom_setup' );
  * Enqueue wp.com-specific styles
  */
 function lodestar_wpcom_styles() {
- wp_enqueue_style( 'lodestar-wpcom', get_template_directory_uri() . '/inc/wpcom-style.css', '20160708' );
+	wp_enqueue_style( 'lodestar-wpcom', get_template_directory_uri() . '/inc/wpcom-style.css', '20160708' );
 }
 add_action( 'wp_enqueue_scripts', 'lodestar_wpcom_styles' );
 
@@ -44,8 +44,7 @@ add_action( 'wp_enqueue_scripts', 'lodestar_wpcom_styles' );
  */
 function lodestar_move_logo() {
 	if ( current_theme_supports( 'custom-logo' ) && ! get_theme_mod( 'custom_logo' ) && $jp_logo = get_option( 'site_logo' ) ) {
-		set_theme_mod( 'custom_logo', $jp_logo['id'] );
-		delete_option( 'site_logo' );
+		set_theme_mod( 'custom_logo', $jp_logo );
 	}
 }
 add_action( 'init', 'lodestar_move_logo' );

--- a/lodestar/style.css
+++ b/lodestar/style.css
@@ -4,7 +4,7 @@ Theme URI: http://theme.wordpress.com/themes/lodestar
 Author: Automattic
 Author URI: https://www.wordpress.com
 Description: Lodestar is a trendy one-page theme designed with startups and small business ventures in mind.
-Version: 1.0.15-wpcom
+Version: 1.0.16-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: lodestar


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates theme code to be compatible with Jetpack 9.9 changes to site_logo, which transform the site_logo option from an array to an attachment ID.

See https://github.com/Automattic/jetpack/pull/20192

Matching diff at D63676-code

This should be released after the Jetpack 9.9 release on July 6th.

#### Testing Instructions


- On a set running Jetpack 9.9:
- Activate another theme that uses the legacy Jetpack site-logo feature, like Canard or Scratchpad.
- Set a logo in the Customizer.
- Switch theme to Lodestar, and make sure the logo shows up in the new theme.

