### PR TITLE
Fix FSE padding for BB themes.

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -3,8 +3,8 @@
  * - Reset the browser
  */
 body {
-	margin: 0;
-	padding: 0;
+	margin: 0 !important;
+	padding: 0 !important;
 }
 
 body {
@@ -55,11 +55,6 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
-.is-root-container {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}
-
 .wp-block-group.alignfull,
 *[class*="wp-container-"] {
 	padding-left: var(--wp--custom--post-content--padding--left);

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,10 +1,3 @@
-// This targets the editor. It is the closest equivalent to .wp-block-post-content,
-// since the editor does not output that class. 
-.is-root-container {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}
-
 .wp-block-group.alignfull,
 *[class*="wp-container-"] //Anything that inherits layout (container)
 {

--- a/blockbase/sass/base/_normalize.scss
+++ b/blockbase/sass/base/_normalize.scss
@@ -1,8 +1,8 @@
 
 // Remove the margin in all browsers.
 body {
-  margin: 0;
-  padding: 0;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 // Smooth out the fonts


### PR DESCRIPTION

With [this recent change](https://github.com/Automattic/themes/pull/4123) the way page padding works changed a bit.

That change, however, never took into account the FSE.  This change addresses that to ensure that what is reflected in the FSE editor matches the view.

#### Changes proposed in this Pull Request:

Force the 'body' (which, in the editor is applied to a different
element) margin and padding to obey the values set by the theme.

Remove the padding applied to the "post content" as the padding is now
applied a different way.

Before:
<img src="https://user-images.githubusercontent.com/146530/124652573-43c7cf80-de6a-11eb-96b2-6fa26b4f5f6a.png" width=400>
<img src="https://user-images.githubusercontent.com/146530/124653320-2b0be980-de6b-11eb-9ad3-f4ddab901f31.png" width=400>

After:
<img src="https://user-images.githubusercontent.com/146530/124652502-33175980-de6a-11eb-9d75-869846e4d92b.png" width=400>
<img src="https://user-images.githubusercontent.com/146530/124653416-41b24080-de6b-11eb-8eeb-ddca6880b15d.png" width=400>
