### PR TITLE
Blockbase: remove generic has-background padding

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -244,14 +244,6 @@ p {
 	padding: 0;
 }
 
-.has-background:not(.wp-block-separator) {
-	padding: var(--wp--custom--gap--vertical) var(--wp--custom--gap--horizontal);
-}
-
-.has-background :last-child {
-	margin-bottom: 0;
-}
-
 /**
  * Elements
  * - Styles for basic HTML elemants

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -12,14 +12,3 @@
 .has-background-no-padding.wp-block-columns.has-background {
 	padding: 0;
 }
-
-// Needed until we have a solution for https://github.com/WordPress/gutenberg/issues/34588.
-.has-background {
-	&:not(.wp-block-separator){
-		padding: var(--wp--custom--gap--vertical) var(--wp--custom--gap--horizontal);
-	}
-
-	:last-child {
-		margin-bottom: 0;
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

In #4629, a standard padding was added to all blocks with the `has-background` class. Based on discussion [here](https://github.com/Automattic/themes/issues/4735#issuecomment-930155711), I don't think that's the best approach. This PR removes that CSS and fixes #4735. 

Before | After
-------- | -------
<img width="1170" alt="Screenshot 2021-09-29 at 09 31 39" src="https://user-images.githubusercontent.com/3593343/135223245-601208ac-886c-4094-8e81-ec2f39d335d8.png"> | <img width="1182" alt="Screen Shot 2021-09-29 at 4 26 07 PM" src="https://user-images.githubusercontent.com/5375500/135343387-3eb8e39a-2bdd-49f3-bdbd-1b5ea7f404ed.png">

Will removing this CSS cause regressions in any other Blockbase & co patterns?

#### Rationale

The [original issue](https://github.com/Automattic/themes/issues/4617) suggested that group blocks with a background color were missing padding. I think it's better to not supply any padding by default, since padding on group blocks is customizable via the editor.

In addition, we could consider improving how this padding is added / calculated in Gutenberg, as suggested here https://github.com/WordPress/gutenberg/issues/34588

#### Related issue(s):

Solves https://github.com/Automattic/themes/issues/4735