### PR TITLE
Quadrat: Add pagination arrows through block settings, not in CSS

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -419,21 +419,6 @@ ul ul {
 	border-top: 1px solid var(--wp--custom--color--primary);
 }
 
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-	content: "←";
-	margin-right: 0.5em;
-}
-
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-	content: "→";
-	margin-left: 0.5em;
-}
-
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-	display: inline-block;
-}
-
 .wp-block-query-pagination .page-numbers {
 	padding: 0 0.1em;
 }

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -11,7 +11,7 @@
 		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /--></div>

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -10,6 +10,15 @@
 		<!-- wp:post-excerpt /-->
 
 	<!-- /wp:query-loop -->
+
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
+		<div class="wp-block-query-pagination alignwide">
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		</div>
+	<!-- /wp:query-pagination -->
+
 	<!-- /wp:query -->
 
 </main>

--- a/quadrat/inc/patterns/query-diamond.php
+++ b/quadrat/inc/patterns/query-diamond.php
@@ -30,12 +30,12 @@ return array(
 	<!-- /wp:columns -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
-
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
+	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-
 	<!-- wp:query-pagination-next /--></div>
-	<!-- /wp:query-pagination --></div>
+	<!-- /wp:query-pagination -->
+
+	</div>
 	<!-- /wp:query -->',
 );

--- a/quadrat/sass/blocks/_query-pagination.scss
+++ b/quadrat/sass/blocks/_query-pagination.scss
@@ -1,24 +1,6 @@
 .wp-block-query-pagination {
 	border-top: 1px solid var(--wp--custom--color--primary);
 
-	.wp-block-query-pagination-previous {
-		&::before{
-			content:"←";
-			margin-right: 0.5em;
-		}
-	}
-	.wp-block-query-pagination-next {
-		&::after{
-			content:"→";
-			margin-left: 0.5em;
-		}
-	}
-
-	.wp-block-query-pagination-previous::before,
-	.wp-block-query-pagination-next::after {
-		display: inline-block;
-	}
-
 	.page-numbers {
 		padding: 0 0.1em;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Now that https://github.com/WordPress/gutenberg/pull/33656 has merged we can set pagination arrows in block attributes. This is better for RTL and customization.
