### PR TITLE
Blockbase: Update font name

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -180,13 +180,13 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--segoe-ui)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"lineHeight": 1.6
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--segoe-ui)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
@@ -305,8 +305,8 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-					"slug": "segoe-ui",
-					"name": "Segoe UI"
+					"slug": "system-font",
+					"name": "System Font"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
To match Quadat and the other themes, we should use the same name for the System font

To test:
- open the customizer fonts panel and confirm that System Font is selected
