### PR TITLE
Blockbase: Fix 404 template

### DIFF
--- a/blockbase/404.php
+++ b/blockbase/404.php
@@ -5,20 +5,14 @@
  * @package Blockbase
  * @since 1.1.1
  */
-wp_head();
-
-echo gutenberg_block_template_part( 'header' );
+get_header();
 ?>
+	<main class="container-404">
+		<h1 class="has-text-align-center has-large-font-size"><?php _e( 'Oops! That page can&rsquo;t be found.', 'blockbase' ); ?></h1>
 
-<main class="container-404">
-	<h1 class="has-text-align-center has-large-font-size"><?php _e( 'Oops! That page can&rsquo;t be found.', 'blockbase' ); ?></h1>
+		<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'blockbase' ); ?></p>
 
-	<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'blockbase' ); ?></p>
-
-	<?php echo do_blocks('<!-- wp:search {"label":""} /-->'); ?>
-</main>
-
+		<?php echo do_blocks('<!-- wp:search {"label":""} /-->'); ?>
+	</main>
 <?php
-echo gutenberg_block_template_part( 'footer' );
-
-wp_footer();
+get_footer();

--- a/blockbase/footer.php
+++ b/blockbase/footer.php
@@ -1,9 +1,9 @@
-<div class="wp-block-template-part site-footer-container">
+<footer class="wp-block-template-part site-footer-container">
 		<?php
 			echo gutenberg_block_template_part( 'footer' );
 		?>
 	</div>
-</div>
+</footer>
 
 <?php wp_footer(); ?>
 

--- a/blockbase/footer.php
+++ b/blockbase/footer.php
@@ -1,0 +1,11 @@
+<div class="wp-block-template-part site-footer-container">
+		<?php
+			echo gutenberg_block_template_part( 'footer' );
+		?>
+	</div>
+</div>
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/blockbase/header.php
+++ b/blockbase/header.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="profile" href="https://gmpg.org/xfn/11" />
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+
+	<div class="wp-site-blocks">
+		<header class="wp-block-template-part">
+			<?php
+				echo gutenberg_block_template_part( 'header' );
+			?>
+		</header>

--- a/skatepark/404.php
+++ b/skatepark/404.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * The template for displaying 404 pages (not found)
+ *
+ * @package Skatepark
+ * @since 1.1.1
+ */
+get_header();
+?>
+	<main class="container-404">
+		<h2 class="wp-block-post-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'blockbase' ); ?></h1>
+
+		<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'blockbase' ); ?></p>
+
+		<?php echo do_blocks('<!-- wp:search {"label":""} /-->'); ?>
+	</main>
+<?php
+get_footer();

--- a/skatepark/404.php
+++ b/skatepark/404.php
@@ -8,9 +8,9 @@
 get_header();
 ?>
 	<main class="container-404">
-		<h2 class="wp-block-post-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'blockbase' ); ?></h1>
+		<h2 class="wp-block-post-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'skatepark' ); ?></h1>
 
-		<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'blockbase' ); ?></p>
+		<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'skatepark' ); ?></p>
 
 		<?php echo do_blocks('<!-- wp:search {"label":""} /-->'); ?>
 	</main>


### PR DESCRIPTION
The blockbase 404 was missing some of the classes that are needed to do things like force the footer to the bottom of the page. It was also missing html and body tags. This adds that stuff to header and footer templates so it works like a classic theme for the 404 template. This will also address some of the concerns in https://github.com/Automattic/themes/issues/4323.

Also adding a 404 template for Skatepark so that the title matches the post title.

Fixes #4323