### PR TITLE
Blockbase: change google url for Fira

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -12,6 +12,8 @@ class GlobalStylesFontsCustomizer {
 	private $font_control_default_body;
 	private $font_control_default_heading;
 
+	//Not all fonts support v2 of the API that allows for the shorter URls
+	//list of supported fonts: https://fonts.google.com/variablefonts
 	private $fonts = array(
 		'system-font'       => array(
 			'fontFamily' => '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
@@ -70,7 +72,7 @@ class GlobalStylesFontsCustomizer {
 			'fontFamily' => '"Fira Sans", sans-serif',
 			'slug'       => 'fira-sans',
 			'name'       => 'Fira Sans',
-			'google'     => 'family=Fira+Sans:ital,wght@0,100..900;1,100..900',
+			'google'     => 'family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900',
 		),
 		'inter'             => array(
 			'fontFamily' => '"Inter", sans-serif',


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The Fira Sans font was not being applied because it doesn't support the v2 google font API format. I used the older format to fix it and commented this for future reference.

To test this check that the correct font is applied. Fira Sans is the default body font for Seedlet blocks.

<img width="1240" alt="Screenshot 2021-09-08 at 09 53 50" src="https://user-images.githubusercontent.com/3593343/132469411-ea575f5f-4e27-4ccc-b557-150a3c68a0b8.png">

I went ahead and checked the rest of the fonts on the list and they seemed to be working fine.

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4541