### PR TITLE
Fix unchanged font setting reverting to default

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -386,15 +386,18 @@ class GlobalStylesFontsCustomizer {
 			return;
 		}
 
+		$body_current    = $wp_customize->get_setting( $this->section_key . 'body' )->value();
+		$heading_current = $wp_customize->get_setting( $this->section_key . 'heading' )->value();
+
 		$body_default    = $wp_customize->get_setting( $this->section_key . 'body' )->default;
 		$heading_default = $wp_customize->get_setting( $this->section_key . 'heading' )->default;
 
 		if ( ! isset( $body_value ) ) {
-			$body_value = $body_default;
+			$body_value = $body_current;
 		}
 
 		if ( ! isset( $heading_value ) ) {
-			$heading_value = $heading_default;
+			$heading_value = $heading_current;
 		}
 
 		$body_setting    = $this->fonts[ $body_value ];
@@ -408,14 +411,6 @@ class GlobalStylesFontsCustomizer {
 
 		$body_font_family_variable    = 'var(--wp--preset--font-family--' . $body_setting['slug'] . ')';
 		$heading_font_family_variable = 'var(--wp--preset--font-family--' . $heading_setting['slug'] . ')';
-
-		$google_font_array = array();
-		if ( isset( $body_setting['google'] ) ) {
-			$google_font_array[] = $body_setting['google'];
-		}
-		if ( isset( $heading_setting['google'] ) ) {
-			$google_font_array[] = $heading_setting['google'];
-		}
 
 		// Get the user's theme.json from the CPT.
 		$user_custom_post_type_id     = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
@@ -499,12 +494,12 @@ class GlobalStylesFontsCustomizer {
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
 			unset( $user_theme_json_post_content->styles->typography->fontFamilies );
 			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h1->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h2->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h3->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h4->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h5->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elemenets->h6->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h1->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h2->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h3->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h4->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h5->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->elements->h6->typography->fontFamilies );
 			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamilies );
 		}
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -150,7 +150,7 @@ class GlobalStylesFontsCustomizer {
 			'name'       => 'Raleway',
 			'google'     => 'family=Raleway:ital,wght@0,100..900;1,100..900',
 		),
-		'red-hat-display'=> array(
+		'red-hat-display'   => array(
 			'fontFamily' => '"Red Hat Display", sans-serif',
 			'slug'       => 'red-hat-display',
 			'name'       => 'Red Hat Display',
@@ -379,25 +379,22 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function handle_customize_save_after( $wp_customize ) {
-		$body_value    = $wp_customize->get_setting( $this->section_key . 'body' )->post_value();
-		$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->post_value();
+		$body_value    = $wp_customize->get_setting( $this->section_key . 'body' )->value();
+		$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->value();
 
 		if ( ! isset( $body_value ) && ! isset( $heading_value ) ) {
 			return;
 		}
 
-		$body_current    = $wp_customize->get_setting( $this->section_key . 'body' )->value();
-		$heading_current = $wp_customize->get_setting( $this->section_key . 'heading' )->value();
-
 		$body_default    = $wp_customize->get_setting( $this->section_key . 'body' )->default;
 		$heading_default = $wp_customize->get_setting( $this->section_key . 'heading' )->default;
 
 		if ( ! isset( $body_value ) ) {
-			$body_value = $body_current;
+			$body_value = $body_default;
 		}
 
 		if ( ! isset( $heading_value ) ) {
-			$heading_value = $heading_current;
+			$heading_value = $heading_default;
 		}
 
 		$body_setting    = $this->fonts[ $body_value ];
@@ -492,15 +489,17 @@ class GlobalStylesFontsCustomizer {
 
 		//If the typeface choices === the default then we remove it instead
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
-			unset( $user_theme_json_post_content->styles->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h1->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h2->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h3->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h4->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h5->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->elements->h6->typography->fontFamilies );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamilies );
+			unset( $user_theme_json_post_content->settings->typography->fontFamilies );
+			unset( $user_theme_json_post_content->styles->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h1->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h2->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h3->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h4->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h5->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->elements->h6->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamily );
+			unset( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography->fontFamily );
 		}
 
 		// Update the theme.json with the new settings.


### PR DESCRIPTION
These changes fix issue #4490

1. use current setting instead of default to fill in missing post data
2. remove unused $google_font_array
3 correct type-o `elemenets` in unset values

---

This was tweaked from the [original PR](https://github.com/Automattic/themes/pull/4491) to further address the "unset" logic (so that the correct values were actually being unset) and to continue leveraging the default value (instead of current) for states when the value is not provided.

#### Related issue(s):
#4490