### PR TITLE
Add a 'blank' default block template for blockbase themes

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -37,6 +37,14 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 			)
 		);
 
+		add_filter(
+			'block_editor_settings_all',
+			function( $settings ) {
+				$settings['defaultBlockTemplate'] = '<!-- wp:group {"layout":{"inherit":true}} --><div class="wp-block-group"><!-- wp:post-content /--></div><!-- /wp:group -->';
+				return $settings;
+			}
+		);
+
 	}
 	add_action( 'after_setup_theme', 'blockbase_support', 9 );
 endif;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This sets the default template content to just a group (inheriting layout) containing the post content.

![image](https://user-images.githubusercontent.com/146530/134068096-d3f88aef-87e9-4810-bc38-29a50164e3e6.png)

#### Related issue(s):
Fixes: #4260 