### PR TITLE
Fixed null ref in font customizations

### DIFF
--- a/blockbase/inc/wp-customize-fonts.php
+++ b/blockbase/inc/wp-customize-fonts.php
@@ -4,188 +4,188 @@ class GlobalStylesFontsCustomizer {
 
 	private $section_key = 'customize-global-styles-fonts';
 
-	private $fontSettings;
+	private $font_settings;
 
 	private $fonts = array(
-		"system-font" => array(
-			"fontFamily" => "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-			"slug" => "system-font",
-			"name" => "System Font",
+		'system-font'       => array(
+			'fontFamily' => '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+			'slug'       => 'system-font',
+			'name'       => 'System Font',
 		),
-		"arvo" => array(
-			"fontFamily" => "\"Arvo\", serif",
-			"slug" => "arvo",
-			"name" => "Arvo",
-			"google" => "family=Arvo:ital,wght@0,400;0,500;1,400",
+		'arvo'              => array(
+			'fontFamily' => '"Arvo", serif',
+			'slug'       => 'arvo',
+			'name'       => 'Arvo',
+			'google'     => 'family=Arvo:ital,wght@0,400;0,500;1,400',
 		),
-		"bodoni-moda" => array(
-			"fontFamily" => "\"Bodoni Moda\", serif",
-			"slug" => "bodoni-moda",
-			"name" => "Bodoni Moda",
-			"google" => "family=Bodoni+Moda:ital,wght@0,400;0,500;1,400",
+		'bodoni-moda'       => array(
+			'fontFamily' => '"Bodoni Moda", serif',
+			'slug'       => 'bodoni-moda',
+			'name'       => 'Bodoni Moda',
+			'google'     => 'family=Bodoni+Moda:ital,wght@0,400;0,500;1,400',
 		),
-		"cabin" => array(
-			"fontFamily" => "\"Cabin\", sans-serif",
-			"slug" => "cabin",
-			"name" => "Cabin",
-			"google" => "family=Cabin:ital,wght@0,400;0,500;1,400",
+		'cabin'             => array(
+			'fontFamily' => '"Cabin", sans-serif',
+			'slug'       => 'cabin',
+			'name'       => 'Cabin',
+			'google'     => 'family=Cabin:ital,wght@0,400;0,500;1,400',
 		),
-		"chivo" => array(
-			"fontFamily" => "\"Chivo\", sans-serif",
-			"slug" => "chivo",
-			"name" => "Chivo",
-			"google" => "family=Chivo:ital,wght@0,400;0,500;1,400",
+		'chivo'             => array(
+			'fontFamily' => '"Chivo", sans-serif',
+			'slug'       => 'chivo',
+			'name'       => 'Chivo',
+			'google'     => 'family=Chivo:ital,wght@0,400;0,500;1,400',
 		),
-		"courier-prime" => array(
-			"fontFamily" => "\"Courier Prime\", serif",
-			"slug" => "courier-prime",
-			"name" => "Courier Prime",
-			"google" => "family=Courier+Prime:ital,wght@0,400;0,500;1,400",
+		'courier-prime'     => array(
+			'fontFamily' => '"Courier Prime", serif',
+			'slug'       => 'courier-prime',
+			'name'       => 'Courier Prime',
+			'google'     => 'family=Courier+Prime:ital,wght@0,400;0,500;1,400',
 		),
-		"dm-sans" => array(
-			"fontFamily" => "\"DM Sans\", sans-serif",
-			"slug" => "dm-sans",
-			"name" => "DM Sans",
-			"google" => "family=DM+Sans:ital,wght@0,400;0,500;1,400",
+		'dm-sans'           => array(
+			'fontFamily' => '"DM Sans", sans-serif',
+			'slug'       => 'dm-sans',
+			'name'       => 'DM Sans',
+			'google'     => 'family=DM+Sans:ital,wght@0,400;0,500;1,400',
 		),
-		"domine" => array(
-			"fontFamily" => "\"Domine\", serif",
-			"slug" => "domine",
-			"name" => "Domine",
-			"google" => "family=Domine:ital,wght@0,400;0,500;1,400",
+		'domine'            => array(
+			'fontFamily' => '"Domine", serif',
+			'slug'       => 'domine',
+			'name'       => 'Domine',
+			'google'     => 'family=Domine:ital,wght@0,400;0,500;1,400',
 		),
-		"eb-garamond" => array(
-			"fontFamily" => "\"EB Garamond\", serif",
-			"slug" => "eb-garamond",
-			"name" => "EB Garamond",
-			"google" => "family=EB+Garamond:ital,wght@0,400;0,500;1,400",
+		'eb-garamond'       => array(
+			'fontFamily' => '"EB Garamond", serif',
+			'slug'       => 'eb-garamond',
+			'name'       => 'EB Garamond',
+			'google'     => 'family=EB+Garamond:ital,wght@0,400;0,500;1,400',
 		),
-		"fira-sans" => array(
-			"fontFamily" => "\"Fira Sans\", sans-serif",
-			"slug" => "fira-sans",
-			"name" => "Fira Sans",
-			"google" => "family=Fira+Sans:ital,wght@0,400;0,500;1,400",
+		'fira-sans'         => array(
+			'fontFamily' => '"Fira Sans", sans-serif',
+			'slug'       => 'fira-sans',
+			'name'       => 'Fira Sans',
+			'google'     => 'family=Fira+Sans:ital,wght@0,400;0,500;1,400',
 		),
-		"inter" => array(
-			"fontFamily" => "\"Inter\", sans-serif",
-			"slug" => "inter",
-			"name" => "Inter",
-			"google" => "family=Inter:ital,wght@0,400;0,500;1,400",
+		'inter'             => array(
+			'fontFamily' => '"Inter", sans-serif',
+			'slug'       => 'inter',
+			'name'       => 'Inter',
+			'google'     => 'family=Inter:ital,wght@0,400;0,500;1,400',
 		),
-		"josefin-sans" => array(
-			"fontFamily" => "\"Josefin Sans\", sans-serif",
-			"slug" => "josefin-sans",
-			"name" => "Josefin Sans",
-			"google" => "family=Josefin+Sans:ital,wght@0,400;0,500;1,400",
+		'josefin-sans'      => array(
+			'fontFamily' => '"Josefin Sans", sans-serif',
+			'slug'       => 'josefin-sans',
+			'name'       => 'Josefin Sans',
+			'google'     => 'family=Josefin+Sans:ital,wght@0,400;0,500;1,400',
 		),
-		"libre-baskerville" => array(
-			"fontFamily" => "\"Libre Baskerville\", serif",
-			"slug" => "libre-baskerville",
-			"name" => "Libre Baskerville",
-			"google" => "family=Libre+Baskerville:ital,wght@0,400;0,500;1,400",
+		'libre-baskerville' => array(
+			'fontFamily' => '"Libre Baskerville", serif',
+			'slug'       => 'libre-baskerville',
+			'name'       => 'Libre Baskerville',
+			'google'     => 'family=Libre+Baskerville:ital,wght@0,400;0,500;1,400',
 		),
-		"libre-franklin" => array(
-			"fontFamily" => "\"Libre Franklin\", sans-serif",
-			"slug" => "libre-franklin",
-			"name" => "Libre Franklin",
-			"google" => "family=Libre+Franklin:ital,wght@0,400;0,500;1,400",
+		'libre-franklin'    => array(
+			'fontFamily' => '"Libre Franklin", sans-serif',
+			'slug'       => 'libre-franklin',
+			'name'       => 'Libre Franklin',
+			'google'     => 'family=Libre+Franklin:ital,wght@0,400;0,500;1,400',
 		),
-		"lora" => array(
-			"fontFamily" => "\"Lora\", serif",
-			"slug" => "lora",
-			"name" => "Lora",
-			"google" => "family=Lora:ital,wght@0,400;0,500;1,400",
+		'lora'              => array(
+			'fontFamily' => '"Lora", serif',
+			'slug'       => 'lora',
+			'name'       => 'Lora',
+			'google'     => 'family=Lora:ital,wght@0,400;0,500;1,400',
 		),
-		"merriweather" => array(
-			"fontFamily" => "\"Merriweather\", serif",
-			"slug" => "merriweather",
-			"name" => "Merriweather",
-			"google" => "family=Merriweather:ital,wght@0,400;0,500;1,400",
+		'merriweather'      => array(
+			'fontFamily' => '"Merriweather", serif',
+			'slug'       => 'merriweather',
+			'name'       => 'Merriweather',
+			'google'     => 'family=Merriweather:ital,wght@0,400;0,500;1,400',
 		),
-		"montserrat" => array(
-			"fontFamily" => "\"Montserrat\", sans-serif",
-			"slug" => "montserrat",
-			"name" => "Montserrat",
-			"google" => "family=Montserrat:ital,wght@0,400;0,500;1,400",
+		'montserrat'        => array(
+			'fontFamily' => '"Montserrat", sans-serif',
+			'slug'       => 'montserrat',
+			'name'       => 'Montserrat',
+			'google'     => 'family=Montserrat:ital,wght@0,400;0,500;1,400',
 		),
-		"nunito" => array(
-			"fontFamily" => "\"Nunito\", sans-serif",
-			"slug" => "nunito",
-			"name" => "Nunito",
-			"google" => "family=Nunito:ital,wght@0,400;0,500;1,400",
+		'nunito'            => array(
+			'fontFamily' => '"Nunito", sans-serif',
+			'slug'       => 'nunito',
+			'name'       => 'Nunito',
+			'google'     => 'family=Nunito:ital,wght@0,400;0,500;1,400',
 		),
-		"open-sans" => array(
-			"fontFamily" => "\"Open Sans\", sans-serif",
-			"slug" => "open-sans",
-			"name" => "Open Sans",
-			"google" => "family=Open+Sans:ital,wght@0,400;0,500;1,400",
+		'open-sans'         => array(
+			'fontFamily' => '"Open Sans", sans-serif',
+			'slug'       => 'open-sans',
+			'name'       => 'Open Sans',
+			'google'     => 'family=Open+Sans:ital,wght@0,400;0,500;1,400',
 		),
-		"overpass" => array(
-			"fontFamily" => "\"Overpass\", sans-serif",
-			"slug" => "overpass",
-			"name" => "Overpass",
-			"google" => "family=Overpass:ital,wght@0,400;0,500;1,400",
+		'overpass'          => array(
+			'fontFamily' => '"Overpass", sans-serif',
+			'slug'       => 'overpass',
+			'name'       => 'Overpass',
+			'google'     => 'family=Overpass:ital,wght@0,400;0,500;1,400',
 		),
-		"playfair-display" => array(
-			"fontFamily" => "\"Playfair Display\", serif",
-			"slug" => "playfair-display",
-			"name" => "Playfair Display",
-			"google" => "family=Playfair+Display:ital,wght@0,400;0,500;1,400",
+		'playfair-display'  => array(
+			'fontFamily' => '"Playfair Display", serif',
+			'slug'       => 'playfair-display',
+			'name'       => 'Playfair Display',
+			'google'     => 'family=Playfair+Display:ital,wght@0,400;0,500;1,400',
 		),
-		"poppins" => array(
-			"fontFamily" => "\"Poppins\", sans-serif",
-			"slug" => "poppins",
-			"name" => "Poppins",
-			"google" => "family=Poppins:ital,wght@0,400;0,500;1,400",
+		'poppins'           => array(
+			'fontFamily' => '"Poppins", sans-serif',
+			'slug'       => 'poppins',
+			'name'       => 'Poppins',
+			'google'     => 'family=Poppins:ital,wght@0,400;0,500;1,400',
 		),
-		"raleway" => array(
-			"fontFamily" => "\"Raleway\", sans-serif",
-			"slug" => "raleway",
-			"name" => "Raleway",
-			"google" => "family=Raleway:ital,wght@0,400;0,500;1,400",
+		'raleway'           => array(
+			'fontFamily' => '"Raleway", sans-serif',
+			'slug'       => 'raleway',
+			'name'       => 'Raleway',
+			'google'     => 'family=Raleway:ital,wght@0,400;0,500;1,400',
 		),
-		"roboto" => array(
-			"fontFamily" => "\"Roboto\", sans-serif",
-			"slug" => "roboto",
-			"name" => "Roboto",
-			"google" => "family=Roboto:ital,wght@0,400;0,500;1,400",
+		'roboto'            => array(
+			'fontFamily' => '"Roboto", sans-serif',
+			'slug'       => 'roboto',
+			'name'       => 'Roboto',
+			'google'     => 'family=Roboto:ital,wght@0,400;0,500;1,400',
 		),
-		"roboto-slab" => array(
-			"fontFamily" => "\"Roboto Slab\", sans-serif",
-			"slug" => "roboto-slab",
-			"name" => "Roboto Slab",
-			"google" => "family=Roboto+Slab:ital,wght@0,400;0,500;1,400",
+		'roboto-slab'       => array(
+			'fontFamily' => '"Roboto Slab", sans-serif',
+			'slug'       => 'roboto-slab',
+			'name'       => 'Roboto Slab',
+			'google'     => 'family=Roboto+Slab:ital,wght@0,400;0,500;1,400',
 		),
-		"rubik" => array(
-			"fontFamily" => "\"Rubik\", sans-serif",
-			"slug" => "rubik",
-			"name" => "Rubik",
-			"google" => "family=Rubik:ital,wght@0,400;0,500;1,400",
+		'rubik'             => array(
+			'fontFamily' => '"Rubik", sans-serif',
+			'slug'       => 'rubik',
+			'name'       => 'Rubik',
+			'google'     => 'family=Rubik:ital,wght@0,400;0,500;1,400',
 		),
-		"source-sans-pro" => array(
-			"fontFamily" => "\"Source Sans Pro\", sans-serif",
-			"slug" => "source-sans-pro",
-			"name" => "Source Sans Pro",
-			"google" => "family=Source+Sans+Pro:ital,wght@0,400;0,500;1,400",
+		'source-sans-pro'   => array(
+			'fontFamily' => '"Source Sans Pro", sans-serif',
+			'slug'       => 'source-sans-pro',
+			'name'       => 'Source Sans Pro',
+			'google'     => 'family=Source+Sans+Pro:ital,wght@0,400;0,500;1,400',
 		),
-		"source-serif-pro" => array(
-			"fontFamily" => "\"Source Serif Pro\", serif",
-			"slug" => "source-serif-pro",
-			"name" => "Source Serif Pro",
-			"google" => "family=Source+Serif+Pro:ital,wght@0,400;0,500;1,400",
+		'source-serif-pro'  => array(
+			'fontFamily' => '"Source Serif Pro", serif',
+			'slug'       => 'source-serif-pro',
+			'name'       => 'Source Serif Pro',
+			'google'     => 'family=Source+Serif+Pro:ital,wght@0,400;0,500;1,400',
 		),
-		"space-mono" => array(
-			"fontFamily" => "\"Space Mono\", sans-serif",
-			"slug" => "space-mono",
-			"name" => "Space Mono",
-			"google" => "family=Space+Mono:ital,wght@0,400;0,500;1,400",
+		'space-mono'        => array(
+			'fontFamily' => '"Space Mono", sans-serif',
+			'slug'       => 'space-mono',
+			'name'       => 'Space Mono',
+			'google'     => 'family=Space+Mono:ital,wght@0,400;0,500;1,400',
 		),
-		"work-sans" => array(
-			"fontFamily" => "\"Work Sans\", sans-serif",
-			"slug" => "work-sans",
-			"name" => "Work Sans",
-			"google" => "family=Work+Sans:ital,wght@0,400;0,500;1,400",
-		)
+		'work-sans'         => array(
+			'fontFamily' => '"Work Sans", sans-serif',
+			'slug'       => 'work-sans',
+			'name'       => 'Work Sans',
+			'google'     => 'family=Work+Sans:ital,wght@0,400;0,500;1,400',
+		),
 	);
 
 	function __construct() {
@@ -204,7 +204,7 @@ class GlobalStylesFontsCustomizer {
 	function customize_preview_js( $wp_customize ) {
 		wp_enqueue_script( 'customizer-preview-fonts', get_template_directory_uri() . '/inc/wp-customize-fonts-preview.js', array( 'customize-preview' ) );
 		wp_localize_script( 'customizer-preview-fonts', 'googleFonts', $this->fonts );
-		wp_localize_script( 'customizer-preview-fonts', 'fontSettings', $this->fontSettings );
+		wp_localize_script( 'customizer-preview-fonts', 'fontSettings', $this->font_settings );
 	}
 
 	function enqueue_google_fonts() {
@@ -213,9 +213,9 @@ class GlobalStylesFontsCustomizer {
 
 	function create_customization_style_element( $wp_customize ) {
 		wp_enqueue_style( 'global-styles-fonts-customizations', ' ', array( 'global-styles' ) ); // This needs to load after global_styles, hence the dependency
-		$css = ':root,body{';
-		$css .= '--wp--custom--body--typography--font-family:' . $this->fontSettings['body'] . ';';
-		$css .= '--wp--custom--heading--typography--font-family: ' . $this->fontSettings['heading'] . '}';
+		$css  = ':root,body{';
+		$css .= '--wp--custom--body--typography--font-family:' . $this->font_settings['body'] . ';';
+		$css .= '--wp--custom--heading--typography--font-family: ' . $this->font_settings['heading'] . '}';
 		$css .= '}';
 		wp_add_inline_style( 'global-styles-fonts-customizations', $css );
 	}
@@ -223,20 +223,20 @@ class GlobalStylesFontsCustomizer {
 	function update_font_settings( $wp_customize ) {
 		$body_value = $wp_customize->get_setting( $this->section_key . 'body' )->post_value();
 		if ( $body_value ) {
-			$body_font_setting = $this->fonts[ $body_value ];
-			$this->fontSettings['body'] = $body_font_setting['fontFamily'];
+			$body_font_setting           = $this->fonts[ $body_value ];
+			$this->font_settings['body'] = $body_font_setting['fontFamily'];
 		}
 
 		$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->post_value();
 		if ( $heading_value ) {
-			$heading_font_setting = $this->fonts[ $heading_value ];
-			$this->fontSettings['heading'] = $heading_font_setting['fontFamily'];
+			$heading_font_setting           = $this->fonts[ $heading_value ];
+			$this->font_settings['heading'] = $heading_font_setting['fontFamily'];
 		}
 	}
 
 	function google_fonts_url() {
-		$font_families = [];
-		foreach( $this->fonts as $font ) {
+		$font_families = array();
+		foreach ( $this->fonts as $font ) {
 			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
@@ -248,16 +248,16 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function initialize( $wp_customize ) {
-		$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
-		$body_font_variable = $theme_json['settings']['custom']['body']['typography']['fontFamily'];
+		$theme_json            = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+		$body_font_variable    = $theme_json['settings']['custom']['body']['typography']['fontFamily'];
 		$heading_font_variable = $theme_json['settings']['custom']['heading']['typography']['fontFamily'];
-		$body_font_slug = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $body_font_variable );
-		$heading_font_slug = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $heading_font_variable );
+		$body_font_slug        = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $body_font_variable );
+		$heading_font_slug     = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $heading_font_variable );
 
-		$body_font_setting = $this->fonts[ $body_font_slug ];
+		$body_font_setting    = $this->fonts[ $body_font_slug ];
 		$heading_font_setting = $this->fonts[ $heading_font_slug ];
-		$this->fontSettings = array(
-			'body' => $body_font_setting['fontFamily'],
+		$this->font_settings  = array(
+			'body'    => $body_font_setting['fontFamily'],
 			'heading' => $heading_font_setting['fontFamily'],
 		);
 
@@ -278,19 +278,19 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function add_setting_and_control( $wp_customize, $name, $label, $default ) {
-		$setting_name = $this->section_key . $name;
+		$setting_name          = $this->section_key . $name;
 		$global_styles_setting = new WP_Customize_Global_Styles_Setting(
 			$wp_customize,
 			$setting_name,
 			array(
-				'default' => $default,
+				'default'    => $default,
 				'user_value' => $default,
 			)
 		);
 		$wp_customize->add_setting( $global_styles_setting );
 
-		$choices = [];
-		foreach( $this->fonts as $font_slug => $font_setting ) {
+		$choices = array();
+		foreach ( $this->fonts as $font_slug => $font_setting ) {
 			$choices[ $font_slug ] = $font_setting['name'];
 		}
 
@@ -313,22 +313,30 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function handle_customize_save_after( $wp_customize ) {
-		$body_value = $wp_customize->get_setting( $this->section_key . 'body' )->post_value();
+		$body_value    = $wp_customize->get_setting( $this->section_key . 'body' )->post_value();
 		$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->post_value();
 
-		$body_setting = $this->fonts[ $body_value ];
+		if ( ! isset( $body_value ) ) {
+			$body_value = $wp_customize->get_setting( $this->section_key . 'body' )->default;
+		}
+
+		if ( ! isset( $heading_value ) ) {
+			$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->default;
+		}
+
+		$body_setting    = $this->fonts[ $body_value ];
 		$heading_setting = $this->fonts[ $heading_value ];
 
 		// Set up variables for the theme.json.
 		$font_families = array(
 			$body_setting,
-			$heading_setting
+			$heading_setting,
 		);
 
-		$body_font_family_variable = "var(--wp--preset--font-family--" . $body_setting['slug'] . ")";
-		$heading_font_family_variable = "var(--wp--preset--font-family--" . $heading_setting['slug'] . ")";
+		$body_font_family_variable    = 'var(--wp--preset--font-family--' . $body_setting['slug'] . ')';
+		$heading_font_family_variable = 'var(--wp--preset--font-family--' . $heading_setting['slug'] . ')';
 
-		$google_font_array = [];
+		$google_font_array = array();
 		if ( $body_setting['google'] ) {
 			$google_font_array[] = $body_setting['google'];
 		}
@@ -359,16 +367,16 @@ class GlobalStylesFontsCustomizer {
 					if ( property_exists( $user_theme_json_post_content->settings->custom->body, 'typography' ) ) {
 						$user_theme_json_post_content->settings->custom->body->typography->fontFamily = $body_font_family_variable;
 					} else {
-						$user_theme_json_post_content->settings->custom->body->typography = (object) array( "fontFamily" => $body_font_family_variable );
+						$user_theme_json_post_content->settings->custom->body->typography = (object) array( 'fontFamily' => $body_font_family_variable );
 					}
 				} else {
-					$user_theme_json_post_content->settings->custom->body = (object) array( "typography" => (object) array( "fontFamily" => $body_font_family_variable ) );
+					$user_theme_json_post_content->settings->custom->body = (object) array( 'typography' => (object) array( 'fontFamily' => $body_font_family_variable ) );
 				}
 			} else {
-				$user_theme_json_post_content->settings->custom = (object) array( "body" => (object) array( "typography" => (object) array( "fontFamily" => $body_font_family_variable ) ) );
+				$user_theme_json_post_content->settings->custom = (object) array( 'body' => (object) array( 'typography' => (object) array( 'fontFamily' => $body_font_family_variable ) ) );
 			}
 		} else {
-			$user_theme_json_post_content->settings = (object) array( "custom" => (object) array( "body" => (object) array( "typography" => (object) array( "fontFamily" => $body_font_family_variable ) ) ) );
+			$user_theme_json_post_content->settings = (object) array( 'custom' => (object) array( 'body' => (object) array( 'typography' => (object) array( 'fontFamily' => $body_font_family_variable ) ) ) );
 		}
 
 		// Create the custom heading settings.
@@ -378,16 +386,16 @@ class GlobalStylesFontsCustomizer {
 					if ( property_exists( $user_theme_json_post_content->settings->custom->heading, 'typography' ) ) {
 						$user_theme_json_post_content->settings->custom->heading->typography->fontFamily = $heading_font_family_variable;
 					} else {
-						$user_theme_json_post_content->settings->custom->heading->typography = (object) array( "fontFamily" => $heading_font_family_variable );
+						$user_theme_json_post_content->settings->custom->heading->typography = (object) array( 'fontFamily' => $heading_font_family_variable );
 					}
 				} else {
-					$user_theme_json_post_content->settings->custom->heading = (object) array( "typography" => (object) array( "fontFamily" => $heading_font_family_variable ) );
+					$user_theme_json_post_content->settings->custom->heading = (object) array( 'typography' => (object) array( 'fontFamily' => $heading_font_family_variable ) );
 				}
 			} else {
-				$user_theme_json_post_content->settings->custom = (object) array( "heading" => (object) array( "typography" => (object) array( "fontFamily" => $heading_font_family_variable ) ) );
+				$user_theme_json_post_content->settings->custom = (object) array( 'heading' => (object) array( 'typography' => (object) array( 'fontFamily' => $heading_font_family_variable ) ) );
 			}
 		} else {
-			$user_theme_json_post_content->settings = (object) array( "custom" => (object) array( "heading" => (object) array( "typography" => (object) array( "fontFamily" => $heading_font_family_variable ) ) ) );
+			$user_theme_json_post_content->settings = (object) array( 'custom' => (object) array( 'heading' => (object) array( 'typography' => (object) array( 'fontFamily' => $heading_font_family_variable ) ) ) );
 		}
 
 		// Create the custom google fonts settings.
@@ -395,10 +403,10 @@ class GlobalStylesFontsCustomizer {
 			if ( property_exists( $user_theme_json_post_content->settings, 'custom' ) ) {
 				$user_theme_json_post_content->settings->custom->fontsToLoadFromGoogle = $google_font_array;
 			} else {
-				$user_theme_json_post_content->custom = (object) array( "fontsToLoadFromGoogle" => $google_font_array );
+				$user_theme_json_post_content->custom = (object) array( 'fontsToLoadFromGoogle' => $google_font_array );
 			}
 		} else {
-			$user_theme_json_post_content->settings = (object) array( "custom" => (object) array( "fontsToLoadFromGoogle" => $google_font_array ) );
+			$user_theme_json_post_content->settings = (object) array( 'custom' => (object) array( 'fontsToLoadFromGoogle' => $google_font_array ) );
 		}
 
 		// Update the theme.json with the new settings.


### PR DESCRIPTION
Fixes #4193 

When no fonts have been configured the utility was saving an improper
font value.  This change pulls the 'default' and stores that instead.

The PHP code formatter also got ahold of this file though and I wasn't able to play golf because of that.

[This](https://github.com/Automattic/themes/compare/fix/bb-font-customization-defaults?expand=1#diff-e60fbd817cb00ff02ed3cc541e2d1577147299a706f58b281a2721cd534c84f1R319-R326) is the only relevant change.

Through debugging this I have discovered that even if no changes are made to colors or fonts both are saved to the user JSON.  Even if the user returns to default values the default values are still stored in the user space (rather than being removed and allowing the theme value to shine through).  Perhaps we should consider fixing that in our customization scripts.