### PR TITLE
Blockbase + co: Universal Social menu

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -162,7 +162,8 @@ function blockbase_social_menu_render( $block_content, $block ) {
 		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"' . $class_name . '"} --><ul class="wp-block-social-links has-icon-color ' . $class_name . '">';
 		$menu = wp_get_nav_menu_items( $social_menu_id );
 		foreach ($menu as $menu_item) {
-			$block_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $menu_item->post_name . '"} /-->';
+			$service_name = preg_replace( '/(-[0-9]+)/', '', $menu_item->post_name );
+			$block_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $service_name . '"} /-->';
 		}
 
 		$block_content .= '</ul>';

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -131,9 +131,9 @@ function blockbase_social_menu_render( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$return = $block_content;
-
-	if ( has_nav_menu( 'social' ) ) :
+	if ( ! has_nav_menu( 'social' ) ) :
+		return $block_content;
+	else:
 
 		$return  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
 		
@@ -145,7 +145,8 @@ function blockbase_social_menu_render( $block_content, $block ) {
 		}
 
 		$return .= '</ul>';
+		
+		return $return;
 	endif; 
 
-	return $return;
 }

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -156,8 +156,11 @@ function blockbase_social_menu_render( $block_content, $block ) {
 	if ( blockbase_condition_to_render_social_menu( $block ) ) {
 		$nav_menu_locations = get_nav_menu_locations();
 		$social_menu_id = $nav_menu_locations['social'];
-
-		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} --><ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+		$class_name = 'is-style-logos-only';
+		if( !empty( $block['attrs']['itemsJustification'] ) && $block['attrs']['itemsJustification'] === 'right' ) {
+			$class_name .= ' items-justified-right';
+		}
+		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"' . $class_name . '"} --><ul class="wp-block-social-links has-icon-color ' . $class_name . '">';
 		$menu = wp_get_nav_menu_items( $social_menu_id );
 		foreach ($menu as $menu_item) {
 			$block_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $menu_item->post_name . '"} /-->';

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -154,17 +154,16 @@ function blockbase_condition_to_render_social_menu( $block ) {
 
 function blockbase_social_menu_render( $block_content, $block ) {
 	if ( blockbase_condition_to_render_social_menu( $block ) ) {
-		$block_content  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} --><ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
 
 		$menu = wp_get_nav_menu_items('social');
 		foreach ($menu as $menu_item) {
-			$link = '<!-- wp:social-link {"url":"'.$menu_item->url.'","service":"'.$menu_item->post_name.'"} /-->';
-			$block_content .= str_replace('<li class', '<li style="color: var(--wp--custom--color--primary); " class', do_blocks($link) );
+			$block_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $menu_item->post_name . '"} /-->';
 		}
 
 		$block_content .= '</ul>';
 
-		return $block_content;
+		return do_blocks( $block_content );
 	}
 
 	return $block_content;

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -157,10 +157,9 @@ function blockbase_social_menu_render( $block_content, $block ) {
 		$block_content  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
 
 		$menu = wp_get_nav_menu_items('social');
-
 		foreach ($menu as $menu_item) {
 			$link = '<!-- wp:social-link {"url":"'.$menu_item->url.'","service":"'.$menu_item->post_name.'"} /-->';
-			$return .= str_replace('<li class', '<li style="color: var(--wp--custom--color--primary); " class', do_blocks($link) );
+			$block_content .= str_replace('<li class', '<li style="color: var(--wp--custom--color--primary); " class', do_blocks($link) );
 		}
 
 		$block_content .= '</ul>';

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -134,7 +134,7 @@ function blockbase_condition_to_render_social_menu( $block ) {
 		return false;
 	}
 
-	// The theme should define a social menu.
+	// The theme should have a menu defined at the social location.
 	if ( ! has_nav_menu( 'social' ) ) {
 		return false;
 	}
@@ -154,9 +154,11 @@ function blockbase_condition_to_render_social_menu( $block ) {
 
 function blockbase_social_menu_render( $block_content, $block ) {
 	if ( blockbase_condition_to_render_social_menu( $block ) ) {
-		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} --><ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+		$nav_menu_locations = get_nav_menu_locations();
+		$social_menu_id = $nav_menu_locations['social'];
 
-		$menu = wp_get_nav_menu_items('social');
+		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} --><ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+		$menu = wp_get_nav_menu_items( $social_menu_id );
 		foreach ($menu as $menu_item) {
 			$block_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $menu_item->post_name . '"} /-->';
 		}

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -34,7 +34,6 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'blockbase' ),
-				'social' => __( 'Social Navigation', 'blockbase' )
 			)
 		);
 

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -34,6 +34,7 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'blockbase' ),
+				'social' => __( 'Social Navigation', 'blockbase' )
 			)
 		);
 
@@ -119,3 +120,32 @@ add_action( 'init', 'blockbase_restore_customizer' );
 require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
 require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
 require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
+
+/**
+ * Populate the social links block with the social menu content if it exists
+ *
+ */
+add_filter( 'render_block', 'blockbase_social_menu_render', 10, 2 );
+function blockbase_social_menu_render( $block_content, $block ) {
+	if ( 'core/social-links' !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	$return = $block_content;
+
+	if ( has_nav_menu( 'social' ) ) :
+
+		$return  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+		
+		$menu = wp_get_nav_menu_items('social');
+
+		foreach ($menu as $menu_item) {
+			$link = '<!-- wp:social-link {"url":"'.$menu_item->url.'","service":"'.$menu_item->post_name.'"} /-->';
+			$return .= str_replace('<li class', '<li style="color: var(--wp--custom--color--primary); " class', do_blocks($link) );
+		}
+
+		$return .= '</ul>';
+	endif; 
+
+	return $return;
+}

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -126,17 +126,36 @@ require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
  *
  */
 add_filter( 'render_block', 'blockbase_social_menu_render', 10, 2 );
-function blockbase_social_menu_render( $block_content, $block ) {
-	if ( 'core/social-links' !== $block['blockName'] ) {
-		return $block_content;
+// We should only change the render of the navigtion block
+// to social links in the following conditions.
+function blockbase_condition_to_render_social_menu( $block ) {
+	// The block should be a navigation block.
+	if ( 'core/navigation' !== $block['blockName'] ) {
+		return false;
 	}
 
-	if ( ! has_nav_menu( 'social' ) ) :
-		return $block_content;
-	else:
+	// The theme should define a social menu.
+	if ( ! has_nav_menu( 'social' ) ) {
+		return false;
+	}
 
-		$return  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
-		
+	// The block should have a loction defined.
+	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
+		return false;
+	}
+
+	// The block's location should be 'social'.
+	if ( $block['attrs']['__unstableLocation'] !== 'social' ) {
+		return false;
+	}
+
+	return true;
+}
+
+function blockbase_social_menu_render( $block_content, $block ) {
+	if ( blockbase_condition_to_render_social_menu( $block ) ) {
+		$block_content  = '<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only">';
+
 		$menu = wp_get_nav_menu_items('social');
 
 		foreach ($menu as $menu_item) {
@@ -144,9 +163,10 @@ function blockbase_social_menu_render( $block_content, $block ) {
 			$return .= str_replace('<li class', '<li style="color: var(--wp--custom--color--primary); " class', do_blocks($link) );
 		}
 
-		$return .= '</ul>';
-		
-		return $return;
-	endif; 
+		$block_content .= '</ul>';
 
+		return $block_content;
+	}
+
+	return $block_content;
 }

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -11,16 +11,10 @@
 <div class="wp-block-group nav-links"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} -->
 <!-- /wp:navigation -->
 
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} --><!-- /wp:navigation -->
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
 
 
-<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} -->
-<ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only"><!-- wp:social-link {"url":"twitter.com","service":"twitter"} /-->
-
-<!-- wp:social-link {"url":"facebook.com","service":"facebook"} /-->
-
-<!-- wp:social-link {"url":"instagram.com","service":"instagram"} /--></ul>
-<!-- /wp:social-links --></div>
+</div>
 <!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -11,6 +11,9 @@
 <div class="wp-block-group nav-links"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} -->
 <!-- /wp:navigation -->
 
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} --><!-- /wp:navigation -->
+
+
 <!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"items-justified-right is-style-logos-only"} -->
 <ul class="wp-block-social-links has-icon-color items-justified-right is-style-logos-only"><!-- wp:social-link {"url":"twitter.com","service":"twitter"} /-->
 

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -24,7 +24,8 @@ if ( ! function_exists( 'skatepark_support' ) ) :
 		//Primary navigation is used on the header and the footer pattern
 		register_nav_menus(
 			array(
-				'primary' => __( 'Primary Navigation', 'skatepark' )
+				'primary' => __( 'Primary Navigation', 'skatepark' ),
+				'social' => __( 'Social Navigation', 'blockbase' )
 			)
 		);
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The social link block can't be edited via a customizer only user experience. If our themes (namely Skatepark) include this block on the header, a user with no access to the FSE can't add their social links to it. Here I'm using the block's render callback to inject the social menu from the customizer if it's selected, else it renders the default block's content.

To test this:

- Go to Customizer > menus and add a menu to "Social Navigation"
- Check that the menu is changed to the correct items both in the customizer preview and the frontend.
- Check that when no menu is assigned to "Social Navigation", the default content from the block is shown instead.

<img width="1222" alt="Screenshot 2021-08-25 at 10 43 38" src="https://user-images.githubusercontent.com/3593343/130759123-2c165042-7b64-4278-909f-77869b57c4f5.png">
<img width="374" alt="Screenshot 2021-08-25 at 10 43 29" src="https://user-images.githubusercontent.com/3593343/130759128-12bda363-4e03-421b-b839-1c66b68017ee.png">

A few comments on this:

- This is being built on Blockbase and I'm using skatepark specific settings for it, not all themes will want the block to have it justified right or show in primary color. This is a first pass, I'm not sure what's the best way to customize this
- This doesn't allow for multiple variations of the block. In the case of Skatepark we have it on two places, header and footer block pattern. The footer one is not aligned to the right, I'm not sure how we can account for that.

#### Related issue(s):

Closes #4378