### PR TITLE
Blockbase: Load editor styles for blockbase before those of the child theme

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -1,7 +1,6 @@
 <?php
 if ( ! function_exists( 'blockbase_support' ) ) :
 	function blockbase_support() {
-		var_dump( 'blockbase support' );
 		// Alignwide and alignfull classes in the block editor.
 		add_theme_support( 'align-wide' );
 

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! function_exists( 'blockbase_support' ) ) :
 	function blockbase_support() {
-
+		var_dump( 'blockbase support' );
 		// Alignwide and alignfull classes in the block editor.
 		add_theme_support( 'align-wide' );
 
@@ -39,7 +39,7 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		);
 
 	}
-	add_action( 'after_setup_theme', 'blockbase_support' );
+	add_action( 'after_setup_theme', 'blockbase_support', 9 );
 endif;
 
 /**

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -3,7 +3,7 @@
 
 if ( ! function_exists( 'skatepark_support' ) ) :
 	function skatepark_support() {
-
+		var_dump('skatepark_support');
 		// Enqueue editor styles.
 		add_editor_style(
 			array(

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -3,7 +3,6 @@
 
 if ( ! function_exists( 'skatepark_support' ) ) :
 	function skatepark_support() {
-		var_dump('skatepark_support');
 		// Enqueue editor styles.
 		add_editor_style(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
In the front end we load the blockbase styles before the child theme, so we should do the same in the editor:

Before:
<img width="715" alt="Screenshot 2021-08-10 at 10 33 37" src="https://user-images.githubusercontent.com/275961/128844785-584710e3-33d8-4fdb-8f2b-822c9009063e.png">

After:
<img width="714" alt="Screenshot 2021-08-10 at 10 34 01" src="https://user-images.githubusercontent.com/275961/128844833-b0934a7b-7e19-4435-b428-f4c0b8546e82.png">
