### PR TITLE
Blockbase: Fix gap on image-no-margin utility class when image has a hyperlink

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -116,7 +116,7 @@ p, h1, h2, h3, h4, h5, h6 {
 	margin: 0;
 }
 
-.image-no-margin > * {
+.image-no-margin * {
 	vertical-align: bottom;
 }
 

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -3,7 +3,7 @@
 //Apply to Image block when we don't want margin bottom before caption
 .image-no-margin {
 	margin: 0;
-	& * { //the first sibling is a div on the editor, and an image or a link on the frontend
+	& * { //Removes any whitespace created by child elements (a div on the editor, and an image or link on the frontend)
 		vertical-align: bottom;
 	}
 }

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -3,7 +3,7 @@
 //Apply to Image block when we don't want margin bottom before caption
 .image-no-margin {
 	margin: 0;
-	& > * { //the first sibling is a div on the editor and an image on the frontend
+	& * { //the first sibling is a div on the editor, and an image or a link on the frontend
 		vertical-align: bottom;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change removes a gap between the image and the content when the 'image-no-margin' utility class is used on an image inside a hyperlink.

Before (first column):
![image](https://user-images.githubusercontent.com/1645628/125312059-da453680-e32b-11eb-81fb-02ecc0fe343d.png)

After (first column):
![image](https://user-images.githubusercontent.com/1645628/125311964-c4377600-e32b-11eb-881a-6c0001179be3.png)

#### Testing:
There's some example markup for this layout in the [original issue](https://github.com/Automattic/themes/issues/4202).

#### Related issue(s):
Fixes #4202