### PR TITLE
Blockbase: Fix notices related to missing properties in theme.json

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -320,20 +320,25 @@ class GlobalStylesFontsCustomizer {
 		$variable = get_settings_array( $array, $configuration );
 		$slug     = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $variable );
 		if ( ! isset( $this->fonts[ $slug ] ) ) {
-			$this->fonts[ $slug ] = $this->build_font_from_theme_data( $slug, $location, $configuration );
+			$this->fonts[ $slug ] = $this->build_font_from_theme_data( $slug, $configuration );
 		}
 		return $this->fonts[ $slug ];
 	}
 
-	function build_font_from_theme_data( $slug, $location, $configuration ) {
+	function build_font_from_theme_data( $slug, $configuration ) {
 		$new_font      = array();
-		$google_fonts  = $configuration['settings']['custom']['fontsToLoadFromGoogle'];
 		$font_families = $configuration['settings']['typography']['fontFamilies']['theme'];
 		foreach ( $font_families as $font_family ) {
 			if ( $font_family['slug'] === $slug ) {
 				$new_font['fontFamily'] = $font_family['fontFamily'];
 				$new_font['name']       = $font_family['name'];
 			}
+		}
+
+		// Get data about the font if we have it.
+		$google_fonts = $configuration['settings']['custom']['fontsToLoadFromGoogle'];
+		if ( empty( $google_fonts ) ) {
+			return false;
 		}
 		foreach ( $google_fonts as $google_font ) {
 			$aux = str_replace( '+', '-', $google_font );

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -160,6 +160,7 @@
 			},
 			"body": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--spartan)",
 					"lineHeight": 1.7
 				}
 			},
@@ -418,7 +419,7 @@
 			}
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
+			"fontFamily": "var(--wp--preset--font-family--spartan)",
 			"fontWeight": "400"
 		},
 		"core/site-logo": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -258,7 +258,8 @@
 			},
 			"body": {
 				"typography": {
-					"lineHeight": 1.7
+					"lineHeight": 1.7,
+					"fontFamily": "var(--wp--preset--font-family--spartan)"
 				}
 			},
 			"heading": {
@@ -676,7 +677,7 @@
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
-			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
+			"fontFamily": "var(--wp--preset--font-family--spartan)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
If a user specifies a font in theme.json that isn't one of our defined fonts we create several notices. This PR escapes in those cases to stop the notices appearing.

To test, check that you don't see any PHP notices with this PR.

#### Related issue(s):
#4460