### PR TITLE
Try/add batch utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"sandbox:push:ignore": "./sandbox.sh push --ignore",
 		"sandbox:push:force": "./sandbox.sh push --force",
 		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
-		"batch:build": "./theme-batch-utils.sh build",
+		"batch:build:changed": "./theme-batch-utils.sh build",
+		"batch:build:all": "./theme-batch-utils.sh build-all",
 		"batch:install": "./theme-batch-utils.sh install-dependencies",
 		"batch:audit": "./theme-batch-utils.sh audit-dependencies",
 		"batch:version-bump": "./theme-batch-utils.sh version-bump"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"batch:build:changed": "./theme-batch-utils.sh build",
 		"batch:build:all": "./theme-batch-utils.sh build-all",
 		"batch:install": "./theme-batch-utils.sh install-dependencies",
-		"batch:audit": "./theme-batch-utils.sh audit-dependencies",
+		"batch:audit:fix": "./theme-batch-utils.sh audit-dependencies",
 		"batch:version-bump": "./theme-batch-utils.sh version-bump"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"sandbox:push:ignore": "./sandbox.sh push --ignore",
 		"sandbox:push:force": "./sandbox.sh push --force",
 		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
+		"local:clean": "git reset --hard HEAD; git clean -fd",
 		"batch:build:changed": "./theme-batch-utils.sh build",
 		"batch:build:all": "./theme-batch-utils.sh build-all",
 		"batch:install": "./theme-batch-utils.sh install-dependencies",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
 		"sandbox:push": "./sandbox.sh push",
 		"sandbox:push:ignore": "./sandbox.sh push --ignore",
 		"sandbox:push:force": "./sandbox.sh push --force",
-		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial"
+		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
+		"batch:build": "./theme-batch-utils.sh build",
+		"batch:install": "./theme-batch-utils.sh install-dependencies",
+		"batch:audit": "./theme-batch-utils.sh audit-dependencies",
+		"batch:version-bump": "./theme-batch-utils.sh version-bump"
 	},
 	"devDependencies": {
 		"@wordpress/prettier-config": "^1.0.1",

--- a/theme-batch-utils.sh
+++ b/theme-batch-utils.sh
@@ -4,7 +4,7 @@ git remote update > /dev/null
 current_branch=$(git branch --show-current)
 hash_at_divergence=$(git merge-base origin/trunk ${current_branch})
 
-# version bump (patch) any project that has any *comitted* changes
+# version bump (patch) any theme that has any *comitted* changes since it was branched from /trunk or any *uncomitted* changes
 version-bump() {
 	has_uncomitted_changes=$(git diff-index --name-only HEAD -- .)
 	has_comitted_changes=$(git diff --name-only ${hash_at_divergence} HEAD -- .)
@@ -17,7 +17,7 @@ version-bump() {
 	fi
 }
 
-# copy the version from package.json (the source of truth) to other standard locations.
+# copy the version from package.json (the source of truth) to other standard locations (including style.css, style.scss and style-child-theme.scss).
 apply-version() {
 
  	current_version=$(node -p "require('./package.json').version")

--- a/theme-batch-utils.sh
+++ b/theme-batch-utils.sh
@@ -48,6 +48,17 @@ apply-version() {
 
 }
 
+# only build the project if is has changed since it diverged from trunk
+build-if-changed() {
+	# Only version bump things that have changes
+	uncomitted_changes=$(git diff-index --name-only HEAD -- .)
+	comitted_changes=$(git diff --name-only ${hash_at_divergence} HEAD -- .)
+	if [ -z "$comitted_changes" ] && [ -z "$uncomitted_changes" ]; then
+		return
+	fi
+	npm run build
+}
+
 command=$1
 echo
 
@@ -67,6 +78,9 @@ for theme in */ ; do
 				echo
 				;;
 			"build")
+				build-if-changed ${theme}
+				;;
+			"build-all")
 				echo 'Building '${theme}
 				npm run build
 				echo

--- a/theme-batch-utils.sh
+++ b/theme-batch-utils.sh
@@ -52,7 +52,7 @@ version-bump() {
 apply-version() {
 
  	current_version=$(node -p "require('./package.json').version")
-	files_to_update=( $(find . -name style.css -o -name style.scss -o -name style-child-theme.scss) )
+	files_to_update=( $(find . -name style.css -o -name style.scss -o -name style-child-theme.scss -maxdepth 2) )
 
 	for file_to_update in "${files_to_update[@]}"; do
 		if test -f "$file_to_update"; then

--- a/theme-batch-utils.sh
+++ b/theme-batch-utils.sh
@@ -1,0 +1,82 @@
+#!/bin/zsh
+
+git remote update > /dev/null
+current_branch=$(git branch --show-current)
+hash_at_divergence=$(git merge-base origin/trunk ${current_branch})
+
+# version bump (patch) any project that has any *comitted* changes
+version-bump() {
+	has_uncomitted_changes=$(git diff-index --name-only HEAD -- .)
+	has_comitted_changes=$(git diff --name-only ${hash_at_divergence} HEAD -- .)
+	#TODO: Determine if version has changed since divergence and skip if so.  Otherwise we might version-bump something that has already version bumped.
+	if [ -n "$has_comitted_changes" ] || [ -n "$has_uncomitted_changes" ]; then
+		echo "Version bumping $1"
+		npm version patch --no-git-tag-version
+		apply-version $1
+		echo
+	fi
+}
+
+# copy the version from package.json (the source of truth) to other standard locations.
+apply-version() {
+
+ 	current_version=$(node -p "require('./package.json').version")
+	files_to_update=( $(find . -name style.css -o -name style.scss -o -name style-child-theme.scss) )
+
+	for file_to_update in "${files_to_update[@]}"; do
+		if test -f "$file_to_update"; then
+			echo "Apply version from package.json to $file_to_update"
+	 		perl -pi -e 's/Version: (.*)$/"Version: '$current_version'"/ge' $file_to_update 
+		fi
+	done
+
+}
+
+command=$1
+echo
+
+# Do things for all of the themes
+for theme in */ ; do
+	if test -f "./${theme}/package.json"; then
+		cd './'${theme}
+		case $command in
+			"install-dependencies")
+				echo 'Installing Dependencies for '${theme}
+				npm install
+				echo
+				;;
+			"audit-dependencies")
+				echo 'Auditing and fixing dependencies for '${theme}
+				npm audit fix
+				echo
+				;;
+			"build")
+				echo 'Building '${theme}
+				npm run build
+				echo
+				;;
+			"version-bump")
+				version-bump ${theme}
+				;;
+			"apply-version")
+				echo 'Applying version from package.json throughout '${theme}
+				apply-version ${theme}
+				echo
+				;;
+		esac	
+		cd ..
+	else
+		# echo 'Skipping '${theme}
+	fi
+done
+
+# Do things for the root folder
+case $command in
+	"audit-dependencies")
+		echo 'Auditing and fixing dependencies for root project'
+		npm audit fix
+		;;
+	"version-bump")
+		version-bump "root project"
+		;;
+esac


### PR DESCRIPTION
I ttook the small script from #4475 and made it a bigger script.

This new "theme batch util" script does the following:
* installs all theme project dependencies `npm run batch:install`
* builds all theme projects `npm run batch:build:all`
* builds all theme projects that have changed resources `npm run batch:build:changed`
* audits all theme project dependencies `npm run batch:audit`
* version bumps all projects that have any changes `npm run batch:version-bump`

The first few are pretty straightforward.  
The last one is my favorite.

If ANY changes are in a theme project (from the point of divergence from /trunk to now) then that theme gets a patch version bump.  If the version has changed since that divergence it skips it, for instance major/minor version changes done manually, as well as previous runs of 'version-bump'. The version is then copied to the relevant theme files (style.css, style.scss, etc).

This utility could be leveraged in a number of different places in a deployment workflow.  