### PR TITLE
Blockbase: Remove CSS for HTML block

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -446,11 +446,6 @@ input[type=checkbox] + label {
 	font-size: var(--wp--custom--gallery--caption--font-size);
 }
 
-.block-library-html__edit .block-editor-plain-text {
-	color: var(--wp--custom--form--color--text);
-	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-}
-
 .wp-block-image {
 	/*
 	From what I can tell the below are styles regularly used by themes

--- a/blockbase/sass/blocks/_html.scss
+++ b/blockbase/sass/blocks/_html.scss
@@ -1,7 +1,0 @@
-// See https://github.com/WordPress/gutenberg/issues/34645
-.block-library-html__edit {
-	.block-editor-plain-text {
-		color: var(--wp--custom--form--color--text);
-		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
-	}
-}

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -11,7 +11,6 @@
 //   spacing with CSS-variables overrides
 @import "blocks/button";
 @import "blocks/gallery";
-@import "blocks/html";
 @import "blocks/image";
 @import "blocks/latest-posts";
 @import "blocks/list";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/pull/34727 merged, we can remove this CSS

#### Related issue(s):
https://github.com/WordPress/gutenberg/pull/34727