### PR TITLE
Quadrat: Add a new podcast template

### DIFF
--- a/quadrat/404.php
+++ b/quadrat/404.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * 404 template file
+ * The template for displaying 404 pages (not found)
  *
- * This is the most generic template file in a WordPress theme
- * and one of the two required files for a theme (the other being style.css).
- * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *
  * @package Quadrat
  * @since 1.0.0

--- a/quadrat/block-template-parts/podcast.html
+++ b/quadrat/block-template-parts/podcast.html
@@ -1,0 +1,46 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","bottom":"30px"}}},"layout":{"inherit":true}} -->
+<div class="wp-block-group" style="padding-top:30px;padding-bottom:30px;">
+	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
+	<!-- wp:spacer {"height":30} -->
+	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:post-featured-image {"align":"wide"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list","columns":3},"align":"wide","className":"is-style-quadrat-diamond-posts"} -->
+	<div class="wp-block-query alignwide is-style-quadrat-diamond-posts"><!-- wp:post-template -->
+	<!-- wp:columns -->
+	<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center"} -->
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"className":"post-meta"} -->
+	<div class="wp-block-group post-meta"><!-- wp:post-date {"fontSize":"tiny"} /-->
+	
+	<!-- wp:post-terms {"term":"category","fontSize":"tiny"} /--></div>
+	<!-- /wp:group -->
+	
+	<!-- wp:post-title {"textAlign":"left","isLink":true,"fontSize":"extra-large"} /-->
+	
+	<!-- wp:post-excerpt {"moreText":"Read more","fontSize":"normal"} /--></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:post-featured-image /--></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns -->
+	<!-- /wp:post-template -->
+	
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+	
+	<!-- wp:query-pagination-numbers /-->
+	
+	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+	<!-- /wp:query-pagination --></div>
+	<!-- /wp:query --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/quadrat/block-templates/podcast.html
+++ b/quadrat/block-templates/podcast.html
@@ -1,0 +1,1 @@
+<!-- wp:template-part {"slug":"podcast"} /-->

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -1,4 +1,13 @@
 {
+	"customTemplates": [
+		{
+			"name": "podcast",
+			"title": "Podcast",
+			"postTypes": [
+				"page"
+			]
+		}
+	],
 	"settings": {
 		"color": {
 			"gradients": [],

--- a/quadrat/page.php
+++ b/quadrat/page.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * Singular template file
+ * The template for displaying all single posts
  *
- * This is the most generic template file in a WordPress theme
- * and one of the two required files for a theme (the other being style.css).
- * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
  * @package Quadrat
  * @since 1.0.0

--- a/quadrat/podcast.php
+++ b/quadrat/podcast.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Template Name: Podcast
+ *
+ * @package Quadrat
+ * @since 1.1.0
+ */
+get_header();
+
+	echo gutenberg_block_template_part( 'podcast' );
+
+get_footer();

--- a/quadrat/search.php
+++ b/quadrat/search.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * Search template file
+ * The template for displaying search results pages
  *
- * This is the most generic template file in a WordPress theme
- * and one of the two required files for a theme (the other being style.css).
- * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *
  * @package Quadrat
  * @since 1.0.0

--- a/quadrat/single.php
+++ b/quadrat/single.php
@@ -2,7 +2,7 @@
 /**
  * Template file for rendering a single post
  *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
  * @package Quadrat
  * @since 1.0.0

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -12,19 +12,10 @@
 	],
 	"customTemplates": [
 		{
-			"name": "blank",
-			"title": "Blank",
+			"name": "podcast",
+			"title": "Podcast",
 			"postTypes": [
-				"page",
-				"post"
-			]
-		},
-		{
-			"name": "header-footer-only",
-			"title": "Header and Footer Only",
-			"postTypes": [
-				"page",
-				"post"
+				"page"
 			]
 		}
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR includes a custom template called "Podcast" that will use the new Query loop block style.

<img width="1557" alt="Screenshot 2021-07-08 at 12 53 09" src="https://user-images.githubusercontent.com/3593343/124910110-806f0480-dfeb-11eb-90ec-0668255643af.png">


While on "classic" mode the user can edit this template using the new Custom template editor, there they can change the Query block to only show a specific category of posts (such as Podcast).

While doing this PR I found out two issues:

- Quadrat inherits Blockbase custom templates even if we are overriding the `customTemplates` array on theme.json with this new change.
- Our php templates are showing up on the Custom template editor dropdown, showing as duplicates, that's confusing but I'm not sure how we can avoid this.

<img width="269" alt="Screenshot 2021-07-08 at 12 22 48" src="https://user-images.githubusercontent.com/3593343/124908799-01c59780-dfea-11eb-89d7-01752d19cfd8.png">

#### Testing instructions:

- Create a new page
- Select the podcast template (the lower case one is the HTML one, the other one is the php one but they are effectively the same thing).
<img width="284" alt="Screenshot 2021-07-08 at 12 43 18" src="https://user-images.githubusercontent.com/3593343/124909195-76003b00-dfea-11eb-8b1e-aa5a1417b11e.png">
- Test that you can edit the template within the Custom template editor and change the Query block to show a specific category
