### PR TITLE
Remove the redundant query pagination labels

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -17,11 +17,11 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous {"label":"Previous Page"} /-->
+	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
 
 		<!-- wp:query-pagination-numbers /-->
 
-		<!-- wp:query-pagination-next {"label":"Next Page"} /--></div>
+		<!-- wp:query-pagination-next /--></div>
 	<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
Since [this Gutenberg issue ](https://github.com/WordPress/gutenberg/pull/33626)was merged the labels for the pagination links are no longer needed.

This change removes them.
