### PR TITLE
Quadrat: add footer + credits in php

### DIFF
--- a/quadrat/block-template-parts/footer.html
+++ b/quadrat/block-template-parts/footer.html
@@ -1,9 +1,0 @@
-<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
-<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
-
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph -->
-
-</div>
-<!-- /wp:group -->

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -51,6 +51,31 @@ function quadrat_scripts() {
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 
 /**
+ * Add a filter to the render callback of the footer, 
+ * so it can be translated or customized for WordPress.com.
+ */
+function quadrat_add_markup_to_footer_template( $block_content, $block ) {
+	if ( $block['blockName'] === 'core/template-part' && $block['attrs']['slug'] === 'footer' ) {
+		// If we are on WPCOM, do not render a credit so that the WP.com footer credit plugin can handle it
+		if ( class_exists( 'WPCOM_Block_Theme_Footer_Credits') ){
+			return '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+			<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
+			</div><!-- /wp:group -->';
+		} else {
+			return '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+			<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">' . __( 'Proudly Powered by ', 'quadrat') . '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+			<!-- /wp:paragraph -->
+			</div><!-- /wp:group -->';
+
+		}
+	}
+	return $block_content;
+}
+add_filter( 'render_block', 'quadrat_add_markup_to_footer_template', 9, 2 ); // Make the priority one higher than the default so it filters before the WPCOM plugin
+
+/**
  * Block Patterns.
  */
 require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -51,27 +51,6 @@ function quadrat_scripts() {
 add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 
 /**
- * Add a filter to the render callback of the footer, 
- * so it can be translated or customized for WordPress.com.
- */
-function quadrat_add_markup_to_footer_template( $block_content, $block ) {
-	if ( $block['blockName'] === 'core/template-part' && $block['attrs']['slug'] === 'footer' ) {
-		// If we are on WPCOM, do not render a credit so that the WP.com footer credit plugin can handle it
-		$wp_credit = '';
-		if ( ! class_exists( 'WPCOM_Block_Theme_Footer_Credits') ){
-			$wp_credit = '<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center">' . __( 'Proudly Powered by ', 'quadrat') . '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-			<!-- /wp:paragraph -->';
-		} 
-		return sprintf( '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
-		<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">%s
-		</div><!-- /wp:group -->', $wp_credit );
-	}
-	return $block_content;
-}
-add_filter( 'render_block', 'quadrat_add_markup_to_footer_template', 9, 2 ); // Make the priority one higher than the default so it filters before the WPCOM plugin
-
-/**
  * Block Patterns.
  */
 require get_stylesheet_directory() . '/inc/block-patterns.php';
@@ -80,3 +59,8 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
+
+/**
+ * Footer Renderer
+ */
+require get_stylesheet_directory() . '/inc/footer-renderer.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -57,19 +57,15 @@ add_action( 'wp_enqueue_scripts', 'quadrat_scripts' );
 function quadrat_add_markup_to_footer_template( $block_content, $block ) {
 	if ( $block['blockName'] === 'core/template-part' && $block['attrs']['slug'] === 'footer' ) {
 		// If we are on WPCOM, do not render a credit so that the WP.com footer credit plugin can handle it
-		if ( class_exists( 'WPCOM_Block_Theme_Footer_Credits') ){
-			return '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
-			<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
-			</div><!-- /wp:group -->';
-		} else {
-			return '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
-			<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">
-			<!-- wp:paragraph {"align":"center"} -->
+		$wp_credit = '';
+		if ( ! class_exists( 'WPCOM_Block_Theme_Footer_Credits') ){
+			$wp_credit = '<!-- wp:paragraph {"align":"center"} -->
 			<p class="has-text-align-center">' . __( 'Proudly Powered by ', 'quadrat') . '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-			<!-- /wp:paragraph -->
-			</div><!-- /wp:group -->';
-
-		}
+			<!-- /wp:paragraph -->';
+		} 
+		return sprintf( '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+		<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px">%s
+		</div><!-- /wp:group -->', $wp_credit );
 	}
 	return $block_content;
 }

--- a/quadrat/inc/footer-renderer.php
+++ b/quadrat/inc/footer-renderer.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Add a filter to the render callback of the footer so it can be translated.
+ */
+function quadrat_add_markup_to_footer_template( $block_content, $block ) {
+	if ( 'core/template-part' !== $block['blockName'] || 'footer' !== $block['attrs']['slug'] ) {
+		return $block_content;
+	}
+	$wp_credit = __( 'Proudly Powered by ', 'quadrat' );
+	return sprintf(
+		'<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+	<div class="wp-block-group site-footer" style="padding-top:150px;padding-bottom: 150px"><!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center"> %s <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+	<!-- /wp:paragraph --></div><!-- /wp:group -->',
+		$wp_credit
+	);
+}
+add_filter( 'render_block', 'quadrat_add_markup_to_footer_template', 9, 2 );

--- a/quadrat/inc/wpcom.php
+++ b/quadrat/inc/wpcom.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Add a filter to the render callback of the footer so it can be translated.
+ * Overrides the functionality in footer-renderer.
+ */
+function quadrat_add_wpcom_markup_to_footer_template( $block_content, $block ) {
+	if ( 'core/template-part' !== $block['blockName'] || 'footer' !== $block['attrs']['slug'] ) {
+		return $block_content;
+	}
+	// If we are on WPCOM, do not render a credit so that the WP.com footer credit plugin can handle it
+	return '<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"top":"150px","bottom":"150px"}}}} -->
+	<div class="wp-block-group site-footer site-info" style="padding-top:150px;padding-bottom: 150px">
+	</div><!-- /wp:group -->';
+}
+add_filter( 'render_block', 'quadrat_add_wpcom_markup_to_footer_template', 9, 2 ); // Make the priority one higher than the default so it filters before the WPCOM plugin


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR is an attempt to unblock how footer credits are handled in Quadrat, by solving two issues:

1. Allows the string to be translated on dotorg
2. Allows the wpcom mechanism to add footer credits in that environment, background here: pcjTuq-ff-p2.

It also requires a small change for the wpcom environment: D64851-code 

#### Related issue(s):

This slack discussion and feedback: p1627461480480400/1627413124.455900-slack-C029FM1EH.

**To Test**
- Check out this PR locally
- Verify the footer and credits appear as expected
- Check out this PR onto your sandbox along with [the patch](D64851-code)
- Verify the wpcom-specific credits appear

It does not look great on wpcom, so we could add some styles that position it closer to the dotorg version cc @kjellr @beafialho 

<img width="1904" alt="Screen Shot 2021-07-28 at 4 14 45 PM" src="https://user-images.githubusercontent.com/5375500/127393055-b70d6240-4d00-436e-849d-4fd93f9c3156.png">
