### PR TITLE
Inject blocks.css styles as editor styles as well

### DIFF
--- a/rebalance/functions.php
+++ b/rebalance/functions.php
@@ -299,6 +299,7 @@ add_action( 'wp_enqueue_scripts', 'rebalance_scripts' );
  */
 function rebalance_editor_styles() {
 	wp_enqueue_style( 'rebalance-editor-block-style', get_template_directory_uri() . '/editor-blocks.css' );
+	wp_enqueue_style( 'rebalance-editor-block-additional-style', get_template_directory_uri() . '/blocks.css', 8 );
 	wp_enqueue_style( 'rebalance-fonts', rebalance_fonts_url(), array(), null );
 }
 add_action( 'enqueue_block_editor_assets', 'rebalance_editor_styles' );


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This is an attempt to fix https://github.com/Automattic/wp-calypso/issues/54990. 

Please note that we injected `blocks.css` as-is, without much consideration to the rest of CSS and the clashes that might occur. 

This PR is intended to show a quick way to fix the issue.


#### Related issue(s):

https://github.com/Automattic/wp-calypso/issues/54990