### PR TITLE
Skatepark: index template

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -206,6 +206,15 @@
 	text-decoration: none;
 }
 
+.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
+	text-decoration-thickness: 0.07em;
+	text-underline-offset: 0.46ex;
+}
+
+.wp-block-query-pagination .wp-block-query-pagination-numbers .page-numbers {
+	padding: 10px;
+}
+
 .wp-block-search .wp-block-search__button:active, .wp-block-search .wp-block-search__button:focus {
 	outline-offset: -0.25em;
 }
@@ -303,6 +312,10 @@
 
 .is-style-indented-paragraph {
 	text-indent: 10em;
+}
+
+.is-style-indented-post-excerpt p {
+	text-indent: 5em;
 }
 
 .pre-footer h3 {
@@ -427,6 +440,27 @@ header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-
 .blog .wp-block-query-title,
 .home .wp-block-query-title {
 	margin-bottom: 0;
+}
+
+.archive .wp-block-post-title,
+.blog .wp-block-post-title,
+.home .wp-block-post-title {
+	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
+}
+
+.archive .wp-block-post-excerpt__excerpt,
+.blog .wp-block-post-excerpt__excerpt,
+.home .wp-block-post-excerpt__excerpt {
+	margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
+}
+
+.archive .wp-block-post-date,
+.blog .wp-block-post-date,
+.home .wp-block-post-date {
+	text-decoration: underline;
+	text-decoration-thickness: 0.07em;
+	text-underline-offset: 0.46ex;
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -257,6 +257,24 @@
 	left: calc( -1 * var(--wp--custom--button--border--width));
 }
 
+.wp-block-separator.is-style-wide {
+	border-bottom: 3px solid #000;
+}
+
+.pre-footer h3 {
+	text-transform: uppercase;
+}
+
+.pre-footer .wp-block-social-links.is-style-logos-only {
+	margin-left: calc( -1 * ( 8px + 0.25em ));
+}
+
+.pre-footer .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
+	--wp--custom--button--typography--font-size: 14px;
+	--wp--custom--button--spacing--padding--top: 0.5em;
+	--wp--custom--button--spacing--padding--bottom: 0.5em;
+}
+
 .is-style-skatepark-aside-caption {
 	align-items: center;
 	display: flex;
@@ -403,6 +421,12 @@ header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-
 		width: 100%;
 		border-bottom: 2px solid var(--wp--custom--color--primary);
 	}
+}
+
+.archive .wp-block-query-title,
+.blog .wp-block-query-title,
+.home .wp-block-query-title {
+	margin-bottom: 0;
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -1,32 +1,35 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"tagName":"main","queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-		<!-- wp:post-title {"isLink":true} /-->
-		<!-- wp:post-featured-image {"isLink":true} /-->
-		<!-- wp:post-excerpt /-->
-		<!-- wp:spacer {"height":40} -->
-		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-	</div>
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"2.5em"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-top:2.5em">
+	<!-- wp:query-title {"type":"archive","align":"wide"} /-->
+	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
+	<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:separator {"className":"is-style-wide"} -->
+	<hr class="wp-block-separator is-style-wide"/>
+	<!-- /wp:separator -->
+	
+	<!-- wp:post-featured-image /-->
+	
+	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
+	
+	<!-- wp:post-excerpt /-->
+	
+	<!-- wp:post-date /--></div>
 	<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:group {"layout":{"inherit":true}} -->
-		<div class="wp-block-group">
-		<!-- wp:query-pagination -->
-		<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
 	
-			<!-- wp:query-pagination-numbers /-->
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
 	
-			<!-- wp:query-pagination-next /--></div>
-		<!-- /wp:query-pagination -->
-		</div>
-		<!-- /wp:group -->
-	</main>
+	<!-- wp:query-pagination-numbers /-->
+	
+	<!-- wp:query-pagination-next /--></div>
+	<!-- /wp:query-pagination --></div>
 	<!-- /wp:query -->
-	
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->
-	
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -1,10 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"2.5em"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="padding-top:2.5em">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"2.5em","bottom":"2.5em"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-top:2.5em;padding-bottom:2.5em">
 	<!-- wp:query-title {"type":"archive","align":"wide"} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
-<div class="wp-block-query alignwide"><!-- wp:post-template -->
+	<div class="wp-block-query alignwide"><!-- wp:post-template -->
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 	<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator is-style-wide"/>
@@ -14,9 +14,9 @@
 	
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 	
-	<!-- wp:post-excerpt /-->
+	<!-- wp:post-excerpt {"className":"is-style-indented-post-excerpt"} /-->
 	
-	<!-- wp:post-date /--></div>
+	<!-- wp:post-date {"style":{"typography":{"fontWeight":"500"}},"fontSize":"tiny"} /--></div>
 	<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -201,6 +201,9 @@
 				"baseline": "15px",
 				"horizontal": "30px",
 				"vertical": "45px"
+			},
+			"separator": {
+				"margin": "calc( 0.5 * var(--wp--custom--margin--vertical) ) auto"
 			}
 		},
 		"layout": {

--- a/skatepark/inc/block-styles.php
+++ b/skatepark/inc/block-styles.php
@@ -41,6 +41,15 @@ if ( ! function_exists( 'skatepark_register_block_styles' ) ) :
 					'style_handle' => 'indented-paragraph',
 				)
 			);
+	
+			register_block_style(
+				'core/post-excerpt',
+				array(
+					'name'         => 'indented-post-excerpt',
+					'label'        => __( 'Indented post excerpt', 'skatepark' ),
+					'style_handle' => 'indented-post-excerpt',
+				)
+			);
 		}
 	}
 endif;

--- a/skatepark/sass/base/_mixins.scss
+++ b/skatepark/sass/base/_mixins.scss
@@ -1,0 +1,4 @@
+@mixin text-decoration() {
+	text-decoration-thickness: 0.07em;
+	text-underline-offset: 0.46ex;
+}

--- a/skatepark/sass/block-styles/_indented-paragraph.scss
+++ b/skatepark/sass/block-styles/_indented-paragraph.scss
@@ -1,3 +1,6 @@
 .is-style-indented-paragraph {
 	text-indent: 10em;
 }
+.is-style-indented-post-excerpt p {
+	text-indent: 5em;
+}

--- a/skatepark/sass/blocks/_query.scss
+++ b/skatepark/sass/blocks/_query.scss
@@ -1,0 +1,10 @@
+.wp-block-query-pagination{
+	.wp-block-query-pagination-numbers {
+		.current {
+			@include text-decoration;
+		}
+		.page-numbers {
+			padding: 10px;
+		}
+	}
+}

--- a/skatepark/sass/blocks/_separator.scss
+++ b/skatepark/sass/blocks/_separator.scss
@@ -1,0 +1,7 @@
+
+.wp-block-separator {
+	&.is-style-wide {
+		border-bottom: 3px solid #000;
+	}
+
+}

--- a/skatepark/sass/blocks/_separator.scss
+++ b/skatepark/sass/blocks/_separator.scss
@@ -3,5 +3,4 @@
 	&.is-style-wide {
 		border-bottom: 3px solid #000;
 	}
-
 }

--- a/skatepark/sass/elements/_links.scss
+++ b/skatepark/sass/elements/_links.scss
@@ -1,6 +1,5 @@
 a {
-	text-decoration-thickness: 0.07em;
-	text-underline-offset: 0.46ex;
+	@include text-decoration;
 }
 
 .wp-block-post-content p a {

--- a/skatepark/sass/templates/_index.scss
+++ b/skatepark/sass/templates/_index.scss
@@ -4,4 +4,15 @@
 	.wp-block-query-title {
 		margin-bottom: 0;
 	}
+	.wp-block-post-title{
+		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
+	}
+	.wp-block-post-excerpt__excerpt {
+		margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) );
+		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
+	}
+	.wp-block-post-date {
+		text-decoration: underline;
+		@include text-decoration;
+	}
 }

--- a/skatepark/sass/templates/_index.scss
+++ b/skatepark/sass/templates/_index.scss
@@ -1,0 +1,7 @@
+.archive,
+.blog,
+.home {
+	.wp-block-query-title {
+		margin-bottom: 0;
+	}
+}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -1,8 +1,10 @@
 @import "../../blockbase/sass/base/breakpoints"; // Get the mobile-only media query and make it available to this theme's styles
 @import "../../blockbase/sass/base/mixins";
 @import "base/text";
+@import "base/mixins";
 @import "blocks/buttons";
 @import "blocks/post-comments";
+@import "blocks/query";
 @import "blocks/search";
 @import "blocks/separator";
 @import "block-patterns/pre-footer";

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -4,9 +4,12 @@
 @import "blocks/buttons";
 @import "blocks/post-comments";
 @import "blocks/search";
+@import "blocks/separator";
+@import "block-patterns/pre-footer";
 @import "block-styles/image-caption";
 @import "block-styles/indented-paragraph";
 @import "block-patterns/pre-footer";
 @import "elements/headings";
 @import "elements/links";
 @import "templates/header";
+@import "templates/index";

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -343,7 +343,7 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--margin--vertical) auto",
+				"margin": "calc( 0.5 * var(--wp--custom--margin--vertical) ) auto",
 				"width": "150px"
 			},
 			"table": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR aligns the index.html template with the design. I'm making use of https://github.com/WordPress/gutenberg/pull/34070 to get the post date block to have a custom font-weight.

Home page:

![Screenshot 2021-08-13 at 15-04-01 free – Just another WordPress site](https://user-images.githubusercontent.com/3593343/129361233-b950164c-1655-423f-9011-fe099fb6c0f8.png)

Archive page:

![Screenshot 2021-08-13 at 15-03-27 Gutenberg – free](https://user-images.githubusercontent.com/3593343/129361241-60898314-bc96-44fb-8ed3-3d0d8457e2b9.png)

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4306