### PR TITLE
Drop "fontsToLoadFromGoogle" for child themes

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -320,25 +320,21 @@ class GlobalStylesFontsCustomizer {
 		$variable = get_settings_array( $array, $configuration );
 		$slug     = preg_replace( '/var\(--wp--preset--font-family--(.*)\)/', '$1', $variable );
 		if ( ! isset( $this->fonts[ $slug ] ) ) {
-			$this->fonts[ $slug ] = $this->build_font_from_theme_data( $slug, $location, $configuration );
+			$this->fonts[ $slug ] = $this->build_font_from_theme_data( $slug, $configuration );
 		}
 		return $this->fonts[ $slug ];
 	}
 
-	function build_font_from_theme_data( $slug, $location, $configuration ) {
+	function build_font_from_theme_data( $slug, $configuration ) {
 		$new_font      = array();
-		$google_fonts  = $configuration['settings']['custom']['fontsToLoadFromGoogle'];
 		$font_families = $configuration['settings']['typography']['fontFamilies']['theme'];
 		foreach ( $font_families as $font_family ) {
 			if ( $font_family['slug'] === $slug ) {
 				$new_font['fontFamily'] = $font_family['fontFamily'];
 				$new_font['name']       = $font_family['name'];
-			}
-		}
-		foreach ( $google_fonts as $google_font ) {
-			$aux = str_replace( '+', '-', $google_font );
-			if ( strripos( $aux, $slug ) !== false ) {
-				$new_font['google'] = $google_font;
+				if ( ! empty( $font_family['google'] ) ) {
+					$new_font['google'] = $font_family['google'];
+				}
 			}
 		}
 		$new_font['slug'] = $slug;

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -132,9 +132,6 @@
 					}
 				}
 			],
-			"fontsToLoadFromGoogle": [
-				"family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
-			],
 			"form": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -348,9 +348,6 @@
 					"margin": "var(--wp--custom--gap--vertical) auto"
 				}
 			},
-			"fontsToLoadFromGoogle": [
-				"family=Red+Hat+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,500;1,700;1,900"
-			],
 			"line-height": {
 				"body": 1.6
 			}


### PR DESCRIPTION
Drop "fontsToLoadFromGoogle" in favor of  the common "google" parameter. Child themes can simply set a "google" key/value for any Google fonts they need, just as the Blockbase does everywhere else.

I see no need (anymore) to have this separate custom section in the child theme json. Or am I missing something?

It just needs to be communicated and coordinated with child theme devs that still use "fontsToLoadFromGoogle"...

This also fixes #4460 and #4621


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
