### PR TITLE
Skatepark: created duotone presets

### DIFF
--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -2,6 +2,38 @@
 	"settings": {
 		"color": {
 			"gradients": [],
+			"duotone": [
+                {
+                    "colors": [ "#000", "#BFF5A5" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                },
+                {
+                    "colors": [ "#000", "#FFF" ],
+                    "slug": "white-filter",
+                    "name": "White Filter"
+                },
+                {
+                    "colors": [ "#000", "#F3B2A9" ],
+                    "slug": "red-filter",
+                    "name": "Red Filter"
+                },
+                {
+                    "colors": [ "#000", "#C9E4ED" ],
+                    "slug": "blue-filter",
+                    "name": "Blue Filter"
+                },
+                {
+                    "colors": [ "#252B39", "#F9EED4" ],
+                    "slug": "blue-cream-filter",
+                    "name": "Blue/Cream Filter"
+                },
+                {
+                    "colors": [ "#153232", "#F7B9A9" ],
+                    "slug": "green-pink-filter",
+                    "name": "Green/Pink Filter"
+                }
+            ],
 			"palette": [
 				{
 					"slug": "primary",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -48,6 +48,56 @@
 					"color": "#BFF5A5",
 					"name": "Background"
 				}
+			],
+			"duotone": [
+				{
+					"colors": [
+						"#000",
+						"#BFF5A5"
+					],
+					"slug": "default-filter",
+					"name": "Default filter"
+				},
+				{
+					"colors": [
+						"#000",
+						"#FFF"
+					],
+					"slug": "white-filter",
+					"name": "White Filter"
+				},
+				{
+					"colors": [
+						"#000",
+						"#F3B2A9"
+					],
+					"slug": "red-filter",
+					"name": "Red Filter"
+				},
+				{
+					"colors": [
+						"#000",
+						"#C9E4ED"
+					],
+					"slug": "blue-filter",
+					"name": "Blue Filter"
+				},
+				{
+					"colors": [
+						"#252B39",
+						"#F9EED4"
+					],
+					"slug": "blue-cream-filter",
+					"name": "Blue/Cream Filter"
+				},
+				{
+					"colors": [
+						"#153232",
+						"#F7B9A9"
+					],
+					"slug": "green-pink-filter",
+					"name": "Green/Pink Filter"
+				}
 			]
 		},
 		"custom": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

After talking with @jeffikus we thought that the best course of action for the moment is to provide the presets for all the alternative palettes on the filter so that the user can change their images manually until a solution for https://github.com/WordPress/gutenberg/issues/33905 is applied and we can have dynamic filters. This PR adds filters for all the palettes in the theme:

<img width="527" alt="Screenshot 2021-08-11 at 12 07 15" src="https://user-images.githubusercontent.com/3593343/129011057-5afa4611-3faa-40e1-abcb-6ce253873877.png">

![Screenshot 2021-08-11 at 12-03-50 Test duotone – free](https://user-images.githubusercontent.com/3593343/129011044-ee434854-5ab1-434c-8a33-8ea8a07660db.png)

#### Related issue(s):

#4329