### PR TITLE
Quadrat/update font sizes

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -301,7 +301,7 @@ ul ul {
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
 	padding: 0;
-	font-size: 15px;
+	font-size: 16px;
 	line-height: 40px;
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -301,7 +301,7 @@ ul ul {
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
 	padding: 0;
-	font-size: 16px;
+	font-size: var(--wp--preset--font-size--tiny);
 	line-height: 40px;
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -270,7 +270,7 @@ ul ul {
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item,
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link {
-	font-size: 20px;
+	font-size: var(--wp--preset--font-size--normal);
 	line-height: 50px;
 	margin: 0;
 	align-items: flex-end;

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -278,7 +278,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "20px"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"core/navigation-link": {
@@ -306,7 +306,7 @@
 				},
 				"citation": {
 					"typography": {
-						"fontSize": "16px",
+						"fontSize": "var(--wp--preset--font-size--tiny)",
 						"fontWeight": "400"
 					}
 				},
@@ -349,7 +349,7 @@
 			},
 			"core/query-pagination": {
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "500"
 				}
 			},
@@ -358,7 +358,7 @@
 					"link": "var(--wp--custom--color--primary)"
 				},
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": 700,
 					"textTransform": "uppercase"
 				}
@@ -389,21 +389,21 @@
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "22px",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": 1.4
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"lineHeight": 1.4
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "18px",
+					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": 1.4
 				}
 			},

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -278,7 +278,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "18px"
+					"fontSize": "20px"
 				}
 			},
 			"core/navigation-link": {
@@ -358,7 +358,7 @@
 					"link": "var(--wp--custom--color--primary)"
 				},
 				"typography": {
-					"fontSize": "18px",
+					"fontSize": "20px",
 					"fontWeight": 700,
 					"textTransform": "uppercase"
 				}

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -219,17 +219,17 @@
 			"fontSizes": [
 				{
 					"name": "Tiny",
-					"size": "15px",
+					"size": "16px",
 					"slug": "tiny"
 				},
 				{
 					"name": "Small",
-					"size": "17px",
+					"size": "18px",
 					"slug": "small"
 				},
 				{
 					"name": "Normal",
-					"size": "18px",
+					"size": "20px",
 					"slug": "normal"
 				},
 				{
@@ -239,7 +239,7 @@
 				},
 				{
 					"name": "Extra Large",
-					"size": "min(max(28px, 5vw), 35px)",
+					"size": "min(max(28px, 5vw), 38px)",
 					"slug": "extra-large"
 				},
 				{
@@ -306,7 +306,7 @@
 				},
 				"citation": {
 					"typography": {
-						"fontSize": "15px",
+						"fontSize": "16px",
 						"fontWeight": "400"
 					}
 				},
@@ -349,7 +349,7 @@
 			},
 			"core/query-pagination": {
 				"typography": {
-					"fontSize": "18px",
+					"fontSize": "20px",
 					"fontWeight": "500"
 				}
 			},
@@ -389,21 +389,21 @@
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "20px",
+					"fontSize": "22px",
 					"lineHeight": 1.4
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "18px",
+					"fontSize": "20px",
 					"lineHeight": 1.4
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-					"fontSize": "16px",
+					"fontSize": "18px",
 					"lineHeight": 1.4
 				}
 			},

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -52,7 +52,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "700"
 				}
 			},
@@ -271,7 +271,7 @@
 					"background": "var(--wp--custom--color--tertiary)"
 				},
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "400",
 					"lineHeight": "1.6"
 				}

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -45,7 +45,7 @@
 						.wp-block-pages-list__item__link,
 						.wp-block-navigation-link__content {
 							padding: 0;
-							font-size: 16px;
+							font-size: var(--wp--preset--font-size--tiny);
 							line-height: 40px;
 						}
 					}

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -28,7 +28,7 @@
 		&.has-modal-open {
 			.wp-block-pages-list__item,
 			.wp-block-navigation-link {
-				font-size: 20px;
+				font-size: var(--wp--preset--font-size--normal);
 				line-height: 50px;
 				margin: 0;
 				align-items: flex-end;

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -45,7 +45,7 @@
 						.wp-block-pages-list__item__link,
 						.wp-block-navigation-link__content {
 							padding: 0;
-							font-size: 15px;
+							font-size: 16px;
 							line-height: 40px;
 						}
 					}

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -476,7 +476,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "18px"
+					"fontSize": "20px"
 				}
 			},
 			"core/post-title": {
@@ -528,7 +528,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontSize": "18px",
+					"fontSize": "20px",
 					"fontWeight": 700,
 					"textTransform": "uppercase"
 				},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -476,7 +476,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "20px"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"core/post-title": {
@@ -528,7 +528,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": 700,
 					"textTransform": "uppercase"
 				},
@@ -555,7 +555,7 @@
 				},
 				"citation": {
 					"typography": {
-						"fontSize": "16px",
+						"fontSize": "var(--wp--preset--font-size--tiny)",
 						"fontWeight": "400"
 					}
 				}
@@ -582,7 +582,7 @@
 			},
 			"core/query-pagination": {
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "500"
 				}
 			}
@@ -639,7 +639,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "22px"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"margin": {
@@ -653,7 +653,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "20px"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				},
 				"spacing": {
 					"margin": {
@@ -667,7 +667,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "18px"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				},
 				"spacing": {
 					"margin": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -96,7 +96,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "700",
 					"lineHeight": 2
 				}
@@ -451,7 +451,7 @@
 				},
 				"typography": {
 					"fontFamily": "monospace",
-					"fontSize": "20px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "400",
 					"lineHeight": "1.6"
 				},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -555,7 +555,7 @@
 				},
 				"citation": {
 					"typography": {
-						"fontSize": "15px",
+						"fontSize": "16px",
 						"fontWeight": "400"
 					}
 				}
@@ -582,7 +582,7 @@
 			},
 			"core/query-pagination": {
 				"typography": {
-					"fontSize": "18px",
+					"fontSize": "20px",
 					"fontWeight": "500"
 				}
 			}

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -386,17 +386,17 @@
 			"fontSizes": [
 				{
 					"name": "Tiny",
-					"size": "15px",
+					"size": "16px",
 					"slug": "tiny"
 				},
 				{
 					"name": "Small",
-					"size": "17px",
+					"size": "18px",
 					"slug": "small"
 				},
 				{
 					"name": "Normal",
-					"size": "18px",
+					"size": "20px",
 					"slug": "normal"
 				},
 				{
@@ -406,7 +406,7 @@
 				},
 				{
 					"name": "Extra Large",
-					"size": "min(max(28px, 5vw), 35px)",
+					"size": "min(max(28px, 5vw), 38px)",
 					"slug": "extra-large"
 				},
 				{

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -459,6 +459,21 @@
 					"background": "var(--wp--custom--color--tertiary)"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
+			"core/group": {
+				"spacing": {
+					"margin": {
+						"top": "var(--wp--custom--gap--vertical)",
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "18px"
@@ -624,7 +639,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "20px"
+					"fontSize": "22px"
 				},
 				"spacing": {
 					"margin": {
@@ -638,7 +653,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "18px"
+					"fontSize": "20px"
 				},
 				"spacing": {
 					"margin": {
@@ -652,7 +667,7 @@
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": 1.4,
-					"fontSize": "16px"
+					"fontSize": "18px"
 				},
 				"spacing": {
 					"margin": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the font sizes to match the Design file changes from @beafialho 

#### Related issue(s):

None.

#### Test Plan:

**Test that the font sizes on Desktop are:**
h1: 80px
h2: 65px
h3: 38px
h4: 22px
h5: 20px
h6: 18px
P Tiny: 16px
P Small: 18px
P Normal: 20px
P Large: 22px
P Extra Large: 38px
P Huge: 48px
Site Title: 20px
Site Tag: 16px

**Test that the font sizes on Mobile are:**
h1: 48px
h2: 36px
h3: 28px
h4: 22px
h5: 20px
h6: 18px
P Tiny: 16px
P Small: 18px
P Normal: 20px
P Large: 22px
P Extra Large: 28px
P Huge: 36px

Test that Quote Citation font size is: 16px
Test that Query Pagination font size is: 20px
