### PR TITLE
Blockbase: fixed alignments on single and custom templates

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -55,16 +55,12 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
-.wp-block-group.alignfull,
-*[class*="wp-container-"] {
+.wp-block-group.alignfull {
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
-.wp-block-group.alignfull *[class*="wp-container-"],
-.wp-block-group.alignfull > .alignfull,
-*[class*="wp-container-"] *[class*="wp-container-"],
-*[class*="wp-container-"] > .alignfull {
+.wp-block-group.alignfull > .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
 	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
 	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right)) !important;

--- a/blockbase/block-templates/header-footer-only.html
+++ b/blockbase/block-templates/header-footer-only.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-group">
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true}, "align":"full"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -8,9 +8,9 @@
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-group post-content">
-<!-- wp:post-featured-image {"align":"full"} /-->
+<!-- wp:post-featured-image {"align":"wide"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}, "align":"full"} /-->
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -10,7 +10,7 @@
 <main class="wp-block-group post-content">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content /-->
+<!-- wp:post-content {"layout":{"inherit":true}, "align":"full"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,12 +1,8 @@
-.wp-block-group.alignfull,
-*[class*="wp-container-"] //Anything that inherits layout (container)
-{
+.wp-block-group.alignfull {
 	//give it some padding
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);
 
-	//Any nested containers, and anything that is alignfull
-	*[class*="wp-container-"], // Any nested containers
 	> .alignfull { // Any direct descendant that is alignfull
 		// bust out of the container's padding
 		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR fixes alignments that were broken after we added the extra main wrapper required for the skip links to work.

To test this, create a page with blocks set to different alignments. Test the singular template and the header-and-footer-only one. The frontend and the editor should match.

Right now the nested group block inside the cover doesn't work with any alignments. I don't know if it's a theme issue or a GB issue.

Editor:

<img width="1575" alt="Screenshot 2021-07-16 at 11 54 36" src="https://user-images.githubusercontent.com/3593343/125929707-e1452cd2-4ced-4772-b654-10a5ef39f3cd.png">

Frontend:

<img width="1556" alt="Screenshot 2021-07-16 at 11 54 46" src="https://user-images.githubusercontent.com/3593343/125929698-e2dc4027-b6fd-4dfc-9daa-356e9d00df64.png">



#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4239