### PR TITLE
Quadrat: created new query block pattern

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -56,27 +56,21 @@
 	   object-fit: cover;
 }
 
-.horizontal-query-pattern {
+div.horizontal-query-pattern {
 	align-items: stretch;
+	flex-wrap: nowrap;
+	gap: 0;
 }
 
-.horizontal-query-pattern figure.wp-block-post-featured-image {
+div.horizontal-query-pattern .wp-block-cover,
+div.horizontal-query-pattern figure.wp-block-post-featured-image {
 	margin-top: 0;
-	height: 100%;
 }
 
-.horizontal-query-pattern img {
-	height: 100%;
+div.horizontal-query-pattern img {
+	aspect-ratio: 1.12;
 	-o-object-fit: cover;
 	   object-fit: cover;
-}
-
-.horizontal-query-pattern .wp-block-column {
-	margin-top: 0;
-}
-
-.horizontal-query-pattern.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column:not(:first-child) {
-	margin-left: 0;
 }
 
 .wp-block-cover.is-style-quadrat-cover-diamond::after {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -57,9 +57,13 @@
 }
 
 div.horizontal-query-pattern {
-	align-items: stretch;
-	flex-wrap: nowrap;
 	gap: 0;
+}
+
+@media (min-width: 600px) {
+	div.horizontal-query-pattern {
+		flex-wrap: nowrap;
+	}
 }
 
 div.horizontal-query-pattern .wp-block-cover,
@@ -67,10 +71,22 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 	margin-top: 0;
 }
 
-div.horizontal-query-pattern img {
+@media (min-width: 600px) {
+	div.horizontal-query-pattern figure.wp-block-post-featured-image {
+		width: 57%;
+	}
+}
+
+div.horizontal-query-pattern figure.wp-block-post-featured-image img {
 	aspect-ratio: 1.12;
 	-o-object-fit: cover;
 	   object-fit: cover;
+}
+
+@media (min-width: 600px) {
+	div.horizontal-query-pattern figure.wp-block-post-featured-image img {
+		min-height: 360px;
+	}
 }
 
 .wp-block-cover.is-style-quadrat-cover-diamond::after {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -71,6 +71,10 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 	margin-top: 0;
 }
 
+div.horizontal-query-pattern figure.wp-block-post-featured-image {
+	align-self: stretch;
+}
+
 @media (min-width: 600px) {
 	div.horizontal-query-pattern figure.wp-block-post-featured-image {
 		width: 57%;
@@ -81,6 +85,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
 	aspect-ratio: 1.12;
 	-o-object-fit: cover;
 	   object-fit: cover;
+	height: 100%;
 }
 
 @media (min-width: 600px) {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -41,6 +41,44 @@
 	text-align: right;
 }
 
+.horizontal-query-pattern .wp-block-post-title a,
+.vertical-query-pattern .wp-block-post-title a {
+	text-decoration: none;
+}
+
+.vertical-query-pattern .wp-block-cover {
+	margin-top: 0;
+}
+
+.vertical-query-pattern img {
+	aspect-ratio: 16 / 9;
+	-o-object-fit: cover;
+	   object-fit: cover;
+}
+
+.horizontal-query-pattern {
+	align-items: stretch;
+}
+
+.horizontal-query-pattern figure.wp-block-post-featured-image {
+	margin-top: 0;
+	height: 100%;
+}
+
+.horizontal-query-pattern img {
+	height: 100%;
+	-o-object-fit: cover;
+	   object-fit: cover;
+}
+
+.horizontal-query-pattern .wp-block-column {
+	margin-top: 0;
+}
+
+.horizontal-query-pattern.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column:not(:first-child) {
+	margin-left: 0;
+}
+
 .wp-block-cover.is-style-quadrat-cover-diamond::after {
 	background-image: url(rotated.svg);
 	background-position: center;

--- a/quadrat/inc/block-patterns.php
+++ b/quadrat/inc/block-patterns.php
@@ -23,6 +23,7 @@ if ( ! function_exists( 'quadrat_register_block_patterns' ) ) :
 				'headline-button',
 				'headlines-and-buttons',
 				'query-diamond',
+				'query-episodes',
 				'latest-episodes',
 				'listen-to-the-podcast',
 				'media-text-button',

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -25,12 +25,12 @@ return array(
 	<!-- wp:query {"queryId":34,"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
 	<!-- wp:columns {"className":"horizontal-query-pattern"} -->
-	<div class="wp-block-columns horizontal-query-pattern"><!-- wp:column {"width":"33%"} -->
-	<div class="wp-block-column" style="flex-basis:33%"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /--></div>
+	<div class="wp-block-columns horizontal-query-pattern"><!-- wp:column {"width":"44%"} -->
+	<div class="wp-block-column" style="flex-basis:44%"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /--></div>
 	<!-- /wp:column -->
 	
-	<!-- wp:column {"width":"66%"} -->
-	<div class="wp-block-column" style="flex-basis:66%"><!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<!-- wp:column {"width":"56%"} -->
+	<div class="wp-block-column" style="flex-basis:56%"><!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
 	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
 	
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -22,7 +22,7 @@ return array(
 	<!-- /wp:group -->
 	<!-- /wp:post-template --></div>
 	<!-- /wp:query -->
-	<!-- wp:query {"queryId":34,"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
+	<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
 
 	<!-- wp:group {"className":"horizontal-query-pattern","layout":{"type":"flex"}} -->

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Latest three episodes.
+ *
+ * @package Quadrat
+ */
+
+return array(
+	'title'      => __( 'Latest three episodes', 'quadrat' ),
+	'categories' => array( 'quadrat' ),
+	'blockTypes' => array( 'core/query' ),
+	'content'    => '<!-- wp:query {"query":{"perPage":"2","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":2},"align":"wide"} -->
+	<div class="wp-block-query alignwide"><!-- wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"className":"vertical-query-pattern","layout":{"inherit":false}} -->
+	<div class="wp-block-group vertical-query-pattern" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /-->
+	
+	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
+	
+	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
+	<!-- /wp:cover --></div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template --></div>
+	<!-- /wp:query -->
+	<!-- wp:query {"queryId":34,"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
+	<div class="wp-block-query alignwide"><!-- wp:post-template -->
+	<!-- wp:columns {"className":"horizontal-query-pattern"} -->
+	<div class="wp-block-columns horizontal-query-pattern"><!-- wp:column {"width":"33%"} -->
+	<div class="wp-block-column" style="flex-basis:33%"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /--></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column {"width":"66%"} -->
+	<div class="wp-block-column" style="flex-basis:66%"><!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
+	
+	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
+	<!-- /wp:cover --></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns -->
+	<!-- /wp:post-template --></div>
+	<!-- /wp:query -->',
+);

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -24,12 +24,21 @@ return array(
 	<!-- /wp:query -->
 	<!-- wp:query {"queryId":34,"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
-	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container">
-	<!-- wp:post-featured-image {"align":"left","className":"image-no-margin mb-0"} /-->
+
+	<!-- wp:group {"className":"horizontal-query-pattern","layout":{"type":"flex"}} -->
+	<div class="wp-block-group horizontal-query-pattern">
+
+	<!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /-->
+
+	<!-- wp:cover {"className":"horizontal-query-pattern","overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0 horizontal-query-pattern" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container">
 	<!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
 	<!-- /wp:cover -->
+
+	</div>
+	<!-- /wp:group -->
+
 	<!-- /wp:post-template --></div>
 	<!-- /wp:query -->',
 );

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -13,10 +13,10 @@ return array(
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"className":"vertical-query-pattern","layout":{"inherit":false}} -->
 	<div class="wp-block-group vertical-query-pattern" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /-->
-	
+
 	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
 	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
-	
+
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
 	<!-- /wp:cover --></div>
 	<!-- /wp:group -->
@@ -24,19 +24,12 @@ return array(
 	<!-- /wp:query -->
 	<!-- wp:query {"queryId":34,"query":{"perPage":"1","pages":0,"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->
-	<!-- wp:columns {"className":"horizontal-query-pattern"} -->
-	<div class="wp-block-columns horizontal-query-pattern"><!-- wp:column {"width":"44%"} -->
-	<div class="wp-block-column" style="flex-basis:44%"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /--></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column {"width":"56%"} -->
-	<div class="wp-block-column" style="flex-basis:56%"><!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
-	
+	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container">
+	<!-- wp:post-featured-image {"align":"left","className":"image-no-margin mb-0"} /-->
+	<!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
-	<!-- /wp:cover --></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns -->
+	<!-- /wp:cover -->
 	<!-- /wp:post-template --></div>
 	<!-- /wp:query -->',
 );

--- a/quadrat/sass/block-patterns/_query.scss
+++ b/quadrat/sass/block-patterns/_query.scss
@@ -1,0 +1,34 @@
+.horizontal-query-pattern,
+.vertical-query-pattern {
+	.wp-block-post-title a {
+		text-decoration: none;
+	}
+}
+
+.vertical-query-pattern {
+	.wp-block-cover {
+		margin-top: 0;
+	}
+	img {
+		aspect-ratio: 16 / 9;
+		object-fit: cover;
+	}
+}
+
+.horizontal-query-pattern {
+	align-items: stretch;
+	figure.wp-block-post-featured-image {
+		margin-top: 0;
+		height: 100%;
+	}
+	img {
+		height: 100%;
+		object-fit: cover;
+	}
+	.wp-block-column {
+		margin-top: 0;
+	}
+	&.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column:not(:first-child) {
+		margin-left: 0;
+	}
+}

--- a/quadrat/sass/block-patterns/_query.scss
+++ b/quadrat/sass/block-patterns/_query.scss
@@ -28,6 +28,7 @@ div.horizontal-query-pattern {
 	}
 
 	figure.wp-block-post-featured-image {
+		align-self: stretch;
 		@include break-small() {
 			width: 57%; // I'm not sure why this number works but it does seem to!
 		}
@@ -36,6 +37,7 @@ div.horizontal-query-pattern {
 		img {
 			aspect-ratio: 1.12;
 			object-fit: cover;
+			height: 100%;
 
 			@include break-small() {
 				min-height: 360px;

--- a/quadrat/sass/block-patterns/_query.scss
+++ b/quadrat/sass/block-patterns/_query.scss
@@ -16,17 +16,30 @@
 }
 
 div.horizontal-query-pattern {
-	align-items: stretch;
-	flex-wrap: nowrap;
 	gap: 0;
+
+	@include break-small() {
+		flex-wrap: nowrap;
+	}
 
 	.wp-block-cover,
 	figure.wp-block-post-featured-image {
 		margin-top: 0;
 	}
 
-	img {
-		aspect-ratio: 1.12;
-		object-fit: cover;
+	figure.wp-block-post-featured-image {
+		@include break-small() {
+			width: 57%; // I'm not sure why this number works but it does seem to!
+		}
+
+
+		img {
+			aspect-ratio: 1.12;
+			object-fit: cover;
+
+			@include break-small() {
+				min-height: 360px;
+			}
+		}
 	}
 }

--- a/quadrat/sass/block-patterns/_query.scss
+++ b/quadrat/sass/block-patterns/_query.scss
@@ -15,20 +15,18 @@
 	}
 }
 
-.horizontal-query-pattern {
+div.horizontal-query-pattern {
 	align-items: stretch;
+	flex-wrap: nowrap;
+	gap: 0;
+
+	.wp-block-cover,
 	figure.wp-block-post-featured-image {
 		margin-top: 0;
-		height: 100%;
 	}
+
 	img {
-		height: 100%;
+		aspect-ratio: 1.12;
 		object-fit: cover;
-	}
-	.wp-block-column {
-		margin-top: 0;
-	}
-	&.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column:not(:first-child) {
-		margin-left: 0;
 	}
 }

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -2,6 +2,7 @@
 @import "../../blockbase/sass/base/mixins";
 @import "block-patterns/headlines";
 @import "block-patterns/join";
+@import "block-patterns/query";
 @import "block-styles/cover";
 @import "block-styles/query";
 @import "../../blockbase/sass/blocks/_buttons-outline-style";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

After having a conversation with @kriskorn and the team about what users want from a theme and mentioning static vs dynamic content, I wanted to try and see how hard it would be to make the episodes patterns into a dynamic query block. Turns out it's complex but not difficult. I had to use 2 query loops since the design is asymmetric and I ended adding a bunch of CSS to remove gaps and force the aspect ratio (TIL: [aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) is a thing and it's SWEET) of the images since the featured image offers no control over the image sizes and we can't use them inside the media+text pattern either. Turned out looking quite ok to use as a pattern:

<img width="1293" alt="Screenshot 2021-09-29 at 10 23 31" src="https://user-images.githubusercontent.com/3593343/135232119-e5dc6884-6d59-4ceb-be15-345cee877383.png">


/cc @beafialho @kjellr 
