### PR TITLE
Blockbase: add a zero margin top utility class

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -244,6 +244,10 @@ p {
 	padding: 0;
 }
 
+.mt-0 {
+	margin-top: 0 !important;
+}
+
 /**
  * Elements
  * - Styles for basic HTML elemants

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -12,3 +12,8 @@
 .has-background-no-padding.wp-block-columns.has-background {
 	padding: 0;
 }
+
+// For when we do not want the vertical block gap. Needed until we have per-block margin controls.
+.mt-0 {
+	margin-top: 0 !important;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a utility class to blockbase that can be used in patterns. This is needed until we have per-block margin controls.

Quadrat's Latest Episode pattern already contained a class `mt-0` added to the respective blocks, although the class wasn't defined in CSS. 

Before | After
------- | ------
<img width="1224" alt="Screen Shot 2021-09-29 at 3 28 48 PM" src="https://user-images.githubusercontent.com/5375500/135335716-2ec7dbae-482b-474a-ad69-43d25290c17d.png"> | <img width="1220" alt="Screen Shot 2021-09-29 at 3 28 37 PM" src="https://user-images.githubusercontent.com/5375500/135335725-63783266-4e0a-4a7d-8a7c-c53d7a920097.png">

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4736