### PR TITLE
Skatepark: Add search template

### DIFF
--- a/skatepark/404.php
+++ b/skatepark/404.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 	<main class="container-404">
-		<h2 class="wp-block-post-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'skatepark' ); ?></h1>
+		<h2 class="wp-block-post-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'skatepark' ); ?></h2>
 
 		<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'skatepark' ); ?></p>
 

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -215,10 +215,6 @@
 	padding: 10px;
 }
 
-.search-results .wp-block-query-loop li:not(:last-child) {
-	border-bottom: var(--wp--custom--button--border--width) var(--wp--custom--button--border--style) var(--wp--custom--button--border--color);
-}
-
 .wp-block-search .wp-block-search__button:active, .wp-block-search .wp-block-search__button:focus {
 	outline-offset: -0.25em;
 }

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -215,6 +215,10 @@
 	padding: 10px;
 }
 
+.search-results .wp-block-query-loop li:not(:last-child) {
+	border-bottom: var(--wp--custom--button--border--width) var(--wp--custom--button--border--style) var(--wp--custom--button--border--color);
+}
+
 .wp-block-search .wp-block-search__button:active, .wp-block-search .wp-block-search__button:focus {
 	outline-offset: -0.25em;
 }

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -1,0 +1,20 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
+<main class="wp-block-group">
+
+	<!-- wp:search {"label":"","buttonText":"Search"} /-->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<!-- wp:query-loop -->
+
+		<!-- wp:post-title {"level":3,"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+
+	<!-- /wp:query-loop -->
+	<!-- /wp:query -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:search {"label":"","buttonText":"Search"} /-->
+	<!-- wp:search {"label":"""} /-->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:query-loop -->

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -14,6 +14,9 @@
 
 		<!-- wp:post-title {"level":3,"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
+		<!-- wp:separator {"className":"is-style-wide"} -->
+			<hr class="wp-block-separator is-style-wide"/>
+		<!-- /wp:separator -->
 
 	<!-- /wp:query-loop -->
 	<!-- /wp:query -->

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -10,7 +10,7 @@
 	<!-- /wp:spacer -->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
-	<!-- wp:query-loop -->
+	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":3,"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
@@ -18,7 +18,7 @@
 			<hr class="wp-block-separator is-style-wide"/>
 		<!-- /wp:separator -->
 
-	<!-- /wp:query-loop -->
+	<!-- /wp:post-template -->
 	<!-- /wp:query -->
 
 </main>

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -5,6 +5,10 @@
 
 	<!-- wp:search {"label":""} /-->
 
+	<!-- wp:spacer {"height":45} -->
+		<div style="height:45px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:query-loop -->
 

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:search {"label":"""} /-->
+	<!-- wp:search {"label":""} /-->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:query-loop -->

--- a/skatepark/sass/blocks/_query.scss
+++ b/skatepark/sass/blocks/_query.scss
@@ -8,3 +8,11 @@
 		}
 	}
 }
+
+.search-results {
+	.wp-block-query-loop {
+		li:not(:last-child) {
+			border-bottom: var(--wp--custom--button--border--width) var(--wp--custom--button--border--style) var(--wp--custom--button--border--color);
+		}
+	}
+}

--- a/skatepark/sass/blocks/_query.scss
+++ b/skatepark/sass/blocks/_query.scss
@@ -8,11 +8,3 @@
 		}
 	}
 }
-
-.search-results {
-	.wp-block-query-loop {
-		li:not(:last-child) {
-			border-bottom: var(--wp--custom--button--border--width) var(--wp--custom--button--border--style) var(--wp--custom--button--border--color);
-		}
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds a search block template for Skatepark.

Here's how it's looking so far:

![search](https://user-images.githubusercontent.com/1645628/129570663-5e86a83d-2a9a-49b4-b127-b2ba40b63ac2.png)

@melchoyce, I know you mentioned adding a page title in the original issue. If we add this to the block template, I think that currently means we can't translate the title text. But then I believe we can get around this by creating a PHP template instead. Should we go with a PHP template so we can have a page title?

I've also added the search block at the top and made the results titles all H3.

#### Related issue(s):
Closes #4322
