### PR TITLE
Blockbase + Children: fix Marketing bar overlap

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -3,8 +3,8 @@
  * - Reset the browser
  */
 body {
-	margin: 0 !important;
-	padding: 0 !important;
+	margin: 0;
+	padding: 0;
 }
 
 body {

--- a/blockbase/sass/base/_normalize.scss
+++ b/blockbase/sass/base/_normalize.scss
@@ -1,8 +1,8 @@
 
 // Remove the margin in all browsers.
 body {
-  margin: 0 !important;
-  padding: 0 !important;
+  margin: 0;
+  padding: 0;
 }
 
 // Smooth out the fonts


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Removed !important from the normalize file so the marketing bar can push the body down when it's present. It looks like the original purpose of these important rules are no longer the case:

FSE:

![Untitled](https://user-images.githubusercontent.com/3593343/125749628-652ee236-e545-4c44-9d37-54ea40c3afb3.jpg)

Frontend with marketing bar:

<img width="1578" alt="Screenshot 2021-07-15 at 09 42 49" src="https://user-images.githubusercontent.com/3593343/125749480-00e1c529-eb14-44c5-a47a-865154cc0b0c.png">

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4226