### PR TITLE
Added block template support to seedlet & spearhead.

### DIFF
--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -269,6 +269,16 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 				'enable_theme_default' => true,
 			)
 		);
+
+		// Add support for block templates (default template is content-only)
+		add_theme_support( 'block-templates' );
+		add_filter(
+			'block_editor_settings_all',
+			function( $settings ) {
+				$settings['defaultBlockTemplate'] = '<!-- wp:post-content /-->';
+				return $settings;
+			}
+		);
 	}
 endif;
 add_action( 'after_setup_theme', 'seedlet_setup' );
@@ -307,7 +317,7 @@ function seedlet_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Added Block Template support to varia and all varia children.
Defined a default template consisting of just the post content.

<img src="https://user-images.githubusercontent.com/146530/126191995-73e745d6-43a8-43ff-b764-fe3c49b26121.png" width=200>

To test:
* Activate Seedlet or Spearhead theme.
* Edit a page/post
* Note the new 'Template' panel.
* Create a new template.
* Save the template, save the page.
* Observe the view for that new page; it should follow the design of the template.

#### Related issue(s):

Partially addresses #4149 