### PR TITLE
Blockbase: Don't reset the settings array if it doesn't exist

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -148,8 +148,11 @@ class GlobalStylesColorCustomizer {
 		$user_theme_json_post_content->version                     = 1;
 		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
 
-		// Start with reset palette settings.
-		unset( $user_theme_json_post_content->settings->color->palette );
+		// Only reset the palette if the setting exists, otherwise the whole settings array gets destroyed.
+		if ( property_exists( $user_theme_json_post_content, 'settings' ) && property_exists( $user_theme_json_post_content->settings, 'color' ) && property_exists( $user_theme_json_post_content->settings->color, 'palette' ) ) {
+			// Start with reset palette settings.
+			unset( $user_theme_json_post_content->settings->color->palette );
+		}
 
 		//Set the color palette if it is !== the default
 		if ( ! $this->check_if_colors_are_default() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When we edit menus the theme.json settings get changed to `null`. This introduces a check before we reset the settings array to ensure that we don't accidentally set the settings array to `null`.

To test:
1. Switch to Quadrat
2. Add a new menu and add a menu item to it in Customizer
3. Save changes
4. Without this PR your site colors will be reset, with this PR nothing will change.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/4682