### PR TITLE
Blockbase: Remove padding from the separator

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -207,7 +207,7 @@ p {
 	padding: 0;
 }
 
-.has-background {
+.has-background:not(.wp-block-separator) {
 	padding: var(--wp--custom--gap--vertical) var(--wp--custom--gap--horizontal);
 }
 

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -15,7 +15,9 @@
 
 // Needed until we have a solution for https://github.com/WordPress/gutenberg/issues/34588.
 .has-background {
-	padding: var(--wp--custom--gap--vertical) var(--wp--custom--gap--horizontal);
+	&:not(.wp-block-separator){
+		padding: var(--wp--custom--gap--vertical) var(--wp--custom--gap--horizontal);
+	}
 
 	:last-child {
 		margin-bottom: 0;


### PR DESCRIPTION
Before:

<img width="684" alt="before-5" src="https://user-images.githubusercontent.com/905781/134891122-0dd6b725-483f-4438-8237-337591fd5f79.png">

After:

<img width="703" alt="HR_–_themes" src="https://user-images.githubusercontent.com/905781/134891146-e7d28a95-123b-4db8-8223-c76cbdb6724d.png">

Closes #4710 