### PR TITLE
Blockbase: Add comments to Blockbase for the respective Gutenberg issues

### DIFF
--- a/blockbase/sass/blocks/_button-mixins.scss
+++ b/blockbase/sass/blocks/_button-mixins.scss
@@ -1,4 +1,5 @@
 // NOTE: These remain for the styling of buttons that are NOT blocks and is used elsewhere.  This can be removed when those no longer exist.
+// See https://github.com/WordPress/gutenberg/issues/29167
 @mixin button-main-styles {
 	@include button-padding-styles;
 	@include button-typography-styles;
@@ -47,6 +48,7 @@
 
 // NOTE: These remain for the hover styling of blocks.  This can be removed when the button block has configurable hover states.
 // The mechanism below ONLY CHANGES CSS VARIABLES that are already applied to properties (above)
+// See https://github.com/WordPress/gutenberg/issues/4543
 @mixin button-hover-styles {
 	//The following changes should ONLY be changed if the user has NOT set a custom color
 	&:not(.has-background):not(.has-text-color) {

--- a/blockbase/sass/blocks/_code.scss
+++ b/blockbase/sass/blocks/_code.scss
@@ -1,4 +1,4 @@
-// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code (https://github.com/WordPress/gutenberg/issues/31135)
+// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code.
 .wp-block-code code {
-	font-family: var(--wp--custom--code--typography--font-family);
+	font-family: var(--wp--custom--code--typography--font-family); // See https://github.com/WordPress/gutenberg/issues/31135
 }

--- a/blockbase/sass/blocks/_columns.scss
+++ b/blockbase/sass/blocks/_columns.scss
@@ -1,5 +1,6 @@
 // TODO: This can be removed when Gutenberg no longer expresses opinion about the bottom margin of the block columns
 // or perhaps when the margins of blocks can be styled with the "style" portion of theme.json
+// See: https://github.com/WordPress/gutenberg/pull/34630
 .wp-block-columns {
 	margin-bottom: unset;
 }

--- a/blockbase/sass/blocks/_file.scss
+++ b/blockbase/sass/blocks/_file.scss
@@ -1,6 +1,6 @@
 @import 'button-mixins';
 
-// TODO: Remove when https://github.com/WordPress/gutenberg/issues/27760 is fixed
+// TODO: Remove when https://github.com/WordPress/gutenberg/issues/27760 is fixed.
 .wp-block-file .wp-block-file__button {
 	@include button-main-styles;
 	@include button-hover-styles;

--- a/blockbase/sass/blocks/_gallery.scss
+++ b/blockbase/sass/blocks/_gallery.scss
@@ -2,7 +2,7 @@
 	.blocks-gallery-image,
 	.blocks-gallery-item {
 		figcaption {
-			font-size: var(--wp--custom--gallery--caption--font-size);
+			font-size: var(--wp--custom--gallery--caption--font-size); // See https://github.com/WordPress/gutenberg/issues/34643.
 		}
 	}
 }

--- a/blockbase/sass/blocks/_html.scss
+++ b/blockbase/sass/blocks/_html.scss
@@ -1,3 +1,4 @@
+// See https://github.com/WordPress/gutenberg/issues/34645
 .block-library-html__edit {
 	.block-editor-plain-text {
 		color: var(--wp--custom--form--color--text);

--- a/blockbase/sass/blocks/_image.scss
+++ b/blockbase/sass/blocks/_image.scss
@@ -5,7 +5,7 @@
 	default styles.  It's difficult to say how this will land, however
 	based on discussion found in (many) related issues here:
 	https://github.com/WordPress/gutenberg/issues/28923
-	See also: https://github.com/WordPress/gutenberg/issues/34646
+	https://github.com/WordPress/gutenberg/issues/29506
 	*/
 	text-align: center;
 }

--- a/blockbase/sass/blocks/_image.scss
+++ b/blockbase/sass/blocks/_image.scss
@@ -1,10 +1,11 @@
 .wp-block-image {
-	/* 
+	/*
 	From what I can tell the below are styles regularly used by themes
 	to fix the image block.  I believe these should go into the block's
-	default styles.  It's difficult to say how this will land, however 
-	based on discussion found in (many) related issues here: 
+	default styles.  It's difficult to say how this will land, however
+	based on discussion found in (many) related issues here:
 	https://github.com/WordPress/gutenberg/issues/28923
+	See also: https://github.com/WordPress/gutenberg/issues/34646
 	*/
 	text-align: center;
 }

--- a/blockbase/sass/blocks/_latest-posts.scss
+++ b/blockbase/sass/blocks/_latest-posts.scss
@@ -1,4 +1,4 @@
 .wp-block-latest-posts .wp-block-latest-posts__post-date,
 .wp-block-latest-posts .wp-block-latest-posts__post-author {
-	color: var(--wp--custom--latest-posts--meta--color--text);
+	color: var(--wp--custom--latest-posts--meta--color--text); // See https://github.com/WordPress/gutenberg/issues/34647.
 }

--- a/blockbase/sass/blocks/_list.scss
+++ b/blockbase/sass/blocks/_list.scss
@@ -1,3 +1,4 @@
+// See https://github.com/WordPress/gutenberg/pull/27511
 ul,
 ol {
 	padding-left: var(--wp--custom--list--spacing--padding--left);

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -1,3 +1,4 @@
+// See https://github.com/WordPress/gutenberg/issues/34648
 .wp-block-navigation.is-responsive {
 	.wp-block-navigation__responsive-container.is-menu-open {
 		background-color: var(--wp--custom--color--background);

--- a/blockbase/sass/blocks/_paragraph.scss
+++ b/blockbase/sass/blocks/_paragraph.scss
@@ -1,6 +1,4 @@
 p {
-
-
 	// Override `color: inherit` from Core styles.
 	&.has-text-color a {
 		color: var( --wp--style--color--link, var(--wp--custom--color--primary) );

--- a/blockbase/sass/blocks/_post-author.scss
+++ b/blockbase/sass/blocks/_post-author.scss
@@ -1,3 +1,3 @@
 .wp-block-post-author__name {
-	font-weight: var(--wp--custom--post-author--font-weight);
+	font-weight: var(--wp--custom--post-author--font-weight); // See https://github.com/WordPress/gutenberg/issues/34640
 }

--- a/blockbase/sass/blocks/_pullquote.scss
+++ b/blockbase/sass/blocks/_pullquote.scss
@@ -1,6 +1,6 @@
 .wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
-	text-align: var(--wp--custom--pullquote--typography--text-align);
+	text-align: var(--wp--custom--pullquote--typography--text-align); // See https://github.com/WordPress/gutenberg/pull/31996
 	blockquote {
 		padding: 0;
 		margin: 0;

--- a/blockbase/sass/blocks/_separator.scss
+++ b/blockbase/sass/blocks/_separator.scss
@@ -1,7 +1,7 @@
 .wp-block-separator {
-	margin: var(--wp--custom--separator--margin);
-	opacity: var(--wp--custom--separator--opacity); // Mirror controls that Gutenberg theme.css offers: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/separator/theme.scss
+	margin: var(--wp--custom--separator--margin); // See https://github.com/WordPress/gutenberg/pull/30609 is merged
+	opacity: var(--wp--custom--separator--opacity); // Mirror controls that Gutenberg theme.css offers: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/separator/theme.scss - See: https://github.com/WordPress/gutenberg/issues/34637
 	&:not(.is-style-wide){
-		width: var(--wp--custom--separator--width);
+		width: var(--wp--custom--separator--width); // See https://github.com/WordPress/gutenberg/issues/34638
 	}
 }

--- a/blockbase/sass/blocks/_table.scss
+++ b/blockbase/sass/blocks/_table.scss
@@ -1,15 +1,17 @@
+// See https://github.com/WordPress/gutenberg/issues/31261
 .wp-block-table.is-style-stripes,
 .wp-block-table {
-	figcaption {
+	figcaption { // See https://github.com/WordPress/gutenberg/issues/34650
 		font-size: var(--wp--custom--table--figcaption--typography--font-size);
 		text-align: center;
 	}
 
 	td, th {
+		// See https://github.com/WordPress/gutenberg/issues/31261
 		border: 1px solid;
 		padding: calc(0.5*var(--wp--custom--margin--vertical)) calc(0.5*var(--wp--custom--margin--horizontal));
 	}
 
-	margin-bottom: 1em;
+	margin-bottom: 1em; // See https://github.com/WordPress/gutenberg/issues/34652
 	border-bottom: none;
 }

--- a/blockbase/sass/blocks/_video.scss
+++ b/blockbase/sass/blocks/_video.scss
@@ -1,5 +1,5 @@
 .wp-block-video {
-	figcaption {
+	figcaption { // https://github.com/WordPress/gutenberg/issues/34642
 		margin: var(--wp--custom--video--caption--margin);
 		text-align: var(--wp--custom--video--caption--text-align);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds comments to Blockbase connecting the CSS to issues in Gutenberg which need to be solved in order to remove the CSS. I did most of the blocks but there is still more work to do here.

#### Related issue(s):
https://github.com/WordPress/gutenberg/issues/34653