### PR TITLE
Blockbase: Remove the background color from Navigation Links

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -383,11 +383,6 @@
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "var(--wp--custom--color--background)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -414,11 +414,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "var(--wp--custom--color--background)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -447,12 +447,6 @@
 					"fontSize": "18px"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
@@ -532,6 +526,12 @@
 						"fontSize": "15px",
 						"fontWeight": "400"
 					}
+				}
+			},
+			"core/navigation-link": {
+				"color": {
+					"background": "transparent",
+					"text": "var(--wp--custom--color--foreground)"
 				}
 			},
 			"list": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -443,11 +443,6 @@
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "var(--wp--custom--color--background)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--custom--heading--typography--font-family)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Removes the color for navigation links. I'm not sure why this was added.

Before:
<img width="663" alt="Screenshot 2021-07-08 at 11 44 40" src="https://user-images.githubusercontent.com/275961/124909048-ea82ac00-dfe1-11eb-9daa-dd8184421f2e.png">

After:
<img width="672" alt="Screenshot 2021-07-08 at 11 44 20" src="https://user-images.githubusercontent.com/275961/124909041-e8205200-dfe1-11eb-8150-7ac399167351.png">

#### Related issue(s):
Fixes #4083 