### PR TITLE
Blank Canvas, IP2, Lodestar: Add support for selective refresh widgets

### DIFF
--- a/blank-canvas/functions.php
+++ b/blank-canvas/functions.php
@@ -87,7 +87,6 @@ add_filter( 'seedlet_colors', 'blank_canvas_colors' );
 function blank_canvas_remove_parent_theme_features() {
 	// Theme Support.
 	remove_theme_support( 'custom-header' );
-	remove_theme_support( 'customize-selective-refresh-widgets' );
 }
 add_action( 'after_setup_theme', 'blank_canvas_remove_parent_theme_features', 11 );
 

--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'independent_publisher_2_setup' ) ) :
 		 */
 		add_theme_support( 'title-tag' );
 
-		add_theme_support( 'customize_selective_refresh_widgets' );
+		add_theme_support( 'customize-selective-refresh-widgets' );
 
 		/*
 		 * Enable support for Post Thumbnails on posts and pages.

--- a/lodestar/functions.php
+++ b/lodestar/functions.php
@@ -90,7 +90,7 @@ if ( ! function_exists( 'lodestar_setup' ) ) :
 		);
 
 		// Add support to selectively refresh widgets in Customizer
-		add_theme_support( 'customize_selective_refresh_widgets' );
+		add_theme_support( 'customize-selective-refresh-widgets' );
 
 		// Add theme support for Custom Logo.
 		add_theme_support(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Enables support for selective refresh widgets in the Customizer in these themes for better performance when widgets are enabled, and to help unblock Widget Visibility. See Automattic/wp-calypso#55970 for more details.
* Related dotcom diffs: D66350-code D66346-code and D66358-code