### PR TITLE
Blockbase: Remove wpcom CSS

### DIFF
--- a/blockbase/inc/wpcom-style.css
+++ b/blockbase/inc/wpcom-style.css
@@ -1,8 +1,0 @@
-/**
- * WP.com stylesheet for Blockbase
- */
-
-/* NOTE: This is a wp.com-specific fix so that the comment form presented there (highlander) is NOT displayed as a GRID. */
-body.highlander-enabled .wp-block-post-comments form {
-	display: revert;
-}

--- a/blockbase/inc/wpcom.php
+++ b/blockbase/inc/wpcom.php
@@ -8,15 +8,6 @@
  */
 
 /**
- * Enqueue our WP.com styles for front-end.
- * Loads after theme styles so we can add overrides.
- */
-function blockbase_wpcom_scripts() {
-	wp_enqueue_style( 'blockbase-wpcom-style', get_template_directory_uri() . '/inc/wpcom-style.css', array( 'blockbase-ponyfill' ) );
-}
-add_action( 'wp_enqueue_scripts', 'blockbase_wpcom_scripts' );
-
-/**
  * Restores the Customizer since we still rely on it.
  * (For WPcom REST API requests to work properly.)
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We should move this WPCOM specific CSS to the WPCOM repo: D66603-code

#### Related issue(s):