### PR TITLE
Replace query-loop with post-template

### DIFF
--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -218,7 +218,7 @@ ul ul {
 	margin-left: 20%;
 }
 
-.wp-block-query-loop .wp-block-post-excerpt__more-text,
+.wp-block-post-template .wp-block-post-excerpt__more-text,
 .wp-block-query .wp-block-post-excerpt__more-text {
 	font-size: var(--wp--custom--font-sizes--tiny) !important;
 }

--- a/geologist/block-templates/search.html
+++ b/geologist/block-templates/search.html
@@ -4,12 +4,12 @@
 <main class="wp-block-group">
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
-	<!-- wp:query-loop -->
+	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":5,"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
 
-	<!-- /wp:query-loop -->
+	<!-- /wp:post-template -->
 	<!-- /wp:query -->
 
 </main>

--- a/geologist/sass/blocks/_query.scss
+++ b/geologist/sass/blocks/_query.scss
@@ -1,4 +1,4 @@
-.wp-block-query-loop,
+.wp-block-post-template,
 .wp-block-query {
 
 	// Important is necessary to override any other font size rules applied to the exerpt.

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -354,7 +354,7 @@ ul ul {
 	margin-left: 20%;
 }
 
-.wp-block-query-loop .wp-block-post-excerpt__more-text,
+.wp-block-post-template .wp-block-post-excerpt__more-text,
 .wp-block-query .wp-block-post-excerpt__more-text {
 	font-size: var(--wp--custom--font-sizes--tiny) !important;
 }

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -4,12 +4,12 @@
 <main class="wp-block-group">
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
-	<!-- wp:query-loop -->
+	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":5,"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
 
-	<!-- /wp:query-loop -->
+	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 		<div class="wp-block-query-pagination alignwide">

--- a/quadrat/sass/blocks/_query.scss
+++ b/quadrat/sass/blocks/_query.scss
@@ -1,4 +1,4 @@
-.wp-block-query-loop,
+.wp-block-post-template,
 .wp-block-query {
 
 	// Important is necessary to override any other font size rules applied to the exerpt.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Renames instances of query-loop block to post-template.

#### Related issue(s):

Fixes #4731 