### PR TITLE
Blockbase: Refactor Button Color styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -254,16 +254,7 @@ input[type=checkbox] + label {
 	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
 	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
-	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-family: inherit;
-	font-size: var(--wp--custom--button--typography--font-size);
-	line-height: var(--wp--custom--button--typography--line-height);
 	text-decoration: none;
-	opacity: 1;
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
@@ -284,11 +275,6 @@ input[type=checkbox] + label {
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
 .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--text);
-}
-
-.wp-block-button.wp-block-button__link svg,
-.wp-block-button .wp-block-button__link svg {
 	fill: var(--wp--custom--button--color--text);
 }
 

--- a/blockbase/sass/blocks/_button.scss
+++ b/blockbase/sass/blocks/_button.scss
@@ -10,7 +10,8 @@
 	&.wp-block-button__link,
 	.wp-block-button__link {
 		@include button-hover-styles;
-		@include button-main-styles;
+		@include button-padding-styles;
+		text-decoration: none;
 	}
 	&.is-style-outline {
 		&.wp-block-button__link,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR is an attempt to solve one part of #4435 by lowering the CSS specificity of the button styles. It removes the hover styles for now while we discuss a way forward there.

We discussed a few ideas p1629312308145500/1629295598.131100-slack-C029FM1EH, I'm not sure this is the right approach but wanted to get a feel for the problem and spark a discussion in any case.

**To test**
- ~Check out https://github.com/WordPress/gutenberg/pull/34147~
- Activate blockbase
- Add a button somewhere to a template via the Site Editor
- Change the button's colors (text and background) and save
- Verify those customizations show up correctly in the editor and view
- Go to the post editor
- Add a button, verify you can still use the "Outline" block style variation

#### Related issue(s):

#4435