### PR TITLE
Quadrat: change label for illustrations patterns

### DIFF
--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -49,8 +49,8 @@ if ( ! function_exists( 'quadrat_register_illustration_patterns' ) ) :
 	function quadrat_register_illustration_patterns() {
 		if ( function_exists( 'register_block_pattern_category' ) ) {
 			register_block_pattern_category(
-				'quadrat-images',
-				array( 'label' => __( 'Quadrat Images', 'quadrat' ) )
+				'quadrat-illustrations',
+				array( 'label' => __( 'Quadrat Illustrations', 'quadrat' ) )
 			);
 		}
 
@@ -85,7 +85,7 @@ if ( ! function_exists( 'quadrat_register_illustration_patterns' ) ) :
 					'quadrat/' . $illustration_pattern_key,
 					array(
 						'title'      => $illustration_pattern_name,
-						'categories' => array( 'quadrat-images' ),
+						'categories' => array( 'quadrat-illustrations' ),
 						'content'    => '<!-- wp:image {"sizeSlug":"large"} -->
 						<figure class="wp-block-image size-large"><img src="' . get_stylesheet_directory_uri() . '/assets/illustrations/' . $illustration_pattern_key . '.png" alt=""/></figure>
 						<!-- /wp:image -->',


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Changes the label from "Quadrat Images" to "Quadrat Illustrations". 

#### Related issue(s):

https://github.com/Automattic/themes/pull/4247#issuecomment-883416792
