### PR TITLE
Blockbase: Add focus styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -233,6 +233,11 @@ a:hover, a:focus {
 	text-decoration: none;
 }
 
+a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
+	outline: 1px dotted currentColor;
+	text-decoration: none;
+}
+
 input.wp-block-search__input,
 input[type="text"],
 input[type="email"],
@@ -276,8 +281,17 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-	color: var(--wp--custom--form--color--text);
 	border-color: var(--custom--form--color--border);
+	color: var(--wp--custom--form--color--text);
+	outline: 1px dotted currentColor;
+	outline-offset: 2px;
+}
+
+input[type="checkbox"]:focus,
+input[type="submit"]:focus,
+button:focus {
+	outline: 1px dotted currentColor;
+	outline-offset: 2px;
 }
 
 select {
@@ -560,6 +574,11 @@ p.has-drop-cap:not(:focus):first-letter {
 	width: var(--wp--custom--form--checkbox--checked--sizing--width);
 	height: var(--wp--custom--form--checkbox--checked--sizing--height);
 	font-size: var(--wp--custom--form--checkbox--checked--font-size);
+}
+
+.wp-block-post-comments form .comment-form-cookies-consent input[type="checkbox"]:focus + ::before {
+	outline: 1px dotted currentColor;
+	outline-offset: 2px;
 }
 
 .wp-block-post-comments .comment-reply-title small {

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -114,6 +114,11 @@
 					height: var(--wp--custom--form--checkbox--checked--sizing--height);
 					font-size: var(--wp--custom--form--checkbox--checked--font-size);
 				}
+
+				&:focus + ::before {
+					outline: 1px dotted currentColor;
+					outline-offset: 2px;
+				}
 			}
 		}
 	}
@@ -132,7 +137,7 @@
 				font-size: var(--wp--custom--post-comment--typography--font-size);
 				line-height: var(--wp--custom--post-comment--typography--line-height);
 				margin-bottom: var(--wp--custom--gap--vertical);
-				margin-top: var(--wp--custom--gap--vertical);	
+				margin-top: var(--wp--custom--gap--vertical);
 			}
 		}
 	}

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -24,8 +24,19 @@ textarea {
 	padding: var(--wp--custom--form--padding);
 
 	&:focus {
-		color: var(--wp--custom--form--color--text);
 		border-color: var(--custom--form--color--border);
+		color: var(--wp--custom--form--color--text);
+		outline: 1px dotted currentColor;
+		outline-offset: 2px;
+	}
+}
+
+input[type="checkbox"],
+input[type="submit"],
+button {
+	&:focus {
+		outline: 1px dotted currentColor;
+		outline-offset: 2px;
 	}
 }
 

--- a/blockbase/sass/elements/_links.scss
+++ b/blockbase/sass/elements/_links.scss
@@ -20,3 +20,12 @@ a {
 		text-decoration: none;
 	}
 }
+
+// Select the focus states of all non-wpadmin and screen reader links
+a:not(.ab-item):not(.screen-reader-shortcut) {
+	&:active,
+	&:focus {
+		outline: 1px dotted currentColor;
+		text-decoration: none;
+	}
+}

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -469,6 +469,7 @@ input[type="submit"]:focus,
 input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
+input[type="checkbox"]:focus,
 textarea:focus {
 	outline: 1px dotted currentColor;
 }

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -14,6 +14,7 @@ input[type="submit"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input[type="checkbox"],
 textarea {
 	&:focus {
 		outline: 1px dotted currentColor;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This moves the focus styles from Quadrat into Blockbase so that they work with all themes.

This is how it looks in all our themes:

Blockbase:
![blockbase focus](https://user-images.githubusercontent.com/275961/134382307-12f7aee8-e5ba-490b-a387-a03fa7f0c21e.gif)

Quadrat:
![quadrat-focus](https://user-images.githubusercontent.com/275961/134382334-66ba3984-3687-4a92-ada9-89acfa482f8e.gif)

Skatepark:
![skatepark-focus](https://user-images.githubusercontent.com/275961/134382367-05562f5a-eca5-42cb-a827-a4402b8644d0.gif)

Geologist:
![geologist-focus](https://user-images.githubusercontent.com/275961/134382401-e72bf8d6-9c73-4016-ae5d-d9d5fdcd38de.gif)

Seedlet Blocks:
![seedlet-blocks-focus](https://user-images.githubusercontent.com/275961/134382467-e47165f0-de17-4836-a624-8897a662a835.gif)

Mayland Blocks:
![mayland-blocks-focus](https://user-images.githubusercontent.com/275961/134382593-19330757-1325-40d5-b900-5d14fe24d1fa.gif)

Videomaker:
![videomaker-focus](https://user-images.githubusercontent.com/275961/134382605-df10045d-1f1c-4cd9-bd4e-5e9ef99a81a8.gif)

