### PR TITLE
Rebalanace: Add block CSS to the editor so that colors work as expected

### DIFF
--- a/rebalance/functions.php
+++ b/rebalance/functions.php
@@ -228,7 +228,7 @@ function rebalance_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );
@@ -298,6 +298,7 @@ add_action( 'wp_enqueue_scripts', 'rebalance_scripts' );
  * Gutenberg Editor Styles
  */
 function rebalance_editor_styles() {
+	wp_enqueue_style( 'rebalance-block-style', get_template_directory_uri() . '/blocks.css' );
 	wp_enqueue_style( 'rebalance-editor-block-style', get_template_directory_uri() . '/editor-blocks.css' );
 	wp_enqueue_style( 'rebalance-fonts', rebalance_fonts_url(), array(), null );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The color definition for blocks in Rebalance are in blocks.css so we need this file in the editor too. Ideally we'd ship the same CSS to the editor and the front end, but we noticed issues with the buttons in the editor so this solution seemed simpler given that this is an older theme.

<img width="847" alt="Screenshot 2021-09-30 at 17 09 38" src="https://user-images.githubusercontent.com/275961/135491862-b6ee3fc7-576d-4d8e-ab68-d236e7567610.png">


#### Related issue(s):
Fixes https://github.com/Automattic/wp-calypso/issues/54990 for Rebalance