### PR TITLE
Add post meta to Geologist Theme

### DIFF
--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -398,18 +398,9 @@ textarea:focus {
 	}
 }
 
-.post-meta .wp-block-post-date::before {
-	display: none;
-}
-
 .post-meta > *,
 .post-meta .wp-block-post-date {
 	margin: 0 8px;
-}
-
-.post-meta > *::before,
-.post-meta .wp-block-post-date::before {
-	content: "";
 }
 
 .post-meta .wp-block-post-terms {

--- a/geologist/block-template-parts/post-meta.html
+++ b/geologist/block-template-parts/post-meta.html
@@ -1,0 +1,8 @@
+<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
+<div class="wp-block-group post-meta">
+    <!-- wp:post-author {"showAvatar":false,"showBio":false,"fontSize":"tiny"} /-->
+    <!-- wp:post-date {"fontSize":"tiny","isLink":true} /-->
+    <!-- wp:post-terms {"term":"category","fontSize":"tiny"} /-->
+    <!-- wp:post-terms {"term": "post_tag", "fontSize":"tiny"} /-->
+</div>
+<!-- /wp:group -->

--- a/geologist/block-templates/index.html
+++ b/geologist/block-templates/index.html
@@ -6,7 +6,7 @@
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"left"} /-->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
-		<!-- wp:post-date {"fontSize":"tiny","textAlign":"left"} /-->
+		<!-- wp:template-part {"slug":"post-meta","layout":{"inherit":true}} /-->
 		<!-- wp:spacer {"height":120} -->
 		<div style="height:120px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->

--- a/geologist/block-templates/single.html
+++ b/geologist/block-templates/single.html
@@ -12,12 +12,7 @@
 
 	<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-	<!-- wp:group {"layout":{"inherit":true},"className":"post-meta"} -->
-	<div class="wp-block-group post-meta">
-		<!-- wp:post-date {"textAlign":"left","fontSize":"tiny"} /-->
-		<!-- wp:post-terms {"term":"category","textAlign":"left","fontSize":"tiny"} /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:template-part {"slug":"post-meta","layout":{"inherit":true}} /-->
 
 	<!-- wp:spacer {"height":150} -->
 	<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/geologist/sass/templates/_meta.scss
+++ b/geologist/sass/templates/_meta.scss
@@ -6,16 +6,9 @@
 		margin-bottom: -20px;
 	}
 
-	.wp-block-post-date::before {
-		display: none;
-	}
-
 	> *,
 	.wp-block-post-date {
 		margin: 0 8px;
-		&::before {
-			content: "";
-		}
 	}
 
 	.wp-block-post-terms {


### PR DESCRIPTION
This follows up on #4565 and adds the new post meta template part to Geologist (both in the archive and single post views). 

The only bug I'm seeing is that the date icon isn't loading? I'm not sure why. 🤔 

Before|After
---|---
<img width="718" alt="Screen Shot 2021-09-20 at 1 03 46 PM" src="https://user-images.githubusercontent.com/1202812/134043753-d639826a-c824-4b93-a516-25b382a13236.png">|<img width="767" alt="Screen Shot 2021-09-20 at 12 55 31 PM" src="https://user-images.githubusercontent.com/1202812/134043757-d323dcec-5b05-4742-b8d4-8703ced5439e.png">


