### PR TITLE
Skatepark: Add custom padding to cover block

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -139,10 +139,6 @@ p {
 	letter-spacing: 0.1em;
 }
 
-.wp-block-cover {
-	padding: clamp(2em, 15%, 8em);
-}
-
 .wp-block-post-comments .reply a {
 	--wp--custom--button--typography--font-size: var(--wp--preset--font-size--normal);
 	border-style: var(--wp--custom--button--border--style);

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -139,10 +139,6 @@ p {
 	letter-spacing: 0.1em;
 }
 
-.wp-block-cover {
-	padding: 11.5%;
-}
-
 .wp-block-cover .wp-block-cover__inner-container {
 	width: auto;
 }

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -139,6 +139,24 @@ p {
 	letter-spacing: 0.1em;
 }
 
+.wp-block-cover {
+	padding: 11.5%;
+}
+
+.wp-block-cover .wp-block-cover__inner-container {
+	width: auto;
+}
+
+.wp-block-cover.has-custom-content-position.is-position-top-left, .wp-block-cover.has-custom-content-position.is-position-top-center, .wp-block-cover.has-custom-content-position.is-position-top-right {
+	padding-top: 5.75%;
+	padding-bottom: 17.25%;
+}
+
+.wp-block-cover.has-custom-content-position.is-position-bottom-left, .wp-block-cover.has-custom-content-position.is-position-bottom-center, .wp-block-cover.has-custom-content-position.is-position-bottom-right {
+	padding-top: 17.25%;
+	padding-bottom: 5.75%;
+}
+
 .wp-block-post-comments .reply a {
 	--wp--custom--button--typography--font-size: var(--wp--preset--font-size--normal);
 	border-style: var(--wp--custom--button--border--style);

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -139,6 +139,10 @@ p {
 	letter-spacing: 0.1em;
 }
 
+.wp-block-cover {
+	padding: clamp(2em, 15%, 8em);
+}
+
 .wp-block-post-comments .reply a {
 	--wp--custom--button--typography--font-size: var(--wp--preset--font-size--normal);
 	border-style: var(--wp--custom--button--border--style);

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -139,18 +139,14 @@ p {
 	letter-spacing: 0.1em;
 }
 
-.wp-block-cover .wp-block-cover__inner-container {
-	width: auto;
+.wp-block-cover.alignfull {
+	padding-left: 0;
+	padding-right: 0;
 }
 
-.wp-block-cover.has-custom-content-position.is-position-top-left, .wp-block-cover.has-custom-content-position.is-position-top-center, .wp-block-cover.has-custom-content-position.is-position-top-right {
-	padding-top: 5.75%;
-	padding-bottom: 17.25%;
-}
-
-.wp-block-cover.has-custom-content-position.is-position-bottom-left, .wp-block-cover.has-custom-content-position.is-position-bottom-center, .wp-block-cover.has-custom-content-position.is-position-bottom-right {
-	padding-top: 17.25%;
-	padding-bottom: 5.75%;
+.wp-block-cover.alignfull .wp-block-cover__inner-container {
+	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
+	padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
 }
 
 .wp-block-post-comments .reply a {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -140,7 +140,7 @@ p {
 }
 
 .wp-block-cover.alignfull {
-	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
+	padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 }
 

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -140,13 +140,8 @@ p {
 }
 
 .wp-block-cover.alignfull {
-	padding-left: 0;
-	padding-right: 0;
-}
-
-.wp-block-cover.alignfull .wp-block-cover__inner-container {
-	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
-	padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
+	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
+	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 }
 
 .wp-block-post-comments .reply a {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -270,11 +270,6 @@
 					"textTransform": "uppercase"
 				}
 			},
-			"core/cover": {
-				"spacing": {
-					"padding": "min(8em, 11.5%)"
-				}
-			},
 			"core/post-date": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -272,7 +272,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "clamp(2em, 15%, 8em)"
+					"padding": "min(160px, 11.5%)"
 				}
 			},
 			"core/post-date": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -270,6 +270,11 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/cover": {
+				"spacing": {
+					"padding": "clamp(2em, 15%, 8em)"
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -272,7 +272,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "5.75%"
+					"padding": "15vh"
 				}
 			},
 			"core/post-date": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -272,7 +272,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "min(160px, 11.5%)"
+					"padding": "min(8em, 11.5%)"
 				}
 			},
 			"core/post-date": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -272,7 +272,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "11.5%"
+					"padding": "5.75%"
 				}
 			},
 			"core/post-date": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -270,6 +270,11 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/cover": {
+				"spacing": {
+					"padding": "11.5%"
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,17 +1,10 @@
 .wp-block-cover {
-	.wp-block-cover__inner-container {
-		width: auto;
-	}
-
-	&.has-custom-content-position {
-		&.is-position-top-left, &.is-position-top-center, &.is-position-top-right {
-			padding-top: 5.75%;
-			padding-bottom: 17.25%;
-		}
-
-		&.is-position-bottom-left, &.is-position-bottom-center, &.is-position-bottom-right {
-			padding-top: 17.25%;
-			padding-bottom: 5.75%;
+	&.alignfull {
+		padding-left: 0;
+		padding-right: 0;
+		.wp-block-cover__inner-container {
+			padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
+			padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
 		}
 	}
 }

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,3 +1,0 @@
-.wp-block-cover {
-	padding: clamp(2em, 15%, 8em);
-}

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,0 +1,19 @@
+.wp-block-cover {
+	padding: 11.5%;
+
+	.wp-block-cover__inner-container {
+		width: auto;
+	}
+
+	&.has-custom-content-position {
+		&.is-position-top-left, &.is-position-top-center, &.is-position-top-right {
+			padding-top: 5.75%;
+			padding-bottom: 17.25%;
+		}
+
+		&.is-position-bottom-left, &.is-position-bottom-center, &.is-position-bottom-right {
+			padding-top: 17.25%;
+			padding-bottom: 5.75%;
+		}
+	}
+}

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,6 +1,6 @@
 .wp-block-cover {
 	&.alignfull {
-		padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
+		padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 		padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 	}
 }

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,0 +1,3 @@
+.wp-block-cover {
+	padding: clamp(2em, 15%, 8em);
+}

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,10 +1,6 @@
 .wp-block-cover {
 	&.alignfull {
-		padding-left: 0;
-		padding-right: 0;
-		.wp-block-cover__inner-container {
-			padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
-			padding-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
-		}
+		padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
+		padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--post-content--padding--left), var(--wp--custom--post-content--padding--left) ));
 	}
 }

--- a/skatepark/sass/blocks/_cover.scss
+++ b/skatepark/sass/blocks/_cover.scss
@@ -1,6 +1,4 @@
 .wp-block-cover {
-	padding: 11.5%;
-
 	.wp-block-cover__inner-container {
 		width: auto;
 	}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -5,6 +5,7 @@
 @import "blocks/author";
 @import "../../blockbase/sass/blocks/_buttons-outline-style";
 @import "blocks/buttons";
+@import "blocks/cover";
 @import "blocks/post-comments";
 @import "blocks/post-title";
 @import "blocks/query";

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -5,7 +5,6 @@
 @import "blocks/author";
 @import "../../blockbase/sass/blocks/_buttons-outline-style";
 @import "blocks/buttons";
-@import "blocks/cover";
 @import "blocks/post-comments";
 @import "blocks/post-title";
 @import "blocks/query";

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -539,7 +539,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "clamp(2em, 15%, 8em)"
+					"padding": "min(160px, 11.5%)"
 				}
 			},
 			"core/post-terms": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -539,7 +539,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "11.5%"
+					"padding": "5.75%"
 				}
 			},
 			"core/post-terms": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -539,7 +539,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "min(160px, 11.5%)"
+					"padding": "min(8em, 11.5%)"
 				}
 			},
 			"core/post-terms": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -537,6 +537,11 @@
 					"fontStyle": "normal"
 				}
 			},
+			"core/cover": {
+				"spacing": {
+					"padding": "clamp(2em, 15%, 8em)"
+				}
+			},
 			"core/post-terms": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -537,6 +537,11 @@
 					"fontStyle": "normal"
 				}
 			},
+			"core/cover": {
+				"spacing": {
+					"padding": "11.5%"
+				}
+			},
 			"core/post-terms": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -537,11 +537,6 @@
 					"fontStyle": "normal"
 				}
 			},
-			"core/cover": {
-				"spacing": {
-					"padding": "min(8em, 11.5%)"
-				}
-			},
 			"core/post-terms": {
 				"typography": {
 					"fontWeight": "500"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -539,7 +539,7 @@
 			},
 			"core/cover": {
 				"spacing": {
-					"padding": "5.75%"
+					"padding": "15vh"
 				}
 			},
 			"core/post-terms": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds custom padding to the cover block for Skatepark:

![Screenshot 2021-08-24 at 17 41 23](https://user-images.githubusercontent.com/1645628/130656222-a2da8e8a-9f51-4ab8-ad8b-fb45c4c1d4e9.png)

I've tried this using `clamp()`, mainly so the padding isn't too large at smaller resolutions. But we could also use a `calc()` based on one of the spacing settings maybe, or use a percentage?

#### Related issue(s):
Closes #4413.