### PR TITLE
Blockbase: Remove code block CSS

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -342,10 +342,6 @@ input[type=checkbox] + label {
 	margin-bottom: 0;
 }
 
-.wp-block-code code {
-	font-family: var(--wp--custom--code--typography--font-family);
-}
-
 .wp-block-gallery .blocks-gallery-image figcaption,
 .wp-block-gallery .blocks-gallery-item figcaption {
 	font-size: var(--wp--custom--gallery--caption--font-size);
@@ -357,12 +353,13 @@ input[type=checkbox] + label {
 }
 
 .wp-block-image {
-	/* 
+	/*
 	From what I can tell the below are styles regularly used by themes
 	to fix the image block.  I believe these should go into the block's
-	default styles.  It's difficult to say how this will land, however 
-	based on discussion found in (many) related issues here: 
+	default styles.  It's difficult to say how this will land, however
+	based on discussion found in (many) related issues here:
 	https://github.com/WordPress/gutenberg/issues/28923
+	https://github.com/WordPress/gutenberg/issues/29506
 	*/
 	text-align: center;
 }

--- a/blockbase/rebuild-child-themes.sh
+++ b/blockbase/rebuild-child-themes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a ChildThemes=( "mayland-blocks" "seedlet-blocks" "quadrat" "skatepark" )
+declare -a ChildThemes=( "mayland-blocks" "seedlet-blocks" "quadrat" "skatepark" "geologist" )
 
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}

--- a/blockbase/sass/blocks/_code.scss
+++ b/blockbase/sass/blocks/_code.scss
@@ -1,4 +1,0 @@
-// TODO: This can be removed when Gutenberg applies fontFamily correcly to .wp-block-code code.
-.wp-block-code code {
-	font-family: var(--wp--custom--code--typography--font-family); // See https://github.com/WordPress/gutenberg/issues/31135
-}

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -10,7 +10,6 @@
 // - These styles replace key Gutenberg Block styles for fonts, colors, and
 //   spacing with CSS-variables overrides
 @import "blocks/button";
-@import "blocks/code";
 @import "blocks/gallery";
 @import "blocks/html";
 @import "blocks/image";

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -103,11 +103,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--foreground)",
 				"background": "var(--wp--preset--color--background)",
@@ -389,6 +384,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "2px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -397,11 +398,8 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "2px"
+				"typography": {
+					"fontFamily": "monospace"
 				}
 			},
 			"core/navigation": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -106,11 +106,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--primary)",
 				"background": "var(--wp--preset--color--background)",
@@ -450,6 +445,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "0px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -458,19 +459,14 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "0px"
-				},
-				"color": {
-					"background": "var(--wp--custom--color--secondary)"
-				},
 				"typography": {
+					"fontFamily": "monospace",
 					"fontSize": "20px",
 					"fontWeight": "400",
 					"lineHeight": "1.6"
+				},
+				"color": {
+					"background": "var(--wp--custom--color--secondary)"
 				}
 			},
 			"core/navigation": {

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -111,11 +111,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--foreground)",
 				"background": "var(--wp--preset--color--background)",
@@ -418,6 +413,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "2px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -426,11 +427,8 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "2px"
+				"typography": {
+					"fontFamily": "monospace"
 				}
 			},
 			"core/navigation": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -101,11 +101,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--primary)",
 				"background": "var(--wp--preset--color--background)",
@@ -445,6 +440,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "0px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -453,19 +454,14 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "0px"
-				},
-				"color": {
-					"background": "var(--wp--custom--color--secondary)"
-				},
 				"typography": {
+					"fontFamily": "monospace",
 					"fontSize": "20px",
 					"fontWeight": "400",
 					"lineHeight": "1.6"
+				},
+				"color": {
+					"background": "var(--wp--custom--color--secondary)"
 				}
 			},
 			"core/navigation": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -144,11 +144,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--foreground)",
 				"background": "var(--wp--preset--color--background)",
@@ -447,6 +442,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "2px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -455,11 +456,8 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "2px"
+				"typography": {
+					"fontFamily": "monospace"
 				}
 			},
 			"core/navigation": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -138,11 +138,6 @@
 					"lineHeight": 2
 				}
 			},
-			"code": {
-				"typography": {
-					"fontFamily": "monospace"
-				}
-			},
 			"color": {
 				"foreground": "var(--wp--preset--color--primary)",
 				"background": "var(--wp--preset--color--background)",
@@ -446,6 +441,12 @@
 				}
 			},
 			"core/code": {
+				"border": {
+					"color": "#CCCCCC",
+					"radius": "0px",
+					"style": "solid",
+					"width": "2px"
+				},
 				"spacing": {
 					"padding": {
 						"left": "var(--wp--custom--margin--horizontal)",
@@ -454,11 +455,8 @@
 						"bottom": "var(--wp--custom--margin--vertical)"
 					}
 				},
-				"border": {
-					"color": "#CCCCCC",
-					"radius": "0px",
-					"style": "solid",
-					"width": "2px"
+				"typography": {
+					"fontFamily": "monospace"
 				}
 			},
 			"core/navigation": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/issues/31135 got merged, we can set the typeography for the code block in theme.json.

Monospace is the default for `code` elements in Chrome (and maybe other browsers) so maybe this is unnecessary, but it's probably better to be explicit?