### PR TITLE
Morden: fix hover color for social navigation icons

### DIFF
--- a/morden/style.css
+++ b/morden/style.css
@@ -3094,7 +3094,7 @@ body:not(.fse-enabled) .main-navigation a {
 }
 
 .social-navigation a:hover {
-	color: rgba(var(--wp--preset--color--background), 0.8);
+	opacity: 0.8;
 }
 
 .social-navigation svg {


### PR DESCRIPTION
Issue:
Morden social navigation icons become invisible when hovered on.
Cause: seems that the rgba value using both a variable and opacity causes the theme to nope out - icons become invisible:

![invisible](https://user-images.githubusercontent.com/36608681/131483627-dfcbfe7c-696e-4d89-a8e4-8449e4c2266a.png)

#### Changes proposed in this Pull Request:
Removing this:

```
.social-navigation a:hover {
    color: rgba(var(--wp--preset--color--background),.8);
}
```

Adding this:

```
.social-navigation a:hover {
	opacity: 0.8;
}
```

![opacity](https://user-images.githubusercontent.com/36608681/131479141-163a6097-db91-4c09-ba34-f47203e70836.png)

#### Related issue(s):
#4513 4513
