### PR TITLE
Fix/quadrat main element

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -721,11 +721,6 @@ textarea:focus {
 	margin-top: 0;
 }
 
-.page-content {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}
-
 .post-meta {
 	align-items: center;
 	justify-content: center;

--- a/quadrat/block-templates/404.html
+++ b/quadrat/block-templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
-<div class="wp-block-group page-content">
+<!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
+<main class="wp-block-group">
 
 	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"large"} -->
 	<h1 class="has-text-align-center has-large-font-size">Oops! That page can’t be found.</h1>
@@ -12,7 +12,7 @@
 	<!-- /wp:paragraph -->
 
 	<!-- wp:search {"label":"","buttonText":"Search"} /-->
-	</div>
-	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/front-page.html
+++ b/quadrat/block-templates/front-page.html
@@ -4,6 +4,10 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:query {"className":"page-content","tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-<main class="wp-block-query page-content">
+<!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<main class="wp-block-query">
 	<!-- wp:post-template -->
 		<!-- wp:post-date {"fontSize":"tiny","textAlign":"center"} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -14,6 +14,10 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true}, "className":"page-content"} -->
-<div class="wp-block-group page-content">
+<!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
+<main class="wp-block-group">
 
 	<!-- wp:heading -->
 	<h2>Results:</h2>
@@ -16,7 +16,7 @@
 	<!-- /wp:query-loop -->
 	<!-- /wp:query -->
 
-	</div>
-	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"className":"post-header"} -->
-<div class="wp-block-group post-header">
+<!-- wp:group {"className":"post-header", "tagName":"main"} -->
+<main class="wp-block-group post-header">
 
 	<!-- wp:group {"className":"post-meta"} -->
 	<div class="wp-block-group post-meta">
@@ -56,5 +56,8 @@
 		<!-- wp:post-comments /-->
 	</div>
 	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -25,9 +25,6 @@
 	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	</div>
-	<!-- /wp:group -->
-
 	<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 	<!-- wp:spacer {"height":150} -->

--- a/quadrat/sass/templates/_index.scss
+++ b/quadrat/sass/templates/_index.scss
@@ -1,8 +1,3 @@
 .wp-block-post-featured-image {
 	margin-top: 0;
 }
-
-.page-content {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}


### PR DESCRIPTION
Added (or converted existing div) `<main>` elements to all Quadrat page templates.

Removed the (now defunct) .page-content class.  (The padding this was providing is now being supplied by [other means](https://github.com/Automattic/themes/blob/trunk/blockbase/sass/base/_alignment.scss#L2).)

Fixes #4218 

