### PR TITLE
Stratford/Varia: Fixed a color mapping which was pointing to the wrong variable

### DIFF
--- a/stratford/package.json
+++ b/stratford/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratford",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Stratford",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/stratford/sass/_config-child-theme-deep.scss
+++ b/stratford/sass/_config-child-theme-deep.scss
@@ -292,8 +292,8 @@ $config-header: (
 		// Colors
 		"color": (
 			"text": map-deep-get($config-global, "color", "foreground", "light"),
-			"link": map-deep-get($config-global, "color", "primary", "hover"),
-			"link-hover": map-deep-get($config-global, "color", "primary", "default"),
+			"link": map-deep-get($config-global, "color", "secondary", "default"),
+			"link-hover": map-deep-get($config-global, "color", "secondary", "hover"),
 		),
 		// Fonts & Typography
 		"title": (

--- a/stratford/sass/_extra-child-theme.scss
+++ b/stratford/sass/_extra-child-theme.scss
@@ -125,7 +125,7 @@ a {
 							border-color: $color_secondary;
 							border-style: solid;
 							border-width: 0 0 .125em;
-							color: $color_primary_hover;
+							color: $color_secondary;
 						}
 					}
 				}
@@ -137,12 +137,12 @@ a {
 							border-color: $color_secondary;
 							border-style: solid;
 							border-width: 0 0 .125em;
-							color: $color_primary_hover;
+							color: $color_secondary;
 						}
 					}
 					a {
 						&::after {
-							color: $color_primary_hover;
+							color: $color_secondary;
 						}
 					}
 					ul {

--- a/stratford/sass/style-child-theme.scss
+++ b/stratford/sass/style-child-theme.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -4232,18 +4232,18 @@ p:not(.site-title) a:hover {
 	border-color: var(--wp--preset--color--secondary);
 	border-style: solid;
 	border-width: 0 0 .125em;
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li.current-menu-item > a {
 	border-color: var(--wp--preset--color--secondary);
 	border-style: solid;
 	border-width: 0 0 .125em;
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li a::after {
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li ul {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2801,7 +2801,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .site-title {
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 	font-family: "Poppins", sans-serif;
 	font-family: var(--font-headings, "Poppins", sans-serif);
 	letter-spacing: normal;
@@ -2818,7 +2818,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .site-title a:hover {
-	color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--secondary-hover);
 }
 
 .site-description {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4261,18 +4261,18 @@ p:not(.site-title) a:hover {
 	border-color: var(--wp--preset--color--secondary);
 	border-style: solid;
 	border-width: 0 0 .125em;
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li.current-menu-item > a {
 	border-color: var(--wp--preset--color--secondary);
 	border-style: solid;
 	border-width: 0 0 .125em;
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li a::after {
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 }
 
 #masthead .site-header-wrapper .main-navigation ul li ul {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.10
+Version: 1.4.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2820,7 +2820,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .site-title {
-	color: var(--wp--preset--color--primary-hover);
+	color: var(--wp--preset--color--secondary);
 	font-family: "Poppins", sans-serif;
 	font-family: var(--font-headings, "Poppins", sans-serif);
 	letter-spacing: normal;
@@ -2837,7 +2837,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .site-title a:hover {
-	color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--secondary-hover);
 }
 
 .site-description {

--- a/varia/inc/color-annotations-preview.js
+++ b/varia/inc/color-annotations-preview.js
@@ -91,7 +91,7 @@ function changeColorLuminescence( hex, amount ) {
 				'--wp--preset--color--border-high-contrast: ' + borderHighContrast + ';';
 			}
 
-			const extraCSS = ':root {' + cssVariables + '}';
+			const extraCSS = ':root body {' + cssVariables + '}';
 
 			// Append an extra style element that overrides the previous extra CSS
 			if ( $('#custom-colors-extra-css').length ) {


### PR DESCRIPTION
[Original Issue](https://github.com/Automattic/wp-calypso/issues/52562)

### NOTE:
The site title is looking better, but it looks like something is wrong with the menu as well, I'm still looking into that.

---

As best as I can tell, it looks like the site-title was mistakenly set to use the primary-hover color all the time. We can't use the hover color for the site-title because it's not directly configurable from the [custom-colors customizer](https://user-images.githubusercontent.com/10274366/125542660-11c6f5c6-6edf-49e9-9280-e20a0e603413.png).

Another option we could pursue with this change would be to change the site-title to use the primary color. Then the site title would be black by default. I have chosen the secondary color for now so that I don't change the appearance of stratford, just fix the customizer for now.

https://user-images.githubusercontent.com/10274366/125543996-69010108-c5fa-4351-b732-6759c6c801ac.mov

### Testing Steps

1. SCP the stratford and varia folders from this pull request into your sandbox
1. Make sure your sandbox is enabled in the hosts file and calypso is using your sandbox in general
1. Create a new site
1. Either choose "edison" when you get to http://calypso.localhost:3000/new/design, OR choose whatever and switch to "stratford" theme later.
1. Go to the customizer
1. Wait a minute or so while the customizer loads (This step is questionable, I know. I'm still looking into it)
1. Go to "Colors & Backgrounds"
1. Change the secondary color
1. Note that the site title changes.




