### PR TITLE
Skatepark applied duotone to index featured images

### DIFF
--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -10,7 +10,7 @@
 	<hr class="wp-block-separator is-style-wide"/>
 	<!-- /wp:separator -->
 	
-	<!-- wp:post-featured-image /-->
+	<!-- wp:post-featured-image {"style":{"color":{"duotone":["#000","#B9FB9C"]}}} /-->
 	
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 	


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I forgot about adding the duotone filter to the featured images on the index template:

<img width="1319" alt="Screenshot 2021-08-19 at 11 06 11" src="https://user-images.githubusercontent.com/3593343/130041646-636ae545-a325-4b13-a264-da764fa3313b.png">



