### PR TITLE
Quadrat: Remove labels from Pagination links

### DIFF
--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -12,9 +12,9 @@
 		<!-- /wp:spacer -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+	<!-- wp:query-pagination-next /--></div>
 	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->

--- a/quadrat/inc/patterns/query-diamond.php
+++ b/quadrat/inc/patterns/query-diamond.php
@@ -15,27 +15,27 @@ return array(
 	<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center"} -->
 	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"className":"post-meta"} -->
 	<div class="wp-block-group post-meta"><!-- wp:post-date {"fontSize":"tiny"} /-->
-	
+
 	<!-- wp:post-terms {"term":"category","fontSize":"tiny"} /--></div>
 	<!-- /wp:group -->
-	
+
 	<!-- wp:post-title {"textAlign":"left","isLink":true,"fontSize":"extra-large"} /-->
-	
+
 	<!-- wp:post-excerpt {"moreText":"Read more","fontSize":"normal"} /--></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column -->
 	<div class="wp-block-column"><!-- wp:post-featured-image /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 	<!-- /wp:post-template -->
-	
+
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
-	
+	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+
 	<!-- wp:query-pagination-numbers /-->
-	
-	<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+
+	<!-- wp:query-pagination-next /--></div>
 	<!-- /wp:query-pagination --></div>
 	<!-- /wp:query -->',
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We added these labels so that the default &raquo; and &laquo; arrows didn't show. Now that https://github.com/WordPress/gutenberg/pull/33626 has merged, we don't need to do this, so this PR just removes the labels. This means these buttons will now be translated.

#### Related issue(s):
Should help with: https://github.com/Automattic/themes/issues/3653
