### PR TITLE
Quadrat+Skatepark: Remove code that removes support for block templates

### DIFF
--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -35,8 +35,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 				'primary' => __( 'Primary Navigation', 'quadrat' ),
 			)
 		);
-
-		remove_theme_support( 'block-templates' );
 	}
 	add_action( 'after_setup_theme', 'quadrat_support' );
 endif;

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -28,8 +28,6 @@ if ( ! function_exists( 'skatepark_support' ) ) :
 				'social' => __( 'Social Navigation', 'skatepark' )
 			)
 		);
-
-		remove_theme_support( 'block-templates' );
 	}
 	add_action( 'after_setup_theme', 'skatepark_support' );
 endif;
@@ -61,7 +59,7 @@ require get_stylesheet_directory() . '/inc/block-styles.php';
 /**
  * Add class to body if post/page has a featured image.
  */
-function add_featured_image_class( $classes ) {    
+function add_featured_image_class( $classes ) {
 	global $post;
 	if ( isset ( $post->ID ) && get_the_post_thumbnail( $post->ID ) ) {
 		$classes[] = 'has-featured-image';


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I think these themes should support block templates, I'm not sure why we removed the support.

#### Related issue(s):
