### PR TITLE
Skatepark: refactor duotone blocks to use the new opacity setting

### DIFF
--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -10,7 +10,7 @@
 	<hr class="wp-block-separator is-style-wide"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":["#000","#B9FB9C"]}}} /-->
+	<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} /-->
 
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 

--- a/skatepark/block-templates/page.html
+++ b/skatepark/block-templates/page.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"5em"}}}} -->
 <div class="wp-block-group" style="padding-bottom:5em">
-<!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","#B9FB9C"]}}} /--></div>
+<!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"5em"}}}} -->
 <div class="wp-block-group" style="padding-bottom:5em">
-<!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","#B9FB9C"]}}} /--></div>
+<!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/skatepark/inc/patterns/blog-posts.php
+++ b/skatepark/inc/patterns/blog-posts.php
@@ -15,7 +15,7 @@ return array(
 	<hr class="wp-block-separator is-style-wide"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":["#000","#B9FB9C"]}}} /-->
+	<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} /-->
 
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal"} /-->
 

--- a/skatepark/inc/patterns/columns-in-container.php
+++ b/skatepark/inc/patterns/columns-in-container.php
@@ -39,7 +39,7 @@ return array(
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:image {"align":"wide","id":26,"sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#B9FB9C"]}}} -->
+	<!-- wp:image {"align":"wide","id":26,"sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} -->
 	<figure class="wp-block-image alignwide size-large"><img src="https://skateparkdemo.files.wordpress.com/2021/08/693372530767c766f2db45bbfb132770-2048x1365-1.jpeg?w=1024" alt="' . esc_html__( 'Close-up of a person riding a skateboard, focusing on their feet and the board. One foot is on the board, while the other foot is up, in motion. A skatepark is blurred in the background.', 'skatepark' ) . '" class="wp-image-26"/></figure>
 	<!-- /wp:image -->
 

--- a/skatepark/inc/patterns/full-width-image-with-aside-caption.php
+++ b/skatepark/inc/patterns/full-width-image-with-aside-caption.php
@@ -8,7 +8,7 @@
 return array(
 	'title'      => __( 'Full width image with aside caption', 'skatepark' ),
 	'categories' => array( 'skatepark' ),
-	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#BFF5A5"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
+	'content'    => '<!-- wp:image {"align":"full","sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]},"border":{"radius":"0px"}},"className":"is-style-skatepark-aside-caption"} -->
 	<figure class="wp-block-image alignfull size-large is-style-skatepark-aside-caption" style="border-radius:0px"><img src="https://skateparkdemo.files.wordpress.com/2021/08/stocksnap_5otfjyvyse.jpg" alt="' . esc_attr__( "A skateboarder does a grab trick in a bowl-shaped skate park. In the background is a watching crowd, palm trees, and the ocean.", 'skatepark' ) . '"/><figcaption>' . esc_html__( "Learn the basics of skating along with a group of your peers. More advanced at skating? Our skateboarding coaches will work with you 1:1 to advance your technique.", 'skatepark' ) . '</figcaption></figure>
 	<!-- /wp:image -->',
 );

--- a/skatepark/inc/patterns/mixed-media-in-container.php
+++ b/skatepark/inc/patterns/mixed-media-in-container.php
@@ -29,7 +29,7 @@ return array(
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	
-	<!-- wp:image {"sizeSlug":"large","style":{"color":{"duotone":["#000","#BFF5A5"]}}} -->
+	<!-- wp:image {"sizeSlug":"large","style":{"color":{"duotone":["#000","rgba(0, 0, 0, 0)"]}}} -->
 	<figure class="wp-block-image size-large"><img src="' . get_stylesheet_directory_uri() . '/assets/images/skateboard-sideways.jpg" " alt="' . esc_attr__( 'A skateboard laying on its side on top of concrete.', 'skatepark' ) . '"/></figure>
 	<!-- /wp:image -->
 	


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR applies the changes from [this change](https://github.com/WordPress/gutenberg/pull/34130) to the duotone filter. This changes the block patterns and templates that use duotone so that they don't have the green/black combination but instead they use a black/transparent combination to blend with the background. This means that when we change colors for the theme the duotone images are no longer green, but they blend in with the background.

![Screenshot 2021-08-30 at 15-45-21 Duotone tests – fdsfsdf](https://user-images.githubusercontent.com/3593343/131349763-01b682e6-1816-457e-8083-49dc956dbc0f.png)

There's still an issue with the Blue/Cream and Green/Pink color options, since in the design those are expecting the opposite combination of background/foreground colors on their duotone filter. These two combinations are not blending into the background color but instead are doing the opposite:

![Screenshot 2021-08-30 at 15-45-47 Duotone tests – fdsfsdf](https://user-images.githubusercontent.com/3593343/131350042-829edcbd-c484-4438-b1f4-275798a6cc92.png)



