### PR TITLE
Independent Publisher 2: Fix menu toggle for default color scheme

### DIFF
--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -846,6 +846,7 @@ input::-moz-focus-inner {
 	border: solid 2px currentColor;
 	border-radius: 4px;
 	background: none;
+	color: #383838;
 
 	-webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removing the `button:not('.menu-toggle')` rule in D65100-code caused the menu toggle to become invisible when the default color palette was set. This re-adds the correct color to the stylesheet.

**Before**

<img width="341" alt="Screen Shot 2021-08-09 at 9 49 02 AM" src="https://user-images.githubusercontent.com/2124984/128716879-c5abe00e-c0ee-4468-acad-518affa972e8.png">


**After**

<img width="338" alt="Screen Shot 2021-08-09 at 9 39 06 AM" src="https://user-images.githubusercontent.com/2124984/128716797-a421bc42-73c3-4c61-ab81-95509d1ef72e.png">

Same as D65278-code

#### Testing instructions

* Apply this patch to your sandbox and activate Independent Publisher 2 on your sandboxed test site
* Make sure you're using the default colors under Colors & Backgrounds in the Customizer
* Make sure you have a menu set under the Primary menu item
* Look at the mobile view of your site 
* The Menu toggle should be visible
* The Menu toggle should still be visible when changing colors in the Customizer

#### Related issue(s):

Fixes Automattic/wp-calypso#55272