### PR TITLE
Skatepark: Add submenu styling

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -126,6 +126,11 @@
 	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--gap--horizontal), var(--wp--custom--gap--horizontal) ));
 }
 
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation-link__container {
+	background-color: var(--wp--custom--color--background);
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
+}
+
 .wp-block-post-comments .reply a {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/sass/blocks/_navigation.scss
+++ b/skatepark/sass/blocks/_navigation.scss
@@ -1,0 +1,7 @@
+// See https://github.com/WordPress/gutenberg/issues/34648
+.wp-block-navigation.is-responsive {
+	.has-child .wp-block-navigation-link__container {
+		background-color: var(--wp--custom--color--background);
+		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
+	}
+}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -6,6 +6,7 @@
 @import "../../blockbase/sass/blocks/_buttons-outline-style";
 @import "blocks/buttons";
 @import "blocks/cover";
+@import "blocks/navigation";
 @import "blocks/post-comments";
 @import "blocks/post-title";
 @import "blocks/query";


### PR DESCRIPTION
I wasn't able to find any theme.json supported settings in the navigation block.

I find it hard to believe that no one has created a Gutenberg issue for this so far, but I wasn't able to find anything.

#4586 

