### PR TITLE
Skatepark: Add title divider

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -234,7 +234,7 @@ p {
 }
 
 .wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
-	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2);
 }
 

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -233,6 +233,11 @@ p {
 	text-decoration: none;
 }
 
+.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
+	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2);
+}
+
 .wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -57,3 +57,15 @@ require get_stylesheet_directory() . '/inc/block-patterns.php';
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';
+
+/**
+ * Add class to body if post/page has a featured image.
+ */
+function add_featured_image_class( $classes ) {    
+	global $post;
+	if ( isset ( $post->ID ) && get_the_post_thumbnail( $post->ID ) ) {
+		$classes[] = 'has-featured-image';
+	}
+	return $classes;
+}
+add_filter( 'body_class', 'add_featured_image_class' );

--- a/skatepark/sass/blocks/_post-title.scss
+++ b/skatepark/sass/blocks/_post-title.scss
@@ -1,4 +1,4 @@
 .wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
-	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2 );
 }

--- a/skatepark/sass/blocks/_post-title.scss
+++ b/skatepark/sass/blocks/_post-title.scss
@@ -1,0 +1,4 @@
+.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
+	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
+	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2 );
+}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -5,6 +5,7 @@
 @import "blocks/author";
 @import "blocks/buttons";
 @import "blocks/post-comments";
+@import "blocks/post-title";
 @import "blocks/query";
 @import "blocks/search";
 @import "blocks/separator";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds a bottom border to the post title block if there is no featured image.

<img width="1251" alt="Screenshot 2021-08-27 at 14 09 47" src="https://user-images.githubusercontent.com/1645628/131133256-f78ddae6-6c2e-4568-8878-53392da6573d.png">

I tried to do this with CSS but ended up adding a PHP function to add a class to the body instead.. not sure how we'd normally handle something like this!

#### Related issue(s):
Closes #4417.