### PR TITLE
Skatepark: improve header styles to fit new design guidelines

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -610,7 +610,7 @@ header.wp-block-template-part .site-brand .wp-block-site-logo {
 
 @media (max-width: 599px) {
 	header.wp-block-template-part .site-brand .wp-block-site-logo {
-		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
+		margin-bottom: calc( 0.75 * var(--wp--custom--margin--vertical));
 	}
 }
 
@@ -625,11 +625,17 @@ header.wp-block-template-part .site-brand .wp-block-site-tagline {
 }
 
 @media (max-width: 599px) {
+	header.wp-block-template-part .site-brand .wp-block-site-tagline {
+		margin-bottom: calc( 0.25 * var(--wp--custom--margin--vertical));
+	}
+}
+
+@media (max-width: 599px) {
 	.nav-links {
 		display: contents;
 	}
 	.nav-links .wp-block-navigation__responsive-container-open {
-		margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+		margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) - 3px);
 	}
 	.nav-links .wp-block-navigation {
 		grid-area: menu;

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -553,6 +553,15 @@ header.wp-block-template-part > .wp-block-group {
 	align-items: flex-start;
 }
 
+@media (max-width: 599px) {
+	header.wp-block-template-part > .wp-block-group {
+		grid-row-gap: calc( 0.25 * var(--wp--custom--margin--vertical));
+		display: grid;
+		grid-template-areas: "brand menu" "social social";
+		border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
+	}
+}
+
 header.wp-block-template-part > .wp-block-group > * {
 	flex-grow: 1;
 }
@@ -588,6 +597,7 @@ header.wp-block-template-part .site-brand {
 @media (max-width: 599px) {
 	header.wp-block-template-part .site-brand {
 		grid-template-areas: "logo" "title" "tagline";
+		grid-area: brand;
 	}
 }
 
@@ -596,7 +606,6 @@ header.wp-block-template-part .site-brand .wp-block-site-logo {
 	margin: 0;
 	max-width: 120px;
 	align-self: center;
-	justify-self: flex-end;
 }
 
 @media (max-width: 599px) {
@@ -617,10 +626,17 @@ header.wp-block-template-part .site-brand .wp-block-site-tagline {
 
 @media (max-width: 599px) {
 	.nav-links {
-		display: flex;
-		justify-content: space-between;
-		width: 100%;
-		border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
+		display: contents;
+	}
+	.nav-links .wp-block-navigation__responsive-container-open {
+		margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+	}
+	.nav-links .wp-block-navigation {
+		grid-area: menu;
+	}
+	.nav-links .wp-block-social-links {
+		justify-content: flex-start;
+		grid-area: social;
 	}
 }
 

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -582,6 +582,12 @@ header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-
 	margin-right: calc( -1 * ( 8px + 0.25em ));
 }
 
+@media (min-width: 600px) {
+	header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
+		margin-top: calc( -1 * ( 8px + 0.25em ));
+	}
+}
+
 @media (max-width: 599px) {
 	header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
 		margin-left: -0.25em;
@@ -624,6 +630,12 @@ header.wp-block-template-part .site-brand .wp-block-site-logo {
 header.wp-block-template-part .site-brand .wp-block-site-title {
 	grid-area: title;
 	margin: 0 0 0.5em;
+}
+
+@media (max-width: 599px) {
+	header.wp-block-template-part .site-brand .wp-block-site-title {
+		margin: 0 0 0.25em;
+	}
 }
 
 header.wp-block-template-part .site-brand .wp-block-site-tagline {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -582,6 +582,13 @@ header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-
 	margin-right: calc( -1 * ( 8px + 0.25em ));
 }
 
+@media (max-width: 599px) {
+	header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only {
+		margin-left: -0.25em;
+		margin-right: 0;
+	}
+}
+
 header.wp-block-template-part > .wp-block-group .wp-block-social-links.is-style-logos-only > .wp-social-link {
 	padding: 0;
 }

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -30,6 +30,10 @@ header.wp-block-template-part {
 
 		.wp-block-social-links.is-style-logos-only {
 			margin-right: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the right
+			@include break-small-only(){
+				margin-left: -0.25em;
+				margin-right: 0;
+			}
 			> .wp-social-link {
 				padding: 0; // Needed to override Gutenberg default padding on this block style variation
 			}

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -57,7 +57,7 @@ header.wp-block-template-part {
 			max-width: 120px;
 			align-self: center;
 			@include break-small-only(){
-				margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
+				margin-bottom: calc( 0.75 * var(--wp--custom--margin--vertical) );
 			}
 		}
 		.wp-block-site-title {
@@ -67,6 +67,9 @@ header.wp-block-template-part {
 		.wp-block-site-tagline {
 			grid-area: tagline;
 			margin: 0;
+			@include break-small-only(){
+				margin-bottom: calc( 0.25 * var(--wp--custom--margin--vertical) );
+			}
 		}
 	}
 }
@@ -75,7 +78,7 @@ header.wp-block-template-part {
 	.nav-links {
 		display: contents;
 		.wp-block-navigation__responsive-container-open {
-			margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+			margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) - 3px );
 		}
 		.wp-block-navigation {
 			grid-area: menu;

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -7,6 +7,15 @@ header.wp-block-template-part {
 		gap: 0;
 		justify-content: space-between; // Apply a cluster (flex?) layout
 		align-items: flex-start;
+
+		@include break-small-only(){
+			grid-row-gap: calc( 0.25 * var(--wp--custom--margin--vertical) );
+			display: grid;
+			grid-template-areas: 
+				"brand menu"
+				"social social";
+			border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
+		}
 		> * {
 			flex-grow: 1; // Needed to maintain alignment when the containers stack
 			> * { // Apply a stack layout (page 69 of the every-layout.dev PDF) 
@@ -40,13 +49,13 @@ header.wp-block-template-part {
 				"logo"
 				"title"
 				"tagline";
+			grid-area: brand;
 		}
 		.wp-block-site-logo {
 			grid-area: logo;
 			margin: 0;
 			max-width: 120px;
 			align-self: center;
-			justify-self: flex-end;
 			@include break-small-only(){
 				margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
 			}
@@ -64,9 +73,16 @@ header.wp-block-template-part {
 
 @include break-small-only(){
 	.nav-links {
-		display: flex;
-		justify-content: space-between;
-		width: 100%;
-		border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
+		display: contents;
+		.wp-block-navigation__responsive-container-open {
+			margin-top: calc( 0.5 * var(--wp--custom--margin--vertical));
+		}
+		.wp-block-navigation {
+			grid-area: menu;
+		}
+		.wp-block-social-links {
+			justify-content: flex-start;
+			grid-area: social;
+		}
 	}
 }

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -30,6 +30,9 @@ header.wp-block-template-part {
 
 		.wp-block-social-links.is-style-logos-only {
 			margin-right: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the right
+			@include break-small(){
+				margin-top: calc( -1 * ( 8px + 0.25em ) ); // Visually align social links to the tagline
+			}
 			@include break-small-only(){
 				margin-left: -0.25em;
 				margin-right: 0;
@@ -67,6 +70,9 @@ header.wp-block-template-part {
 		.wp-block-site-title {
 			grid-area: title;
 			margin: 0 0 0.5em;
+			@include break-small-only(){
+				margin: 0 0 0.25em;
+			}
 		}
 		.wp-block-site-tagline {
 			grid-area: tagline;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR changes the responsive header to fit the new design guidelines from https://github.com/Automattic/themes/issues/4518 This PR does not affect the desktop header layout, since that was working as intended.

I'm still working on this to refine spacings a bit to make it look as closely as possible to the design, it's hard because not all blocks are present all the time so I'll try to get it as close as possible.

<img width="394" alt="Screenshot 2021-09-02 at 10 54 28" src="https://user-images.githubusercontent.com/3593343/131817449-8de4a9b0-00a4-49d6-b85e-09cfc8bb5558.png">
<img width="386" alt="Screenshot 2021-09-02 at 10 53 59" src="https://user-images.githubusercontent.com/3593343/131817456-c1734cfc-7522-4595-9b64-c8ab9d92e6e5.png">
<img width="392" alt="Screenshot 2021-09-02 at 10 53 37" src="https://user-images.githubusercontent.com/3593343/131817464-f1bb2a10-68fd-40d8-93df-d61c7d5eb486.png">
<img width="387" alt="Screenshot 2021-09-02 at 10 53 10" src="https://user-images.githubusercontent.com/3593343/131817468-dc930206-642b-421f-93ab-8dc0a8f3f056.png">


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4518
