### PR TITLE
Geologist: Fix header and post meta alignments

### DIFF
--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR fixes the alignment for the Geologist header by adding flex to the header block (looks like this is all that was missing):

![Screenshot 2021-09-13 at 11 07 09](https://user-images.githubusercontent.com/1645628/133065756-78efec5a-2756-4b79-9eec-89428bc33811.png)

In the original issue, @MaggieCabrera also mentioned the post meta is left aligned. I've checked Figma and it looks like the post meta was originally on the left. Is there something else that needs changing for the post meta alignment?

#### Related issue(s):
Closes #4552.