### PR TITLE
Skatepark: use variables in header

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -551,8 +551,8 @@ header.wp-block-template-part > .wp-block-group > * {
 }
 
 header.wp-block-template-part > .wp-block-group > * > * {
-	margin-top: 20px;
-	margin-bottom: 20px;
+	margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
 }
 
 header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
@@ -568,7 +568,7 @@ header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
-		border-bottom: 2px solid var(--wp--custom--color--primary);
+		border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
 	}
 }
 

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -10,8 +10,8 @@ header.wp-block-template-part {
 		> * {
 			flex-grow: 1; // Needed to maintain alignment when the containers stack
 			> * { // Apply a stack layout (page 69 of the every-layout.dev PDF) 
-				margin-top: 20px;
-				margin-bottom: 20px;
+				margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+				margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
 			}
 		}
 
@@ -29,6 +29,6 @@ header.wp-block-template-part {
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
-		border-bottom: 2px solid var(--wp--custom--color--primary);
+		border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The separator thickness in the mobile header did not match the design.  I updated it to use variables, as well as the padding values which were previously hard-coded.

Before | After 
------ | ------
<img width="487" alt="Screen Shot 2021-08-27 at 11 10 40 AM" src="https://user-images.githubusercontent.com/5375500/131150424-d33fd27c-bcad-4b53-ad4a-4862fda01ad8.png"> | <img width="407" alt="Screen Shot 2021-08-27 at 11 17 23 AM" src="https://user-images.githubusercontent.com/5375500/131150436-15012fbb-65cd-415a-8bf5-6698cf8f1db9.png">

(screenshots include changes introduced in #4483)

#### Related issue(s):
Discovered when testing https://github.com/Automattic/themes/pull/4483