### PR TITLE
Move the paragraph indent style to the first paragraph of every container

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -48,16 +48,6 @@ p {
 	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
 }
 
-.wp-block-post-content p:first-of-type {
-	text-indent: 15%;
-}
-
-.wp-block-post-author__content p:first-of-type,
-.wp-block-post-comments p:first-of-type,
-.wp-block-quote p:first-of-type {
-	text-indent: 0;
-}
-
 .wp-block-post-author__content {
 	display: flex;
 	flex-direction: column;

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -48,6 +48,16 @@ p {
 	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
 }
 
+.wp-block-post-content p:first-of-type {
+	text-indent: 15%;
+}
+
+.wp-block-post-author__content p:first-of-type,
+.wp-block-post-comments p:first-of-type,
+.wp-block-quote p:first-of-type {
+	text-indent: 0;
+}
+
 .wp-block-post-author__content {
 	display: flex;
 	flex-direction: column;
@@ -335,14 +345,6 @@ p {
 .is-style-skatepark-aside-caption.alignfull figcaption {
 	margin-left: var(--wp--custom--post-content--padding--left);
 	margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--post-content--padding--left) ));
-}
-
-.is-style-indented-paragraph {
-	text-indent: 10em;
-}
-
-.is-style-indented-post-excerpt p:first-of-type:not(.wp-block-post-excerpt__more-text) {
-	text-indent: 5em;
 }
 
 .wp-block-quote.is-style-side-quote {

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -14,7 +14,7 @@
 
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 
-	<!-- wp:post-excerpt {"className":"is-style-indented-post-excerpt"} /-->
+	<!-- wp:post-excerpt /-->
 
 	<!-- wp:post-date {"style":{"typography":{"fontWeight":"500"}},"fontSize":"tiny","isLink":true} /--></div>
 	<!-- /wp:group -->

--- a/skatepark/inc/block-styles.php
+++ b/skatepark/inc/block-styles.php
@@ -30,24 +30,6 @@ if ( ! function_exists( 'skatepark_register_block_styles' ) ) :
 					'name'         => 'skatepark-aside-caption',
 					'label'        => __( 'Aside caption', 'skatepark' ),
 					'style_handle' => 'skatepark-aside-caption',
-					)
-				);
-	
-			register_block_style(
-				'core/paragraph',
-				array(
-					'name'         => 'indented-paragraph',
-					'label'        => __( 'Indented paragraph', 'skatepark' ),
-					'style_handle' => 'indented-paragraph',
-				)
-			);
-	
-			register_block_style(
-				'core/post-excerpt',
-				array(
-					'name'         => 'indented-post-excerpt',
-					'label'        => __( 'Indented post excerpt', 'skatepark' ),
-					'style_handle' => 'indented-post-excerpt',
 				)
 			);
 

--- a/skatepark/inc/patterns/blog-posts.php
+++ b/skatepark/inc/patterns/blog-posts.php
@@ -19,7 +19,7 @@ return array(
 
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 
-	<!-- wp:post-excerpt {"moreText":"' . esc_html__( 'Continue reading', 'skatepark' ) . '","className":"is-style-indented-post-excerpt"} /-->
+	<!-- wp:post-excerpt {"moreText":"' . esc_html__( 'Continue reading', 'skatepark' ) . '"} /-->
 
 	<!-- wp:post-date {"style":{"typography":{"fontWeight":"500"}},"fontSize":"tiny","isLink":true} /--></div>
 	<!-- /wp:group -->

--- a/skatepark/inc/patterns/columns-in-container.php
+++ b/skatepark/inc/patterns/columns-in-container.php
@@ -19,8 +19,8 @@ return array(
 	<h4>' . esc_html__( 'Learn to skate', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skatepark welcomes youth of all ages and experience levels. Whether you’ve never been on a board before, or you can already do tricks, there’s a place for you and something to learn.', 'skatepark' ) . '</p>
+	<!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skatepark welcomes youth of all ages and experience levels. Whether you’ve never been on a board before, or you can already do tricks, there’s a place for you and something to learn.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column -->
 
@@ -29,8 +29,8 @@ return array(
 	<h4>' . esc_html__( 'Make new friends', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skateboarding is a social sport! Come hang out and meet some new friends to cheer you on while you skate. We have a strict no-bullying policy and maintain a supportive environment.', 'skatepark' ) . '</p>
+	<!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skateboarding is a social sport! Come hang out and meet some new friends to cheer you on while you skate. We have a strict no-bullying policy and maintain a supportive environment.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
@@ -47,8 +47,8 @@ return array(
 	<div style="height:5px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
+	<!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:group -->',
 );

--- a/skatepark/inc/patterns/mixed-media-in-container.php
+++ b/skatepark/inc/patterns/mixed-media-in-container.php
@@ -11,7 +11,7 @@ return array(
 	'content'    => '<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
-	
+
 	<!-- wp:group {"align":"wide","style":{"border":{"style":"solid"},"spacing":{"padding":{"top":"4%","right":"4%","bottom":"4%","left":"4%"}}},"className":"skatepark-mixed-media-in-container"} -->
 	<div class="wp-block-group alignwide skatepark-mixed-media-in-container" style="border-style:solid;padding-top:4%;padding-right:4%;padding-bottom:4%;padding-left:4%"><!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->
@@ -19,71 +19,71 @@ return array(
 	<h3>' . esc_html__( 'Why Camp?', 'skatepark' ) . '</h3>
 	<!-- /wp:heading --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column {"width":"66.66%"} -->
-	<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard. Just think of all the cool tricks you’ll learn!', 'skatepark' ) . '</p>
+	<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard. Just think of all the cool tricks you’ll learn!', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph -->
-	
+
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
-	
+
 	<!-- wp:image {"sizeSlug":"large","style":{"color":{"duotone":["#000","#BFF5A5"]}}} -->
 	<figure class="wp-block-image size-large"><img src="' . get_stylesheet_directory_uri() . '/assets/images/skateboard-sideways.jpg" " alt="' . esc_attr__( 'A skateboard laying on its side on top of concrete.', 'skatepark' ) . '"/></figure>
 	<!-- /wp:image -->
-	
+
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
-	
+
 	<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column -->
 	<div class="wp-block-column"><!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'Discipline', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, and you’ll have fun.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --><!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column -->
 	<div class="wp-block-column"></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column -->
 	<div class="wp-block-column"><!-- wp:heading {"level":4} -->
 	<h4>' . esc_html( 'Friendship', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html( 'Skateboarding is a social sport! Come hang out and meet some new friends to cheer you on while you skate. We have a strict no-bullying policy and maintain a supportive environment.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
-	
+
 	<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column -->
 	<div class="wp-block-column"><!-- wp:separator {"color":"primary","className":"is-style-wide"} -->
 	<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-wide"/>
 	<!-- /wp:separator --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column -->
 	<div class="wp-block-column"><!-- wp:heading {"level":4} -->
 	<h4>' . esc_html( 'Mentoring', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html( 'Work 1:1 with our team of coaches to learn how to skate. They’ll be your mentors and guides while you’re at camp. Plus, many of our older campers will mentor the younger skaters.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column -->
 	<div class="wp-block-column"></div>
 	<!-- /wp:column --></div>

--- a/skatepark/inc/patterns/paragraph-with-quote.php
+++ b/skatepark/inc/patterns/paragraph-with-quote.php
@@ -12,21 +12,21 @@ return array(
 	<div class="wp-block-columns alignwide paragraph-with-quote"><!-- wp:column {"width":"25%"} -->
 	<div class="wp-block-column" style="flex-basis:25%"></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column {"width":"50%"} -->
 	<div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'Why come to Skatepark?', 'skatepark' ) . '</h4>
 	<!-- /wp:heading -->
-	
-	<!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
+
+	<!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html__( 'Skateboarding is a social sport! Come hang out and meet some new friends to cheer you on while you skate. We have a strict no-bullying policy and maintain a supportive environment for all camp attendees. Plus, you’ll work 1:1 with our team of coaches to learn how to skate.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column {"width":"25%"} -->
 	<div class="wp-block-column" style="flex-basis:25%"><!-- wp:quote {"className":"is-style-side-quote"} -->
 	<blockquote class="wp-block-quote is-style-side-quote"><p>' . esc_html__( 'I learned how to do a kick flip and made a bunch of new friends. Can’t wait to go back!', 'skatepark' ) . '</p><cite>' . esc_html__( '– Jane Doe, 11', 'skatepark' ) . '</cite></blockquote>

--- a/skatepark/inc/patterns/two-columns-of-text.php
+++ b/skatepark/inc/patterns/two-columns-of-text.php
@@ -14,16 +14,16 @@ return array(
 	<p class="has-medium-font-size">' . esc_html__( 'Steph Harper. Buddy Sellers. Mehmet Farrow. Bob Lopez. Tammy Habich. Tye Barclay. Kaden Price. Lily Rivera. Chris Wright. Sammy Sanchez. They are all skateboarding icons. Some of them even have video games you may have played.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:column -->
-	
+
 	<!-- wp:column {"width":"550px"} -->
-	<div class="wp-block-column" style="flex-basis:550px"><!-- wp:paragraph {"className":"is-style-indented-paragraph"} -->
-	<p class="is-style-indented-paragraph">' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
+	<div class="wp-block-column" style="flex-basis:550px"><!-- wp:paragraph -->
+	<p>' . esc_html__( 'Skateboarding can teach people discipline, patience, and resiliency. It’s a great sport for kids with a lot of energy! We’ll help build up some structure and support in your life, all while you meet new people and have a ton of fun learning how to skateboard.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html__( 'Skateboarding is a social sport! Come hang out and meet some new friends to cheer you on while you skate. We have a strict no-bullying policy and maintain a supportive environment for all camp attendees.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph -->
-	
+
 	<!-- wp:paragraph -->
 	<p>' . esc_html__( 'Work 1:1 with our team of coaches to learn how to skate. They’ll be your mentors and guides while you’re at camp. Plus, many of our older campers will mentor the younger skaters.', 'skatepark' ) . '</p>
 	<!-- /wp:paragraph --></div>

--- a/skatepark/sass/base/_text.scss
+++ b/skatepark/sass/base/_text.scss
@@ -6,4 +6,18 @@
 p {
 	margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) );
 	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
-} 
+}
+
+.wp-block-post-content {
+	p:first-of-type {
+		text-indent: 15%;
+	}
+}
+
+.wp-block-post-author__content,
+.wp-block-post-comments,
+.wp-block-quote {
+	p:first-of-type {
+		text-indent: 0;
+	}
+}

--- a/skatepark/sass/base/_text.scss
+++ b/skatepark/sass/base/_text.scss
@@ -7,17 +7,3 @@ p {
 	margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) );
 	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
 }
-
-.wp-block-post-content {
-	p:first-of-type {
-		text-indent: 15%;
-	}
-}
-
-.wp-block-post-author__content,
-.wp-block-post-comments,
-.wp-block-quote {
-	p:first-of-type {
-		text-indent: 0;
-	}
-}

--- a/skatepark/sass/block-styles/_indented-paragraph.scss
+++ b/skatepark/sass/block-styles/_indented-paragraph.scss
@@ -1,6 +1,0 @@
-.is-style-indented-paragraph {
-	text-indent: 10em;
-}
-.is-style-indented-post-excerpt p:first-of-type:not(.wp-block-post-excerpt__more-text) {
-	text-indent: 5em;
-}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -10,7 +10,6 @@
 @import "blocks/separator";
 @import "block-patterns/pre-footer";
 @import "block-styles/image-caption";
-@import "block-styles/indented-paragraph";
 @import "block-styles/side-quote";
 @import "block-styles/testimonial-quote";
 @import "block-patterns/pre-footer";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the indented block styles, and replaces them with some CSS to target the first paragraph in each container. The CSS is restricted in scope to only within the post content.

To test, try adding all the block patterns to a post.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/4445
