### PR TITLE
Blockbase: hide no comments message

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -652,6 +652,10 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin-bottom: var(--wp--custom--gap--baseline);
 }
 
+.wp-block-post-comments .nocomments {
+	display: none;
+}
+
 .wp-block-post-template {
 	margin-top: 0;
 	margin-bottom: 0;

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -157,6 +157,7 @@
 		margin-bottom: var(--wp--custom--gap--baseline);
 	}
 
+	// Needed until we have the option to hide this message via the block.
 	.nocomments {
 		display: none;
 	}

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -157,4 +157,7 @@
 		margin-bottom: var(--wp--custom--gap--baseline);
 	}
 
+	.nocomments {
+		display: none;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Hides the "Comments are Closed" message. To test, go to a post whose comments are disabled (alternatively disable them site wide), and verify you do not see the message.

#### Related issue(s):
Fixes #4750