### PR TITLE
Blockbase: Remove alignment fix

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -79,10 +79,6 @@ img {
 	}
 }
 
-.wp-block-group:not(.site-header) {
-	overflow: auto;
-}
-
 .aligncenter {
 	text-align: center;
 }

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -25,13 +25,6 @@
 	}
 }
 
-// When content is aligned left/right (particularly inside of a container) it is floated left/right
-// and needs something to ensure that the content follows the block rather than nestling up beside the floated element.
-// The issue should be resolved upstream: https://github.com/WordPress/gutenberg/issues/10299
-.wp-block-group:not(.site-header) {
-	overflow: auto;
-}
-
 // This was added for the 'site-logo' block which centers with an 'align:center' attribute
 // instead of 'textAlign' center which sets an .aligncenter class instead of a has-text-align-center
 // class which would do this for us.  I'm not sure why but this centers things appropriately.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes an alignment fix we added to Blockbase because it causes other issues:

Before:
<img width="670" alt="Screenshot 2021-07-08 at 11 50 54" src="https://user-images.githubusercontent.com/275961/124910269-531e5880-dfe3-11eb-9d7e-cbb8a4a85614.png">

After:
<img width="651" alt="Screenshot 2021-07-08 at 11 52 34" src="https://user-images.githubusercontent.com/275961/124910285-56194900-dfe3-11eb-9488-4928fc23dedf.png">

This will cause issues with left/right floated content inside a container, but since it causes other issues, I think we'd be better to remove it and let those issues be fixed upstream.

#### Related issue(s):
https://github.com/WordPress/gutenberg/issues/10299
