### PR TITLE
Added block template support to seedlet.

### DIFF
--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: seedlet
 Text Domain: blank-canvas
-Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready, auto-loading-homepage
+Tags: one-column, accessibility-ready, block-templates, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready, auto-loading-homepage
 
 Blank Canvas WordPress Theme, (C) 2021 Automattic, Inc.
 Blank Canvas is distributed under the terms of the GNU GPL.

--- a/seedlet/assets/sass/child-theme/style-child-theme.scss
+++ b/seedlet/assets/sass/child-theme/style-child-theme.scss
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: seedlet-child-theme
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, full-site-editing, jetpack-global-styles
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -11,7 +11,7 @@ Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -269,6 +269,16 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 				'enable_theme_default' => true,
 			)
 		);
+
+		// Add support for block templates (default template is content-only)
+		add_theme_support( 'block-templates' );
+		add_filter(
+			'block_editor_settings_all',
+			function( $settings ) {
+				$settings['defaultBlockTemplate'] = '<!-- wp:post-content /-->';
+				return $settings;
+			}
+		);
 	}
 endif;
 add_action( 'after_setup_theme', 'seedlet_setup' );
@@ -307,7 +317,7 @@ function seedlet_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -12,7 +12,7 @@ Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -12,7 +12,7 @@ Version: 1.1.15-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, translation-ready, block-patterns, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/spearhead/assets/sass/style.scss
+++ b/spearhead/assets/sass/style.scss
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 */
 
 @import "../../../seedlet/assets/sass/abstracts/mixins";

--- a/spearhead/package-lock.json
+++ b/spearhead/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spearhead",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spearhead/style-rtl.css
+++ b/spearhead/style-rtl.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 */
 /**
  * Required Variables

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, blog-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, block-templates, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
 */
 /**
  * Required Variables


### PR DESCRIPTION
This is the same PR as #4251 which was previously merged to trunk and then reverted (because the feature was not yet ready on .com).

Partially address #4149 

This shouldn't be brought in until 5.8 has landed more firmly on .com and this feature has been re-evaluated.