### PR TITLE
Seedlet Blocks: Fix block-level global styling for site title block

### DIFF
--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -291,7 +291,6 @@ is passed all of the block attributes on the block definition in the template. *
 
 .wp-block-site-title a:hover, .wp-block-site-title a:focus {
 	text-decoration: none;
-	color: var(--wp--custom--color--secondary);
 	background-size: 8px 0px;
 }
 

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -140,26 +140,21 @@
 /**
  * Links in navigation
  */
+.wp-block-navigation-link a {
+	text-underline-offset: 0.4rem;
+}
+
 .wp-block-navigation-link a :hover {
 	text-decoration: underline;
-	text-underline-offset: 0.4rem;
 }
 
 /**
  * Links in Content
  */
-.is-root-container a:not(.wp-block-button__link):not([download]),
-.wp-block-post-content a:not(.wp-block-button__link):not([download]) {
-	color: var(--wp--custom--color--primary);
-	text-decoration-color: var(--wp--style--color--link);
+.is-root-container a,
+.wp-block-post-content a {
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.2em;
-}
-
-.is-root-container a:not(.wp-block-button__link):not([download]):focus, .is-root-container a:not(.wp-block-button__link):not([download]):hover,
-.wp-block-post-content a:not(.wp-block-button__link):not([download]):focus,
-.wp-block-post-content a:not(.wp-block-button__link):not([download]):hover {
-	color: var(--wp--style--color--link);
 }
 
 .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link {
@@ -291,9 +286,7 @@ is passed all of the block attributes on the block definition in the template. *
 .wp-block-site-title a {
 	text-decoration: underline;
 	text-decoration-thickness: 2px;
-	text-decoration-color: var(--wp--custom--color--secondary);
 	text-underline-offset: 0.13em;
-	transition: background-size 0.1s ease-out;
 }
 
 .wp-block-site-title a:hover, .wp-block-site-title a:focus {

--- a/seedlet-blocks/sass/blocks/_links.scss
+++ b/seedlet-blocks/sass/blocks/_links.scss
@@ -3,9 +3,9 @@
  */
 .wp-block-navigation-link {
 	a {
+		text-underline-offset: 0.4rem;
 		:hover{
 			text-decoration: underline;
-			text-underline-offset: 0.4rem;
 		}
 	}
 } 
@@ -15,15 +15,8 @@
  */
 .is-root-container, // Editor class hack.
 .wp-block-post-content {
-	a:not(.wp-block-button__link):not([download]) {
-		color: var(--wp--custom--color--primary);
-		text-decoration-color: var(--wp--style--color--link);
+	a {
 		text-decoration-thickness: 1px;
 		text-underline-offset: 0.2em;
-
-		&:focus,
-		&:hover {
-			color: var(--wp--style--color--link);
-		}
 	}
 }

--- a/seedlet-blocks/sass/blocks/_site-title.scss
+++ b/seedlet-blocks/sass/blocks/_site-title.scss
@@ -8,7 +8,6 @@
 		&:hover,
 		&:focus {
 			text-decoration: none;
-			color: var(--wp--custom--color--secondary);
 			background-size: 8px 0px;
 		}
 

--- a/seedlet-blocks/sass/blocks/_site-title.scss
+++ b/seedlet-blocks/sass/blocks/_site-title.scss
@@ -3,9 +3,7 @@
 	a {
 		text-decoration: underline;
 		text-decoration-thickness: 2px;
-		text-decoration-color: var(--wp--custom--color--secondary);
 		text-underline-offset: 0.13em;
-		transition: background-size 0.1s ease-out;
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

## Changes proposed in this Pull Request:
Site title block level global styling **text color changes** are being overridden because of a specificity conflict. To elaborate:

- Block level global styles are being applied to the site title block through `.wp-block-site-title a`
- The Seedlet blocks theme has a competing declaration via `.is-root-container a:not(.wp-block-button__link):not([download])`

I'm curious how folks feel about this PR. To keep the surface area of changes small, I tried piggybacking on the `:not` pseudo-selector convention. Rather than tinkering with increasing or decreasing specificities, I include the site title block as another element _not_ to select for the seedlet blocks selector. In doing so, the user customized global style always wins out.

I didn't see any obvious visual regressions.

### Before
![2021-08-16 13 59 55](https://user-images.githubusercontent.com/5414230/129790849-f5b010c1-0e19-4305-8f43-88da3befa5f9.gif)

### After
![2021-08-20 03 11 51](https://user-images.githubusercontent.com/5414230/130218348-d1937964-8942-45ab-a2a0-4b2763c418c5.gif)

## Related issue(s):
https://github.com/Automattic/themes/issues/4447
