### PR TITLE
Remove l/r padding from default posts template

### DIFF
--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -5,8 +5,8 @@
 	<!-- wp:query-title {"type":"archive","align":"wide"} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
-	<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-left:30px"><!-- wp:separator {"className":"is-style-wide"} -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px"}}},"layout":{"inherit":false}} -->
+	<div class="wp-block-group" style="padding-top:30px"><!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator is-style-wide"/>
 	<!-- /wp:separator -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Removes left/right padding from index template bringing content to the same width as everything else.

#### Related issue(s):
Fixes: #4588