### PR TITLE
Blockbase: Update Blockbase and children to use flex

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -107,10 +107,7 @@ img {
 }
 
 .site-header {
-	align-items: center;
-	flex-wrap: wrap;
 	justify-content: space-between;
-	display: flex;
 	overflow: inherit;
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -814,10 +814,6 @@ p.has-background {
 	margin-bottom: unset;
 }
 
-.post-meta {
-	display: flex;
-}
-
 .post-meta .wp-block-post-author,
 .post-meta .wp-block-post-date,
 .post-meta .taxonomy-post_tag,

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -816,7 +816,6 @@ p.has-background {
 .post-meta .taxonomy-post_tag,
 .post-meta .taxonomy-category {
 	display: flex;
-	margin-right: calc(2 * var(--wp--custom--margin--baseline));
 }
 
 .post-meta .wp-block-post-author:before,

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"40px"}}},"className":"site-header"} -->
+<!-- wp:group {"align":"full","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"40px"}}},"className":"site-header"} -->
 <div class="wp-block-group alignfull site-header" style="padding-bottom:40px">
 	<!-- wp:site-title /-->
 	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -1,9 +1,5 @@
-// This is needed until something like https://github.com/WordPress/gutenberg/issues/24473 exists
 .site-header {
-	align-items: center;
-	flex-wrap: wrap;
 	justify-content: space-between;
-	display: flex;
 	overflow: inherit;
 
 	.wp-block-site-title a {

--- a/blockbase/sass/base/_mixins.scss
+++ b/blockbase/sass/base/_mixins.scss
@@ -15,7 +15,6 @@
 
 @mixin post-meta-icon {
 	display: flex;
-	margin-right: calc(2 * var(--wp--custom--margin--baseline) );
 	&:before {
 		align-self: center;
 		content: '';

--- a/blockbase/sass/post/_meta.scss
+++ b/blockbase/sass/post/_meta.scss
@@ -1,7 +1,4 @@
 .post-meta {
-	// TODO - needed until https://github.com/WordPress/gutenberg/issues/24473
-	display: flex;
-
 	.wp-block-post-author,
 	.wp-block-post-date,
 	.taxonomy-post_tag,

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -564,7 +564,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)"
+			"blockGap": "var(--wp--custom--margin--vertical)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -314,7 +314,6 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",
@@ -563,6 +562,9 @@
 					"text": "var(--wp--custom--color--primary)"
 				}
 			}
+		},
+		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -314,6 +314,7 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","className":"site-header"} -->
+<!-- wp:group {"align":"full","layout":{"type":"flex"},"className":"site-header"} -->
 <div class="wp-block-group alignfull site-header">
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->

--- a/mayland-blocks/block-template-parts/post-meta.html
+++ b/mayland-blocks/block-template-parts/post-meta.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"textColor":"gray","className":"post-meta"} -->
+<!-- wp:group {"textColor":"gray","className":"post-meta","layout":{"type":"flex"}} -->
 <div class="post-meta wp-block-group post-meta has-gray-color has-text-color"><!-- wp:post-author {"showAvatar":false,"showBio":false,"fontSize":"small"} /-->
 
 <!-- wp:post-date {"fontSize":"small","isLink":true} /-->

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -326,7 +326,6 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",
@@ -592,6 +591,9 @@
 					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
+		},
+		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -326,6 +326,7 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -593,7 +593,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)"
+			"blockGap": "var(--wp--custom--margin--vertical)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -647,18 +647,12 @@ textarea:focus {
 	display: none;
 }
 
-.post-meta > *,
-.post-meta .wp-block-post-date {
-	margin: 0 8px;
-}
-
 .post-meta > *::before,
 .post-meta .wp-block-post-date::before {
 	content: "";
 }
 
 .post-meta .wp-block-post-terms {
-	margin-left: 0;
 	color: transparent;
 }
 

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:170px">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:group {"className":"post-meta"} -->
+	<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
 	<div class="wp-block-group post-meta">
 		<!-- wp:post-date {"textAlign":"center","fontSize":"tiny","isLink":true} /-->
 		<!-- wp:post-terms {"term":"category","textAlign":"center","fontSize":"tiny"} /-->

--- a/quadrat/inc/patterns/query-diamond.php
+++ b/quadrat/inc/patterns/query-diamond.php
@@ -13,7 +13,7 @@ return array(
 	<div class="wp-block-query alignwide is-style-quadrat-diamond-posts"><!-- wp:post-template -->
 	<!-- wp:columns -->
 	<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"className":"post-meta"} -->
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
 	<div class="wp-block-group post-meta"><!-- wp:post-date {"fontSize":"tiny","isLink":true} /-->
 
 	<!-- wp:post-terms {"term":"category","fontSize":"tiny"} /--></div>

--- a/quadrat/sass/templates/_meta.scss
+++ b/quadrat/sass/templates/_meta.scss
@@ -12,14 +12,12 @@
 
 	> *,
 	.wp-block-post-date {
-		margin: 0 8px;
 		&::before {
 			content: "";
 		}
 	}
 
 	.wp-block-post-terms {
-		margin-left: 0;
 		&::before {
 			color: var(--wp--custom--color--foreground);
 			content: "·";

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -669,7 +669,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)"
+			"blockGap": "var(--wp--custom--margin--vertical)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -364,7 +364,6 @@
 			"wideSize": "1128px"
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",
@@ -668,6 +667,9 @@
 					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
+		},
+		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -364,6 +364,7 @@
 			"wideSize": "1128px"
 		},
 		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",

--- a/seedlet-blocks/block-template-parts/post-meta.html
+++ b/seedlet-blocks/block-template-parts/post-meta.html
@@ -2,7 +2,7 @@
 <hr class="wp-block-separator is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:group {"className":"post-meta"} -->
+<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
 <div class="wp-block-group post-meta"><!-- wp:post-author {"showAvatar":false,"showBio":false,"fontSize":"tiny"} /-->
 
 <!-- wp:post-date {"fontSize":"tiny","isLink":true} /-->

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -627,7 +627,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)"
+			"blockGap": "var(--wp--custom--margin--vertical)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -355,6 +355,7 @@
 			"wideSize": "790px"
 		},
 		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -355,7 +355,6 @@
 			"wideSize": "790px"
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",
@@ -626,6 +625,9 @@
 					"text": "var(--wp--custom--color--primary)"
 				}
 			}
+		},
+		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -509,6 +509,7 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 
 .post-meta {
 	flex-direction: column;
+	align-items: start !important;
 }
 
 .post-meta .wp-block-post-date,

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -507,9 +507,10 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 	text-decoration: none;
 }
 
-.post-meta {
+.post-meta.wp-block-group {
 	flex-direction: column;
-	align-items: start !important;
+	align-items: start;
+	gap: .5em;
 }
 
 .post-meta .wp-block-post-date,

--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -29,7 +29,7 @@
 	<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator is-style-wide"/>
 	<!-- /wp:separator -->
-	<!-- wp:group {"className":"post-meta"} -->
+	<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
 	<div class="wp-block-group post-meta">
 	<!-- wp:post-date {"fontSize":"tiny","isLink":true} /-->
 	<!-- wp:post-terms {"term":"category","fontSize":"tiny"} /-->

--- a/skatepark/sass/elements/_post-meta.scss
+++ b/skatepark/sass/elements/_post-meta.scss
@@ -1,5 +1,6 @@
 .post-meta {
 	flex-direction: column;
+	align-items: start !important;
 
 	.wp-block-post-date,
 	.taxonomy-category,

--- a/skatepark/sass/elements/_post-meta.scss
+++ b/skatepark/sass/elements/_post-meta.scss
@@ -1,6 +1,9 @@
 .post-meta {
-	flex-direction: column;
-	align-items: start !important;
+	&.wp-block-group {
+		flex-direction: column;
+		align-items: start;
+		gap: .5em;
+	}
 
 	.wp-block-post-date,
 	.taxonomy-category,

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -371,7 +371,6 @@
 			"wideSize": "1194px"
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",
@@ -649,6 +648,9 @@
 					"text": "var(--wp--custom--color--primary)"
 				}
 			}
+		},
+		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -371,6 +371,7 @@
 			"wideSize": "1194px"
 		},
 		"spacing": {
+			"blockGap": "var(--wp--custom--margin--horizontal)",
 			"customPadding": true,
 			"units": [
 				"%",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -650,7 +650,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--custom--margin--horizontal)"
+			"blockGap": "var(--wp--custom--margin--vertical)"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/pull/33359/files merged we can use the flex property of the group block to achieve this layout. The `blockGap` setting doesn't seem to be working in my tests.

#### Related issue(s):
https://github.com/Automattic/themes/issues/4463