### PR TITLE
Quadrat: Image alignments in Layout Grid block

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -649,4 +649,8 @@ textarea:focus {
 	margin-top: calc( var(--wp--custom--margin--vertical) / 2);
 }
 
+.wp-block[data-align=right] > .wp-block-image {
+	float: right;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -149,6 +149,10 @@
 	background: #fff;
 }
 
+.wp-block[data-align=right] > .wp-block-image {
+	float: right;
+}
+
 ul ul {
 	list-style-type: disc;
 }
@@ -647,10 +651,6 @@ textarea:focus {
 
 .wp-block-query .wp-block-post-featured-image {
 	margin-top: calc( var(--wp--custom--margin--vertical) / 2);
-}
-
-.wp-block[data-align=right] > .wp-block-image {
-	float: right;
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/quadrat/sass/blocks/_image.scss
+++ b/quadrat/sass/blocks/_image.scss
@@ -1,0 +1,5 @@
+.wp-block[data-align=right] {
+    > .wp-block-image {
+        float: right;
+    }
+}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -5,6 +5,7 @@
 @import "blocks/buttons";
 @import "blocks/calendar";
 @import "blocks/cover";
+@import "blocks/image";
 @import "blocks/list";
 @import "blocks/media-text";
 @import "blocks/navigation";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Currently, when adding an image in a Layout Grid Block and then setting the image alignment to the right, the change is not reflected in the editor. This PR fixes this by applying `float: right` to the image (similar to the styles for alignment on the front end.)

![image](https://user-images.githubusercontent.com/1645628/124758311-5a336100-df26-11eb-9c78-444a4e5f8fd2.png)

#### Testing steps:
- Add a layout grid block
- Add an image to the block
- Align the image to the right
- The image should align to the right of its column in the editor

#### Related issue(s):
Closes #4158