### PR TITLE
Blockbase: Remove wpcom specific code

### DIFF
--- a/blockbase/inc/wpcom-style.css
+++ b/blockbase/inc/wpcom-style.css
@@ -2,17 +2,6 @@
  * WP.com stylesheet for Blockbase
  */
 
-/* Hide the stats smiley */
-img#wpstats {
-	position: absolute !important;
-	clip: rect(0, 0, 0, 0);
-	padding: 0 !important;
-	border: 0 !important;
-	height: 0 !important;
-	width: 0 !important;
-	overflow: hidden;
-}
-
 /* NOTE: This is a wp.com-specific fix so that the comment form presented there (highlander) is NOT displayed as a GRID. */
 body.highlander-enabled .wp-block-post-comments form {
 	display: revert;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In 64-gh-Automattic/analytics we changed the way we load the stats gif so that its always hidden. This means we no longer need CSS in the theme to hide the image.

I plan to do the other themes in another PR