### PR TITLE
corrected package.json version numbers to match style.css (when lower)

### DIFF
--- a/dalston/package.json
+++ b/dalston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalston",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Dalston",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/elegant-business/package.json
+++ b/elegant-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elegant-business",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/friendly-business/package.json
+++ b/friendly-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "friendly-business",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/modern-business/package.json
+++ b/modern-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-business",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/morden/package.json
+++ b/morden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morden",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "Morden",
   "bugs": {
     "url": "https://github.com/Automattic/themes/issues"

--- a/professional-business/package.json
+++ b/professional-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "professional-business",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",

--- a/skatepark/package.json
+++ b/skatepark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skatepark",
-  "version": "1.1.1",
+  "version": "1.0.0",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/skatepark/package.json
+++ b/skatepark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skatepark",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -7,7 +7,7 @@ Description: Skatepark is a bold and exciting WordPress theme designed for moder
 Requires at least: 5.7
 Tested up to: 5.7
 Requires PHP: 5.7
-Version: 1.1.1
+Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/sophisticated-business/package.json
+++ b/sophisticated-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophisticated-business",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Style Variation of the Default WP Theme",
   "devDependencies": {
     "@wordpress/browserslist-config": "^2.6.0",


### PR DESCRIPTION
#4478 illuminated a few cases where the package.json version was lagging behind the style.css version.  This brings all of those instances current (with the expectation that package.json version can be used as source-of-truth henceforth).