### PR TITLE
Blockbase: Fix "Blog pages show at most" reading setting

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"tagName":"main","queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"tagName":"main"} -->
 <main class="wp-block-query">
 <!-- wp:post-template -->
 <!-- wp:group {"layout":{"inherit":true}} -->

--- a/blockbase/block-templates/search.html
+++ b/blockbase/block-templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-group">
 
-<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+<!-- wp:query -->
 <div class="wp-block-query">
 <!-- wp:post-template -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR addresses the issue described in #4521, where Blockbase is overwriting the "Blog pages show at most" reading setting because `perPage` is set to 10 in the `query` parameter on the index template.

I've removed the `queryId` and `query` parameters as suggested by @RavanH. As far as I can see, this doesn't have any negative effects, and it means that the number saved in the "Blog pages show at most" setting is respected.

Here is Blockbase with a "Blog pages show at most" set to 1, which previously would have been ignored:

![Screenshot 2021-09-07 at 11 39 58](https://user-images.githubusercontent.com/1645628/132331414-598fc240-54e2-4967-af84-60ed3e353324.png)

#### Related issue(s):
Fixes #4521.