### PR TITLE
Skatepark: footer and pre footer block pattern

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -565,8 +565,12 @@ p.has-background {
 	font-style: var(--wp--custom--quote--citation--typography--font-style);
 }
 
+.wp-block-search {
+	margin-top: var(--wp--custom--margin--baseline);
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-	padding: var(--wp--custom--form--padding);
+	padding: var(--wp--custom--form--border--width);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	border-radius: var(--wp--custom--form--border--radius);
 }
@@ -581,7 +585,7 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-.wp-block-search .wp-block-search__button {
+.wp-block-search .wp-block-search__button.wp-block-search__button {
 	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
@@ -600,14 +604,14 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
-.wp-block-search .wp-block-search__button svg {
+.wp-block-search .wp-block-search__button.wp-block-search__button svg {
 	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):hover,
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):focus,
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
@@ -619,14 +623,14 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
 	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
-.wp-block-search .wp-block-search__button.has-icon {
+.wp-block-search .wp-block-search__button.wp-block-search__button.has-icon {
 	line-height: 0;
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -179,6 +179,7 @@ a:hover, a:focus {
 	text-decoration: none;
 }
 
+input.wp-block-search__input,
 input[type="text"],
 input[type="email"],
 input[type="url"],
@@ -204,6 +205,7 @@ textarea {
 	padding: var(--wp--custom--form--padding);
 }
 
+input.wp-block-search__input:focus,
 input[type="text"]:focus,
 input[type="email"]:focus,
 input[type="url"]:focus,
@@ -576,7 +578,7 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
-	padding: 0;
+	padding: 0 var(--wp--custom--form--padding);
 }
 
 .wp-block-search .wp-block-search__input {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -582,6 +582,7 @@ p.has-background {
 }
 
 .wp-block-search .wp-block-search__input {
+	line-height: var(--wp--custom--button--typography--line-height);
 	padding: var(--wp--custom--form--padding);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 }

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -1,10 +1,11 @@
 @import 'button-mixins';
 
 .wp-block-search {
+	margin-top: var(--wp--custom--margin--baseline);
 
 	&.wp-block-search__button-inside {
 		.wp-block-search__inside-wrapper{
-			padding: var(--wp--custom--form--padding);
+			padding: var(--wp--custom--form--border--width);
 			border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 			border-radius: var(--wp--custom--form--border--radius);
 			.wp-block-search__input {
@@ -19,7 +20,7 @@
 	}
 
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-	.wp-block-search__button {
+	.wp-block-search__button.wp-block-search__button {
 		@include button-main-styles;
 		@include button-hover-styles;
 		&.has-icon {

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -9,7 +9,7 @@
 			border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 			border-radius: var(--wp--custom--form--border--radius);
 			.wp-block-search__input {
-				padding: 0;
+				padding: 0 var(--wp--custom--form--padding);
 			}
 		}
 	}

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -15,6 +15,7 @@
 	}
 
 	.wp-block-search__input {
+		line-height: var(--wp--custom--button--typography--line-height);
 		padding: var(--wp--custom--form--padding);
 		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	}

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -1,3 +1,4 @@
+input.wp-block-search__input,
 input[type="text"],
 input[type="email"],
 input[type="url"],

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -57,6 +57,7 @@
 
 .wp-block-file .wp-block-file__button {
 	text-transform: uppercase;
+	letter-spacing: 0.1em;
 }
 
 .wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
@@ -72,6 +73,7 @@
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 .wp-block-search .wp-block-search__button.wp-block-search__button {
 	text-transform: uppercase;
+	letter-spacing: 0.1em;
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus,
@@ -89,6 +91,7 @@
 
 .wp-block-post-comments input[type="submit"], .wp-block-post-comments .reply a {
 	text-transform: uppercase;
+	letter-spacing: 0.1em;
 }
 
 .wp-block-post-comments input[type="submit"]:hover, .wp-block-post-comments input[type="submit"]:focus, .wp-block-post-comments input[type="submit"].has-focus, .wp-block-post-comments .reply a:hover, .wp-block-post-comments .reply a:focus, .wp-block-post-comments .reply a.has-focus {
@@ -107,6 +110,57 @@
 .wp-block-button.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
 	color: var(--wp--custom--button--color--background);
 	background-color: var(--wp--custom--button--color--text);
+}
+
+.wp-block-search .wp-block-search__button:active, .wp-block-search .wp-block-search__button:focus {
+	outline-offset: -0.25em;
+}
+
+.wp-block-search .wp-block-search__button svg {
+	min-width: 2em;
+	min-height: 2em;
+}
+
+.wp-block-search .wp-block-search__button.has-icon {
+	--wp--custom--button--spacing--padding--left: calc( 1.75 * var(--wp--custom--button--spacing--padding--top) );
+	--wp--custom--button--spacing--padding--right: calc( 1.75 * var(--wp--custom--button--spacing--padding--top) );
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	padding: 0;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
+	--wp--custom--button--color--text: var(--wp--custom--color--primary);
+	--wp--custom--button--color--background: var(--wp--custom--color--background);
+	position: relative;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button::before {
+	content: "";
+	height: 80%;
+	width: 1px;
+	background: var(--wp--custom--color--primary);
+	position: absolute;
+	left: 0;
+	top: 10%;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover {
+	--wp--custom--button--color--text: var(--wp--custom--color--background);
+	--wp--custom--button--color--background: var(--wp--custom--color--primary);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover.has-focus {
+	outline-color: var(--wp--custom--color--background);
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
+	border-color: transparent;
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus::before, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus::before {
+	left: calc( -1 * var(--wp--custom--button--border--width));
 }
 
 .pre-footer h3 {
@@ -172,7 +226,9 @@ h6 a,
 	        text-decoration-line: underline;
 }
 
-a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
+.wp-block-search__button:active, .wp-block-search__button:focus,
+a:not(.ab-item):not(.screen-reader-shortcut):active,
+a:not(.ab-item):not(.screen-reader-shortcut):focus {
 	outline: 1px dotted var(--wp--custom--color--primary);
 	outline-offset: 0.1em;
 	text-decoration: none;

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -42,6 +42,7 @@
 	color: var(--wp--preset--color--background);
 }
 
+<<<<<<< HEAD
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
@@ -172,6 +173,10 @@ a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen
 	outline: 1px dotted var(--wp--custom--color--primary);
 	outline-offset: 0.1em;
 	text-decoration: none;
+=======
+.pre-footer h3 {
+	text-transform: uppercase;
+>>>>>>> 5f27bc46 (removed links css)
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -109,6 +109,10 @@
 	background-color: var(--wp--custom--button--color--text);
 }
 
+.pre-footer h3 {
+	text-transform: uppercase;
+}
+
 a {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -42,7 +42,6 @@
 	color: var(--wp--preset--color--background);
 }
 
-<<<<<<< HEAD
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
@@ -71,14 +70,14 @@
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-.wp-block-search .wp-block-search__button {
+.wp-block-search .wp-block-search__button.wp-block-search__button {
 	text-transform: uppercase;
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-focus,
-.wp-block-search .wp-block-search__button:hover,
-.wp-block-search .wp-block-search__button:focus,
-.wp-block-search .wp-block-search__button.has-focus {
+.wp-block-search .wp-block-search__button.wp-block-search__button:hover,
+.wp-block-search .wp-block-search__button.wp-block-search__button:focus,
+.wp-block-search .wp-block-search__button.wp-block-search__button.has-focus {
 	border-style: var(--wp--custom--button--border--style);
 	border-color: currentColor;
 	border-width: var(--wp--custom--button--border--width);
@@ -112,6 +111,10 @@
 
 .pre-footer h3 {
 	text-transform: uppercase;
+}
+
+.pre-footer .wp-block-social-links.is-style-logos-only {
+	margin-left: calc( -1 * ( 8px + 0.25em ));
 }
 
 a {
@@ -173,14 +176,6 @@ a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen
 	outline: 1px dotted var(--wp--custom--color--primary);
 	outline-offset: 0.1em;
 	text-decoration: none;
-=======
-.pre-footer h3 {
-	text-transform: uppercase;
->>>>>>> 5f27bc46 (removed links css)
-}
-
-.pre-footer .wp-block-social-links.is-style-logos-only {
-	margin-left: calc( -1 * ( 8px + 0.25em ));
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -179,4 +179,8 @@ a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen
 >>>>>>> 5f27bc46 (removed links css)
 }
 
+.pre-footer .wp-block-social-links.is-style-logos-only {
+	margin-left: calc( -1 * ( 8px + 0.25em ));
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -171,6 +171,12 @@
 	margin-left: calc( -1 * ( 8px + 0.25em ));
 }
 
+.pre-footer .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
+	--wp--custom--button--typography--font-size: 14px;
+	--wp--custom--button--spacing--padding--top: 0.5em;
+	--wp--custom--button--spacing--padding--bottom: 0.5em;
+}
+
 a {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/block-template-parts/footer.html
+++ b/skatepark/block-template-parts/footer.html
@@ -1,0 +1,44 @@
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}},"className":"pre-footer"} -->
+<div class="wp-block-group alignwide pre-footer" style="padding-top:60px;padding-bottom:60px"><!-- wp:columns -->
+	<div class="wp-block-columns"><!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"large"} /-->
+	
+	<!-- wp:paragraph {"fontSize":"small"} -->
+	<p class="has-small-font-size">Skate ipsum dolor sit amet, poseur nollie casper pop shove-it. Kickturn noseblunt tailslide.</p>
+	<!-- /wp:paragraph -->
+	
+	<!-- wp:social-links {"iconColor":"primary","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+	<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"http://twitter.com","service":"twitter"} /-->
+	
+	<!-- wp:social-link {"url":"http://facebook.com","service":"facebook"} /-->
+	
+	<!-- wp:social-link {"url":"http://instagram.com","service":"instagram"} /--></ul>
+	<!-- /wp:social-links --></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:paragraph {"fontSize":"tiny"} -->
+	<p class="has-tiny-font-size"><strong>More info</strong></p>
+	<!-- /wp:paragraph -->
+	
+	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"secondary","fontSize":"small"} /--></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:paragraph {"fontSize":"tiny"} -->
+	<p class="has-tiny-font-size"><strong>Subscribe</strong></p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns --></div>
+	<!-- /wp:group -->
+
+<!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"bottom":"30px"}}}} -->
+<div class="wp-block-group site-footer" style="padding-bottom: 30px">
+
+	<!-- wp:paragraph {"align":"center","fontSize":"tiny"} -->
+	<p class="has-text-align-center has-tiny-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+	<!-- /wp:paragraph -->
+	
+	</div>
+	<!-- /wp:group -->
+	

--- a/skatepark/block-template-parts/footer.html
+++ b/skatepark/block-template-parts/footer.html
@@ -1,37 +1,3 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}},"className":"pre-footer"} -->
-<div class="wp-block-group alignwide pre-footer" style="padding-top:60px;padding-bottom:60px"><!-- wp:columns -->
-	<div class="wp-block-columns"><!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"large"} /-->
-	
-	<!-- wp:paragraph {"fontSize":"small"} -->
-	<p class="has-small-font-size">Skate ipsum dolor sit amet, poseur nollie casper pop shove-it. Kickturn noseblunt tailslide.</p>
-	<!-- /wp:paragraph -->
-	
-	<!-- wp:social-links {"iconColor":"primary","iconColorValue":"#000000","className":"is-style-logos-only"} -->
-	<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"http://twitter.com","service":"twitter"} /-->
-	
-	<!-- wp:social-link {"url":"http://facebook.com","service":"facebook"} /-->
-	
-	<!-- wp:social-link {"url":"http://instagram.com","service":"instagram"} /--></ul>
-	<!-- /wp:social-links --></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:paragraph {"fontSize":"tiny"} -->
-	<p class="has-tiny-font-size"><strong>More info</strong></p>
-	<!-- /wp:paragraph -->
-	
-	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"secondary","fontSize":"small"} /--></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:paragraph {"fontSize":"tiny"} -->
-	<p class="has-tiny-font-size"><strong>Subscribe</strong></p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns --></div>
-	<!-- /wp:group -->
-
 <!-- wp:group {"className":"site-footer","style":{"spacing":{"padding":{"bottom":"30px"}}}} -->
 <div class="wp-block-group site-footer" style="padding-bottom: 30px">
 

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -101,6 +101,19 @@
 					}
 				}
 			],
+			"form": {
+				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
+				"border": {
+					"color": "var(--wp--custom--color--primary)",
+					"width": "2px"
+				},
+				"color": {
+					"background": "transparent"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"fontsToLoadFromGoogle": [
 				"family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
 			],

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -105,7 +105,7 @@
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
-					"width": "2px"
+					"width": "3px"
 				},
 				"color": {
 					"background": "transparent"

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -26,6 +26,7 @@ if ( ! function_exists( 'skatepark_support' ) ) :
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'skatepark' ),
+				'secondary' => __( 'Secondary Navigation', 'skatepark' ),
 			)
 		);
 

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -22,11 +22,10 @@ if ( ! function_exists( 'skatepark_support' ) ) :
 			)
 		);
 
-		// This theme uses wp_nav_menu() in two locations.
+		//Primary navigation is used on the header and the footer pattern
 		register_nav_menus(
 			array(
-				'primary' => __( 'Primary Navigation', 'skatepark' ),
-				'secondary' => __( 'Secondary Navigation', 'skatepark' ),
+				'primary' => __( 'Primary Navigation', 'skatepark' )
 			)
 		);
 

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -43,3 +43,8 @@ function skatepark_scripts() {
 	wp_enqueue_style( 'skatepark-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blockbase-ponyfill' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'wp_enqueue_scripts', 'skatepark_scripts' );
+
+/**
+ * Block Patterns.
+ */
+require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/skatepark/inc/block-patterns.php
+++ b/skatepark/inc/block-patterns.php
@@ -21,10 +21,6 @@ if ( ! function_exists( 'skatepark_register_block_patterns' ) ) :
 				'pre-footer',
 			);
 
-			if ( class_exists( 'WP_Block_Type_Registry' ) && \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
-				$block_patterns[] = 'pre-footer';
-			}
-
 			foreach ( $block_patterns as $block_pattern ) {
 				register_block_pattern(
 					'skatepark/' . $block_pattern,

--- a/skatepark/inc/block-patterns.php
+++ b/skatepark/inc/block-patterns.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Skatepark Theme: Block Patterns
+ *
+ * @package Skatepark
+ * @since   1.0.0
+ */
+if ( ! function_exists( 'skatepark_register_block_patterns' ) ) :
+
+	function skatepark_register_block_patterns() {
+
+		if ( function_exists( 'register_block_pattern_category' ) ) {
+			register_block_pattern_category(
+				'skatepark',
+				array( 'label' => __( 'Skatepark', 'skatepark' ) )
+			);
+		}
+
+		if ( function_exists( 'register_block_pattern' ) ) {
+			$block_patterns = array(
+				'pre-footer',
+			);
+
+			if ( class_exists( 'WP_Block_Type_Registry' ) && \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/subscriptions' ) ) {
+				$block_patterns[] = 'pre-footer';
+			}
+
+			foreach ( $block_patterns as $block_pattern ) {
+				register_block_pattern(
+					'skatepark/' . $block_pattern,
+					require __DIR__ . '/patterns/' . $block_pattern . '.php'
+				);
+			}
+		}
+	}
+endif;
+
+add_action( 'init', 'skatepark_register_block_patterns', 9 );

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -17,7 +17,7 @@ return array(
 		<p class="has-small-font-size">' . esc_html__( 'Skate ipsum dolor sit amet, poseur nollie casper pop shove-it. Kickturn noseblunt tailslide.', 'skatepark' ) . '</p>
 		<!-- /wp:paragraph -->
 		
-		<!-- wp:social-links {"iconColor":"primary","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+		<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--foreground)","className":"is-style-logos-only"} -->
 		<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"http://twitter.com","service":"twitter"} /-->
 		
 		<!-- wp:social-link {"url":"http://facebook.com","service":"facebook"} /-->

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -31,14 +31,12 @@ return array(
 		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'More info', 'skatepark' ) . '</strong></h3>
 		<!-- /wp:heading -->
 		
-		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"secondary","style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
+		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"primary","style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
-		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Search', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
-		<h3 class="has-tiny-font-size"><strong>Search</strong></h3>
-		<!-- /wp:heading --></div>
+		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Search', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside"} /--></div>
 		<!-- /wp:column --></div>
 		<!-- /wp:columns --></div>
 		<!-- /wp:group -->',

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Pre Footer.
+ *
+ * @package Skatepark
+ */
+
+return array(
+	'title'      => __( 'Footer', 'skatepark' ),
+	'categories' => array( 'skatepark' ),
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}},"className":"pre-footer"} -->
+	<div class="wp-block-group alignwide pre-footer" style="padding-top:60px;padding-bottom:60px"><!-- wp:columns -->
+		<div class="wp-block-columns"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"large"} /-->
+		
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size">' . esc_html__( 'Skate ipsum dolor sit amet, poseur nollie casper pop shove-it. Kickturn noseblunt tailslide.', 'skatepark' ) . '</p>
+		<!-- /wp:paragraph -->
+		
+		<!-- wp:social-links {"iconColor":"primary","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+		<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"http://twitter.com","service":"twitter"} /-->
+		
+		<!-- wp:social-link {"url":"http://facebook.com","service":"facebook"} /-->
+		
+		<!-- wp:social-link {"url":"http://instagram.com","service":"instagram"} /--></ul>
+		<!-- /wp:social-links --></div>
+		<!-- /wp:column -->
+		
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
+		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'More info', 'skatepark' ) . '</strong></h3>
+		<!-- /wp:heading -->
+		
+		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"secondary","style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
+		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Subscribe', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:jetpack/subscriptions {"submitButtonText":"' . esc_html__( 'Submit', 'skatepark' ) . '","buttonBackgroundColor":"background","textColor":"primary","fontSize":"14px","customFontSize":"14px","borderRadius":0,"borderWeight":3,"borderColor":"#000000","customBorderColor":"#000000","spacing":0} -->
+		<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" submit_button_text="' . esc_html__( 'Submit', 'skatepark' ) . '" custom_font_size="14px" custom_border_radius="0" custom_border_weight="3" custom_border_color="#000000" custom_padding="15" custom_spacing="10" submit_button_classes="no-border-radius has-14-px-font-size has-000000-border-color has-text-color has-primary-color has-background has-background-background-color" email_field_classes="no-border-radius has-14-px-font-size has-000000-border-color" show_only_email_and_button="true"]</div>
+		<!-- /wp:jetpack/subscriptions --></div>
+		<!-- /wp:column --></div>
+		<!-- /wp:columns --></div>
+		<!-- /wp:group -->',
+);

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -36,7 +36,7 @@ return array(
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
-		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Search', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside"} /--></div>
+		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Search', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:search {"label":"' . esc_html__( 'Search', 'skatepark' ) . '","showLabel":false,"buttonText":"' . esc_html__( 'Search', 'skatepark' ) . '","buttonPosition":"button-inside"} /--></div>
 		<!-- /wp:column --></div>
 		<!-- /wp:columns --></div>
 		<!-- /wp:group -->',

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -14,7 +14,7 @@ return array(
 		<div class="wp-block-column"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"large"} /-->
 		
 		<!-- wp:paragraph {"fontSize":"small"} -->
-		<p class="has-small-font-size">' . esc_html__( 'Skate ipsum dolor sit amet, poseur nollie casper pop shove-it. Kickturn noseblunt tailslide.', 'skatepark' ) . '</p>
+		<p class="has-small-font-size">' . esc_html__( "Skatepark's coaches will work with you to develop and improve your skating abilities.", 'skatepark' ) . '</p>
 		<!-- /wp:paragraph -->
 		
 		<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--foreground)","className":"is-style-logos-only"} -->

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -36,9 +36,9 @@ return array(
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
-		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Subscribe', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:jetpack/subscriptions {"submitButtonText":"' . esc_html__( 'Submit', 'skatepark' ) . '","buttonBackgroundColor":"background","textColor":"primary","fontSize":"14px","customFontSize":"14px","borderRadius":0,"borderWeight":3,"borderColor":"#000000","customBorderColor":"#000000","spacing":0} -->
-		<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" submit_button_text="' . esc_html__( 'Submit', 'skatepark' ) . '" custom_font_size="14px" custom_border_radius="0" custom_border_weight="3" custom_border_color="#000000" custom_padding="15" custom_spacing="10" submit_button_classes="no-border-radius has-14-px-font-size has-000000-border-color has-text-color has-primary-color has-background has-background-background-color" email_field_classes="no-border-radius has-14-px-font-size has-000000-border-color" show_only_email_and_button="true"]</div>
-		<!-- /wp:jetpack/subscriptions --></div>
+		<h3 class="has-tiny-font-size"><strong>' . esc_html__( 'Search', 'skatepark' ) . '</strong></h3><!-- /wp:heading --><!-- wp:heading {"level":3,"fontSize":"tiny"} -->
+		<h3 class="has-tiny-font-size"><strong>Search</strong></h3>
+		<!-- /wp:heading --></div>
 		<!-- /wp:column --></div>
 		<!-- /wp:columns --></div>
 		<!-- /wp:group -->',

--- a/skatepark/sass/block-patterns/_pre-footer.scss
+++ b/skatepark/sass/block-patterns/_pre-footer.scss
@@ -5,4 +5,9 @@
 	.wp-block-social-links.is-style-logos-only {
 		margin-left: calc( -1 * ( 8px + 0.25em ) );
 	}
+	.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
+		--wp--custom--button--typography--font-size: 14px;
+		--wp--custom--button--spacing--padding--top: 0.5em;
+		--wp--custom--button--spacing--padding--bottom: 0.5em;
+	}
 }

--- a/skatepark/sass/block-patterns/_pre-footer.scss
+++ b/skatepark/sass/block-patterns/_pre-footer.scss
@@ -1,0 +1,5 @@
+.pre-footer {
+	h3 {
+		text-transform: uppercase;
+	}
+}

--- a/skatepark/sass/block-patterns/_pre-footer.scss
+++ b/skatepark/sass/block-patterns/_pre-footer.scss
@@ -2,4 +2,7 @@
 	h3 {
 		text-transform: uppercase;
 	}
+	.wp-block-social-links.is-style-logos-only {
+		margin-left: calc( -1 * ( 8px + 0.25em ) );
+	}
 }

--- a/skatepark/sass/blocks/_buttons.scss
+++ b/skatepark/sass/blocks/_buttons.scss
@@ -26,7 +26,7 @@
 
 .wp-block-search {
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-	.wp-block-search__button {
+	.wp-block-search__button.wp-block-search__button {
 		text-transform: uppercase;
 		@include skatepark_button_hover_styles;
 	}

--- a/skatepark/sass/blocks/_buttons.scss
+++ b/skatepark/sass/blocks/_buttons.scss
@@ -21,6 +21,7 @@
 }
 .wp-block-file .wp-block-file__button {
 	text-transform: uppercase;
+	letter-spacing: 0.1em;
 	@include skatepark_button_hover_styles;
 }	
 
@@ -28,6 +29,7 @@
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
 	.wp-block-search__button.wp-block-search__button {
 		text-transform: uppercase;
+		letter-spacing: 0.1em;
 		@include skatepark_button_hover_styles;
 	}
 }
@@ -35,6 +37,7 @@
 .wp-block-post-comments {
 	input[type="submit"], .reply a {
 		text-transform: uppercase;
+		letter-spacing: 0.1em;
 		@include skatepark_button_hover_styles;
 	}
 }

--- a/skatepark/sass/blocks/_search.scss
+++ b/skatepark/sass/blocks/_search.scss
@@ -1,0 +1,52 @@
+.wp-block-search {
+	.wp-block-search__button {
+		&:active,
+		&:focus {
+			outline-offset: -0.25em;
+		}
+		svg {
+			min-width: 2em;
+			min-height: 2em;
+		}
+		&.has-icon {
+			--wp--custom--button--spacing--padding--left: calc( 1.75 * var(--wp--custom--button--spacing--padding--top) );
+			--wp--custom--button--spacing--padding--right: calc( 1.75 * var(--wp--custom--button--spacing--padding--top) );
+		}
+	}
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper{
+			padding: 0;
+			.wp-block-search__button {
+				--wp--custom--button--color--text: var(--wp--custom--color--primary);
+				--wp--custom--button--color--background: var(--wp--custom--color--background);
+				position: relative;
+				&::before {
+					content: "";
+					height: 80%;
+					width: 1px;
+					background: var(--wp--custom--color--primary);
+					position: absolute;
+					left: 0;
+					top: 10%;
+				}
+				&:not(.has-background):not(.has-text-color) {
+					&:hover {
+						--wp--custom--button--color--text: var(--wp--custom--color--background);
+						--wp--custom--button--color--background: var(--wp--custom--color--primary);
+						&:focus,
+						&.has-focus {
+							outline-color: var(--wp--custom--color--background);
+						}
+					}
+					&:focus,
+					&.has-focus {
+						border-color: transparent;
+						&::before {
+							left: calc( -1 * var(--wp--custom--button--border--width) );
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/skatepark/sass/elements/_links.scss
+++ b/skatepark/sass/elements/_links.scss
@@ -42,6 +42,7 @@ h6 a,
 }
 
 // Select the focus states of all non-wpadmin and screen reader links
+.wp-block-search__button,
 a:not(.ab-item):not(.screen-reader-shortcut) {
 	&:active,
 	&:focus {

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -2,5 +2,6 @@
 @import "../../blockbase/sass/base/mixins";
 @import "base/text";
 @import "blocks/buttons";
+@import "blocks/search";
 @import "block-patterns/pre-footer";
 @import "elements/links";

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -2,4 +2,5 @@
 @import "../../blockbase/sass/base/mixins";
 @import "base/text";
 @import "blocks/buttons";
+@import "block-patterns/pre-footer";
 @import "elements/links";

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -149,7 +149,7 @@
 					"color": "var(--wp--custom--color--primary)",
 					"radius": "0",
 					"style": "solid",
-					"width": "2px"
+					"width": "3px"
 				},
 				"color": {
 					"background": "transparent",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -146,7 +146,7 @@
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--margin--horizontal) )",
 				"border": {
-					"color": "#EFEFEF",
+					"color": "var(--wp--custom--color--primary)",
 					"radius": "0",
 					"style": "solid",
 					"width": "2px"
@@ -162,7 +162,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"gallery": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR includes the footer template part that only has the WP credits and a block pattern with the pre footer. Since the block pattern contains the jetpack subscription block it won't show on a local install. I tested this on my [atomic test site](https://atomictest365300111.wpcomstaging.com/). I didn't want to go much into styling the subscription form mainly because the form has a few settings to control its appearance and I was hesitant to override those using much CSS and have users not be able to use the settings on the form, @melchoyce I would like your input on this.

<img width="1615" alt="Screenshot 2021-07-29 at 15 09 46" src="https://user-images.githubusercontent.com/3593343/127497779-362d8e4e-12ba-41c2-aba1-e9ce93b5d4a4.png">


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4312
