### PR TITLE
Quadrat: Remove bottom space

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -101,24 +101,25 @@ h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.h
 
 /**
  * This file pushes the footer to the bottom of the page.
- * The 32px is for the admin bar, if it exsits.
  */
-html {
-	height: calc( 100% - 32px);
-}
-
-body {
-	height: calc( 100% + 32px);
-}
-
-body.admin-bar {
-	height: calc( 100%);
+:root {
+	--wpadmin-bar--height: 46px;
 }
 
 .wp-site-blocks {
+	min-height: 100vh;
 	display: grid;
-	height: 100%;
 	grid-template-rows: auto 1fr;
+}
+
+@media (min-width: 600px) {
+	body.admin-bar {
+		--wpadmin-bar--height: 32px;
+	}
+}
+
+body.admin-bar .wp-site-blocks {
+	min-height: calc( 100vh - var(--wpadmin-bar--height));
 }
 
 ::selection {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -96,7 +96,29 @@ img {
 }
 
 h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.has-background, h6.has-background {
-	padding: var(--wp--custom--padding--vertical) var(--wp--custom--padding--vertical);
+	padding: var(--wp--custom--padding--vertical) var(--wp--custom--padding--horizontal);
+}
+
+/**
+ * This file pushes the footer to the bottom of the page.
+ * The 32px is for the admin bar, if it exsits.
+ */
+html {
+	height: calc( 100% - 32px);
+}
+
+body {
+	height: calc( 100% + 32px);
+}
+
+body.admin-bar {
+	height: calc( 100%);
+}
+
+.wp-site-blocks {
+	display: grid;
+	height: 100%;
+	grid-template-rows: auto 1fr;
 }
 
 ::selection {
@@ -366,7 +388,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 p.has-background {
-	padding: var(--wp--custom--padding--vertical) var(--wp--custom--padding--vertical);
+	padding: var(--wp--custom--padding--vertical) var(--wp--custom--padding--horizontal);
 }
 
 .wp-block-post-author__name {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -99,17 +99,18 @@ h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.h
 	padding: var(--wp--custom--padding--vertical) var(--wp--custom--padding--horizontal);
 }
 
-/**
- * This file pushes the footer to the bottom of the page.
- */
 :root {
 	--wpadmin-bar--height: 46px;
 }
 
 .wp-site-blocks {
 	min-height: 100vh;
-	display: grid;
-	grid-template-rows: auto 1fr;
+	display: flex;
+	flex-direction: column;
+}
+
+.site-footer-container {
+	margin-top: auto;
 }
 
 @media (min-width: 600px) {

--- a/blockbase/block-templates/404.html
+++ b/blockbase/block-templates/404.html
@@ -15,4 +15,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/blockbase/block-templates/header-footer-only.html
+++ b/blockbase/block-templates/header-footer-only.html
@@ -7,4 +7,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -28,4 +28,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/blockbase/block-templates/search.html
+++ b/blockbase/block-templates/search.html
@@ -21,4 +21,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -18,4 +18,4 @@
 <div class="wp-block-group"><!-- wp:post-comments /--></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/blockbase/sass/base/_footer.scss
+++ b/blockbase/sass/base/_footer.scss
@@ -1,0 +1,22 @@
+/**
+ * This file pushes the footer to the bottom of the page.
+ * The 32px is for the admin bar, if it exsits.
+ */
+
+html {
+	height: calc( 100% - 32px );
+}
+
+body {
+	height: calc( 100% + 32px );
+
+	&.admin-bar {
+		height: calc( 100% );
+	}
+}
+
+.wp-site-blocks {
+	display: grid;
+	height: 100%;
+	grid-template-rows: auto 1fr;
+}

--- a/blockbase/sass/base/_footer.scss
+++ b/blockbase/sass/base/_footer.scss
@@ -1,22 +1,23 @@
 /**
  * This file pushes the footer to the bottom of the page.
- * The 32px is for the admin bar, if it exsits.
  */
 
-html {
-	height: calc( 100% - 32px );
-}
-
-body {
-	height: calc( 100% + 32px );
-
-	&.admin-bar {
-		height: calc( 100% );
-	}
+:root {
+	--wpadmin-bar--height: 46px;
 }
 
 .wp-site-blocks {
+	min-height: 100vh;
 	display: grid;
-	height: 100%;
 	grid-template-rows: auto 1fr;
+}
+
+body.admin-bar {
+	@include break-small() {
+		--wpadmin-bar--height: 32px;
+	}
+
+	.wp-site-blocks {
+		min-height: calc( 100vh - var(--wpadmin-bar--height) );
+	}
 }

--- a/blockbase/sass/base/_layout.scss
+++ b/blockbase/sass/base/_layout.scss
@@ -1,15 +1,15 @@
-/**
- * This file pushes the footer to the bottom of the page.
- */
-
 :root {
 	--wpadmin-bar--height: 46px;
 }
 
 .wp-site-blocks {
 	min-height: 100vh;
-	display: grid;
-	grid-template-rows: auto 1fr;
+	display: flex;
+	flex-direction: column;
+}
+
+.site-footer-container {
+	margin-top: auto;
 }
 
 body.admin-bar {

--- a/blockbase/sass/base/_style.scss
+++ b/blockbase/sass/base/_style.scss
@@ -8,6 +8,6 @@
 
 @import "alignment";
 @import "header";
-@import "footer";
+@import "layout";
 @import "text";
 @import "utility";

--- a/blockbase/sass/base/_style.scss
+++ b/blockbase/sass/base/_style.scss
@@ -8,5 +8,6 @@
 
 @import "alignment";
 @import "header";
+@import "footer";
 @import "text";
 @import "utility";

--- a/mayland-blocks/assets/theme.css
+++ b/mayland-blocks/assets/theme.css
@@ -27,6 +27,10 @@ body {
 	}
 }
 
+.site-footer {
+	margin-top: auto;
+}
+
 /* Adjust heading letter spacing. */
 h1, h2, h3 {
 	letter-spacing: -0.015em;

--- a/mayland-blocks/sass/theme.scss
+++ b/mayland-blocks/sass/theme.scss
@@ -28,6 +28,10 @@ body {
 	}
 }
 
+.site-footer {
+	margin-top: auto;
+}
+
 /* Adjust heading letter spacing. */
 
 h1, h2, h3 {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -630,8 +630,11 @@ textarea:focus {
 	z-index: -1;
 }
 
-.site-header {
+.wp-site-blocks {
 	position: relative;
+}
+
+.site-header {
 	overflow: inherit;
 	padding: 10px var(--wp--custom--post-content--padding--left) 60px;
 }
@@ -684,7 +687,7 @@ textarea:focus {
 	content: "";
 	background-color: var(--wp--custom--color--secondary);
 	position: absolute;
-	height: 100vw;
+	bottom: 0;
 	top: 0;
 	left: 0;
 	right: 0;

--- a/quadrat/block-templates/404.html
+++ b/quadrat/block-templates/404.html
@@ -15,4 +15,4 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/front-page.html
+++ b/quadrat/block-templates/front-page.html
@@ -6,4 +6,4 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -19,4 +19,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -16,4 +16,4 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -19,4 +19,4 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -57,4 +57,4 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/sass/templates/_header.scss
+++ b/quadrat/sass/templates/_header.scss
@@ -1,5 +1,8 @@
+.wp-site-blocks {
+	position: relative; // This is needed so that the polygon is stretched across the whole site.
+}
+
 .site-header {
-	position: relative;
 	overflow: inherit;
 	padding: 10px var(--wp--custom--post-content--padding--left) 60px; // TODO: Maybe replace with a responsive custom variable?
 
@@ -44,7 +47,7 @@
 		content: "";
 		background-color: var(--wp--custom--color--secondary);
 		position: absolute;
-		height: 100vw;
+		bottom: 0;
 		top: 0;
 		left: 0;
 		right: 0;

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -18,4 +18,4 @@
 </div>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/seedlet-blocks/block-templates/singular.html
+++ b/seedlet-blocks/block-templates/singular.html
@@ -37,4 +37,4 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove the bottom spacing on the front page template.

When the screen is wider than it is tall, and there's not much content on the page we get a space appear at the bottom:
<img width="1440" alt="Screenshot 2021-07-08 at 13 28 23" src="https://user-images.githubusercontent.com/275961/124921523-671c8700-dff0-11eb-932b-bbc7c8d1294d.png">

This changes the way that the polygon is positioned, by stretching the div across the whole site:
<img width="1440" alt="Screenshot 2021-07-08 at 13 28 08" src="https://user-images.githubusercontent.com/275961/124921540-6a177780-dff0-11eb-89ce-0d61c0ee0b16.png">

