### PR TITLE
Quadrat: add a front page template

### DIFF
--- a/quadrat/block-templates/front-page.html
+++ b/quadrat/block-templates/front-page.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:spacer {"height":60} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

We needed a new Home page template that wouldn't show the Page title block. 

Before | After
--- | ---
<img width="1757" alt="Screenshot 2021-07-08 at 17 18 54" src="https://user-images.githubusercontent.com/3593343/124948475-03568600-e011-11eb-947b-42f563ef8ee2.png"> | <img width="1754" alt="Screenshot 2021-07-08 at 17 20 22" src="https://user-images.githubusercontent.com/3593343/124948462-018cc280-e011-11eb-83a7-395dd25c5e47.png">

@kjellr I kept the spacer block that the page template has, let me know if this looks fine for you

This PR assumes that we are removing the php templates with https://github.com/Automattic/themes/pull/4187 and I didn't bother creating one for this page.



