### PR TITLE
Blockbase: fix navigation on Safari

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -676,7 +676,7 @@ div.wp-block-query-pagination .wp-block-query-pagination-previous {
 }
 
 div.wp-block-query-pagination .wp-block-query-pagination-next {
-	justify-self: end;
+	justify-self: flex-end;
 	grid-area: next;
 }
 

--- a/blockbase/sass/blocks/_query-pagination.scss
+++ b/blockbase/sass/blocks/_query-pagination.scss
@@ -16,7 +16,7 @@ div.wp-block-query-pagination { // This CSS needs to be stronger than Gutenberg'
 	}
 
 	.wp-block-query-pagination-next {
-		justify-self: end;
+		justify-self: flex-end;
 		grid-area: next;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This fixes the problem in Safari where the navigation would show aligned to the left instead of to the right.

#### Related issue(s):

Closes #4721