### PR TITLE
Blockbase: Add Red Hat Display to the list of supported fonts

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -150,6 +150,12 @@ class GlobalStylesFontsCustomizer {
 			'name'       => 'Raleway',
 			'google'     => 'family=Raleway:ital,wght@0,100..900;1,100..900',
 		),
+		'red-hat-display'=> array(
+			'fontFamily' => '"Red Hat Display", sans-serif',
+			'slug'       => 'red-hat-display',
+			'name'       => 'Red Hat Display',
+			'google'     => 'family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900',
+		),
 		'roboto'            => array(
 			'fontFamily' => '"Roboto", sans-serif',
 			'slug'       => 'roboto',


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Adds Red Hat Display to our list of supported fonts for customization, since its used in Skatepark.

To test, switch to a Blockbase family theme and try switching to "Red Hat Display" in the customizer.