### PR TITLE
Added font color and size styles to form input placeholder

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -332,6 +332,27 @@ button:focus {
 	outline-offset: 2px;
 }
 
+input.wp-block-search__input::placeholder,
+input[type="text"]::placeholder,
+input[type="email"]::placeholder,
+input[type="url"]::placeholder,
+input[type="password"]::placeholder,
+input[type="search"]::placeholder,
+input[type="number"]::placeholder,
+input[type="tel"]::placeholder,
+input[type="range"]::placeholder,
+input[type="date"]::placeholder,
+input[type="month"]::placeholder,
+input[type="week"]::placeholder,
+input[type="time"]::placeholder,
+input[type="datetime"]::placeholder,
+input[type="datetime-local"]::placeholder,
+input[type="color"]::placeholder,
+textarea::placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
 select {
 	font-family: inherit;
 	font-size: 100%;
@@ -821,6 +842,11 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon,
 .wp-block-search .wp-block-search__button.has-icon {
 	line-height: 0;
+}
+
+.wp-block-search .wp-block-search__input::placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
 }
 
 .wp-block-separator {

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -29,4 +29,10 @@
 		}
 	}
 
+	.wp-block-search__input {
+		&::placeholder {
+			color: var(--wp--custom--form--color--text);
+			opacity: 0.66;
+		}
+	}
 }

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -38,6 +38,11 @@ button {
 		outline: 1px dotted currentColor;
 		outline-offset: 2px;
 	}
+
+	&::placeholder {
+		color: var(--wp--custom--form--color--text);
+		opacity: 0.66;
+	}
 }
 
 select {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -432,21 +432,6 @@ ul ul {
 	border: none;
 }
 
-.wp-block-search .wp-block-search__input::-moz-placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
-}
-
-.wp-block-search .wp-block-search__input:-ms-input-placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
-}
-
-.wp-block-search .wp-block-search__input::placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
-}
-
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;
@@ -540,37 +525,6 @@ input[type="color"]:focus,
 input[type="checkbox"]:focus,
 textarea:focus {
 	outline: 1px dotted currentColor;
-}
-
-input[type="text"]::-moz-placeholder, input[type="email"]::-moz-placeholder, input[type="url"]::-moz-placeholder, input[type="password"]::-moz-placeholder, input[type="search"]::-moz-placeholder, input[type="number"]::-moz-placeholder, input[type="tel"]::-moz-placeholder, input[type="range"]::-moz-placeholder, input[type="date"]::-moz-placeholder, input[type="month"]::-moz-placeholder, input[type="week"]::-moz-placeholder, input[type="time"]::-moz-placeholder, input[type="submit"]::-moz-placeholder, input[type="datetime"]::-moz-placeholder, input[type="datetime-local"]::-moz-placeholder, input[type="color"]::-moz-placeholder, textarea::-moz-placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
-}
-
-input[type="text"]:-ms-input-placeholder, input[type="email"]:-ms-input-placeholder, input[type="url"]:-ms-input-placeholder, input[type="password"]:-ms-input-placeholder, input[type="search"]:-ms-input-placeholder, input[type="number"]:-ms-input-placeholder, input[type="tel"]:-ms-input-placeholder, input[type="range"]:-ms-input-placeholder, input[type="date"]:-ms-input-placeholder, input[type="month"]:-ms-input-placeholder, input[type="week"]:-ms-input-placeholder, input[type="time"]:-ms-input-placeholder, input[type="submit"]:-ms-input-placeholder, input[type="datetime"]:-ms-input-placeholder, input[type="datetime-local"]:-ms-input-placeholder, input[type="color"]:-ms-input-placeholder, textarea:-ms-input-placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
-}
-
-input[type="text"]::placeholder,
-input[type="email"]::placeholder,
-input[type="url"]::placeholder,
-input[type="password"]::placeholder,
-input[type="search"]::placeholder,
-input[type="number"]::placeholder,
-input[type="tel"]::placeholder,
-input[type="range"]::placeholder,
-input[type="date"]::placeholder,
-input[type="month"]::placeholder,
-input[type="week"]::placeholder,
-input[type="time"]::placeholder,
-input[type="submit"]::placeholder,
-input[type="datetime"]::placeholder,
-input[type="datetime-local"]::placeholder,
-input[type="color"]::placeholder,
-textarea::placeholder {
-	color: var(--wp--custom--form--color--text);
-	opacity: 0.66;
 }
 
 .home .site-footer.wp-block-group:before {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -432,6 +432,21 @@ ul ul {
 	border: none;
 }
 
+.wp-block-search .wp-block-search__input::-moz-placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
+.wp-block-search .wp-block-search__input:-ms-input-placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
+.wp-block-search .wp-block-search__input::placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -486,6 +486,26 @@ a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen
 	text-decoration: none;
 }
 
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="submit"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
+textarea {
+	font-size: var(--wp--preset--font-size--normal);
+}
+
 input[type="text"]:focus,
 input[type="email"]:focus,
 input[type="url"]:focus,
@@ -505,6 +525,37 @@ input[type="color"]:focus,
 input[type="checkbox"]:focus,
 textarea:focus {
 	outline: 1px dotted currentColor;
+}
+
+input[type="text"]::-moz-placeholder, input[type="email"]::-moz-placeholder, input[type="url"]::-moz-placeholder, input[type="password"]::-moz-placeholder, input[type="search"]::-moz-placeholder, input[type="number"]::-moz-placeholder, input[type="tel"]::-moz-placeholder, input[type="range"]::-moz-placeholder, input[type="date"]::-moz-placeholder, input[type="month"]::-moz-placeholder, input[type="week"]::-moz-placeholder, input[type="time"]::-moz-placeholder, input[type="submit"]::-moz-placeholder, input[type="datetime"]::-moz-placeholder, input[type="datetime-local"]::-moz-placeholder, input[type="color"]::-moz-placeholder, textarea::-moz-placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
+input[type="text"]:-ms-input-placeholder, input[type="email"]:-ms-input-placeholder, input[type="url"]:-ms-input-placeholder, input[type="password"]:-ms-input-placeholder, input[type="search"]:-ms-input-placeholder, input[type="number"]:-ms-input-placeholder, input[type="tel"]:-ms-input-placeholder, input[type="range"]:-ms-input-placeholder, input[type="date"]:-ms-input-placeholder, input[type="month"]:-ms-input-placeholder, input[type="week"]:-ms-input-placeholder, input[type="time"]:-ms-input-placeholder, input[type="submit"]:-ms-input-placeholder, input[type="datetime"]:-ms-input-placeholder, input[type="datetime-local"]:-ms-input-placeholder, input[type="color"]:-ms-input-placeholder, textarea:-ms-input-placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
+}
+
+input[type="text"]::placeholder,
+input[type="email"]::placeholder,
+input[type="url"]::placeholder,
+input[type="password"]::placeholder,
+input[type="search"]::placeholder,
+input[type="number"]::placeholder,
+input[type="tel"]::placeholder,
+input[type="range"]::placeholder,
+input[type="date"]::placeholder,
+input[type="month"]::placeholder,
+input[type="week"]::placeholder,
+input[type="time"]::placeholder,
+input[type="submit"]::placeholder,
+input[type="datetime"]::placeholder,
+input[type="datetime-local"]::placeholder,
+input[type="color"]::placeholder,
+textarea::placeholder {
+	color: var(--wp--custom--form--color--text);
+	opacity: 0.66;
 }
 
 .home .site-footer.wp-block-group:before {

--- a/quadrat/sass/blocks/_search.scss
+++ b/quadrat/sass/blocks/_search.scss
@@ -1,3 +1,12 @@
-.wp-block-search .wp-block-search__button {
-	border: none;
+.wp-block-search {
+	.wp-block-search__button {
+		border: none;
+	}
+
+	.wp-block-search__input {
+		&::placeholder {
+			color: var(--wp--custom--form--color--text);
+			opacity: 0.66;
+		}
+	}
 }

--- a/quadrat/sass/blocks/_search.scss
+++ b/quadrat/sass/blocks/_search.scss
@@ -2,11 +2,4 @@
 	.wp-block-search__button {
 		border: none;
 	}
-
-	.wp-block-search__input {
-		&::placeholder {
-			color: var(--wp--custom--form--color--text);
-			opacity: 0.66;
-		}
-	}
 }

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -19,4 +19,9 @@ textarea {
 	&:focus {
 		outline: 1px dotted currentColor;
 	}
+	font-size: var(--wp--preset--font-size--normal);
+	&::placeholder {
+		color: var(--wp--custom--form--color--text);
+		opacity: 0.66;
+	}
 }

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -20,9 +20,4 @@ textarea {
 		outline: 1px dotted currentColor;
 	}
 	font-size: var(--wp--preset--font-size--normal);
-
-	&::placeholder {
-		color: var(--wp--custom--form--color--text);
-		opacity: 0.66;
-	}
 }

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -20,6 +20,7 @@ textarea {
 		outline: 1px dotted currentColor;
 	}
 	font-size: var(--wp--preset--font-size--normal);
+
 	&::placeholder {
 		color: var(--wp--custom--form--color--text);
 		opacity: 0.66;

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -458,13 +458,6 @@
 					"background": "var(--wp--custom--color--tertiary)"
 				}
 			},
-			"core/gallery": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--gap--vertical)"
-					}
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -458,6 +458,13 @@
 					"background": "var(--wp--custom--color--tertiary)"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

In order to differentiate between prompt and entered text could we set the opacity?  (.66 pictured below)
Before:
![image](https://user-images.githubusercontent.com/146530/134063592-58744eea-9ab6-4279-beaf-e76eb849e8a2.png)


After:
![image](https://user-images.githubusercontent.com/146530/134062701-6ae353be-dbfb-4a5d-a940-a861ea6c4416.png)
![image](https://user-images.githubusercontent.com/146530/134062736-918bb704-6c41-4734-a422-24950a2e6bbe.png)

Note: Setting the following does not work as I expected it to:
```
"core/search": {
	"typography": {
		"fontSize": "var(--wp--preset--font-size--normal)"
	}
},
```

#### Related issue(s):

Fixes: #4596