### PR TITLE
Skatepark: full width image pattern

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -177,22 +177,30 @@
 	--wp--custom--button--spacing--padding--bottom: 0.5em;
 }
 
-.is-style-skatepark-aside-caption figcaption {
+.is-style-skatepark-aside-caption {
+	align-items: center;
 	display: flex;
-	justify-content: flex-end;
-	margin: 20px auto 0;
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-	max-width: calc( var(--wp--custom--layout--wide-size) + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
+	flex-direction: column;
 }
 
-.is-style-skatepark-aside-caption figcaption strong {
+.is-style-skatepark-aside-caption img {
+	justify-self: center;
+}
+
+.is-style-skatepark-aside-caption figcaption {
+	align-self: flex-end;
+	border-top: 3px solid var(--wp--preset--color--primary);
+	font-size: var(--wp--preset--font-size--small);
+	margin-bottom: 0;
+	margin-top: 20px;
 	padding-top: 20px;
 	max-width: 455px;
 	text-align: left;
-	border-top: 3px solid var(--wp--preset--color--primary);
-	font-size: var(--wp--preset--font-size--small);
-	font-weight: normal;
+}
+
+.is-style-skatepark-aside-caption.alignfull figcaption {
+	margin-left: var(--wp--custom--post-content--padding--left);
+	margin-right: var(--wp--custom--post-content--padding--right);
 }
 
 h1.is-style-skatepark-heading-border, h2.is-style-skatepark-heading-border, h3.is-style-skatepark-heading-border, h4.is-style-skatepark-heading-border, h5.is-style-skatepark-heading-border, h6.is-style-skatepark-heading-border {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -200,7 +200,7 @@
 
 .is-style-skatepark-aside-caption.alignfull figcaption {
 	margin-left: var(--wp--custom--post-content--padding--left);
-	margin-right: var(--wp--custom--post-content--padding--right);
+	margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
 }
 
 h1.is-style-skatepark-heading-border, h2.is-style-skatepark-heading-border, h3.is-style-skatepark-heading-border, h4.is-style-skatepark-heading-border, h5.is-style-skatepark-heading-border, h6.is-style-skatepark-heading-border {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -177,6 +177,24 @@
 	--wp--custom--button--spacing--padding--bottom: 0.5em;
 }
 
+.is-style-skatepark-aside-caption figcaption {
+	display: flex;
+	justify-content: flex-end;
+	margin: 20px auto 0;
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+	max-width: calc( var(--wp--custom--layout--wide-size) + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
+}
+
+.is-style-skatepark-aside-caption figcaption strong {
+	padding-top: 20px;
+	max-width: 455px;
+	text-align: left;
+	border-top: 3px solid var(--wp--preset--color--primary);
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: normal;
+}
+
 h1.is-style-skatepark-heading-border, h2.is-style-skatepark-heading-border, h3.is-style-skatepark-heading-border, h4.is-style-skatepark-heading-border, h5.is-style-skatepark-heading-border, h6.is-style-skatepark-heading-border {
 	display: inline-block;
 	border-top: 2px solid var(--wp--custom--color--primary);

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -151,7 +151,8 @@
 				}
 			},
 			"layout": {
-				"contentSize": "684px"
+				"contentSize": "684px",
+				"wideSize": "1194px"
 			},
 			"line-height": {
 				"body": 1.6

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -231,6 +231,11 @@
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)"
 				}
 			},
+			"core/separator": {
+				"border": {
+					"width": "0 0 3px 0"
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -51,3 +51,8 @@ require get_stylesheet_directory() . '/inc/block-styles.php';
  * Block Patterns.
  */
 require get_stylesheet_directory() . '/inc/block-patterns.php';
+
+/**
+ * Block Styles.
+ */
+require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/skatepark/inc/block-patterns.php
+++ b/skatepark/inc/block-patterns.php
@@ -19,7 +19,8 @@ if ( ! function_exists( 'skatepark_register_block_patterns' ) ) :
 		if ( function_exists( 'register_block_pattern' ) ) {
 			$block_patterns = array(
 				'pre-footer',
-				'text-list-with-button'
+				'text-list-with-button',
+				'full-width-image-with-aside-caption',
 			);
 
 			foreach ( $block_patterns as $block_pattern ) {

--- a/skatepark/inc/block-styles.php
+++ b/skatepark/inc/block-styles.php
@@ -23,6 +23,15 @@ if ( ! function_exists( 'skatepark_register_block_styles' ) ) :
 					'style_handle' => 'skatepark-heading-border',
 				)
 			);
+
+			register_block_style(
+				'core/image',
+				array(
+					'name'         => 'skatepark-aside-caption',
+					'label'        => __( 'Aside caption', 'skatepark' ),
+					'style_handle' => 'skatepark-aside-caption',
+				)
+			);
 		}
 	}
 endif;

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -9,6 +9,6 @@ return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
 	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
-	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption><strong>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</strong></figcaption></figure>
+	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</figcaption></figure>
 	<!-- /wp:image -->',
 );

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -9,6 +9,6 @@ return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
 	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
-	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</figcaption></figure>
+	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt="' . esc_attr__( "A skateboarder does a grab trick in a bowl-shaped skate park. In the background is a watching crowd, palm trees, and the ocean.", 'skatepark' ) . '"/><figcaption>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</figcaption></figure>
 	<!-- /wp:image -->',
 );

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -8,5 +8,23 @@
 return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
-	'content'    => '',
+	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}}} -->
+	<figure class="wp-block-image alignfull size-large" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/></figure>
+	<!-- /wp:image -->
+	
+	<!-- wp:columns {"align":"wide","className":"aside-caption"} -->
+	<div class="wp-block-columns alignwide aside-caption"><!-- wp:column -->
+	<div class="wp-block-column"></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column {"width":"455px"} -->
+	<div class="wp-block-column" style="flex-basis:455px"><!-- wp:separator {"className":"is-style-wide"} -->
+	<hr class="wp-block-separator is-style-wide"/>
+	<!-- /wp:separator -->
+	
+	<!-- wp:paragraph {"fontSize":"small"} -->
+	<p class="has-small-font-size">Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns -->',
 );

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -9,6 +9,6 @@ return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
 	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
-	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption><strong>Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.</strong></figcaption></figure>
+	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption><strong>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</strong></figcaption></figure>
 	<!-- /wp:image -->',
 );

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -8,23 +8,7 @@
 return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
-	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}}} -->
-	<figure class="wp-block-image alignfull size-large" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/></figure>
-	<!-- /wp:image -->
-	
-	<!-- wp:columns {"align":"wide","className":"aside-caption"} -->
-	<div class="wp-block-columns alignwide aside-caption"><!-- wp:column -->
-	<div class="wp-block-column"></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column {"width":"455px"} -->
-	<div class="wp-block-column" style="flex-basis:455px"><!-- wp:separator {"className":"is-style-wide"} -->
-	<hr class="wp-block-separator is-style-wide"/>
-	<!-- /wp:separator -->
-	
-	<!-- wp:paragraph {"fontSize":"small"} -->
-	<p class="has-small-font-size">Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns -->',
+	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
+	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt=""/><figcaption><strong>Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.</strong></figcaption></figure>
+	<!-- /wp:image -->',
 );

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Full width image with aside caption.
+ *
+ * @package Skatepark
+ */
+
+return array(
+	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
+	'categories' => array( 'skatepark' ),
+	'content'    => '',
+);

--- a/skatepark/sass/block-patterns/_image-caption.scss
+++ b/skatepark/sass/block-patterns/_image-caption.scss
@@ -1,3 +1,0 @@
-.aside-caption {
-	
-}

--- a/skatepark/sass/block-patterns/_image-caption.scss
+++ b/skatepark/sass/block-patterns/_image-caption.scss
@@ -1,0 +1,3 @@
+.aside-caption {
+	
+}

--- a/skatepark/sass/block-styles/_image-caption.scss
+++ b/skatepark/sass/block-styles/_image-caption.scss
@@ -1,18 +1,25 @@
 .is-style-skatepark-aside-caption {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+
+	img {
+		justify-self: center;
+	}
+
 	figcaption {
-		display: flex;
-		justify-content: flex-end;
-		margin: 20px auto 0;
-		padding-left: var(--wp--custom--post-content--padding--left);
-		padding-right: var(--wp--custom--post-content--padding--right);
-		max-width: calc( var(--wp--custom--layout--wide-size) + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
-		strong {
-			padding-top: 20px;
-			max-width: 455px;
-			text-align: left;
-			border-top: 3px solid var(--wp--preset--color--primary);
-			font-size: var(--wp--preset--font-size--small);
-			font-weight: normal;
-		}
+		align-self: flex-end;
+		border-top: 3px solid var(--wp--preset--color--primary);
+		font-size: var(--wp--preset--font-size--small);
+		margin-bottom: 0;
+		margin-top: 20px;
+		padding-top: 20px;
+		max-width: 455px;
+		text-align: left;
+	}
+
+	&.alignfull figcaption {
+		margin-left: var(--wp--custom--post-content--padding--left);
+		margin-right: var(--wp--custom--post-content--padding--right);
 	}
 }

--- a/skatepark/sass/block-styles/_image-caption.scss
+++ b/skatepark/sass/block-styles/_image-caption.scss
@@ -20,6 +20,6 @@
 
 	&.alignfull figcaption {
 		margin-left: var(--wp--custom--post-content--padding--left);
-		margin-right: var(--wp--custom--post-content--padding--right);
+		margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ) );
 	}
 }

--- a/skatepark/sass/block-styles/_image-caption.scss
+++ b/skatepark/sass/block-styles/_image-caption.scss
@@ -1,0 +1,18 @@
+.is-style-skatepark-aside-caption {
+	figcaption {
+		display: flex;
+		justify-content: flex-end;
+		margin: 20px auto 0;
+		padding-left: var(--wp--custom--post-content--padding--left);
+		padding-right: var(--wp--custom--post-content--padding--right);
+		max-width: calc( var(--wp--custom--layout--wide-size) + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right));
+		strong {
+			padding-top: 20px;
+			max-width: 455px;
+			text-align: left;
+			border-top: 3px solid var(--wp--preset--color--primary);
+			font-size: var(--wp--preset--font-size--small);
+			font-weight: normal;
+		}
+	}
+}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -3,6 +3,7 @@
 @import "base/text";
 @import "blocks/buttons";
 @import "blocks/search";
+@import "block-patterns/image-caption";
 @import "block-patterns/pre-footer";
 @import "elements/headings";
 @import "elements/links";

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -3,8 +3,8 @@
 @import "base/text";
 @import "blocks/buttons";
 @import "blocks/search";
-@import "block-patterns/image-caption";
 @import "block-patterns/pre-footer";
+@import "block-styles/image-caption";
 @import "elements/headings";
 @import "elements/links";
 @import "templates/header";

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -471,7 +471,7 @@
 				"border": {
 					"color": "currentColor",
 					"style": "solid",
-					"width": "0 0 1px 0"
+					"width": "0 0 3px 0"
 				}
 			},
 			"core/site-title": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -238,7 +238,8 @@
 				}
 			},
 			"layout": {
-				"contentSize": "684px"
+				"contentSize": "684px",
+				"wideSize": "1194px"
 			},
 			"list": {
 				"spacing": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR creates a block pattern and a block style for a full-width image with an aside caption. Positioning the caption correctly was incredibly convoluted and brittle without an extra wrapper on the text inside the caption so I wrapped the text in a `strong` tag to make it simpler. I'm not sure how much I hate it. Any ideas to improve this are welcome.

Desktop | Mobile
--- | ---
![Screenshot 2021-08-12 at 10-53-19 aaaa – free](https://user-images.githubusercontent.com/3593343/129168752-1238f884-9115-40ba-b0e1-d1ceef9e1ed8.png) | ![Screenshot 2021-08-12 at 10-53-04 aaaa – free](https://user-images.githubusercontent.com/3593343/129168771-486edfd3-13f9-419b-bf0a-af2e40f90bcb.png)

(the wide group block on the screenshot is not part of the pattern, it's there for reference)

#### Related issue(s):

Part of #4308
