### PR TITLE
Skatepark: Add default duotone configuration to theme.json

### DIFF
--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -313,12 +313,13 @@
 			},
 			"core/image": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--red-filter)"
+					"duotone": "url(#wp-duotone-red-filter)"
+
 				}
 			},
 			"core/cover": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--blue-filter)"
+					"duotone": "url(#wp-duotone-blue-filter)"
 				}
 			}
 		},

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -270,6 +270,11 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/post-author": {
+				"color": {
+					"duotone": "url(#wp-duotone-red-filter)"
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -313,7 +313,12 @@
 			},
 			"core/image": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
+					"duotone": "var(--wp--preset--duotone--red-filter)"
+				}
+			},
+			"core/cover": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone--blue-filter)"
 				}
 			}
 		},

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -316,15 +316,24 @@
 					"letterSpacing": "0.05em"
 				}
 			},
-			"core/image": {
-				"color": {
-					"duotone": "url(#wp-duotone-red-filter)"
-
-				}
-			},
 			"core/cover": {
 				"color": {
-					"duotone": "url(#wp-duotone-blue-filter)"
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
+				}
+			},
+			"core/image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
+				}
+			},
+			"core/post-author": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone-filter--default-filter)"
+				}
+			},
+			"core/post-featured-image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
 				}
 			}
 		},

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -310,6 +310,11 @@
 				"typography": {
 					"letterSpacing": "0.05em"
 				}
+			},
+			"core/image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
 			}
 		},
 		"elements": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -539,7 +539,7 @@
 			},
 			"core/post-author": {
 				"color": {
-					"duotone": "url(#wp-duotone-red-filter)"
+					"duotone": "var(--wp--preset--duotone-filter--default-filter)"
 				}
 			},
 			"core/post-terms": {
@@ -552,14 +552,19 @@
 					"fontWeight": "500"
 				}
 			},
-			"core/image": {
-				"color": {
-					"duotone": "url(#wp-duotone-red-filter)"
-				}
-			},
 			"core/cover": {
 				"color": {
-					"duotone": "url(#wp-duotone-blue-filter)"
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
+				}
+			},
+			"core/image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
+				}
+			},
+			"core/post-featured-image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone-filter--blue-filter)"
 				}
 			}
 		},

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -549,7 +549,12 @@
 			},
 			"core/image": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
+					"duotone": "var(--wp--preset--duotone--red-filter)"
+				}
+			},
+			"core/cover": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone--blue-filter)"
 				}
 			}
 		},

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -549,12 +549,12 @@
 			},
 			"core/image": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--red-filter)"
+					"duotone": "url(#wp-duotone-red-filter)"
 				}
 			},
 			"core/cover": {
 				"color": {
-					"duotone": "var(--wp--preset--duotone--blue-filter)"
+					"duotone": "url(#wp-duotone-blue-filter)"
 				}
 			}
 		},

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -537,6 +537,11 @@
 					"fontStyle": "normal"
 				}
 			},
+			"core/post-author": {
+				"color": {
+					"duotone": "url(#wp-duotone-red-filter)"
+				}
+			},
 			"core/post-terms": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -546,6 +546,11 @@
 				"typography": {
 					"fontWeight": "500"
 				}
+			},
+			"core/image": {
+				"color": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
 			}
 		},
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a default duotone filter to all image blocks.

Needs https://github.com/WordPress/gutenberg/pull/34073/files

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/4329