### PR TITLE
Unnested blockbase post-content blocks from parent layouts

### DIFF
--- a/blockbase/block-templates/header-footer-only.html
+++ b/blockbase/block-templates/header-footer-only.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/blockbase/block-templates/search.html
+++ b/blockbase/block-templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-group">

--- a/blockbase/block-templates/singular.html
+++ b/blockbase/block-templates/singular.html
@@ -6,11 +6,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content /-->
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change ensures that all instances of post-content blocks have `{"layout":{"inherit":true}}` and are the TOPMOST container that has `{"layout":{"inherit":true}}` applied.

The post editor assumes the above situation (and is USUALLY correct).  This change adjusts all templates in the theme so that it can be correct in the assumption 100% of the time.

#### Related issue(s):

Addresses: #4239
An alternative to: #4240
Relevant discussion in this issue: https://github.com/WordPress/gutenberg/pull/33501