### PR TITLE
Blockbase: Remove wpcom specific CSS file

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -408,6 +408,41 @@ p.has-background {
 	font-weight: var(--wp--custom--post-author--font-weight);
 }
 
+body:not(.highlander-enabled) .wp-block-post-comments form {
+	display: grid;
+	column-gap: 1em;
+	grid-template-rows: auto;
+	grid-template-areas: "notes notes" "author author" "email url" "comment comment" "cookies-consent cookies-consent" "form-submit form-submit";
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-notes {
+	grid-area: notes;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-form-author {
+	grid-area: author;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-form-email {
+	grid-area: email;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-form-url {
+	grid-area: url;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-form-comment {
+	grid-area: comment;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .comment-form-cookies-consent {
+	grid-area: cookies-consent;
+}
+
+body:not(.highlander-enabled) .wp-block-post-comments form .form-submit {
+	grid-area: form-submit;
+}
+
 .wp-block-post-comments label, .wp-block-post-comments .comment-meta {
 	font-size: var(--wp--custom--form--label--typography--font-size);
 }
@@ -424,13 +459,6 @@ p.has-background {
 
 .wp-block-post-comments .reply a:hover {
 	text-decoration: none;
-}
-
-.wp-block-post-comments form {
-	display: grid;
-	column-gap: 1em;
-	grid-template-rows: auto;
-	grid-template-areas: "notes notes" "author author" "email url" "comment comment" "cookies-consent cookies-consent" "form-submit form-submit";
 }
 
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),
@@ -456,34 +484,6 @@ p.has-background {
 .wp-block-post-comments form p {
 	margin-top: 0;
 	margin-bottom: var(--wp--custom--margin--vertical);
-}
-
-.wp-block-post-comments form .comment-notes {
-	grid-area: notes;
-}
-
-.wp-block-post-comments form .comment-form-author {
-	grid-area: author;
-}
-
-.wp-block-post-comments form .comment-form-email {
-	grid-area: email;
-}
-
-.wp-block-post-comments form .comment-form-url {
-	grid-area: url;
-}
-
-.wp-block-post-comments form .comment-form-comment {
-	grid-area: comment;
-}
-
-.wp-block-post-comments form .comment-form-cookies-consent {
-	grid-area: cookies-consent;
-}
-
-.wp-block-post-comments form .form-submit {
-	grid-area: form-submit;
 }
 
 .wp-block-post-comments form .comment-form-cookies-consent input[type="checkbox"] {

--- a/blockbase/inc/wpcom-style.css
+++ b/blockbase/inc/wpcom-style.css
@@ -1,8 +1,0 @@
-/**
- * WP.com stylesheet for Blockbase
- */
-
-/* NOTE: This is a wp.com-specific fix so that the comment form presented there (highlander) is NOT displayed as a GRID. */
-body.highlander-enabled .wp-block-post-comments form {
-	display: revert;
-}

--- a/blockbase/inc/wpcom.php
+++ b/blockbase/inc/wpcom.php
@@ -8,15 +8,6 @@
  */
 
 /**
- * Enqueue our WP.com styles for front-end.
- * Loads after theme styles so we can add overrides.
- */
-function blockbase_wpcom_scripts() {
-	wp_enqueue_style( 'blockbase-wpcom-style', get_template_directory_uri() . '/inc/wpcom-style.css', array( 'blockbase-ponyfill' ) );
-}
-add_action( 'wp_enqueue_scripts', 'blockbase_wpcom_scripts' );
-
-/**
  * Restores the Customizer since we still rely on it.
  * (For WPcom REST API requests to work properly.)
  */

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -1,3 +1,48 @@
+body:not(.highlander-enabled) {
+	.wp-block-post-comments {
+		form {
+			display: grid;
+			column-gap: 1em;
+			grid-template-rows: auto;
+			grid-template-areas:
+				"notes notes"
+				"author author"
+				"email url"
+				"comment comment"
+				"cookies-consent cookies-consent"
+				"form-submit form-submit";
+
+			.comment-notes {
+				grid-area: notes;
+			}
+
+			.comment-form-author {
+				grid-area: author;
+			}
+
+			.comment-form-email {
+				grid-area: email;
+			}
+
+			.comment-form-url {
+				grid-area: url;
+			}
+
+			.comment-form-comment {
+				grid-area: comment;
+			}
+
+			.comment-form-cookies-consent {
+				grid-area: cookies-consent;
+			}
+
+			.form-submit {
+				grid-area: form-submit;
+			}
+		}
+	}
+}
+
 .wp-block-post-comments {
 	label, .comment-meta {
 		font-size: var(--wp--custom--form--label--typography--font-size);
@@ -17,17 +62,6 @@
 	}
 
 	form {
-		display: grid;
-		column-gap: 1em;
-		grid-template-rows: auto;
-		grid-template-areas:
-			"notes notes"
-			"author author"
-			"email url"
-			"comment comment"
-			"cookies-consent cookies-consent"
-			"form-submit form-submit";
-
 		input:not([type=submit]):not([type=checkbox]),
 		textarea {
 			font-size: var(--wp--preset--font-size--normal);
@@ -51,34 +85,6 @@
 		p {
 			margin-top: 0;
 			margin-bottom: var(--wp--custom--margin--vertical);
-		}
-
-		.comment-notes {
-			grid-area: notes;
-		}
-
-		.comment-form-author {
-			grid-area: author;
-		}
-
-		.comment-form-email {
-			grid-area: email;
-		}
-
-		.comment-form-url {
-			grid-area: url;
-		}
-
-		.comment-form-comment {
-			grid-area: comment;
-		}
-
-		.comment-form-cookies-consent {
-			grid-area: cookies-consent;
-		}
-
-		.form-submit {
-			grid-area: form-submit;
 		}
 
 		.comment-form-cookies-consent {
@@ -132,7 +138,7 @@
 				font-size: var(--wp--custom--post-comment--typography--font-size);
 				line-height: var(--wp--custom--post-comment--typography--line-height);
 				margin-bottom: var(--wp--custom--margin--vertical);
-				margin-top: var(--wp--custom--margin--vertical);	
+				margin-top: var(--wp--custom--margin--vertical);
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the wpcom specific CSS file and refactors the post comments block CSS so that it doesn't have an impact on wpcom.

I would rather we didn't have any wpcom specific code in the repo at all, but I can't find another way to remove this line.

To test:
- On a dotorg site, check that the comments form has grid applied
- On a dotcom site, check that the comments form doesn't have any grid code applied