### PR TITLE
Removed unused post-content class

### DIFF
--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true},"className":"post-header"} -->
-<div class="wp-block-group post-header">
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
 <!-- wp:post-title /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -7,7 +7,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-group post-content">
+<main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
 <!-- wp:post-content /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"className":"post-header", "tagName":"main"} -->
-<main class="wp-block-group post-header">
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
 
 	<!-- wp:group {"className":"post-meta"} -->
 	<div class="wp-block-group post-meta">


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

While poking around alignment classes I found an instance of "post-content" class which Blockbase USED to use for top-level alignment purposes but has sense been replaced by other methods.  I believe this class was just missed when the rest were removed.
