### PR TITLE
added % units to blockbase and rebuilt children

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -291,6 +291,7 @@
 		"spacing": {
 			"customPadding": true,
 			"units": [
+				"%",
 				"px",
 				"em",
 				"rem",

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -90,10 +90,6 @@
 			"contentSize": "782px",
 			"wideSize": "1000px"
 		},
-		"spacing": {
-			"customPadding": true,
-			"units": [ "px", "em", "rem", "vh", "vw" ]
-		},
 		"typography": {
 			"customFontSize": true,
 			"customLineHeight": true,

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -303,6 +303,7 @@
 		"spacing": {
 			"customPadding": true,
 			"units": [
+				"%",
 				"px",
 				"em",
 				"rem",

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -209,16 +209,6 @@
 			"contentSize": "664px",
 			"wideSize": "1128px"
 		},
-		"spacing": {
-			"customPadding": true,
-			"units": [
-				"px",
-				"em",
-				"rem",
-				"vh",
-				"vw"
-			]
-		},
 		"typography": {
 			"customFontSize": true,
 			"customLineHeight": true,

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -341,6 +341,7 @@
 		"spacing": {
 			"customPadding": true,
 			"units": [
+				"%",
 				"px",
 				"em",
 				"rem",

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -332,6 +332,7 @@
 		"spacing": {
 			"customPadding": true,
 			"units": [
+				"%",
 				"px",
 				"em",
 				"rem",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -336,6 +336,7 @@
 		"spacing": {
 			"customPadding": true,
 			"units": [
+				"%",
 				"px",
 				"em",
 				"rem",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Blockbase didn't support % units, this PR adds it to the theme and its children. To test it, create a column block and change the width of the children using % units. 

#### Related issue(s):

Closes #4398
