### PR TITLE
Blockbase: fixed alignments, take 999

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -61,9 +61,7 @@ img {
 	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
-.wp-block-group.alignfull *[class*="wp-container-"],
 .wp-block-group.alignfull > .alignfull,
-*[class*="wp-container-"] *[class*="wp-container-"],
 *[class*="wp-container-"] > .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
 	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -61,6 +61,12 @@ img {
 	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
+.wp-block-group.alignfull [class*="wp-container-"],
+*[class*="wp-container-"] [class*="wp-container-"] {
+	padding-left: unset;
+	padding-right: unset;
+}
+
 .wp-block-group.alignfull > .alignfull,
 *[class*="wp-container-"] > .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -55,23 +55,41 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
-.wp-block-group.alignfull,
-*[class*="wp-container-"] {
+/*.wp-block-group.alignfull,
+*[class*="wp-container-"] //Anything that inherits layout (container)
+{
+	//give it some padding
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+
+	//nested containers don't need the extra padding
+	[class*="wp-container-"] {
+		padding-left: unset;
+		padding-right: unset;
+	}
+
+	> .alignfull { // Any direct descendant that is alignfull
+		// bust out of the container's padding
+		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
+		margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
+		width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) ) !important;
+	}
+}*/
+.wp-site-blocks {
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);
 }
 
-.wp-block-group.alignfull [class*="wp-container-"],
-*[class*="wp-container-"] [class*="wp-container-"] {
-	padding-left: unset;
-	padding-right: unset;
-}
-
-.wp-block-group.alignfull > .alignfull,
-*[class*="wp-container-"] > .alignfull {
+.wp-site-blocks .alignfull {
+	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right)) !important;
 	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
 	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
-	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right)) !important;
+}
+
+.wp-site-blocks .alignfull .alignfull {
+	width: auto !important;
+	margin-left: auto !important;
+	margin-right: auto !important;
 }
 
 @media (min-width: 480px) {

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -5,6 +5,12 @@
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);
 
+	//nested containers don't need the extra padding
+	[class*="wp-container-"] {
+		padding-left: unset;
+		padding-right: unset;
+	}
+
 	> .alignfull { // Any direct descendant that is alignfull
 		// bust out of the container's padding
 		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,4 +1,4 @@
-.wp-block-group.alignfull,
+/*.wp-block-group.alignfull,
 *[class*="wp-container-"] //Anything that inherits layout (container)
 {
 	//give it some padding
@@ -16,6 +16,21 @@
 		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
 		margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
 		width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) ) !important;
+	}
+}*/
+
+.wp-site-blocks {
+	padding-left: var(--wp--custom--post-content--padding--left);
+	padding-right: var(--wp--custom--post-content--padding--right);
+	.alignfull {
+		width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) ) !important;
+		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
+		margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
+		.alignfull {
+			width: auto !important;
+			margin-left: auto !important;
+			margin-right: auto !important;
+		}
 	}
 }
 

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -5,8 +5,6 @@
 	padding-left: var(--wp--custom--post-content--padding--left);
 	padding-right: var(--wp--custom--post-content--padding--right);
 
-	//Any nested containers, and anything that is alignfull
-	*[class*="wp-container-"], // Any nested containers
 	> .alignfull { // Any direct descendant that is alignfull
 		// bust out of the container's padding
 		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I tried to understand why we were modifying margin+width for any nested containers but I couldn't see it clearly after reading the [original PR](https://github.com/Automattic/themes/pull/4123) that modifies it. I think I might be missing an edge case for this. I spent most of the time in this PR trying to find the ways this could break, I think having test content to cover most of the possible scenarios would help a lot.

This is the code that I used to test against, it is mostly based on the previous issues with have with alignments [here](https://github.com/Automattic/themes/issues/3747) and [here](https://github.com/Automattic/themes/issues/4099):

```
<!-- wp:paragraph -->
<p>This is a paragraph outside of a Group block. It should align on the left and right edges with the paragraph below.</p>
<!-- /wp:paragraph -->

<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
<div class="wp-block-group alignfull"><!-- wp:paragraph -->
<p>This is a paragraph inside of a Group block. It should align on the left and right edges with the paragraph above.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>This is a query block with full width featured images:</p>
<!-- /wp:paragraph -->

<!-- wp:query {"queryId":15,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"full"} -->
<div class="wp-block-query alignfull"><!-- wp:post-template -->
<!-- wp:group {"layout":{"inherit":true}} -->
<div class="wp-block-group"><!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-featured-image {"isLink":true,"align":"full"} /-->

<!-- wp:post-excerpt /-->

<!-- wp:post-date /--></div>
<!-- /wp:group -->
<!-- /wp:post-template --></div>
<!-- /wp:query -->

<!-- wp:cover {"overlayColor":"primary","align":"full"} -->
<div class="wp-block-cover alignfull has-primary-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Full width cover block, needs to touch the browser's borders</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:group {"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
<div class="wp-block-group has-background-color has-primary-background-color has-text-color has-background"><!-- wp:paragraph -->
<p>This is a group block with "inherit default layout" turned on.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Before | After 
--- | ---
![Screenshot 2021-08-20 at 15-47-41 Alignments the vengeance – free](https://user-images.githubusercontent.com/3593343/130243139-0e91f3b8-49c0-451e-9208-f0f860577388.png) | ![Screenshot 2021-08-20 at 15-42-48 Alignments the vengeance – free](https://user-images.githubusercontent.com/3593343/130243089-0858aa36-5f25-4ea7-aab3-7c5c95277bbb.png)

Note that in the Before screenshot you can see a gap to the right of the site that was causing a horizontal scroll. That is also fixed with this PR

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4426