### PR TITLE
Blockbase: Remove alignment styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -55,19 +55,11 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
-.wp-block-group.alignfull,
-*[class*="wp-container-"] {
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-}
-
-.wp-block-group.alignfull *[class*="wp-container-"],
-.wp-block-group.alignfull > .alignfull,
-*[class*="wp-container-"] *[class*="wp-container-"],
-*[class*="wp-container-"] > .alignfull {
-	margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
-	margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
-	width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right)) !important;
+[data-align="full"] > p,
+.alignfull > p {
+	margin-left: auto;
+	margin-right: auto;
+	width: calc( 100vw - var(--wp--custom--post-content--padding--left) - var(--wp--custom--post-content--padding--right));
 }
 
 @media (min-width: 480px) {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -55,8 +55,7 @@ img {
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */
-[data-align="full"] > p,
-.alignfull > p {
+p {
 	margin-left: auto;
 	margin-right: auto;
 	width: calc( 100vw - var(--wp--custom--post-content--padding--left) - var(--wp--custom--post-content--padding--right));

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,17 +1,10 @@
-.wp-block-group.alignfull,
-*[class*="wp-container-"] //Anything that inherits layout (container)
-{
-	//give it some padding
-	padding-left: var(--wp--custom--post-content--padding--left);
-	padding-right: var(--wp--custom--post-content--padding--right);
-
-	//Any nested containers, and anything that is alignfull
-	*[class*="wp-container-"], // Any nested containers
-	> .alignfull { // Any direct descendant that is alignfull
-		// bust out of the container's padding
-		margin-left: calc(-1 * var(--wp--custom--post-content--padding--left)) !important;
-		margin-right: calc(-1 * var(--wp--custom--post-content--padding--right)) !important;
-		width: calc( 100% + var(--wp--custom--post-content--padding--left) + var(--wp--custom--post-content--padding--right) ) !important;
+[data-align="full"],
+.alignfull {
+	> p {
+		//give it some padding
+		margin-left: auto;
+		margin-right: auto;
+		width: calc( 100vw - var(--wp--custom--post-content--padding--left) - var(--wp--custom--post-content--padding--right) );
 	}
 }
 

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -1,11 +1,8 @@
-[data-align="full"],
-.alignfull {
-	> p {
-		//give it some padding
-		margin-left: auto;
-		margin-right: auto;
-		width: calc( 100vw - var(--wp--custom--post-content--padding--left) - var(--wp--custom--post-content--padding--right) );
-	}
+p {
+	// An alternative to padding.
+	margin-left: auto;
+	margin-right: auto;
+	width: calc( 100vw - var(--wp--custom--post-content--padding--left) - var(--wp--custom--post-content--padding--right) );
 }
 
 @include break-mobile {


### PR DESCRIPTION
This is an alternate approach to https://github.com/Automattic/themes/pull/4448

Gutenberg has changed so that now all group blocks have the `wp-container-*` class. This means that we can no longer rely on this class to target elements that are meant to "inherit layout".

This PR removes all the alignment styles that are trying to change the way that Gutenberg handles alignments. It has become very difficult to modify the default behaviour in the theme.

The one case that I think we should try to handle is this: https://github.com/Automattic/themes/issues/3747

The problem with adding padding to paragraph blocks inside `alignfull` elements is that you can add `alignfull` to elements that "inherit layout", which means that they no longer align to the edge of the layout container.

So instead of setting padding on these elements we can set a max width on this. However the problem with this approach is that elements inside "inherit layout" containers also use `max-width` to constrain them to the correct column size.

So instead this PR proposes that we use `width` to constrain all paragraphs. This will allow "inherit layout" to continue behaving as before, but it will ensure that paragraph blocks don't ever touch the edge of the screen.

To test you can use the markup in https://github.com/Automattic/themes/pull/4448 and https://github.com/Automattic/themes/issues/4412.