### PR TITLE
Blockbase: Switch logic for enabling Site Editor

### DIFF
--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -20,8 +20,9 @@ function add_disable_site_editor_setting() {
 		)
 	);
 
+	readd_legacy_admin_links();
+
 	if ( ! site_editor_enabled() ) {
-		readd_legacy_admin_links();
 		remove_site_editor_admin_link();
 	}
 }
@@ -41,7 +42,7 @@ function readd_legacy_admin_links() {
 		$submenu['themes.php'][6] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
 
 		if (
-			function_exists( 'gutenberg_use_widgets_block_editor') &&
+			function_exists( 'gutenberg_use_widgets_block_editor' ) &&
 			gutenberg_use_widgets_block_editor() &&
 			! function_exists( 'wp_use_widgets_block_editor' ) &&
 			current_theme_supports( 'widgets' )

--- a/blockbase/inc/disable-site-editor.php
+++ b/blockbase/inc/disable-site-editor.php
@@ -15,17 +15,19 @@ function add_disable_site_editor_setting() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Disable Site Editor', 'gutenberg' ),
+			'label' => __( 'Enable Site Editor', 'gutenberg' ),
 			'id'    => 'universal-theme-disable-site-editor',
 		)
 	);
 
-	if ( get_option( 'gutenberg-experiments' ) ) {
-		if ( array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) ) ) {
-			readd_legacy_admin_links();
-			remove_site_editor_admin_link();
-		}
+	if ( ! site_editor_enabled() ) {
+		readd_legacy_admin_links();
+		remove_site_editor_admin_link();
 	}
+}
+
+function site_editor_enabled() {
+	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'universal-theme-disable-site-editor', get_option( 'gutenberg-experiments' ) );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This reverses the logic for hiding the Site Editor - we hide it by default and the checkbox will enable it:

<img width="1440" alt="Screenshot 2021-07-13 at 15 47 13" src="https://user-images.githubusercontent.com/275961/125473083-d9c5a41e-23a0-4018-a94a-73fa0d957540.png">
<img width="1440" alt="Screenshot 2021-07-13 at 15 46 58" src="https://user-images.githubusercontent.com/275961/125473093-1698c88e-fdd5-4be9-9d72-1d2903bafe50.png">
