### PR TITLE
IP2: fix cover font color on light background

### DIFF
--- a/independent-publisher-2/css/editor-blocks.css
+++ b/independent-publisher-2/css/editor-blocks.css
@@ -138,6 +138,10 @@ Description: Used to style Gutenberg Blocks in the editor.
 	}
 }
 
+.wp-block-cover.has-white-background-color .wp-block-cover__inner-container {
+	color: #383838;
+}
+
 /*--------------------------------------------------------------
 2.0 General Block Settings
 --------------------------------------------------------------*/

--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -628,6 +628,10 @@ td {
 	word-break: break-word;
 }
 
+.wp-block-cover.has-white-background-color .wp-block-cover__inner-container {
+	color: #383838;
+}
+
 /*--------------------------------------------------------------
 3.0 - Forms
 --------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Fix cover font color on light background for Independent Publisher 2

Before:
![image](https://user-images.githubusercontent.com/375980/125448395-fd9e0473-e25f-403a-9859-c278caab625f.png)

After:
![image](https://user-images.githubusercontent.com/375980/125448278-d5f92480-2dc3-44a8-a44b-7daac28a4830.png)


#### Testing
1. Download this repo
2. Checkout this branch `fix/IP2-cover-font-color`
2. Run these commands from the root of the themes repo, to clean your sandbox ./sandbox clean , and then push these changes to your WPCOM sandbox ./sandbox push. (more info https://github.com/Automattic/themes#sandbox-tools)
3. Add a cover with white background
4. Verify that the text is visible

#### Related issue(s):
https://github.com/Automattic/themes/issues/3483