### PR TITLE
Blockbase: reduces specificity for search block selectors

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -588,7 +588,7 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-.wp-block-search .wp-block-search__button.wp-block-search__button {
+.wp-block-search .wp-block-search__button {
 	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
@@ -607,14 +607,14 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button svg,
-.wp-block-search .wp-block-search__button.wp-block-search__button svg {
+.wp-block-search .wp-block-search__button svg {
 	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):hover,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):focus,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover,
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus,
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus {
 	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
 	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
 	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
@@ -626,14 +626,14 @@ p.has-background {
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg, .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-search .wp-block-search__button.wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-search .wp-block-search__button:not(.has-background):not(.has-text-color).has-focus svg {
 	fill: var(--wp--custom--button--color--text);
 }
 
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
-.wp-block-search .wp-block-search__button.wp-block-search__button.has-icon {
+.wp-block-search .wp-block-search__button.has-icon {
 	line-height: 0;
 }
 

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -21,7 +21,7 @@
 	}
 
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button,
-	.wp-block-search__button.wp-block-search__button {
+	.wp-block-search__button {
 		@include button-main-styles;
 		@include button-hover-styles;
 		&.has-icon {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This is a follow-up to https://github.com/WordPress/gutenberg/pull/33961 After that's merged we can actually remove the extra specificity that was needed for styles to persist on the editor. To test this check that the search block looks the same with and without this PR.

Test this with the mentioned PR active on your site, I'm waiting on tests to pass to merge it.
