### PR TITLE
Blockbase: Disable the Site Editor on WPCOM

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -102,5 +102,5 @@ require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
 require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
 require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 
-/** Add a checkbox to hide the Site Editor */
-require get_template_directory() . '/inc/disable-site-editor.php';
+/** Add a checkbox to show/hide the Site Editor */
+require get_template_directory() . '/inc/toggle-site-editor.php';

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -3,11 +3,25 @@
 /**
  * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
  */
-function blockbase_add_disable_site_editor_setting() {
+function blockbase_disable_site_editor() {
 	if ( ! is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) ) {
 		return;
 	}
 
+	if ( is_admin() ) {
+		add_action( 'admin_init', 'blockbase_add_settings_field' );
+	}
+
+	if ( get_option( 'gutenberg-experiments' ) ) {
+		if ( array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) ) ) {
+			add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
+			add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
+			add_action( 'admin_bar_menu', 'blockbase_remove_site_editor_link', 50 );
+		}
+	}
+}
+
+function blockbase_add_settings_field() {
 	add_settings_field(
 		'universal-theme-disable-site-editor',
 		__( 'Site Editor', 'gutenberg' ),
@@ -86,6 +100,10 @@ function is_site_editor_menu_item( $menu_item ) {
 	}
 }
 
+function site_editor_enabled() {
+	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) );
+}
+
 /**
  * Removes the Site Editor link from the admin.
  */
@@ -102,4 +120,13 @@ function blockbase_remove_site_editor_admin_link() {
 	unset( $menu[ $site_editor_index ] );
 }
 
-add_action( 'admin_init', 'blockbase_add_disable_site_editor_setting' );
+/**
+ * Removes Site Editor adminbar item.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The admin-bar instance.
+ */
+function blockbase_remove_site_editor_link( $wp_admin_bar ) {
+	$wp_admin_bar->remove_node( 'site-editor' );
+}
+
+add_action( 'init', 'blockbase_disable_site_editor' );

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -3,7 +3,7 @@
 /**
  * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
  */
-function add_disable_site_editor_setting() {
+function blockbase_add_disable_site_editor_setting() {
 	if ( ! is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) ) {
 		return;
 	}
@@ -20,10 +20,10 @@ function add_disable_site_editor_setting() {
 		)
 	);
 
-	readd_legacy_admin_links();
+	blockbase_readd_legacy_admin_links();
 
 	if ( ! site_editor_enabled() ) {
-		remove_site_editor_admin_link();
+		blockbase_remove_site_editor_admin_link();
 	}
 }
 
@@ -34,12 +34,16 @@ function site_editor_enabled() {
 /**
  * Adds the Customizer and Widgets menu links back to the Dashboard under themes.
  */
-function readd_legacy_admin_links() {
+function blockbase_readd_legacy_admin_links() {
 	global $submenu;
 	if ( isset( $submenu['themes.php'] ) ) {
 		// Add Customize back to the admin menu.
 		$customize_url            = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
-		$submenu['themes.php'][6] = array( __( 'Customize', 'blockbase' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
+		$customizer_key = 6;
+		if ( defined( 'IS_WPCOM' ) ) {
+			$customizer_key = 1;
+		}
+		$submenu['themes.php'][ $customizer_key ] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
 
 		if (
 			function_exists( 'gutenberg_use_widgets_block_editor' ) &&
@@ -51,9 +55,9 @@ function readd_legacy_admin_links() {
 			$has_widgets_menu = false;
 			foreach ( $submenu['themes.php'] as $index => $menu_item ) {
 				if (
-					! empty( $menu_item[2] ) &&
-					( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ||
-					false !== strpos( $menu_item[2], 'widgets.php' ) )
+					! empty( $menu_item[ 2 ] ) &&
+					( false !== strpos( $menu_item[ 2 ], 'gutenberg-widgets' ) ||
+					false !== strpos( $menu_item[ 2 ], 'widgets.php' ) )
 				) {
 					$has_widgets_menu = true;
 				}
@@ -79,11 +83,12 @@ function readd_legacy_admin_links() {
 /**
  * Removes the Site Editor link from the admin.
  */
-function remove_site_editor_admin_link() {
+function blockbase_remove_site_editor_admin_link() {
 	global $menu;
+
 	// Remove Site Editor.
 	foreach ( $menu as $index => $menu_item ) {
-		if ( ! empty( $menu_item[5] ) && false !== strpos( $menu_item[5], 'toplevel_page_gutenberg-edit-site' ) ) {
+		if ( ! empty( $menu_item[ 2 ] ) && in_array( $menu_item[ 2 ], array( 'gutenberg-edit-site', 'site-editor' ) ) ) {
 			$site_editor_index = $index;
 		}
 	}
@@ -91,4 +96,4 @@ function remove_site_editor_admin_link() {
 	unset( $menu[ $site_editor_index ] );
 }
 
-add_action( 'admin_init', 'add_disable_site_editor_setting' );
+add_action( 'admin_init', 'blockbase_add_disable_site_editor_setting' );

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -80,6 +80,12 @@ function blockbase_readd_legacy_admin_links() {
 	}
 }
 
+function is_site_editor_menu_item( $menu_item ) {
+	if ( ! empty( $menu_item[ 2 ] ) ) {
+		return false !== strpos( $menu_item[ 2 ], 'gutenberg-edit-site' ) || false !== strpos( $menu_item[ 2 ], 'site-editor' );
+	}
+}
+
 /**
  * Removes the Site Editor link from the admin.
  */
@@ -88,7 +94,7 @@ function blockbase_remove_site_editor_admin_link() {
 
 	// Remove Site Editor.
 	foreach ( $menu as $index => $menu_item ) {
-		if ( ! empty( $menu_item[ 2 ] ) && in_array( $menu_item[ 2 ], array( 'gutenberg-edit-site', 'site-editor' ) ) ) {
+		if ( is_site_editor_menu_item( $menu_item ) ) {
 			$site_editor_index = $index;
 		}
 	}

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -8,16 +8,12 @@ function blockbase_disable_site_editor() {
 		return;
 	}
 
-	if ( is_admin() ) {
-		add_action( 'admin_init', 'blockbase_add_settings_field' );
-	}
+	add_action( 'admin_init', 'blockbase_add_settings_field' );
+	add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
 
-	if ( get_option( 'gutenberg-experiments' ) ) {
-		if ( array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) ) ) {
-			add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
-			add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
-			add_action( 'admin_bar_menu', 'blockbase_remove_site_editor_link', 50 );
-		}
+	if ( ! site_editor_enabled() ) {
+		add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
+		add_action( 'admin_bar_menu', 'blockbase_remove_site_editor_link', 50 );
 	}
 }
 
@@ -33,16 +29,6 @@ function blockbase_add_settings_field() {
 			'id'    => 'universal-theme-disable-site-editor',
 		)
 	);
-
-	blockbase_readd_legacy_admin_links();
-
-	if ( ! site_editor_enabled() ) {
-		blockbase_remove_site_editor_admin_link();
-	}
-}
-
-function site_editor_enabled() {
-	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) );
 }
 
 /**
@@ -117,7 +103,9 @@ function blockbase_remove_site_editor_admin_link() {
 		}
 	}
 
-	unset( $menu[ $site_editor_index ] );
+	if ( ! empty( $site_editor_index ) ) {
+		unset( $menu[ $site_editor_index ] );
+	}
 }
 
 /**

--- a/blockbase/inc/toggle-site-editor.php
+++ b/blockbase/inc/toggle-site-editor.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Adds a setting to the Gutenberg experiments page to disable the Site Editor.
+ * Adds a setting to the Gutenberg experiments page to enable the Site Editor.
  */
-function blockbase_disable_site_editor() {
+function blockbase_toggle_site_editor() {
 	if ( ! is_readable( get_stylesheet_directory() . '/block-templates/index.html' ) ) {
 		return;
 	}
@@ -19,14 +19,14 @@ function blockbase_disable_site_editor() {
 
 function blockbase_add_settings_field() {
 	add_settings_field(
-		'universal-theme-disable-site-editor',
+		'universal-theme-enable-site-editor',
 		__( 'Site Editor', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
 			'label' => __( 'Enable Site Editor', 'gutenberg' ),
-			'id'    => 'universal-theme-disable-site-editor',
+			'id'    => 'universal-theme-enable-site-editor',
 		)
 	);
 }
@@ -87,7 +87,7 @@ function is_site_editor_menu_item( $menu_item ) {
 }
 
 function site_editor_enabled() {
-	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) );
+	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-enable-site-editor', get_option( 'gutenberg-experiments' ) );
 }
 
 /**
@@ -117,4 +117,4 @@ function blockbase_remove_site_editor_link( $wp_admin_bar ) {
 	$wp_admin_bar->remove_node( 'site-editor' );
 }
 
-add_action( 'init', 'blockbase_disable_site_editor' );
+add_action( 'init', 'blockbase_toggle_site_editor' );

--- a/blockbase/inc/toggle-site-editor.php
+++ b/blockbase/inc/toggle-site-editor.php
@@ -91,7 +91,7 @@ function is_site_editor_menu_item( $menu_item ) {
 
 function site_editor_enabled() {
 	// For WPCOM
-	if ( has_blog_sticker( 'core-site-editor-enabled', get_current_blog_id() ) ) {
+	if ( function_exists('has_blog_sticker') && has_blog_sticker( 'core-site-editor-enabled', get_current_blog_id() ) ) {
 		return true;
 	}
 

--- a/blockbase/inc/toggle-site-editor.php
+++ b/blockbase/inc/toggle-site-editor.php
@@ -10,10 +10,13 @@ function blockbase_toggle_site_editor() {
 
 	add_action( 'admin_init', 'blockbase_add_settings_field' );
 	add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
-
+	// For WPCOM
+	add_action( 'admin_menu_rest_api', 'blockbase_readd_legacy_admin_links' );
 	if ( ! site_editor_enabled() ) {
 		add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
 		add_action( 'admin_bar_menu', 'blockbase_remove_site_editor_link', 50 );
+		// For WPCOM
+		add_action( 'admin_menu_rest_api', 'blockbase_remove_site_editor_admin_link' );
 	}
 }
 
@@ -38,7 +41,7 @@ function blockbase_readd_legacy_admin_links() {
 	global $submenu;
 	if ( isset( $submenu['themes.php'] ) ) {
 		// Add Customize back to the admin menu.
-		$customize_url            = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+		$customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
 		$customizer_key = 6;
 		if ( defined( 'IS_WPCOM' ) ) {
 			$customizer_key = 1;

--- a/blockbase/inc/toggle-site-editor.php
+++ b/blockbase/inc/toggle-site-editor.php
@@ -87,6 +87,11 @@ function is_site_editor_menu_item( $menu_item ) {
 }
 
 function site_editor_enabled() {
+	// For WPCOM
+	if ( has_blog_sticker( 'core-site-editor-enabled', get_current_blog_id() ) ) {
+		return true;
+	}
+
 	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-enable-site-editor', get_option( 'gutenberg-experiments' ) );
 }
 

--- a/blockbase/inc/wpcom.php
+++ b/blockbase/inc/wpcom.php
@@ -7,7 +7,6 @@
  * @package Blockbase
  */
 
-
 /**
  * Enqueue our WP.com styles for front-end.
  * Loads after theme styles so we can add overrides.
@@ -17,3 +16,15 @@ function blockbase_wpcom_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'blockbase_wpcom_scripts' );
 
+/**
+ * Disable the Site Editor on WPCOM unless the user is opted in.
+ */
+function blockbase_wpcom_disable_site_editor() {
+	if ( ! has_blog_sticker( 'core-site-editor-enabled', get_current_blog_id() ) ) {
+		add_action( 'admin_menu_rest_api', 'blockbase_readd_legacy_admin_links' );
+		add_action( 'admin_menu_rest_api', 'blockbase_remove_site_editor_admin_link' );
+		add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
+		add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
+	}
+}
+add_action( 'init', 'blockbase_wpcom_disable_site_editor' );

--- a/blockbase/inc/wpcom.php
+++ b/blockbase/inc/wpcom.php
@@ -15,16 +15,3 @@ function blockbase_wpcom_scripts() {
 	wp_enqueue_style( 'blockbase-wpcom-style', get_template_directory_uri() . '/inc/wpcom-style.css', array( 'blockbase-ponyfill' ) );
 }
 add_action( 'wp_enqueue_scripts', 'blockbase_wpcom_scripts' );
-
-/**
- * Disable the Site Editor on WPCOM unless the user is opted in.
- */
-function blockbase_wpcom_disable_site_editor() {
-	if ( ! has_blog_sticker( 'core-site-editor-enabled', get_current_blog_id() ) ) {
-		add_action( 'admin_menu_rest_api', 'blockbase_readd_legacy_admin_links' );
-		add_action( 'admin_menu_rest_api', 'blockbase_remove_site_editor_admin_link' );
-		add_action( 'admin_init', 'blockbase_readd_legacy_admin_links' );
-		add_action( 'admin_init', 'blockbase_remove_site_editor_admin_link' );
-	}
-}
-add_action( 'init', 'blockbase_wpcom_disable_site_editor' );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This disables the Site Editor on WPCOM for Blockbase and children, unless the site is opted in to the Site Editor.

Requires D63947-code to test.

#### Testing instructions:
- Switch to Blockbase on a WordPress.com simple site
- Check that you don't have a link to the Site Editor on the wp-admin dashboard: https://[slug].wordpress.com/wp-admin/
- Check that you do have a link to the Customizer on the wp-admin dashboard: https://[slug].wordpress.com/wp-admin/
- Check that you don't have a link to the Site Editor on the wpcom dashboard: https://wordpress.com/home/[slug].wordpress.com
- Check that you do have a link to the Customizer on the wpcom dashboard: https://wordpress.com/home/[slug].wordpress.com

Unanswered questions:
- what happens on Atomic?
- what happens on Jetpack?
