### PR TITLE
Blockbase + children: Updated tags

### DIFF
--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -11,7 +11,7 @@ Version: 1.1.0
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE 
 Text Domain: blockbase
-Tags: one-column, block-styles, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 Blockbase WordPress Theme, (C) 2021 Automattic, Inc.
 Blockbase is distributed under the terms of the GNU GPL.

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: mayland-blocks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: quadrat
-Tags: one-column, flexible-header, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: seedlet-blocks
-Tags: one-column, flexible-header, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 Seedlet Blocks WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet Blocks is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
Some of the existing tags were not accurate for the themes (I think Quadrat's were the same as Seedlet's). I updated them to the best of my knowledge following what's on the [dotorg docs](https://make.wordpress.org/themes/handbook/review/required/theme-tags/).