### PR TITLE
Blockbase: Add social navigation to blockbase themes

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -194,6 +194,11 @@ pre {
 	}
 }
 
+.wp-site-blocks .site-header .wp-block-navigation__responsive-container-content {
+	display: flex;
+	gap: var(--wp--style--block-gap, 2em);
+}
+
 :root {
 	--wpadmin-bar--height: 46px;
 }

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"fontSize":"tiny"} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group site-header" style="padding-bottom:80px">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"fontSize":"tiny"} /-->
+	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -144,6 +144,8 @@ if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
 	require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 }
 
+require get_template_directory() . '/inc/social-navigation.php';
+
 // Force menus to reload
 add_action(
 	'customize_controls_enqueue_scripts',
@@ -157,72 +159,3 @@ add_action(
 		);
 	}
 );
-
-/**
- * Populate the social links block with the social menu content if it exists
- *
- */
-add_filter( 'render_block', 'blockbase_social_menu_render', 10, 2 );
-// We should only change the render of the navigtion block
-// to social links in the following conditions.
-function blockbase_condition_to_render_social_menu( $block ) {
-	// The block should be a navigation block.
-	if ( 'core/navigation' !== $block['blockName'] ) {
-		return false;
-	}
-
-	// The theme should have a menu defined at the social location.
-	if ( ! has_nav_menu( 'social' ) ) {
-		return false;
-	}
-
-	// The block should have a loction defined.
-	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
-		return false;
-	}
-
-	// The block's location should be 'primary'.
-	if ( $block['attrs']['__unstableLocation'] !== 'primary' ) {
-		return false;
-	}
-
-	return true;
-}
-
-function get_social_menu_as_social_links_block() {
-	$nav_menu_locations = get_nav_menu_locations();
-	$social_menu_id = $nav_menu_locations['social'];
-	$class_name = 'is-style-logos-only';
-	if( ! empty( $block['attrs']['itemsJustification'] ) ) {
-		$class_name .= ' items-justified-' . $block['attrs']['itemsJustification'];
-	}
-	$social_links_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"' . $class_name . '"} --><ul class="wp-block-social-links has-icon-color ' . $class_name . '">';
-	$menu = wp_get_nav_menu_items( $social_menu_id );
-	foreach ($menu as $menu_item) {
-		$service_name = preg_replace( '/(-[0-9]+)/', '', $menu_item->post_name );
-		$social_links_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $service_name . '"} /-->';
-	}
-	$social_links_content .= '</ul><!-- /wp:social-links -->';
-	return do_blocks( $social_links_content );
-}
-
-function append_social_links_block_to_primary_navigation( $primary_navigation, $social_links_block ) {
-	$dom = new domDocument;
-	$dom->loadHTML( $primary_navigation );
-	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 );
-	$social_links_node = $dom->createDocumentFragment();
-	$social_links_node->appendXML( $social_links_block );
-	$wp_block_navigation__container->appendChild( $social_links_node );
-	$navigation_block = $dom->getElementsByTagName('nav')->item( 0 );
-	return $dom->saveXML( $navigation_block );
-}
-
-function blockbase_social_menu_render( $block_content, $block ) {
-	if ( blockbase_condition_to_render_social_menu( $block ) ) {
-		$social_links_block = get_social_menu_as_social_links_block();
-
-		return append_social_links_block_to_primary_navigation( $block_content, $social_links_block );
-	}
-
-	return $block_content;
-}

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -30,10 +30,11 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 			)
 		);
 
-		// This theme has one menu location.
+		// Register two nav menus
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'blockbase' ),
+				'social' => __( 'Social Navigation', 'blockbase' )
 			)
 		);
 
@@ -193,8 +194,8 @@ function blockbase_social_menu_render( $block_content, $block ) {
 		$nav_menu_locations = get_nav_menu_locations();
 		$social_menu_id = $nav_menu_locations['social'];
 		$class_name = 'is-style-logos-only';
-		if( !empty( $block['attrs']['itemsJustification'] ) && $block['attrs']['itemsJustification'] === 'right' ) {
-			$class_name .= ' items-justified-right';
+		if( !empty( $block['attrs']['itemsJustification'] ) ) {
+			$class_name .= ' items-justified-' . $block['attrs']['itemsJustification'];
 		}
 		$block_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"' . $class_name . '"} --><ul class="wp-block-social-links has-icon-color ' . $class_name . '">';
 		$menu = wp_get_nav_menu_items( $social_menu_id );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -13,22 +13,8 @@ function blockbase_condition_to_render_social_menu( $block_content, $block ) {
 		return false;
 	}
 
-	// The block should have a loction defined.
-	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
-		return false;
-	}
-
-	// The block's location should be 'primary'.
-	if ( $block['attrs']['__unstableLocation'] !== 'primary' ) {
-		return false;
-	}
-
 	// The block should have a social links attribute.
 	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
-		return false;
-	}
-
-	if ( empty( $block_content ) ) {
 		return false;
 	}
 
@@ -57,11 +43,14 @@ function get_social_menu_as_social_links_block( $block ) {
 	return do_blocks( $social_links_content );
 }
 
-function append_social_links_block_to_primary_navigation( $primary_navigation, $social_links_block ) {
+function append_social_links_block( $parent_content, $social_links_block ) {
+	if ( empty( $parent_content ) ) {
+		return $social_links_block;
+	}
 	$dom = new domDocument;
 	// Since the nav block uses HTML5 element names, we need to suppress the warnings it sends when we loadHTML with HTML5 elements.
 	libxml_use_internal_errors( true );
-	$dom->loadHTML( $primary_navigation );
+	$dom->loadHTML( $parent_content );
 	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 );
 	$social_links_node = $dom->createDocumentFragment();
 	$social_links_node->appendXML( $social_links_block );
@@ -74,13 +63,13 @@ function blockbase_social_menu_render( $block_content, $block ) {
 	if ( blockbase_condition_to_render_social_menu( $block_content, $block ) ) {
 		$social_links_block = get_social_menu_as_social_links_block( $block );
 
-		return append_social_links_block_to_primary_navigation( $block_content, $social_links_block );
+		return append_social_links_block( $block_content, $social_links_block );
 	}
 
 	return $block_content;
 }
 
 /**
- * Hijack the render of the primary menu to inject a social menu.
+ * Hijack the render of the menu block to inject a social menu.
  */
 add_filter( 'render_block', 'blockbase_social_menu_render', 10, 2 );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -45,6 +45,8 @@ function get_social_menu_as_social_links_block() {
 
 function append_social_links_block_to_primary_navigation( $primary_navigation, $social_links_block ) {
 	$dom = new domDocument;
+	// Since the nav block uses HTML5 element names, we need to suppress the warnings it sends when we loadHTML with HTML5 elements.
+	libxml_use_internal_errors( true );
 	$dom->loadHTML( $primary_navigation );
 	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 );
 	$social_links_node = $dom->createDocumentFragment();

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -1,0 +1,70 @@
+<?php
+
+// We should only change the render of the navigtion block
+// to social links in the following conditions.
+function blockbase_condition_to_render_social_menu( $block ) {
+	// The block should be a navigation block.
+	if ( 'core/navigation' !== $block['blockName'] ) {
+		return false;
+	}
+
+	// The theme should have a menu defined at the social location.
+	if ( ! has_nav_menu( 'social' ) ) {
+		return false;
+	}
+
+	// The block should have a loction defined.
+	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
+		return false;
+	}
+
+	// The block's location should be 'primary'.
+	if ( $block['attrs']['__unstableLocation'] !== 'primary' ) {
+		return false;
+	}
+
+	return true;
+}
+
+function get_social_menu_as_social_links_block() {
+	$nav_menu_locations = get_nav_menu_locations();
+	$social_menu_id = $nav_menu_locations['social'];
+	$class_name = 'is-style-logos-only';
+	if( ! empty( $block['attrs']['itemsJustification'] ) ) {
+		$class_name .= ' items-justified-' . $block['attrs']['itemsJustification'];
+	}
+	$social_links_content = '<!-- wp:social-links {"iconColor":"primary","iconColorValue":"var(--wp--custom--color--primary)","className":"' . $class_name . '"} --><ul class="wp-block-social-links has-icon-color ' . $class_name . '">';
+	$menu = wp_get_nav_menu_items( $social_menu_id );
+	foreach ($menu as $menu_item) {
+		$service_name = preg_replace( '/(-[0-9]+)/', '', $menu_item->post_name );
+		$social_links_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $service_name . '"} /-->';
+	}
+	$social_links_content .= '</ul><!-- /wp:social-links -->';
+	return do_blocks( $social_links_content );
+}
+
+function append_social_links_block_to_primary_navigation( $primary_navigation, $social_links_block ) {
+	$dom = new domDocument;
+	$dom->loadHTML( $primary_navigation );
+	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 );
+	$social_links_node = $dom->createDocumentFragment();
+	$social_links_node->appendXML( $social_links_block );
+	$wp_block_navigation__container->appendChild( $social_links_node );
+	$navigation_block = $dom->getElementsByTagName('nav')->item( 0 );
+	return $dom->saveXML( $navigation_block );
+}
+
+function blockbase_social_menu_render( $block_content, $block ) {
+	if ( blockbase_condition_to_render_social_menu( $block ) ) {
+		$social_links_block = get_social_menu_as_social_links_block();
+
+		return append_social_links_block_to_primary_navigation( $block_content, $social_links_block );
+	}
+
+	return $block_content;
+}
+
+/**
+ * Hijack the render of the primary menu to inject a social menu.
+ */
+add_filter( 'render_block', 'blockbase_social_menu_render', 10, 2 );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -23,12 +23,22 @@ function blockbase_condition_to_render_social_menu( $block ) {
 		return false;
 	}
 
+	// The block should have a social links attribute.
+	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
+		return false;
+	}
+
 	return true;
 }
 
-function get_social_menu_as_social_links_block() {
+function get_social_menu_as_social_links_block( $block ) {
+	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
+		return false;
+	}
+
+	$social_links_location = $block['attrs']['__unstableSocialLinks'];
 	$nav_menu_locations = get_nav_menu_locations();
-	$social_menu_id = $nav_menu_locations['social'];
+	$social_menu_id = $nav_menu_locations[ $social_links_location ];
 	$class_name = 'is-style-logos-only';
 	if( ! empty( $block['attrs']['itemsJustification'] ) ) {
 		$class_name .= ' items-justified-' . $block['attrs']['itemsJustification'];
@@ -58,7 +68,7 @@ function append_social_links_block_to_primary_navigation( $primary_navigation, $
 
 function blockbase_social_menu_render( $block_content, $block ) {
 	if ( blockbase_condition_to_render_social_menu( $block ) ) {
-		$social_links_block = get_social_menu_as_social_links_block();
+		$social_links_block = get_social_menu_as_social_links_block( $block );
 
 		return append_social_links_block_to_primary_navigation( $block_content, $social_links_block );
 	}

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -48,10 +48,11 @@ function append_social_links_block( $parent_content, $social_links_block ) {
 		return $social_links_block;
 	}
 	$dom = new domDocument;
+	$domXPath = new DomXPath( $dom );
 	// Since the nav block uses HTML5 element names, we need to suppress the warnings it sends when we loadHTML with HTML5 elements.
 	libxml_use_internal_errors( true );
 	$dom->loadHTML( $parent_content );
-	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 );
+	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 )->parentNode;
 	$social_links_node = $dom->createDocumentFragment();
 	$social_links_node->appendXML( $social_links_block );
 	$wp_block_navigation__container->appendChild( $social_links_node );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -2,7 +2,7 @@
 
 // We should only change the render of the navigtion block
 // to social links in the following conditions.
-function blockbase_condition_to_render_social_menu( $block ) {
+function blockbase_condition_to_render_social_menu( $block_content, $block ) {
 	// The block should be a navigation block.
 	if ( 'core/navigation' !== $block['blockName'] ) {
 		return false;
@@ -25,6 +25,10 @@ function blockbase_condition_to_render_social_menu( $block ) {
 
 	// The block should have a social links attribute.
 	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
+		return false;
+	}
+
+	if ( empty( $block_content ) ) {
 		return false;
 	}
 
@@ -67,7 +71,7 @@ function append_social_links_block_to_primary_navigation( $primary_navigation, $
 }
 
 function blockbase_social_menu_render( $block_content, $block ) {
-	if ( blockbase_condition_to_render_social_menu( $block ) ) {
+	if ( blockbase_condition_to_render_social_menu( $block_content, $block ) ) {
 		$social_links_block = get_social_menu_as_social_links_block( $block );
 
 		return append_social_links_block_to_primary_navigation( $block_content, $social_links_block );

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -35,4 +35,10 @@
 			order: 10;
 		}
 	}
+
+	.wp-block-navigation__responsive-container-content {
+		// Needed until https://github.com/WordPress/gutenberg/issues/35549 is fixed.
+		display: flex;
+		gap: var( --wp--style--block-gap, 2em );
+	}
 }

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -5,5 +5,6 @@
 <!-- wp:site-tagline {"fontSize":"tiny"} /-->
 <!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -5,6 +5,5 @@
 <!-- wp:site-tagline {"fontSize":"tiny"} /-->
 <!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -2,8 +2,7 @@
 <div class="wp-block-group site-header" style="padding-bottom:32px">
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->
-<!-- wp:site-tagline {"fontSize":"tiny"} /-->
-<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
-<!-- /wp:navigation -->
+<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+<!-- wp:navigation {"textColor":"foreground-light","fontSize":"small","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/functions.php
+++ b/mayland-blocks/functions.php
@@ -10,13 +10,6 @@ if ( ! function_exists( 'mayland_blocks_support' ) ) :
 			)
 		);
 
-		// This theme has one menu location.
-		register_nav_menus(
-			array(
-				'primary' => __( 'Primary Navigation', 'mayland-blocks' ),
-			)
-		);
-
 	}
 	add_action( 'after_setup_theme', 'mayland_blocks_support' );
 endif;

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -17,13 +17,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 			'starter-content',
 			$quadrat_starter_content
 		);
-
-		// This theme uses wp_nav_menu() in two locations.
-		register_nav_menus(
-			array(
-				'primary' => __( 'Primary Navigation', 'quadrat' ),
-			)
-		);
 	}
 	add_action( 'after_setup_theme', 'quadrat_support' );
 endif;

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -170,7 +170,11 @@
 	line-height: 30px;
 }
 
-/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation), 
+.wp-block-navigation__responsive-container:not(.has-modal-open) .wp-block-social-links {
+	flex-basis: 100%;
+}
+
+/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
 is passed all of the block attributes on the block definition in the template. */
 .wp-block-navigation__container {
 	justify-content: center;

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -11,6 +11,8 @@
 <!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
 
+<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"center","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
+
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,8 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary"} -->
-<!-- /wp:navigation -->
+<!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -11,8 +11,6 @@
 <!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
 
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"center","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
-
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/functions.php
+++ b/seedlet-blocks/functions.php
@@ -12,13 +12,6 @@ function seedlet_blocks_support() {
 		)
 	);
 
-	// This theme has one menu location.
-	register_nav_menus(
-		array(
-			'primary' => __( 'Primary Navigation', 'seedlet-blocks' ),
-		)
-	);
-
 }
 add_action( 'after_setup_theme', 'seedlet_blocks_support' );
 

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -16,9 +16,13 @@
 			}
 		}
 	}
+
+	&:not(.has-modal-open) .wp-block-social-links {
+		flex-basis: 100%;
+	}
 }
 
-/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation), 
+/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
 is passed all of the block attributes on the block definition in the template. */
 .wp-block-navigation__container {
 	justify-content: center;

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -524,14 +524,14 @@ header.wp-block-template-part > .wp-block-group > * > * {
 	}
 }
 
-header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
-	margin-right: -2px;
+@media (min-width: 600px) {
+	header.wp-block-template-part > .wp-block-group .wp-block-social-links {
+		flex-basis: 100%;
+	}
 }
 
-@media (min-width: 600px) {
-	header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
-		margin-top: calc( -1 * ( 8px + 0.25em ));
-	}
+header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
+	margin-right: -2px;
 }
 
 @media (max-width: 599px) {
@@ -554,6 +554,12 @@ header.wp-block-template-part .site-brand {
 	display: grid;
 	grid-template-areas: "logo title" "logo tagline";
 	grid-template-columns: auto 1fr;
+}
+
+@media (min-width: 600px) {
+	header.wp-block-template-part .site-brand {
+		grid-template-rows: 35px auto;
+	}
 }
 
 @media (max-width: 599px) {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -524,21 +524,8 @@ header.wp-block-template-part > .wp-block-group > * > * {
 	}
 }
 
-@media (min-width: 600px) {
-	header.wp-block-template-part > .wp-block-group .wp-block-social-links {
-		flex-basis: 100%;
-	}
-}
-
-header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
-	margin-right: -2px;
-}
-
-@media (max-width: 599px) {
-	header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
-		margin-left: -0.25em;
-		margin-right: 0;
-	}
+header.wp-block-template-part > .wp-block-group .wp-block-social-links {
+	margin: 0;
 }
 
 header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only > .wp-social-link {
@@ -616,7 +603,6 @@ header.wp-block-template-part .site-brand .wp-block-site-tagline {
 	}
 	.nav-links .wp-block-social-links {
 		justify-content: flex-start;
-		grid-area: social;
 	}
 }
 

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -11,9 +11,6 @@
 <div class="wp-block-group nav-links"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} -->
 <!-- /wp:navigation -->
 
-<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
-
-
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group { "layout":{"type":"flex"}} -->
+<!-- wp:group {"layout":{"type":"flex"}} -->
 <div class="wp-block-group">
 <!-- wp:group {"className":"site-brand"} -->
 <div class="wp-block-group site-brand">
@@ -8,9 +8,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"className":"nav-links"} -->
-<div class="wp-block-group nav-links"><!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small"} -->
-<!-- /wp:navigation -->
-
+<div class="wp-block-group nav-links">
+	<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -9,14 +9,6 @@ if ( ! function_exists( 'skatepark_support' ) ) :
 				'/assets/theme.css',
 			)
 		);
-
-		//Primary navigation is used on the header and the footer pattern
-		register_nav_menus(
-			array(
-				'primary' => __( 'Primary Navigation', 'skatepark' ),
-				'social' => __( 'Social Navigation', 'skatepark' )
-			)
-		);
 	}
 	add_action( 'after_setup_theme', 'skatepark_support' );
 endif;

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -3,7 +3,7 @@ header.wp-block-template-part {
 	margin: 0 auto;
 	width: 100%;
 	margin-top: calc( 0.5 * var(--wp--custom--gap--vertical) );
-	
+
 	> .wp-block-group {
 		gap: 0;
 		justify-content: space-between; // Apply a cluster (flex?) layout
@@ -30,11 +30,13 @@ header.wp-block-template-part {
 		}
 
 		.wp-block-social-links {
+			@include break-small(){
+				flex-basis: 100%;
+			}
+
 			&.is-style-logos-only {
 				margin-right: -2px; // Visually align social links to the right
-				@include break-small(){
-					margin-top: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the tagline
-				}
+
 				@include break-small-only(){
 					margin-left: -0.25em;
 					margin-right: 0;
@@ -57,6 +59,11 @@ header.wp-block-template-part {
 			"logo title"
 			"logo tagline";
 		grid-template-columns: auto 1fr;
+
+		@include break-small(){
+			grid-template-rows: 35px auto;
+		}
+
 		@include break-small-only(){
 			grid-template-areas:
 				"logo"

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -30,17 +30,9 @@ header.wp-block-template-part {
 		}
 
 		.wp-block-social-links {
-			@include break-small(){
-				flex-basis: 100%;
-			}
+			margin: 0;
 
 			&.is-style-logos-only {
-				margin-right: -2px; // Visually align social links to the right
-
-				@include break-small-only(){
-					margin-left: -0.25em;
-					margin-right: 0;
-				}
 				> .wp-social-link {
 					padding: 0; // Needed to override Gutenberg default padding on this block style variation
 
@@ -108,7 +100,6 @@ header.wp-block-template-part {
 		}
 		.wp-block-social-links {
 			justify-content: flex-start;
-			grid-area: social;
 		}
 	}
 }

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds social navigation to all Blockbase themes:

Seedlet blocks
<img width="569" alt="Screenshot 2021-10-12 at 14 09 19" src="https://user-images.githubusercontent.com/275961/136962477-1cbdde2f-4c01-4abb-92de-8ec3690c3a1c.png">
<img width="475" alt="Screenshot 2021-10-12 at 14 09 08" src="https://user-images.githubusercontent.com/275961/136962487-c50ddea5-86d5-445c-9fcb-91385d5c2fe7.png">

Mayland Blocks
<img width="1109" alt="Screenshot 2021-10-12 at 14 08 33" src="https://user-images.githubusercontent.com/275961/136962495-75314e4e-0b32-42c6-8104-01340111a6de.png">
<img width="477" alt="Screenshot 2021-10-12 at 14 08 45" src="https://user-images.githubusercontent.com/275961/136962493-4e9b3dc9-6e2f-4d16-ad60-edcbc7b711b7.png">

Geologist
<img width="1073" alt="Screenshot 2021-10-12 at 14 07 30" src="https://user-images.githubusercontent.com/275961/136962500-d5e0f37c-0c2c-41aa-95ba-b7ccf7e555cb.png">
<img width="440" alt="Screenshot 2021-10-12 at 14 07 45" src="https://user-images.githubusercontent.com/275961/136962498-952ec1ac-894e-4ff1-9847-aa614ced280a.png">

Quadrat
<img width="1114" alt="Screenshot 2021-10-12 at 14 05 54" src="https://user-images.githubusercontent.com/275961/136962503-7021f499-eea8-4529-9958-1773636acbf0.png">
<img width="508" alt="Screenshot 2021-10-12 at 14 06 08" src="https://user-images.githubusercontent.com/275961/136962502-92ebae6f-9ad8-40c4-81f1-fc76a5d4fbbc.png">

Blockbase:
<img width="1092" alt="Screenshot 2021-10-12 at 14 03 06" src="https://user-images.githubusercontent.com/275961/136962509-46b78a56-8401-4c67-ba99-c641b0960de5.png">
<img width="500" alt="Screenshot 2021-10-12 at 14 03 20" src="https://user-images.githubusercontent.com/275961/136962505-7c6aab86-a293-4a27-8dda-ebf21ad46bb0.png">

Skatepark
<img width="878" alt="Screenshot 2021-10-12 at 13 25 04" src="https://user-images.githubusercontent.com/275961/136962515-9ce9c776-0dbd-4c26-a221-09012d17cd9c.png">
<img width="439" alt="Screenshot 2021-10-12 at 13 25 39" src="https://user-images.githubusercontent.com/275961/136962512-fc39072c-9881-4f83-a7f5-0b2156dc84e3.png">
<img width="439" alt="Screenshot 2021-10-12 at 13 25 14" src="https://user-images.githubusercontent.com/275961/136962513-d82b7a20-66c1-478e-af66-518b79866e4e.png">

