### PR TITLE
Removed block-level margin styles from all themes

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -404,14 +404,6 @@
 					}
 				}
 			},
-			"core/group": {
-				"spacing": {
-					"margin": {
-						"top": "var(--wp--custom--gap--vertical)",
-						"bottom": "var(--wp--custom--gap--vertical)"
-					}
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -433,6 +433,13 @@
 					"background": "var(--wp--custom--color--tertiary)"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "18px"

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -426,6 +426,13 @@
 					"fontFamily": "monospace"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -466,14 +466,6 @@
 					}
 				}
 			},
-			"core/group": {
-				"spacing": {
-					"margin": {
-						"top": "var(--wp--custom--gap--vertical)",
-						"bottom": "var(--wp--custom--gap--vertical)"
-					}
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -455,6 +455,13 @@
 					"fontFamily": "monospace"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -454,6 +454,13 @@
 					"fontFamily": "monospace"
 				}
 			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--custom--gap--vertical)"
+					}
+				}
+			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
[This change](https://github.com/Automattic/themes/pull/4629) introduced top and bottom margins for all [group blocks](https://github.com/Automattic/themes/pull/4629/files#diff-8d19c6d8b05bdcca09ecf489813da09999af47dd7cfafc71b7e263f900b97410R407-R414).  That introduced undesirable margins in other places (such as the header).  I don't believe that change was necessary to achieve the goal; colored background groups seem to continue to look correct with that setting absent.

This change removes that block-level configuration for all Blockbase themes.

Before:
![image](https://user-images.githubusercontent.com/146530/134562864-cd2f8c07-9b03-48fb-be40-f773765c6621.png)

After:
![image](https://user-images.githubusercontent.com/146530/134562802-0d232f3f-6bb8-43fa-9dd3-ac1eb57c7fc6.png)


#### Related issue(s):
