### PR TITLE
Remove block attributes from site-title in header

### DIFF
--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -3,7 +3,7 @@
 <!-- wp:group -->
 <div class="wp-block-group">
 <!-- wp:site-logo /-->
-<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"900"}},"fontSize":"large"} /-->
+<!-- wp:site-title /-->
 <!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontWeight":"500"}}} /--></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Removed block attributes from site-title in header as they are set in theme.json (and some of those items removed were incorrect)

Before:
![image](https://user-images.githubusercontent.com/146530/131397582-4f27e5bc-d96c-4030-af8b-afc1f7f1a0c6.png)

After:
![image](https://user-images.githubusercontent.com/146530/131397547-d60088d2-f117-415b-a8b6-161d52286762.png)
