### PR TITLE
Quadrat: correct hover styles for titles and squares on block pattern

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -85,11 +85,13 @@
 	justify-content: flex-start;
 }
 
+.is-style-quadrat-diamond-posts .wp-block-post-title a,
 .is-style-quadrat-diamond-posts .wp-block-query-pagination a,
 .is-style-quadrat-diamond-posts .post-meta a {
 	text-decoration: none;
 }
 
+.is-style-quadrat-diamond-posts .wp-block-post-title a:hover,
 .is-style-quadrat-diamond-posts .wp-block-query-pagination a:hover,
 .is-style-quadrat-diamond-posts .post-meta a:hover {
 	text-decoration: underline;
@@ -147,7 +149,7 @@
 	left: 0;
 	z-index: -1;
 	opacity: 0;
-	transition: all 0.4s ease-in;
+	transition: opacity 0.4s ease-in-out;
 }
 
 .is-style-quadrat-diamond-posts .wp-block-post-template li:hover:before {
@@ -155,18 +157,10 @@
 }
 
 .is-style-quadrat-diamond-posts .wp-block-post-template li:nth-child(2n+1):before {
-	transform: rotate(16deg) translate(-130px, -20px);
-}
-
-.is-style-quadrat-diamond-posts .wp-block-post-template li:nth-child(2n+1):hover:before {
 	transform: rotate(-8deg) translate(-110px, 0);
 }
 
 .is-style-quadrat-diamond-posts .wp-block-post-template li:nth-child(2n+2):before {
-	transform: rotate(24deg) translate(-130px, 20px);
-}
-
-.is-style-quadrat-diamond-posts .wp-block-post-template li:nth-child(2n+2):hover:before {
 	transform: rotate(16deg) translate(-110px, 40px);
 }
 

--- a/quadrat/sass/block-styles/_query.scss
+++ b/quadrat/sass/block-styles/_query.scss
@@ -2,6 +2,8 @@
 	.post-meta {
 		justify-content: flex-start;
 	}
+
+	.wp-block-post-title,
 	.wp-block-query-pagination,
 	.post-meta {
 		a {
@@ -53,21 +55,15 @@
 				left: 0;
 				z-index: -1;
 				opacity:0;
-				transition: all 0.4s ease-in;
+				transition: opacity 0.4s ease-in-out; 
 			}
 			&:hover:before {
 				opacity:1;
 			}
 			&:nth-child(2n+1):before {
-				transform: rotate(16deg) translate(-130px, -20px);
-			}
-			&:nth-child(2n+1):hover:before {
 				transform: rotate(-8deg) translate(-110px, 0);
 			}
 			&:nth-child(2n+2):before {
-				transform: rotate(24deg) translate(-130px, 20px);
-			}
-			&:nth-child(2n+2):hover:before {
 				transform: rotate(16deg) translate(-110px, 40px);
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Following @beafialho [input](https://github.com/Automattic/themes/issues/3644#issuecomment-878930745) on the Query block pattern issue I have followed up with this PR that addresses those fixes:

![](https://d.pr/i/kVojcs+)

This PR:

- Makes the post titles underline appear on hover instead of the other way around.
- Removes the rotation from the square and leaves just the opacity fade-in.
