### PR TITLE
Blockbase: Update font customization approach

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -393,7 +393,6 @@ p.has-text-color a {
 p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
 	font-family: var(--wp--custom--paragraph--dropcap--typography--font-family);
-	font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
 	margin: var(--wp--custom--paragraph--dropcap--margin);
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -500,7 +500,6 @@ p.has-background {
 .wp-block-pullquote blockquote cite {
 	display: block;
 	font-size: var(--wp--custom--pullquote--citation--typography--font-size);
-	font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 	font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 	font-weight: var(--wp--custom--pullquote--citation--typography--font-weight);
 	margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -392,7 +392,7 @@ p.has-text-color a {
 
 p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
-	font-family: var(--wp--custom--paragraph--dropcap--typography--font-family);
+	font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
 	margin: var(--wp--custom--paragraph--dropcap--margin);
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -201,7 +201,7 @@ textarea {
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
 	color: var(--wp--custom--form--color--text);
-	font-family: var(--wp--custom--body--typography--font-family);
+	font-family: inherit;
 	padding: var(--wp--custom--form--padding);
 }
 
@@ -255,7 +255,7 @@ input[type=checkbox] + label {
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: var(--wp--custom--button--typography--font-family);
+	font-family: inherit;
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
@@ -416,7 +416,7 @@ p.has-background {
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: var(--wp--custom--button--typography--font-family);
+	font-family: inherit;
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
@@ -594,7 +594,7 @@ p.has-background {
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: var(--wp--custom--button--typography--font-family);
+	font-family: inherit;
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
@@ -652,7 +652,7 @@ p.has-background {
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: var(--wp--custom--button--typography--font-family);
+	font-family: inherit;
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -85,7 +85,7 @@ function blockbase_fonts_url() {
 	$font_families = [];
 	if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
 		foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
-			if ( $font['google'] ) {
+			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
 		}
@@ -93,7 +93,7 @@ function blockbase_fonts_url() {
 
 	if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
 		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
-			if ( $font['google'] ) {
+			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
 		}

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -78,16 +78,27 @@ function blockbase_fonts_url() {
 	}
 
 	$theme_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
-	if ( empty( $theme_data ) || empty( $theme_data['custom'] ) ) {
+	if ( empty( $theme_data ) || empty( $theme_data['typography'] ) || empty( $theme_data['typography']['fontFamilies'] ) ) {
 		return '';
 	}
 
-	$custom_data = $theme_data['custom'];
-	if ( ! array_key_exists( 'fontsToLoadFromGoogle', $custom_data ) ) {
-		return '';
+	$font_families = [];
+	if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
+		foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
+			if ( $font['google'] ) {
+				$font_families[] = $font['google'];
+			}
+		}
 	}
 
-	$font_families   = $theme_data['custom']['fontsToLoadFromGoogle'];
+	if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
+		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
+			if ( $font['google'] ) {
+				$font_families[] = $font['google'];
+			}
+		}
+	}
+
 	$font_families[] = 'display=swap';
 
 	// Make a single request for the theme fonts.

--- a/blockbase/inc/customizer/wp-customize-fonts-preview.js
+++ b/blockbase/inc/customizer/wp-customize-fonts-preview.js
@@ -18,7 +18,7 @@ function blockBaseUpdateFontPreview() {
 	innerHTML += `font-family:${ fontSettings[ 'body' ] };`;
 	innerHTML += '}';
 	// Build the new heading CSS
-	innerHTML += 'h1,h2,h3,h4,h5,h6{';
+	innerHTML += 'h1,h2,h3,h4,h5,h6,.wp-block-post-title{';
 	innerHTML += `font-family:${ fontSettings[ 'heading' ] };`;
 	innerHTML += '}';
 

--- a/blockbase/inc/customizer/wp-customize-fonts-preview.js
+++ b/blockbase/inc/customizer/wp-customize-fonts-preview.js
@@ -18,7 +18,7 @@ function blockBaseUpdateFontPreview() {
 	innerHTML += `font-family:${ fontSettings[ 'body' ] };`;
 	innerHTML += '}';
 	// Build the new heading CSS
-	innerHTML += 'h1,h2,h3,h4,h5,h6,.wp-block-post-title{';
+	innerHTML += 'h1,h2,h3,h4,h5,h6,.wp-block-post-title,.wp-block-pullquote{';
 	innerHTML += `font-family:${ fontSettings[ 'heading' ] };`;
 	innerHTML += '}';
 

--- a/blockbase/inc/customizer/wp-customize-fonts-preview.js
+++ b/blockbase/inc/customizer/wp-customize-fonts-preview.js
@@ -13,10 +13,13 @@ if ( fontSettings ) {
 }
 
 function blockBaseUpdateFontPreview() {
-	// Build the new CSS variables.
-	let innerHTML = ':root,body{';
-	innerHTML += `--wp--custom--body--typography--font-family:${ fontSettings[ 'body' ] };`;
-	innerHTML += `--wp--custom--heading--typography--font-family:${ fontSettings[ 'heading' ] };`;
+	// Build the new body CSS
+	let innerHTML = 'body{';
+	innerHTML += `font-family:${ fontSettings[ 'body' ] };`;
+	innerHTML += '}';
+	// Build the new heading CSS
+	innerHTML += 'h1,h2,h3,h4,h5,h6{';
+	innerHTML += `font-family:${ fontSettings[ 'heading' ] };`;
 	innerHTML += '}';
 
 	// Inject them into the body.

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -232,9 +232,11 @@ class GlobalStylesFontsCustomizer {
 
 	function create_customization_style_element( $wp_customize ) {
 		wp_enqueue_style( 'global-styles-fonts-customizations', ' ', array( 'global-styles' ) ); // This needs to load after global_styles, hence the dependency
-		$css  = ':root,body{';
-		$css .= '--wp--custom--body--typography--font-family:' . $this->font_settings['body'] . ';';
-		$css .= '--wp--custom--heading--typography--font-family: ' . $this->font_settings['heading'] . '}';
+		$css  = 'body{';
+		$css .= 'font-family:' . $this->font_settings['body'] . ';';
+		$css .= '}';
+		$css .= 'h1,h2,h3,h4,h5,h6,.wp-block-post-title{';
+		$css .= 'font-family:' . $this->font_settings['heading'] . ';';
 		$css .= '}';
 		wp_add_inline_style( 'global-styles-fonts-customizations', $css );
 	}
@@ -490,10 +492,15 @@ class GlobalStylesFontsCustomizer {
 
 		//If the typeface choices === the default then we remove it instead
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
-			unset( $user_theme_json_post_content->settings->typography->fontFamilies );
-			unset( $user_theme_json_post_content->settings->custom->body->typography->fontFamily );
-			unset( $user_theme_json_post_content->settings->custom->heading->typography->fontFamily );
-			unset( $user_theme_json_post_content->settings->custom->fontsToLoadFromGoogle );
+			unset( $user_theme_json_post_content->styles->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h1->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h2->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h3->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h4->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h5->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elemenets->h6->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamilies );
 		}
 
 		// Update the theme.json with the new settings.

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -272,11 +272,11 @@ class GlobalStylesFontsCustomizer {
 		$merged_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
 		$theme_json  = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_raw_data();
 
-		$body_font_default    = $this->get_font_family( 'body', $theme_json );
-		$heading_font_default = $this->get_font_family( 'heading', $theme_json );
+		$body_font_default    = $this->get_font_family( array( 'styles', 'typography', 'fontFamily' ), $theme_json );
+		$heading_font_default = $this->get_font_family( array( 'styles', 'elements', 'h1', 'typography', 'fontFamily' ), $theme_json );
 
-		$body_font_selected    = $this->get_font_family( 'body', $merged_json );
-		$heading_font_selected = $this->get_font_family( 'heading', $merged_json );
+		$body_font_selected    = $this->get_font_family( array( 'styles', 'typography', 'fontFamily' ), $merged_json );
+		$heading_font_selected = $this->get_font_family( array( 'styles', 'elements', 'h1', 'typography', 'fontFamily' ), $merged_json );
 
 		$this->font_settings = array(
 			'body'    => $body_font_selected['fontFamily'],
@@ -313,8 +313,8 @@ class GlobalStylesFontsCustomizer {
 		$this->add_setting_and_control( $wp_customize, 'heading', __( 'Heading font', 'blockbase' ), $heading_font_default['slug'], $heading_font_selected['slug'] );
 	}
 
-	function get_font_family( $location, $configuration ) {
-		$variable = $configuration['settings']['custom'][ $location ]['typography']['fontFamily'];
+	function get_font_family( $array, $configuration ) {
+		$variable = get_settings_array( $array, $configuration );
 		$slug     = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $variable );
 		if ( ! isset( $this->fonts[ $slug ] ) ) {
 			$this->fonts[ $slug ] = $this->build_font_from_theme_data( $slug, $location, $configuration );
@@ -432,25 +432,60 @@ class GlobalStylesFontsCustomizer {
 			$font_families
 		);
 
-		// Set the custom body settings.
+		// Set the body typography settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
-			array( 'settings', 'custom', 'body', 'typography', 'fontFamily' ),
+			array( 'styles', 'typography', 'fontFamily' ),
 			$body_font_family_variable
 		);
 
-		// Set the custom heading settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
-			array( 'settings', 'custom', 'heading', 'typography', 'fontFamily' ),
+			array( 'styles', 'blocks', 'core/button', 'typography', 'fontFamily' ),
 			$heading_font_family_variable
 		);
 
-		// Set the custom google fonts settings.
+		// Set the heading typography settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
-			array( 'settings', 'custom', 'fontsToLoadFromGoogle' ),
-			$google_font_array
+			array( 'styles', 'elements', 'h1', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'elements', 'h2', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'elements', 'h3', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'elements', 'h4', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'elements', 'h5', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'elements', 'h6', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'blocks', 'core/post-title', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
 		);
 
 		//If the typeface choices === the default then we remove it instead

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -235,7 +235,7 @@ class GlobalStylesFontsCustomizer {
 		$css  = 'body{';
 		$css .= 'font-family:' . $this->font_settings['body'] . ';';
 		$css .= '}';
-		$css .= 'h1,h2,h3,h4,h5,h6,.wp-block-post-title{';
+		$css .= 'h1,h2,h3,h4,h5,h6,.wp-block-post-title,.wp-block-pullquote{';
 		$css .= 'font-family:' . $this->font_settings['heading'] . ';';
 		$css .= '}';
 		wp_add_inline_style( 'global-styles-fonts-customizations', $css );
@@ -486,6 +486,12 @@ class GlobalStylesFontsCustomizer {
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
 			array( 'styles', 'blocks', 'core/post-title', 'typography', 'fontFamily' ),
+			$heading_font_family_variable
+		);
+
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			array( 'styles', 'blocks', 'core/pullquote', 'typography', 'fontFamily' ),
 			$heading_font_family_variable
 		);
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -269,7 +269,6 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function initialize( $wp_customize ) {
-
 		$theme       = wp_get_theme();
 		$merged_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
 		$theme_json  = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_raw_data();

--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -23,3 +23,20 @@ function set_settings_array( $target, $array, $value ) {
 	$current->{ $key } = $value;
 	return $target;
 }
+
+/**
+ *
+ * Get a value from an object at the given location.
+ *
+ * @param   array   $array  The array describing the location of the property to update.
+ * @param   object  $object The object.
+ * @return  object          The value at the location.
+ *
+ */
+function get_settings_array( $array, $object ) {
+	foreach( $array as $property ) {
+		$object = $object[ $property ];
+	}
+
+	return $object;
+}

--- a/blockbase/sass/blocks/_button-mixins.scss
+++ b/blockbase/sass/blocks/_button-mixins.scss
@@ -28,7 +28,7 @@
 
 @mixin button-typography-styles {
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: var(--wp--custom--button--typography--font-family);
+	font-family: inherit;
 	font-size: var(--wp--custom--button--typography--font-size);
 	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none; // Needed because link styles inside .entry-content add a text decoration

--- a/blockbase/sass/blocks/_paragraph.scss
+++ b/blockbase/sass/blocks/_paragraph.scss
@@ -8,7 +8,6 @@ p {
 
 	&.has-drop-cap:not(:focus):first-letter {
 		font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
-		font-family: var(--wp--custom--paragraph--dropcap--typography--font-family);
 		font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
 		margin: var(--wp--custom--paragraph--dropcap--margin);
 	}

--- a/blockbase/sass/blocks/_pullquote.scss
+++ b/blockbase/sass/blocks/_pullquote.scss
@@ -15,7 +15,6 @@
 		cite {
 			display: block;
 			font-size: var(--wp--custom--pullquote--citation--typography--font-size);
-			font-family: var(--wp--custom--pullquote--citation--typography--font-family);
 			font-style: var(--wp--custom--pullquote--citation--typography--font-style);
 			font-weight: var(--wp--custom--pullquote--citation--typography--font-weight);
 			margin-top: var(--wp--custom--pullquote--citation--spacing--margin--top);
@@ -27,4 +26,3 @@
 		color: var(--wp--custom--color--background);
 	}
 }
-

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -20,7 +20,7 @@ textarea {
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
 	color: var(--wp--custom--form--color--text);
-	font-family: var(--wp--custom--body--typography--font-family);
+	font-family: inherit;
 	padding: var(--wp--custom--form--padding);
 
 	&:focus {

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -98,7 +98,6 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
@@ -180,13 +179,11 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"lineHeight": 1.6
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
@@ -217,7 +214,6 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -352,7 +348,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--button--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)"
@@ -381,7 +377,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -453,7 +449,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "48px"
@@ -461,7 +457,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "32px"
@@ -469,7 +465,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--huge)"
@@ -477,7 +473,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--large)"
@@ -485,7 +481,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--normal)"
@@ -493,7 +489,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -507,7 +503,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--custom--body--typography--font-family)",
+			"fontFamily": "var(--wp--preset--font-family--system-font)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -81,17 +81,6 @@
 			"fontsToLoadFromGoogle": [
 				"family=Poppins:ital,wght@0,400;0,600;1,400"
 			],
-			"body": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--poppins)"
-				}
-			},
-			"heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--poppins)",
-					"fontWeight": 600
-				}
-			},
 			"margin": {
 				"horizontal": "32px"
 			},
@@ -165,6 +154,11 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/button": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)"
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -173,7 +167,7 @@
 			"core/post-date": {
 				"color": {
 					"link": null,
-					"text": null 
+					"text": null
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -181,6 +175,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -198,31 +193,37 @@
 		"elements": {
 			"h1": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "41.47px"
 				}
 			},
 			"h2": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--huge)"
 				}
 			},
 			"h3": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"h4": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "24px"
 				}
 			},
 			"h5": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"h6": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
@@ -231,6 +232,9 @@
 					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--poppins)"
 		}
 	}
 }

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -78,9 +78,6 @@
 				"background": "var(--wp--preset--color--background)",
 				"selection": "var(--wp--preset--color--selection)"
 			},
-			"fontsToLoadFromGoogle": [
-				"family=Poppins:ital,wght@0,400;0,600;1,400"
-			],
 			"margin": {
 				"horizontal": "32px"
 			},
@@ -104,7 +101,8 @@
 				{
 					"fontFamily": "\"Poppins\", sans-serif",
 					"slug": "poppins",
-					"name": "Poppins"
+					"name": "Poppins",
+					"google": "family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900"
 				},
 				{
 					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -291,9 +291,6 @@
 					"margin": "var(--wp--custom--margin--vertical) auto"
 				}
 			},
-			"fontsToLoadFromGoogle": [
-				"family=Poppins:ital,wght@0,400;0,600;1,400"
-			],
 			"width": {
 				"default": "750px",
 				"wide": "1022px"
@@ -320,7 +317,8 @@
 				{
 					"fontFamily": "\"Poppins\", sans-serif",
 					"slug": "poppins",
-					"name": "Poppins"
+					"name": "Poppins",
+					"google": "family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900"
 				},
 				{
 					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -106,7 +106,6 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": 600,
 					"lineHeight": 2
@@ -188,14 +187,12 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"lineHeight": 1.6
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--poppins)",
-					"fontWeight": 600,
+					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
 			},
@@ -225,7 +222,6 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -383,7 +379,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--button--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)"
@@ -412,7 +408,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -484,7 +480,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "41.47px"
@@ -492,7 +488,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--huge)"
@@ -500,7 +496,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--large)"
@@ -508,7 +504,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "24px"
@@ -516,7 +512,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--normal)"
@@ -524,7 +520,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -538,7 +534,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--custom--body--typography--font-family)",
+			"fontFamily": "var(--wp--preset--font-family--poppins)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -146,9 +146,6 @@
 					}
 				}
 			],
-			"fontsToLoadFromGoogle": [
-				"family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
-			],
 			"form": {
 				"border": {
 					"color": "var(--wp--custom--color--foreground)"
@@ -157,13 +154,11 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"lineHeight": 1.7
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "500"
 				}
 			},
@@ -276,6 +271,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)"
 				}
@@ -306,6 +302,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(48px, 7vw), 80px)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.2
@@ -383,36 +380,42 @@
 		"elements": {
 			"h1": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(48px, 7vw), 80px)",
 					"lineHeight": 1.2
 				}
 			},
 			"h2": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(36px, 6vw), 65px)",
 					"lineHeight": 1.2
 				}
 			},
 			"h3": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(28px, 5vw), 38px)",
 					"lineHeight": 1.2
 				}
 			},
 			"h4": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "20px",
 					"lineHeight": 1.4
 				}
 			},
 			"h5": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "18px",
 					"lineHeight": 1.4
 				}
 			},
 			"h6": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "16px",
 					"lineHeight": 1.4
 				}
@@ -424,6 +427,7 @@
 			}
 		},
 		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontWeight": "400"
 		},
 		"core/site-logo": {

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -226,7 +226,8 @@
 				{
 					"fontFamily": "\"DM Sans\", sans-serif",
 					"slug": "dm-sans",
-					"name": "DM Sans"
+					"name": "DM Sans",
+					"google": "family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
 				}
 			],
 			"fontSizes": [

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -96,7 +96,6 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "20px",
 					"fontWeight": "700",
 					"lineHeight": 2
@@ -226,13 +225,11 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"lineHeight": 1.7
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "500",
 					"lineHeight": 1.125
 				}
@@ -263,7 +260,6 @@
 				"dropcap": {
 					"margin": "0 .2em .2em 0",
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "var(--wp--preset--font-size--huge)",
 						"fontWeight": "400"
 					}
@@ -334,9 +330,6 @@
 					"margin": "var(--wp--custom--margin--vertical) auto"
 				}
 			},
-			"fontsToLoadFromGoogle": [
-				"family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
-			],
 			"line-height": {
 				"body": 1.7
 			}
@@ -410,7 +403,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--button--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)"
@@ -447,7 +440,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(48px, 7vw), 80px)",
 					"lineHeight": 1.2,
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)"
@@ -560,7 +553,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.2,
 					"fontSize": "min(max(48px, 7vw), 80px)"
@@ -568,7 +561,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.2,
 					"fontSize": "min(max(36px, 6vw), 65px)"
@@ -576,7 +569,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.2,
 					"fontSize": "min(max(28px, 5vw), 38px)"
@@ -584,7 +577,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
 					"fontSize": "20px"
@@ -592,7 +585,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
 					"fontSize": "18px"
@@ -600,7 +593,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
 					"fontSize": "16px"
@@ -614,7 +607,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--custom--body--typography--font-family)",
+			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
 		},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -355,7 +355,8 @@
 				{
 					"fontFamily": "\"DM Sans\", sans-serif",
 					"slug": "dm-sans",
-					"name": "DM Sans"
+					"name": "DM Sans",
+					"google": "family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700"
 				}
 			],
 			"fontSizes": [

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -133,12 +133,14 @@
 				{
 					"fontFamily": "'Fira Sans', Helvetica, Arial, sans-serif",
 					"slug": "fira-sans",
-					"name": "Fira Sans"
+					"name": "Fira Sans",
+					"google": "family=Fira+Sans:ital,wght@0,100..900;1,100..900"
 				},
 				{
 					"fontFamily": "'Playfair Display', Georgia, Times, serif",
 					"slug": "playfair-display",
-					"name": "Playfair Display"
+					"name": "Playfair Display",
+					"google": "family=Playfair+Display:ital,wght@0,400..900;1,400..900"
 				}
 			],
 			"fontSizes": [

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -202,7 +202,7 @@
 					"fontSize": "32px",
 					"fontStyle": "italic",
 					"lineHeight": "1.3",
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)"
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
 				}
 			},
 			"core/separator": {

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -82,11 +82,6 @@
 			]
 		},
 		"custom": {
-			"body": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--fira-sans)"
-				}
-			},
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)"
@@ -99,15 +94,6 @@
 						"color": "var(--wp--custom--color--secondary)"
 					}
 				}
-			},
-			"fontsToLoadFromGoogle": [
-				"family=Fira+Sans:ital,wght@0,400;0,500;1,400",
-				"family=Playfair+Display:ital,wght@0,400;0,700;1,400"
-			],
-			"heading": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
-				}	
 			},
 			"latest-posts": {
 				"meta": {
@@ -123,7 +109,7 @@
 			"pullquote": {
 				"citation": {
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)"
+						"fontFamily": "var(--wp--preset--font-family--playfair-display)"
 					},
 					"spacing": {
 						"margin": {
@@ -190,6 +176,16 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/button": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fira-sans)"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
 			"core/pullquote": {
 				"border": {
 					"style": "none"
@@ -219,6 +215,41 @@
 					"link": "var(--wp--custom--color--primary)"
 				}
 			}
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--fira-sans)"
 		}
 	}
 }

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -108,9 +108,6 @@
 			},
 			"pullquote": {
 				"citation": {
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--playfair-display)"
-					},
 					"spacing": {
 						"margin": {
 							"top": "20px"

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -456,7 +456,7 @@
 					"fontStyle": "italic",
 					"fontSize": "32px",
 					"lineHeight": "1.3",
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)"
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)"
 				},
 				"spacing": {
 					"padding": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -139,7 +139,6 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "normal",
 					"lineHeight": 2
@@ -221,13 +220,11 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--fira-sans)",
 					"lineHeight": 1.6
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": 400,
 					"lineHeight": 1.125
 				}
@@ -258,7 +255,6 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -285,7 +281,7 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
+						"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 						"fontStyle": "italic"
 					},
 					"spacing": {
@@ -327,11 +323,7 @@
 					"textAlign": "center",
 					"margin": "var(--wp--custom--margin--vertical) auto"
 				}
-			},
-			"fontsToLoadFromGoogle": [
-				"family=Fira+Sans:ital,wght@0,400;0,500;1,400",
-				"family=Playfair+Display:ital,wght@0,400;0,700;1,400"
-			]
+			}
 		},
 		"layout": {
 			"contentSize": "620px",
@@ -412,7 +404,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--button--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--fira-sans)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)"
@@ -441,7 +433,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -518,7 +510,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "48px"
@@ -526,7 +518,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "32px"
@@ -534,7 +526,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--huge)"
@@ -542,7 +534,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--large)"
@@ -550,7 +542,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--normal)"
@@ -558,7 +550,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -572,7 +564,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--custom--body--typography--font-family)",
+			"fontFamily": "var(--wp--preset--font-family--fira-sans)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	}

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -346,12 +346,14 @@
 				{
 					"fontFamily": "'Fira Sans', Helvetica, Arial, sans-serif",
 					"slug": "fira-sans",
-					"name": "Fira Sans"
+					"name": "Fira Sans",
+					"google": "family=Fira+Sans:ital,wght@0,100..900;1,100..900"
 				},
 				{
 					"fontFamily": "'Playfair Display', Georgia, Times, serif",
 					"slug": "playfair-display",
-					"name": "Playfair Display"
+					"name": "Playfair Display",
+					"google": "family=Playfair+Display:ital,wght@0,400..900;1,400..900"
 				}
 			],
 			"fontSizes": [

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -281,7 +281,7 @@
 				"citation": {
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--tiny)",
-						"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+						"fontFamily": "inherit",
 						"fontStyle": "italic"
 					},
 					"spacing": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -48,7 +48,6 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"lineHeight": 1.6
 				}
 			},
@@ -114,12 +113,8 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"fontsToLoadFromGoogle": [
-				"family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
-			],
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "700"
 				}
 			},
@@ -191,9 +186,15 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"letterSpacing": "0.1em"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)"
 				}
 			},
 			"core/site-title": {
@@ -208,6 +209,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "min(max(48px, 7vw), 72px)",
 					"fontWeight": "700",
 					"lineHeight": 1.2
@@ -215,6 +217,7 @@
 			},
 			"h2": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "min(max(36px, 5vw), 64px)",
 					"fontWeight": "900",
 					"lineHeight": 1.2
@@ -222,6 +225,7 @@
 			},
 			"h3": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "min(max(30px, 5vw), 48px)",
 					"fontWeight": "900",
 					"lineHeight": 1.3
@@ -229,6 +233,7 @@
 			},
 			"h4": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
@@ -238,6 +243,7 @@
 			},
 			"h5": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
@@ -247,6 +253,7 @@
 			},
 			"h6": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--preset--font-size--tiny)",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
@@ -256,6 +263,7 @@
 			}
 		},
 		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 			"fontWeight": "400"
 		}
 	}

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -141,7 +141,8 @@
 				{
 					"fontFamily": "\"Red Hat Display\", sans-serif",
 					"slug": "red-hat-display",
-					"name": "Red Hat Display"
+					"name": "Red Hat Display",
+					"google": "family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
 				}
 			],
 			"fontSizes": [

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -83,7 +83,6 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--body--typography--font-family)",
 					"fontSize": "16px",
 					"fontWeight": "700",
 					"lineHeight": 2
@@ -172,13 +171,11 @@
 			},
 			"body": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"lineHeight": 1.6
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "700",
 					"lineHeight": 1.125
 				}
@@ -209,7 +206,6 @@
 				"dropcap": {
 					"margin": ".1em .1em 0 0",
 					"typography": {
-						"fontFamily": "var(--wp--custom--body--typography--font-family)",
 						"fontSize": "110px",
 						"fontWeight": "400"
 					}
@@ -279,9 +275,6 @@
 					"margin": "var(--wp--custom--margin--vertical) auto"
 				}
 			},
-			"fontsToLoadFromGoogle": [
-				"family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
-			],
 			"line-height": {
 				"body": 1.6
 			}
@@ -355,7 +348,7 @@
 					"text": "var(--wp--custom--button--color--text)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--custom--button--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--button--typography--line-height)",
@@ -385,7 +378,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
@@ -459,7 +452,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "700",
 					"lineHeight": 1.2,
 					"fontSize": "min(max(48px, 7vw), 72px)"
@@ -467,7 +460,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": 1.2,
 					"fontSize": "min(max(36px, 5vw), 64px)"
@@ -475,7 +468,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": 1.3,
 					"fontSize": "min(max(30px, 5vw), 48px)"
@@ -483,7 +476,7 @@
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": 1.3,
 					"fontSize": "var(--wp--preset--font-size--small)",
@@ -493,7 +486,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": 1.3,
 					"fontSize": "var(--wp--preset--font-size--small)",
@@ -503,7 +496,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--custom--heading--typography--font-family)",
+					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": 1.3,
 					"fontSize": "var(--wp--preset--font-size--tiny)",
@@ -519,7 +512,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--custom--body--typography--font-family)",
+			"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
 		}

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -300,7 +300,8 @@
 				{
 					"fontFamily": "\"Red Hat Display\", sans-serif",
 					"slug": "red-hat-display",
-					"name": "Red Hat Display"
+					"name": "Red Hat Display",
+					"google": "family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This changes our approach to font customization in Blockbase to remove our reliance on CSS variables, and instead declare the fonts directly on the elements/blocks in Global Styles.

This has meant reworking the changes we make the the theme user json CPT when we save the customizer changes, as well as the preview. We also load fonts from Google directly using the declaration in the typography section which is a nice simplification.

This should allow us to work around the issues described in pNEWy-e9M-p2, but that needs testing in tandem with https://github.com/WordPress/gutenberg/pull/33919#issuecomment-896229913.

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/55030