### PR TITLE
Blockbase: check that alternative colors are defined in the default palette

### DIFF
--- a/blockbase/inc/customizer/wp-customize-color-palettes.php
+++ b/blockbase/inc/customizer/wp-customize-color-palettes.php
@@ -37,7 +37,10 @@ class GlobalStylesColorPalettes {
 			foreach ( $custom_palettes as $custom_palette ) {
 				$custom_palette_setting = array();
 				foreach ( $custom_palette['colors'] as $color_slug => $color ) {
-					$custom_palette_setting[ $color_slug ] = $color;
+					//the alternative palettes need to have the same color mapping as the default one
+					if(isset($default_palette_setting[$color_slug])){
+						$custom_palette_setting[ $color_slug ] = $color;
+					}
 				}
 
 				$this->palettes[ $custom_palette['slug'] ] = array(


### PR DESCRIPTION
Blockbase provides 3 5-color alternative palettes that are "inherited" (via the json build tool) by child themes that don't define their own alternative palettes. If the child theme doesn't define 5 colors in their son file, this causes the customizer to break (we get a JS error and the colors are not applied correctly). This PR only allows the customizer script to add the colors that are already defined in the default palette.