### PR TITLE
Skatepark: refactor post title margins

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -178,6 +178,7 @@ p {
 .wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2);
+	margin-bottom: 0;
 }
 
 .wp-block-query-pagination .wp-block-query-pagination-numbers .current {
@@ -599,18 +600,6 @@ header.wp-block-template-part .site-brand .wp-block-site-tagline {
 	}
 }
 
-.archive .wp-block-query-title,
-.blog .wp-block-query-title,
-.home .wp-block-query-title {
-	margin-bottom: 0;
-}
-
-.archive .wp-block-post-title,
-.blog .wp-block-post-title,
-.home .wp-block-post-title {
-	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
-}
-
 .archive .wp-block-post-excerpt__excerpt,
 .blog .wp-block-post-excerpt__excerpt,
 .home .wp-block-post-excerpt__excerpt {
@@ -624,6 +613,12 @@ header.wp-block-template-part .site-brand .wp-block-site-tagline {
 	text-decoration: underline;
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;
+}
+
+.archive .wp-block-query .wp-block-post-title,
+.blog .wp-block-query .wp-block-post-title,
+.home .wp-block-query .wp-block-post-title {
+	margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical));
 }
 
 .wp-block-post-excerpt__more-link {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -175,7 +175,7 @@ p {
 	text-decoration: none;
 }
 
-.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
+h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2);
 	margin-bottom: 0;

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"2.5em","bottom":"2.5em"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="padding-top:2.5em;padding-bottom:2.5em">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"4em","bottom":"2.5em"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-top:4em;padding-bottom:2.5em">
 	<!-- wp:query-title {"type":"archive","align":"wide"} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/skatepark/block-templates/page.html
+++ b/skatepark/block-templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"2.5em"}}}} -->
-<div class="wp-block-group" style="padding-top:2.5em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"4em"}}}} -->
+<div class="wp-block-group" style="padding-top:4em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"5em"}}}} -->

--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -1,14 +1,14 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"2.5em"}}}} -->
-<div class="wp-block-group" style="padding-top:2.5em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"4em"}}}} -->
+<div class="wp-block-group" style="padding-top:4em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"5em"}}}} -->
-<div class="wp-block-group" style="padding-bottom:5em">
+<div class="wp-block-group alignfull" style="padding-bottom:5em">
 <!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","#B9FB9C"]}}} /--></div>
 <!-- /wp:group -->
 

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -291,6 +291,11 @@
 					"fontSize": "min(max(48px, 7vw), 72px)",
 					"fontWeight": "700",
 					"lineHeight": 1.2
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "1em"
+					}
 				}
 			},
 			"core/post-navigation-link": {

--- a/skatepark/sass/blocks/_post-title.scss
+++ b/skatepark/sass/blocks/_post-title.scss
@@ -1,4 +1,5 @@
 .wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2 );
+	margin-bottom: 0;
 }

--- a/skatepark/sass/blocks/_post-title.scss
+++ b/skatepark/sass/blocks/_post-title.scss
@@ -1,4 +1,4 @@
-.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
+h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc( var(--wp--custom--margin--vertical) * 2 );
 	margin-bottom: 0;

--- a/skatepark/sass/templates/_index.scss
+++ b/skatepark/sass/templates/_index.scss
@@ -1,12 +1,6 @@
 .archive,
 .blog,
 .home {
-	.wp-block-query-title {
-		margin-bottom: 0;
-	}
-	.wp-block-post-title{
-		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
-	}
 	.wp-block-post-excerpt__excerpt {
 		margin-top: calc( 0.5 * var(--wp--custom--margin--vertical) );
 		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
@@ -14,6 +8,9 @@
 	.wp-block-post-date {
 		text-decoration: underline;
 		@include text-decoration;
+	}
+	.wp-block-query .wp-block-post-title{
+		margin-bottom: calc( 0.5 * var(--wp--custom--margin--vertical) );
 	}
 }
 

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -473,6 +473,11 @@
 					"fontSize": "min(max(48px, 7vw), 72px)",
 					"lineHeight": 1.2,
 					"fontWeight": "700"
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "1em"
+					}
 				}
 			},
 			"core/post-date": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The post title block is being used in many places and not always needs the same amount of margin bottom. This PR tries to align all of the instances of the block with the figma designs. The rules being applied to the underlined tittle when no featured image is present was affecting the query block instances of the post title too (https://github.com/Automattic/themes/issues/4558). 

To test, check against the design in the following scenarios:

- The home page as a page
- The home page as a list of posts
- A page/post with a featured image
- A page/post without a featured image
- The query block pattern (the post title is smaller within the query block)

<img width="1520" alt="Screenshot 2021-09-09 at 10 52 06" src="https://user-images.githubusercontent.com/3593343/132656245-3984953b-edb7-49e5-b790-8713d3773a85.png">
<img width="1431" alt="Screenshot 2021-09-09 at 10 52 00" src="https://user-images.githubusercontent.com/3593343/132656252-1d26f8f9-903c-4a3d-8f66-329418743595.png">
<img width="1455" alt="Screenshot 2021-09-09 at 10 51 53" src="https://user-images.githubusercontent.com/3593343/132656260-6f026c06-7e8c-497a-aaf3-8722ccd2b41f.png">
<img width="1313" alt="Screenshot 2021-09-09 at 10 51 46" src="https://user-images.githubusercontent.com/3593343/132656269-abd08bc9-9b96-4bda-9bfc-5ab941d78c1c.png">


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4560
Closes https://github.com/Automattic/themes/issues/4558