### PR TITLE
Mayland Blocks, Blockbase: fix header vertical spacing

### DIFF
--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"40px"}}},"className":"site-header"} -->
-<div class="wp-block-group alignfull site-header" style="padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"40px","top":"40px"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<div class="wp-block-group alignfull site-header" style="padding-top:40px;padding-bottom:40px">
 	<!-- wp:site-title /-->
 	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
 </div>

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,9 +1,9 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"32px","bottom":"32px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <div class="wp-block-group alignfull site-header" style="padding-top:32px;padding-bottom:32px">
-	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
-	<!-- /wp:navigation -->
-	</div>
-	<!-- /wp:group -->
+<!-- wp:site-logo /-->
+<!-- wp:site-title /-->
+<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
+<!-- /wp:navigation -->
+</div>
+<!-- /wp:group -->
 	

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,8 +1,9 @@
-<!-- wp:group {"align":"full","layout":{"type":"flex"},"className":"site-header"} -->
-<div class="wp-block-group alignfull site-header">
-<!-- wp:site-logo /-->
-<!-- wp:site-title /-->
-<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
-<!-- /wp:navigation -->
-</div>
-<!-- /wp:group -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"32px","bottom":"32px"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<div class="wp-block-group alignfull site-header" style="padding-top:32px;padding-bottom:32px">
+	<!-- wp:site-logo /-->
+	<!-- wp:site-title /-->
+	<!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
+	<!-- /wp:navigation -->
+	</div>
+	<!-- /wp:group -->
+	


### PR DESCRIPTION
After some of our latest changes we've lost all vertical spacing on the header of Mayland Blocks and Blockbase. I'm opening this PR to fix it separate from https://github.com/Automattic/themes/pull/4482 since that may take a bit longer to fix and this looks pretty bad right now

Before:

<img width="1798" alt="Screenshot 2021-09-08 at 10 00 12" src="https://user-images.githubusercontent.com/3593343/132470579-b264f68c-1224-4a97-a31c-566f9f4c8fa1.png">
<img width="1793" alt="Screenshot 2021-09-08 at 09 58 55" src="https://user-images.githubusercontent.com/3593343/132470582-11205ee4-8906-4302-a84c-532f1ce4eebc.png">

After:

<img width="1642" alt="Screenshot 2021-09-08 at 10 10 38" src="https://user-images.githubusercontent.com/3593343/132471640-fa8ba0f8-bc48-449b-a76a-518828454da3.png">
<img width="1641" alt="Screenshot 2021-09-08 at 10 09 56" src="https://user-images.githubusercontent.com/3593343/132471650-5a46ae64-0cb5-4060-9aec-181359a63a8f.png">

/cc @kjellr 