### PR TITLE
Added additional margin top to achieve design target

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -490,6 +490,7 @@ header.wp-block-template-part {
 	max-width: var(--wp--custom--layout--wide-size);
 	margin: 0 auto;
 	width: 100%;
+	margin-top: calc( 0.5 * var(--wp--custom--gap--vertical));
 }
 
 header.wp-block-template-part > .wp-block-group {

--- a/skatepark/sass/templates/_header.scss
+++ b/skatepark/sass/templates/_header.scss
@@ -2,7 +2,8 @@ header.wp-block-template-part {
 	max-width: var(--wp--custom--layout--wide-size); // Layouts can be flex OR flow/default (inherit), not both. So we need to mimick the wide width alignment supplied by Gutenberg here.
 	margin: 0 auto;
 	width: 100%;
-
+	margin-top: calc( 0.5 * var(--wp--custom--gap--vertical) );
+	
 	> .wp-block-group {
 		gap: 0;
 		justify-content: space-between; // Apply a cluster (flex?) layout


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Added additional margin to header to achieve design target.
HALF of the "vertical gap" was already applied elsewhere in the header.  This change adds another half so the gap is the total of the gap.  Attempting to refactor to use apply the entire gap in one place was proving troublesome.
Note that the "virtical gap" is responsive so it will be the expected `30px` at wide screen but at smaller screens that gap diminishes down to `5vw`

#### Related issue(s):
Fixes #4585