### PR TITLE
Seedlet blocks: fix broken footer

### DIFF
--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -368,9 +368,15 @@ is passed all of the block attributes on the block definition in the template. *
 }
 
 .footer-credit {
-	display: flex;
 	font-family: var(--wp--preset--font-family--headings);
 	white-space: pre-wrap;
+}
+
+.footer-credit[class*="wp-container-"] {
+	margin-left: auto !important;
+	margin-right: auto !important;
+	padding: 0;
+	column-gap: 0;
 }
 
 .footer-credit > * {

--- a/seedlet-blocks/block-template-parts/footer.html
+++ b/seedlet-blocks/block-template-parts/footer.html
@@ -2,22 +2,18 @@
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"className":"footer-credit","layout":{"inherit":false}} -->
+<!-- wp:group {"className":"footer-credit","layout":{"type":"flex"}} -->
 <div class="wp-block-group footer-credit"><!-- wp:site-title {"level":0} /-->
 
-<!-- wp:paragraph -->
-<p>, </p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
-<p class="has-text-align-left has-small-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+	<!-- wp:paragraph -->
+	<p>, </p>
+	<!-- /wp:paragraph -->
+	
+	<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
+	<p class="has-text-align-left has-small-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
 
 <!-- wp:spacer {"height":30} -->
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -18,4 +18,4 @@
 </div>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container","align":"full"} /-->

--- a/seedlet-blocks/sass/theme.scss
+++ b/seedlet-blocks/sass/theme.scss
@@ -31,9 +31,14 @@
 }
 
 .footer-credit {
-	display: flex;
 	font-family: var(--wp--preset--font-family--headings);
 	white-space: pre-wrap;
+	&[class*="wp-container-"] {
+		margin-left: auto !important;
+		margin-right: auto !important;
+		padding: 0;
+		column-gap: 0;
+	}
 }
 
 .footer-credit > * {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -239,6 +239,9 @@
 					}
 				}
 			},
+			"layout": {
+				"contentSize": "620px"
+			},
 			"list": {
 				"spacing": {
 					"padding": {


### PR DESCRIPTION
The footer for Seedlet blocks was broken. This solution leverages [flex layout on the group block](https://github.com/WordPress/gutenberg/issues/33687).

Before:

<img width="1559" alt="Screenshot 2021-08-03 at 17 12 07" src="https://user-images.githubusercontent.com/3593343/128040628-560cad02-1c83-443f-862e-b518f1f38a62.png">

After:

<img width="716" alt="Screenshot 2021-08-03 at 17 09 38" src="https://user-images.githubusercontent.com/3593343/128040638-7d1e934b-ee61-4cc3-be45-a4116037af0d.png">

