### PR TITLE
Blockbase: Remove CSS to bring up the page content and instead remove the bottom margin from post titles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -205,10 +205,6 @@ pre {
 	flex-direction: column;
 }
 
-.wp-site-blocks > main {
-	margin-top: 0;
-}
-
 .site-footer-container {
 	margin-top: auto;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -657,6 +657,10 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin-bottom: 0;
 }
 
+.wp-block-post-template .wp-block-post-featured-image {
+	line-height: 0;
+}
+
 .wp-block-pullquote.is-style-solid-color,
 .wp-block-pullquote {
 	text-align: var(--wp--custom--pullquote--typography--text-align);

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -219,7 +219,8 @@ body.admin-bar .wp-site-blocks {
 	min-height: calc( 100vh - var(--wpadmin-bar--height));
 }
 
-.entry-content > p {
+p.wp-block.wp-block-paragraph,
+p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -220,8 +220,8 @@ body.admin-bar .wp-site-blocks {
 }
 
 p {
-	margin-top: var(--wp--custom--gap--vertical);
-	margin-bottom: var(--wp--custom--gap--vertical);
+	margin-top: var(--wp--style--block-gap);
+	margin-bottom: var(--wp--style--block-gap);
 }
 
 .wp-block-column :first-child, .wp-block-group :first-child {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -220,7 +220,7 @@ body.admin-bar .wp-site-blocks {
 }
 
 p.wp-block.wp-block-paragraph,
-p {
+*[class^="wp-container"] > * + p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -219,9 +219,9 @@ body.admin-bar .wp-site-blocks {
 	min-height: calc( 100vh - var(--wpadmin-bar--height));
 }
 
-p {
-	margin-top: var(--wp--style--block-gap);
-	margin-bottom: var(--wp--style--block-gap);
+.entry-content > p {
+	margin-top: 1em;
+	margin-bottom: 1em;
 }
 
 .wp-block-column :first-child, .wp-block-group :first-child {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -220,7 +220,8 @@ body.admin-bar .wp-site-blocks {
 }
 
 p.wp-block.wp-block-paragraph,
-*[class^="wp-container"] > * + p {
+*[class^="wp-container"] > * + p,
+p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/sass/base/_layout.scss
+++ b/blockbase/sass/base/_layout.scss
@@ -6,9 +6,6 @@
 	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
-	> main {
-		margin-top: 0;
-	}
 }
 
 .site-footer-container {

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,6 +1,7 @@
 // Needed until https://github.com/WordPress/gutenberg/issues/35267 is resolved.
 p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
-*[class^="wp-container"] > * + p {
+*[class^="wp-container"] > * + p,
+p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,6 +1,6 @@
 // Needed until https://github.com/WordPress/gutenberg/issues/35267 is resolved.
 p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
-p {
+*[class^="wp-container"] > * + p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,6 +1,6 @@
 p {
-	margin-top: var(--wp--custom--gap--vertical);
-	margin-bottom: var(--wp--custom--gap--vertical);
+	margin-top: var( --wp--style--block-gap );
+	margin-bottom: var( --wp--style--block-gap );
 }
 
 .wp-block-column, .wp-block-group {

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,6 +1,6 @@
-p {
-	margin-top: var( --wp--style--block-gap );
-	margin-bottom: var( --wp--style--block-gap );
+.entry-content p {
+	margin-top: 1em;
+	margin-bottom: 1em;
 }
 
 .wp-block-column, .wp-block-group {

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,4 +1,5 @@
-.entry-content p {
+p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
+p {
 	margin-top: 1em;
 	margin-bottom: 1em;
 }

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,3 +1,4 @@
+// Needed until https://github.com/WordPress/gutenberg/issues/35267 is resolved.
 p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
 p {
 	margin-top: 1em;

--- a/blockbase/sass/blocks/_post-template.scss
+++ b/blockbase/sass/blocks/_post-template.scss
@@ -1,7 +1,7 @@
 // Needed until https://github.com/WordPress/gutenberg/pull/35193 is merged.
 .wp-block-post-template {
-    margin-top: 0;
-    margin-bottom: 0;
+	margin-top: 0;
+	margin-bottom: 0;
 	.wp-block-post-featured-image {
 		line-height: 0;
 	}

--- a/blockbase/sass/blocks/_post-template.scss
+++ b/blockbase/sass/blocks/_post-template.scss
@@ -2,6 +2,7 @@
 .wp-block-post-template {
 	margin-top: 0;
 	margin-bottom: 0;
+	// Needed until https://github.com/WordPress/gutenberg/pull/35273 is merged.
 	.wp-block-post-featured-image {
 		line-height: 0;
 	}

--- a/blockbase/sass/blocks/_post-template.scss
+++ b/blockbase/sass/blocks/_post-template.scss
@@ -2,4 +2,7 @@
 .wp-block-post-template {
     margin-top: 0;
     margin-bottom: 0;
+	.wp-block-post-featured-image {
+		line-height: 0;
+	}
 }

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -414,6 +414,11 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontSize": "var(--wp--preset--font-size--large)",

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -238,7 +238,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},


### PR DESCRIPTION


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
In https://github.com/Automattic/themes/pull/4733 we removed the margin on top of all `<main>` elements, but this is actually needed for the index template. This PR removes that change and instead removes the bottom margin on Post Title blocks, so that the content sits closer to the post title. This means that https://github.com/Automattic/themes/issues/4722 is now fixed again.

#### Related issue(s):
 https://github.com/Automattic/themes/pull/4733
https://github.com/Automattic/themes/issues/4722