### PR TITLE
BB & Co: style text color of meta for latest posts block

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -336,6 +336,11 @@ input[type=checkbox] + label {
 	text-align: center;
 }
 
+.wp-block-latest-posts .wp-block-latest-posts__post-date,
+.wp-block-latest-posts .wp-block-latest-posts__post-author {
+	color: var(--wp--custom--latest-posts--meta--color--text);
+}
+
 ul,
 ol {
 	padding-left: var(--wp--custom--list--spacing--padding--left);

--- a/blockbase/sass/blocks/_latest-posts.scss
+++ b/blockbase/sass/blocks/_latest-posts.scss
@@ -1,0 +1,4 @@
+.wp-block-latest-posts .wp-block-latest-posts__post-date,
+.wp-block-latest-posts .wp-block-latest-posts__post-author {
+	color: var(--wp--custom--latest-posts--meta--color--text);
+}

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -14,6 +14,7 @@
 @import "blocks/gallery";
 @import "blocks/html";
 @import "blocks/image";
+@import "blocks/latest-posts";
 @import "blocks/list";
 @import "blocks/navigation";
 @import "blocks/paragraph";

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -191,6 +191,13 @@
 					"lineHeight": 1.125
 				}
 			},
+			"latest-posts": {
+				"meta": {
+					"color": {
+						"text": "var(--wp--custom--color--primary)"
+					}
+				}
+			},
 			"list": {
 				"spacing": {
 					"padding": {

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -199,6 +199,13 @@
 					"lineHeight": 1.125
 				}
 			},
+			"latest-posts": {
+				"meta": {
+					"color": {
+						"text": "var(--wp--custom--color--primary)"
+					}
+				}
+			},
 			"list": {
 				"spacing": {
 					"padding": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -235,6 +235,13 @@
 					"fontSize": "min(max(28px, 5vw), 38px)"
 				}
 			},
+			"latest-posts": {
+				"meta": {
+					"color": {
+						"text": "var(--wp--custom--color--primary)"
+					}
+				}
+			},
 			"list": {
 				"spacing": {
 					"padding": {

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -109,6 +109,13 @@
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
 				}	
 			},
+			"latest-posts": {
+				"meta": {
+					"color": {
+						"text": "var(--wp--custom--color--foreground)"
+					}
+				}
+			},
 			"margin": {
 				"horizontal": "25px",
 				"vertical": "30px"

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -232,6 +232,13 @@
 					"lineHeight": 1.125
 				}
 			},
+			"latest-posts": {
+				"meta": {
+					"color": {
+						"text": "var(--wp--custom--color--foreground)"
+					}
+				}
+			},
 			"list": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a custom variable to Blockbase so the author and date's color can be changed from the Gutenberg defaults. 

In Quadrat: 

Before | After
------- | -------
<img width="700" alt="Screenshot 2021-07-06 at 17 02 22" src="https://user-images.githubusercontent.com/3593343/124623229-171cb380-de7c-11eb-8899-0107fa2816a2.png"> | ![Screen Shot 2021-07-06 at 2 42 41 PM](https://user-images.githubusercontent.com/5375500/124651042-74a70500-de68-11eb-8c60-4d7e1cb3d2dd.png)

#### Related issue(s):

Closes #4169
