### PR TITLE
Alternative/skatepark wide header

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -533,32 +533,26 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 	mask-image: url(svg/post-tag.svg);
 }
 
-header.wp-block-template-part {
-	max-width: var(--wp--custom--layout--wide-size);
-	margin: 0 auto;
-	width: 100%;
-}
-
-header.wp-block-template-part > .wp-block-group {
+header.wp-block-template-part > .wp-block-group > .wp-block-group {
 	align-items: flex-end;
 	justify-content: space-between;
 	flex-wrap: wrap-reverse;
 }
 
-header.wp-block-template-part > .wp-block-group > * {
+header.wp-block-template-part > .wp-block-group > .wp-block-group > * {
 	flex-grow: 1;
 }
 
-header.wp-block-template-part > .wp-block-group > * > * {
+header.wp-block-template-part > .wp-block-group > .wp-block-group > * > * {
 	margin-top: 20px;
 	margin-bottom: 20px;
 }
 
-header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
+header.wp-block-template-part > .wp-block-group > .wp-block-group .wp-block-social-links.is-style-logos-only {
 	margin-right: calc( -1 * ( 8px + 0.25em ));
 }
 
-header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only > .wp-social-link {
+header.wp-block-template-part > .wp-block-group > .wp-block-group .wp-block-social-links.is-style-logos-only > .wp-social-link {
 	padding: 0;
 }
 

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -533,6 +533,12 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 	mask-image: url(svg/post-tag.svg);
 }
 
+header.wp-block-template-part {
+	max-width: var(--wp--custom--layout--wide-size);
+	margin: 0 auto;
+	width: 100%;
+}
+
 header.wp-block-template-part > .wp-block-group {
 	align-items: flex-end;
 	justify-content: space-between;

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,5 +1,7 @@
-<!-- wp:group { "layout":{"type":"flex"}} -->
+<!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
+<!-- wp:group {"layout":{"type":"flex"},"align":"wide"} -->
+<div class="wp-block-group alignwide">
 <!-- wp:group -->
 <div class="wp-block-group">
 <!-- wp:site-logo /-->
@@ -18,6 +20,8 @@
 
 <!-- wp:social-link {"url":"instagram.com","service":"instagram"} /--></ul>
 <!-- /wp:social-links --></div>
+<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group { "layout":{"type":"flex"},"align":"full"} -->
+<!-- wp:group { "layout":{"type":"flex"}} -->
 <div class="wp-block-group">
 <!-- wp:group -->
 <div class="wp-block-group">

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -1,5 +1,5 @@
 header.wp-block-template-part {
-	max-width: var(--wp--custom--layout--wide-size);
+	max-width: var(--wp--custom--layout--wide-size); // Layouts can be flex OR flow/default (inherit), not both. So we need to mimick the wide width alignment supplied by Gutenberg here.
 	margin: 0 auto;
 	width: 100%;
 	

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -1,9 +1,5 @@
 header.wp-block-template-part {
-	max-width: var(--wp--custom--layout--wide-size); // Layouts can be flex OR flow/default (inherit), not both. So we need to mimick the wide width alignment supplied by Gutenberg here.
-	margin: 0 auto;
-	width: 100%;
-	
-	> .wp-block-group {
+	> .wp-block-group > .wp-block-group {
 		align-items: flex-end; // Needed until theme.json layout lets me specify
 		justify-content: space-between; // Apply a cluster (flex?) layout
 		flex-wrap: wrap-reverse;

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -1,19 +1,25 @@
-header.wp-block-template-part > .wp-block-group {
-	align-items: flex-end; // Needed until theme.json layout lets me specify
-	justify-content: space-between; // Apply a cluster (flex?) layout
-	flex-wrap: wrap-reverse;
-	> * {
-		flex-grow: 1; // Needed to maintain alignment when the containers stack
-		> * { // Apply a stack layout (page 69 of the every-layout.dev PDF) 
-			margin-top: 20px;
-			margin-bottom: 20px;
+header.wp-block-template-part {
+	max-width: var(--wp--custom--layout--wide-size);
+	margin: 0 auto;
+	width: 100%;
+	
+	> .wp-block-group {
+		align-items: flex-end; // Needed until theme.json layout lets me specify
+		justify-content: space-between; // Apply a cluster (flex?) layout
+		flex-wrap: wrap-reverse;
+		> * {
+			flex-grow: 1; // Needed to maintain alignment when the containers stack
+			> * { // Apply a stack layout (page 69 of the every-layout.dev PDF) 
+				margin-top: 20px;
+				margin-bottom: 20px;
+			}
 		}
-	}
 
-	.wp-block-social-links.is-style-logos-only {
-		margin-right: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the right
-		> .wp-social-link {
-			padding: 0; // Needed to override Gutenberg default padding on this block style variation
+		.wp-block-social-links.is-style-logos-only {
+			margin-right: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the right
+			> .wp-social-link {
+				padding: 0; // Needed to override Gutenberg default padding on this block style variation
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Use a group block instead of applying CSS to the `header.wp-block-template-part` as done in #4464

#### Related issue(s):
#4407 