### PR TITLE
Skatepark: Update green color

### DIFF
--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -4,7 +4,7 @@
 			"gradients": [],
 			"duotone": [
                 {
-                    "colors": [ "#000", "#BFF5A5" ],
+                    "colors": [ "#000", "#B9FB9C" ],
                     "slug": "default-filter",
                     "name": "Default filter"
                 },
@@ -42,7 +42,7 @@
 				},
 				{
 					"slug": "background",
-					"color": "#BFF5A5",
+					"color": "#B9FB9C",
 					"name": "Background"
 				}
 			]

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -45,7 +45,7 @@
 				},
 				{
 					"slug": "background",
-					"color": "#BFF5A5",
+					"color": "#B9FB9C",
 					"name": "Background"
 				}
 			],
@@ -53,7 +53,7 @@
 				{
 					"colors": [
 						"#000",
-						"#BFF5A5"
+						"#B9FB9C"
 					],
 					"slug": "default-filter",
 					"name": "Default filter"


### PR DESCRIPTION
While comparing [screenshots in another issue](https://github.com/Automattic/themes/issues/4417), I noticed that the green in use right now isn't quite as bright and saturated as the green from the comps. This is because browser color profiles differ somewhat from the profile in Figma. 

This PR replaces that color with a different value that looks more similar to the original comps. 

Before|After
---|---
<img width="845" alt="Screen Shot 2021-08-16 at 3 00 25 PM" src="https://user-images.githubusercontent.com/1202812/129616124-b53069d4-3d9c-4c16-9634-51f8282d1e08.png">|<img width="802" alt="Screen Shot 2021-08-16 at 3 00 00 PM" src="https://user-images.githubusercontent.com/1202812/129616129-0d2daa39-42ea-411e-b1c8-d47ef25c3040.png">
