### PR TITLE
Blockbase: Improve blockbase_fonts_url handling

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -83,26 +83,28 @@ function blockbase_fonts_url() {
 	}
 
 	$font_families = [];
-	if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
-		foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
-			if ( ! empty( $font['google'] ) ) {
-				$font_families[] = $font['google'];
-			}
-		}
-	}
-
 	if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
 		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
 			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
 		}
+	} else {
+		if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
+			foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
+				if ( ! empty( $font['google'] ) ) {
+					$font_families[] = $font['google'];
+				}
+			}
+		}
+	}
+	
+	if ( empty( $font_families ) ) {
+		return '';
 	}
 
-	$font_families[] = 'display=swap';
-
-	// Make a single request for the theme fonts.
-	return esc_url_raw( 'https://fonts.googleapis.com/css2?' . implode( '&', $font_families ) );
+	// Make a single request for the theme or user fonts.
+	return esc_url_raw( 'https://fonts.googleapis.com/css2?' . implode( '&', array_unique( $font_families ) ) . '&display=swap' );
 }
 
 /**


### PR DESCRIPTION
This change adresses multiple issues. 

#### Changes proposed in this Pull Request:

1. prevents the possibility of an "empty" call to fonts.googleapis.com by returning empty instead of `https://fonts.googleapis.com/css2?&display=swap`
2. prevents a child theme custom Google font to ALWAYS be called even if it's is not selected in the user settings
3. prevents duplicate URL parameters when both user body and header fonts are set to the same value with `array_unique`

#### Related issue(s):

1. #4458
2. #4487
3. #4488