### PR TITLE
Blockbase: fix post title + content vertical spacing

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -205,6 +205,10 @@ pre {
 	flex-direction: column;
 }
 
+.wp-site-blocks > main {
+	margin-top: 0;
+}
+
 .site-footer-container {
 	margin-top: auto;
 }
@@ -652,6 +656,11 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin-bottom: var(--wp--custom--gap--baseline);
 }
 
+.wp-block-post-template {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 .wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
 	text-align: var(--wp--custom--pullquote--typography--text-align);
@@ -933,10 +942,6 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 .post-meta .taxonomy-post_tag:before {
 	-webkit-mask-image: url(svg/post-tag.svg);
 	mask-image: url(svg/post-tag.svg);
-}
-
-.wp-block-post-template {
-	margin: 0;
 }
 
 /*# sourceMappingURL=ponyfill.css.map */

--- a/blockbase/sass/base/_layout.scss
+++ b/blockbase/sass/base/_layout.scss
@@ -6,6 +6,9 @@
 	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
+	> main {
+		margin-top: 0;
+	}
 }
 
 .site-footer-container {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR overrides the additional margin provided by Gutenberg's default vertical spacing between blocks ("gap"). 

Before | After
-------- | --------
<img width="769" alt="Screen Shot 2021-09-28 at 4 03 48 PM" src="https://user-images.githubusercontent.com/5375500/135157793-edd7f92a-eb0e-4221-b16c-2fbd04bdaa5a.png"> | <img width="765" alt="Screen Shot 2021-09-28 at 4 02 32 PM" src="https://user-images.githubusercontent.com/5375500/135157810-dae7acb2-2213-4085-80a0-cb37ff07a894.png">

#### Related issue(s):

Fixes #4727
