### PR TITLE
Geologist: Minor updates

### DIFF
--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -87,36 +87,6 @@
 						"tertiary": "#313131",
 						"background": "#000000"
 					}
-				},
-				{
-					"label": "Maroon",
-					"slug": "maroon",
-					"colors": {
-						"primary": "#fffbdc",
-						"secondary": "#ffffff",
-						"tertiary": "#3f1818",
-						"background": "#2e0909"
-					}
-				},
-				{
-					"label": "Green/Pink",
-					"slug": "green-pink",
-					"colors": {
-						"primary": "#ffd0d0",
-						"secondary": "#ffffff",
-						"tertiary": "#721A18",
-						"background": "#114144"
-					}
-				},
-				{
-					"label": "Beige",
-					"slug": "beige",
-					"colors": {
-						"primary": "#000000",
-						"secondary": "#000000",
-						"tertiary": "#fefaf1",
-						"background": "#f5f0e5"
-					}
 				}
 			],
 			"form": {

--- a/geologist/inc/block-patterns.php
+++ b/geologist/inc/block-patterns.php
@@ -19,6 +19,7 @@ if ( ! function_exists( 'geologist_register_block_patterns' ) ) :
 		if ( function_exists( 'register_block_pattern' ) ) {
 			$block_patterns = array(
 				'authors',
+				'header-with-rounded-site-logo',
 				'image-feature',
 				'introduction',
 				'quote',

--- a/geologist/inc/patterns/header-with-rounded-site-logo.php
+++ b/geologist/inc/patterns/header-with-rounded-site-logo.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Authors
+ *
+ * @package Geologist
+ */
+
+return array(
+	'title'      => __( 'Header with Rounded Site Logo and Title', 'geologist' ),
+	'categories' => array( 'geologist' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'    => '<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<header class="wp-block-group site-header" style="padding-bottom:90px">
+	<!-- wp:site-logo {"className":"is-style-rounded"} /-->
+	<!-- wp:site-title /-->
+	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+</header>
+<!-- /wp:group -->',
+);

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -134,36 +134,6 @@
 						"tertiary": "#313131",
 						"background": "#000000"
 					}
-				},
-				{
-					"label": "Maroon",
-					"slug": "maroon",
-					"colors": {
-						"primary": "#fffbdc",
-						"secondary": "#ffffff",
-						"tertiary": "#3f1818",
-						"background": "#2e0909"
-					}
-				},
-				{
-					"label": "Green/Pink",
-					"slug": "green-pink",
-					"colors": {
-						"primary": "#ffd0d0",
-						"secondary": "#ffffff",
-						"tertiary": "#721A18",
-						"background": "#114144"
-					}
-				},
-				{
-					"label": "Beige",
-					"slug": "beige",
-					"colors": {
-						"primary": "#000000",
-						"secondary": "#000000",
-						"tertiary": "#fefaf1",
-						"background": "#f5f0e5"
-					}
 				}
 			],
 			"form": {


### PR DESCRIPTION
This PR adds a couple new things: 

- It removes the three palettes that aren't default, white, and black. Let's keep these minimal for now. 
- It adds a new header block pattern that's essentially the same as the default, except: it has a rounded logo and no tagline. 

Colors:

<img width="299" alt="Screen Shot 2021-09-28 at 11 05 43 AM" src="https://user-images.githubusercontent.com/1202812/135114047-fc4f2663-2d43-404a-bd24-3979760635e2.png">

Pattern:

<img width="1364" alt="Screen Shot 2021-09-28 at 11 03 26 AM" src="https://user-images.githubusercontent.com/1202812/135113955-046fbd0c-3e59-4e6c-b20c-f83213858b3c.png">

_(The menu is there, but the preview is invisible in the screenshot. 😕)_
