### PR TITLE
Skatepark: fix separator color

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -43,19 +43,6 @@
 	color: var(--wp--preset--color--background);
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-p {
-	margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
-	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
-=======
-.wp-block-column > p:first-child, .wp-block-column > h1:first-child, .wp-block-column > h2:first-child, .wp-block-column > h3:first-child, .wp-block-column > h4:first-child, .wp-block-column > h5:first-child, .wp-block-column > h6:first-child, .wp-block-group > p:first-child, .wp-block-group > h1:first-child, .wp-block-group > h2:first-child, .wp-block-group > h3:first-child, .wp-block-group > h4:first-child, .wp-block-group > h5:first-child, .wp-block-group > h6:first-child {
-	margin-top: 0;
->>>>>>> Refactor text styles and add padding to groups w border.
-}
-
-=======
->>>>>>> move group and column margin resets to blockbase
 .wp-block-post-author__content {
 	display: flex;
 	flex-direction: column;
@@ -302,7 +289,7 @@ p {
 }
 
 .wp-block-separator.is-style-wide {
-	border-bottom: 3px solid #000;
+	border-bottom: 3px solid currentColor;
 }
 
 .pre-footer h3 {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -289,7 +289,7 @@
 }
 
 .wp-block-separator.is-style-wide {
-	border-bottom: 3px solid currentColor;
+	border-width: 0 0 3px 0;
 }
 
 .pre-footer h3 {

--- a/skatepark/sass/blocks/_separator.scss
+++ b/skatepark/sass/blocks/_separator.scss
@@ -1,6 +1,6 @@
 
 .wp-block-separator {
 	&.is-style-wide {
-		border-bottom: 3px solid #000;
+		border-bottom: 3px solid currentColor;
 	}
 }

--- a/skatepark/sass/blocks/_separator.scss
+++ b/skatepark/sass/blocks/_separator.scss
@@ -1,6 +1,6 @@
 
 .wp-block-separator {
 	&.is-style-wide {
-		border-bottom: 3px solid currentColor;
+		border-width: 0 0 3px 0;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The css for the separator block on skatepark was forcing a black color. I changed it so it doesn't affect the color anymore. To test this check the theme with different body colors and see that the separator matches it and it's still 3px height.

<img width="790" alt="Screenshot 2021-08-26 at 15 20 54" src="https://user-images.githubusercontent.com/3593343/130969886-f13c4b46-ac00-4f3b-8b1c-a2766441be86.png">



