### PR TITLE
Quadrat: remove extra inline padding

### DIFF
--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"30px","left":"20px"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-top:30px;padding-right:20px;padding-bottom:30px;padding-left:20px">
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
 	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
 	<!-- wp:spacer {"height":30} -->
 	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -10,8 +10,8 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","bottom":"30px"}}},"layout":{"inherit":true}} -->
-	<div class="wp-block-group" style="padding-top:30px;padding-bottom:30px;">
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
 		<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
 		<!-- wp:spacer {"height":30} -->
 		<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -31,8 +31,8 @@
 	<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"30px","right":"20px","bottom":"0px","left":"20px"}}}} -->
-	<div class="wp-block-group" style="padding-top:30px;padding-right:20px;padding-bottom:0px;padding-left:20px">
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
 		<!-- wp:columns {"align":"wide","className":"next-prev-links"} -->
 		<div class="wp-block-columns alignwide next-prev-links">
 			<!-- wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Quadrat had some inline padding that I think is now unnecessary based on our alignments work and #4556.

This PR removes the inline padding that was added in the following groups: 
- `page` + `single` template's post title + featured image
- `single` template's pagination + comments

**To test:**
- Activate Quadrat
- Visit a post with a featured image and a page
- Verify the comments, pagination, post title, and featured image appear aligned with the post content, header, and footer across viewports. 

#### Related issue(s):

Note this PR requires #4556 to look correctly aligned with the header.