### PR TITLE
Fix/blockbase customizer meta info

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -133,6 +133,11 @@ class GlobalStylesColorCustomizer {
 		$user_theme_json_post         = get_post( $user_custom_post_type_id );
 		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
 
+		// Set meta settings.
+		$user_theme_json_post_content->version                     = 1;
+		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
+
+		// Set palette settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
 			array( 'settings', 'color', 'palette' ),

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -415,6 +415,10 @@ class GlobalStylesFontsCustomizer {
 		$user_theme_json_post         = get_post( $user_custom_post_type_id );
 		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
 
+		// Set meta settings.
+		$user_theme_json_post_content->version                     = 1;
+		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
+
 		// Set the typography settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,

--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ *
+ * Assign a value to an object at the given location.  Create the nested objects if they aren't already available.
+ *
+ * @param   object  $target The object to assign the value to
+ * @param   array   $array  The array describing the location of the property to update
+ * @return      object  $value  The value to assign
+ * @return  object      The modified $target object with $value assigned where $array describes
+ *
+ */
 function set_settings_array( $target, $array, $value ) {
 	$key     = array_shift( $array );
 	$current =& $target;

--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -6,8 +6,8 @@
  *
  * @param   object  $target The object to assign the value to
  * @param   array   $array  The array describing the location of the property to update
- * @return      object  $value  The value to assign
- * @return  object      The modified $target object with $value assigned where $array describes
+ * @param   object  $value  The value to assign
+ * @return  object          The modified $target object with $value assigned where $array describes
  *
  */
 function set_settings_array( $target, $array, $value ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

It some situations the Theme User JSON doesn't ALREADY have the meta-information `version` and `isGlobalStylesUserThemeJSON`.  

In that situation when the Theme User JSON is parsed (without the meta-information) the resulting theme data returned from the call to `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` results in the Theme User JSON being ignored.

This change ensures that the meta-information is always provided.

#### Testing

I'm unsure how to cause a site to enter into the original situation.  However the result of entering into the situation is that Theme User JSON is set either to `{}` or contains the custom color or font data (but not the meta data).  Using the FSE Global Styles panel once (even if just to "reset global styles to defaults") adds the meta-information to the JSON and stops the issue from happening on that site.

#### Related issue(s):

Fixes #4197