### PR TITLE
Videomaker: Add content width settings

### DIFF
--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -98,6 +98,10 @@
 				}
 			]
 		},
+		"layout": {
+			"contentSize": "886px",
+			"wideSize": "1342px"
+		},
 		"typography": {
 			"fontFamilies": [
 				{
@@ -201,10 +205,6 @@
 					"fontFamily": "var(--wp--preset--font-family--inter)"
 				}
 			}
-		},
-		"layout": {
-			"contentSize": "886px",
-			"wideSize": "1000px"
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--inter)"

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -202,6 +202,10 @@
 				}
 			}
 		},
+		"layout": {
+			"contentSize": "886px",
+			"wideSize": "1000px"
+		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--inter)"
 		}

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -99,8 +99,8 @@
 			]
 		},
 		"layout": {
-			"contentSize": "886px",
-			"wideSize": "1342px"
+			"contentSize": "800px",
+			"wideSize": "1300px"
 		},
 		"typography": {
 			"fontFamilies": [

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -309,8 +309,8 @@
 			}
 		},
 		"layout": {
-			"contentSize": "620px",
-			"wideSize": "1000px"
+			"contentSize": "886px",
+			"wideSize": "1342px"
 		},
 		"spacing": {
 			"blockGap": true,
@@ -604,10 +604,6 @@
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
 			"fontFamily": "var(--wp--preset--font-family--inter)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
-		},
-		"layout": {
-			"contentSize": "886px",
-			"wideSize": "1000px"
 		}
 	}
 }

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -309,8 +309,8 @@
 			}
 		},
 		"layout": {
-			"contentSize": "886px",
-			"wideSize": "1342px"
+			"contentSize": "800px",
+			"wideSize": "1300px"
 		},
 		"spacing": {
 			"blockGap": true,

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -604,6 +604,10 @@
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",
 			"fontFamily": "var(--wp--preset--font-family--inter)",
 			"fontSize": "var(--wp--preset--font-size--normal)"
+		},
+		"layout": {
+			"contentSize": "886px",
+			"wideSize": "1000px"
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the layout settings for Videomaker:

Content width: 886px
Wide size: 1000px

This also uses the same gap size as Blockbase:
```
			"gap": {
				"baseline": "10px",
				"horizontal": "min(30px, 5vw)",
				"vertical": "min(30px, 5vw)"
			},
```

#### Related issue(s):
https://github.com/Automattic/themes/issues/4641
