### PR TITLE
Add batch utility to build a .org compatible .zip of themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"local:clean": "git reset --hard HEAD; git clean -fd",
 		"batch:build:changed": "./theme-batch-utils.sh build",
 		"batch:build:all": "./theme-batch-utils.sh build-all",
+		"batch:build:zip:all": "./theme-batch-utils.sh build-org-zip-all",
+		"batch:build:zip:changed": "./theme-batch-utils.sh build-org-zip-if-changed",
 		"batch:install": "./theme-batch-utils.sh install-dependencies",
 		"batch:audit:fix": "./theme-batch-utils.sh audit-dependencies",
 		"batch:version-bump": "./theme-batch-utils.sh version-bump"

--- a/theme-batch-utils.sh
+++ b/theme-batch-utils.sh
@@ -82,7 +82,6 @@ build-org-zip-if-changed() {
 		return
 	fi
 	build-org-zip $1
-	echo $uncomitted_changes
 }
 
 build-org-zip() {


### PR DESCRIPTION
Use the command `npm run batch:build:zip:all` to build .org compatible zip files ready for upload for all eligible themes (meaning, themes with `package.json` files).

OR use the command 'npm run batch:build:zip:changed` to build the zip files ONLY for those eligible themes that have had changes since the divergence from trunk.

Zip files follow the pattern `/build/THEMENAME_VERSION/THEMENAME.zip`