### PR TITLE
Blockbase: Add menu previews

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -130,6 +130,20 @@ require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
 require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
 require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 
+// Force menus to reload
+add_action(
+	'customize_controls_enqueue_scripts',
+	static function () {
+		wp_enqueue_script(
+			'wp-customize-nav-menu-refresh',
+			get_template_directory_uri() . '/inc/customizer/wp-customize-nav-menu-refresh.js',
+			[ 'customize-nav-menus' ],
+			wp_get_theme()->get( 'Version' ),
+			true
+		);
+	}
+);
+
 /**
  * Populate the social links block with the social menu content if it exists
  *

--- a/blockbase/inc/customizer/wp-customize-nav-menu-refresh.js
+++ b/blockbase/inc/customizer/wp-customize-nav-menu-refresh.js
@@ -1,0 +1,8 @@
+( function () {
+	// Augment each menu item control once it is added and embedded.
+	wp.customize.control.bind( 'change', ( control ) => {
+		if ( control.extended( wp.customize.Menus.MenuItemControl ) ) {
+			wp.customize.previewer.refresh();
+		}
+	} );
+} )();

--- a/blockbase/inc/customizer/wp-customize-nav-menu-refresh.js
+++ b/blockbase/inc/customizer/wp-customize-nav-menu-refresh.js
@@ -1,6 +1,13 @@
 ( function () {
-	// Augment each menu item control once it is added and embedded.
+	// Refresh the preview when menu controls are changed
 	wp.customize.control.bind( 'change', ( control ) => {
+		if ( control.extended( wp.customize.Menus.MenuItemControl ) ) {
+			wp.customize.previewer.refresh();
+		}
+	} );
+
+	// Refresh the preview when menu items are removed
+	wp.customize.control.bind( 'remove', ( control ) => {
 		if ( control.extended( wp.customize.Menus.MenuItemControl ) ) {
 			wp.customize.previewer.refresh();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds code to reload the Customizer preview when the menu is updated in the Customizer.

To test:
- Open the customizer
- Change the menu settings
- Confirm that you see the changes reflected in the preview

This doesn't cover changes made to the label names.

#### Related issue(s):
https://github.com/Automattic/themes/issues/4681