### PR TITLE
Corrected required PHP version for Mayland Blocks

### DIFF
--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: 5.7
 Tested up to: 5.7
-Requires PHP: 7.4
+Requires PHP: 5.7
 Version: 2.1.0
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column block-based theme.
 Requires at least: 5.7
 Tested up to: 5.7
-Requires PHP: 7.3
+Requires PHP: 5.7
 Version: 2.1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This corrects the required version of PHP for Mayland blocks to match it's parent, Blockbase.