### PR TITLE
Blockbase: Add more styles to .aligncenter

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -98,6 +98,9 @@ img {
 
 .aligncenter {
 	text-align: center;
+	display: block;
+	margin-right: auto;
+	margin-left: auto;
 }
 
 .container-404 {

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -47,8 +47,12 @@
 // This was added for the 'site-logo' block which centers with an 'align:center' attribute
 // instead of 'textAlign' center which sets an .aligncenter class instead of a has-text-align-center
 // class which would do this for us.  I'm not sure why but this centers things appropriately.
+// Display and margin properties added to support image alignment from the classic editor.
 .aligncenter {
 	text-align: center;
+    display: block;
+    margin-right: auto;
+    margin-left: auto;
 }
 
 // Mimick the Gutenberg-generated rules of the layout container on the 404 template

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -50,9 +50,9 @@
 // Display and margin properties added to support image alignment from the classic editor.
 .aligncenter {
 	text-align: center;
-    display: block;
-    margin-right: auto;
-    margin-left: auto;
+	display: block;
+	margin-right: auto;
+	margin-left: auto;
 }
 
 // Mimick the Gutenberg-generated rules of the layout container on the 404 template


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a few more styles to the existing `.aligncenter` class to support centering an image from the classic editor.

#### Related issue(s):
Fixes #4619.