### PR TITLE
Fixes navigation justification

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -165,7 +165,7 @@ pre {
 
 .wp-site-blocks .site-header .wp-block-navigation {
 	flex-grow: 1;
-	justify-content: end;
+	justify-content: flex-end;
 }
 
 @media (max-width: 599px) {

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -8,7 +8,7 @@
 	}
 	.wp-block-navigation {
 		flex-grow: 1;
-		justify-content: end;
+		justify-content: flex-end;
 	}
 	// The blockGap is used HORIZONTALLY when the viewport is LARGE (in which case the value defined in theme.json is appropriate)
 	// It needs to be a different value then when the viewport is SMALL and the gap is used VERTICALLY


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes the justification on the header in Safari for Blockbase

Before:
<img width="1257" alt="Screenshot 2021-09-28 at 21 18 37" src="https://user-images.githubusercontent.com/937325/135151788-9c814228-0f4e-4667-9afa-fb93dc5d78ee.png">

After:
<img width="1249" alt="Screenshot 2021-09-28 at 21 18 29" src="https://user-images.githubusercontent.com/937325/135151817-73b97e36-49c9-4d19-92ff-142a2a028673.png">

#### Related issue(s):

Fixes #4723