### PR TITLE
Gallery: Add margins to the gallery block using theme.json

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -396,6 +396,21 @@
 					"fontFamily": "monospace"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
+			"core/group": {
+				"spacing": {
+					"margin": {
+						"top": "var(--wp--custom--gap--vertical)",
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -403,14 +403,6 @@
 					}
 				}
 			},
-			"core/group": {
-				"spacing": {
-					"margin": {
-						"top": "var(--wp--custom--gap--vertical)",
-						"bottom": "var(--wp--custom--gap--vertical)"
-					}
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is an alternative approach to https://github.com/Automattic/themes/pull/4630. We can use theme.json to set the gap, so we don't need extra CSS for it.

Before:
<img width="689" alt="Screenshot 2021-09-17 at 14 16 52" src="https://user-images.githubusercontent.com/275961/133788823-785867be-26b6-4929-ad87-aca85040b4e2.png">

After:
<img width="724" alt="Screenshot 2021-09-17 at 14 16 28" src="https://user-images.githubusercontent.com/275961/133788771-16c771a9-464f-43b1-8df0-1a50efec2c0d.png">


#### Related issue(s):
4613