### PR TITLE
Blockbase: Fix alignments in the Query Pagination block

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -629,7 +629,7 @@ p.has-background {
 	color: var(--wp--custom--color--background);
 }
 
-.wp-block-query-pagination {
+div.wp-block-query-pagination {
 	padding-top: 1.5em;
 	justify-content: space-between;
 	display: grid;
@@ -638,33 +638,33 @@ p.has-background {
 }
 
 @media (max-width: 599px) {
-	.wp-block-query-pagination {
+	div.wp-block-query-pagination {
 		grid-template-areas: "prev next";
 		grid-template-columns: 1fr 1fr;
 	}
 }
 
-.wp-block-query-pagination .wp-block-query-pagination-previous {
+div.wp-block-query-pagination .wp-block-query-pagination-previous {
 	justify-self: start;
 	grid-area: prev;
 }
 
-.wp-block-query-pagination .wp-block-query-pagination-next {
+div.wp-block-query-pagination .wp-block-query-pagination-next {
 	justify-self: end;
 	grid-area: next;
 }
 
-.wp-block-query-pagination .wp-block-query-pagination-numbers {
+div.wp-block-query-pagination .wp-block-query-pagination-numbers {
 	grid-area: numbers;
 	justify-self: center;
 }
 
-.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
+div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 	text-decoration: underline;
 }
 
 @media (max-width: 599px) {
-	.wp-block-query-pagination .wp-block-query-pagination-numbers {
+	div.wp-block-query-pagination .wp-block-query-pagination-numbers {
 		display: none;
 	}
 }

--- a/blockbase/sass/blocks/_query-pagination.scss
+++ b/blockbase/sass/blocks/_query-pagination.scss
@@ -1,4 +1,4 @@
-.wp-block-query-pagination {
+div.wp-block-query-pagination { // This CSS needs to be stronger than Gutenberg's until https://github.com/WordPress/gutenberg/issues/34997 is merged.
 	padding-top: 1.5em;
 	justify-content: space-between;
 	display: grid;
@@ -19,7 +19,7 @@
 		justify-self: end;
 		grid-area: next;
 	}
-	
+
 	.wp-block-query-pagination-numbers{
 		grid-area: numbers;
 		justify-self: center;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This fixes some alignment issues with the Query Pagination block, when there aren't many posts on a site:

Before:
<img width="679" alt="Screenshot 2021-09-21 at 11 07 19" src="https://user-images.githubusercontent.com/275961/134155954-7498faff-53cd-423d-95cd-1c1e0b35be4f.png">
<img width="726" alt="Screenshot 2021-09-21 at 11 07 12" src="https://user-images.githubusercontent.com/275961/134155957-fc15a831-d56c-4c02-9b7a-d32fd2cf3d77.png">

After:
<img width="624" alt="Screenshot 2021-09-21 at 11 33 41" src="https://user-images.githubusercontent.com/275961/134156039-b3caa479-078c-487e-b7fd-b1d262a06565.png">
<img width="621" alt="Screenshot 2021-09-21 at 11 33 36" src="https://user-images.githubusercontent.com/275961/134156044-038818fd-cb80-4743-a7e3-b59632e7a7a3.png">


#### Related issue(s):
Ideally this would be fixed in Gutenberg: https://github.com/WordPress/gutenberg/issues/34997