### PR TITLE
Geologist: Update header spacing

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -832,6 +832,10 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 	width: var(--wp--custom--separator--width);
 }
 
+p.wp-block-site-tagline {
+	margin: 0;
+}
+
 .wp-block-file .wp-block-file__button {
 	border-width: 0;
 	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));

--- a/blockbase/sass/blocks/_site-tagline.scss
+++ b/blockbase/sass/blocks/_site-tagline.scss
@@ -1,0 +1,4 @@
+// Needed until we merge https://github.com/WordPress/gutenberg/issues/35323
+p.wp-block-site-tagline {
+	margin: 0
+}

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -25,6 +25,7 @@
 @import "blocks/quote";
 @import "blocks/search";
 @import "blocks/separator";
+@import "blocks/site-tagline";
 @import "blocks/file";
 @import "blocks/table";
 @import "blocks/video";

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -462,12 +462,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -488,6 +482,12 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700
 				}
 			}
 		},

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -2,7 +2,7 @@
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"20px"},"margin":{"right":"auto"}},"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	<!-- wp:site-tagline {"style":"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -2,7 +2,7 @@
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -117,8 +117,9 @@
 				"body": 1.7
 			},
 			"gap": {
+				"baseline": "10px",
 				"horizontal": "min(20px, 5vw)",
-				"vertical": "min(30px, 5vw)"
+				"vertical": "min(20px, 5vw)"
 			},
 			"paragraph": {
 				"dropcap": {

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -118,8 +118,8 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"horizontal": "min(20px, 5vw)",
-				"vertical": "min(20px, 5vw)"
+				"horizontal": "min(30px, 5vw)",
+				"vertical": "min(30px, 5vw)"
 			},
 			"paragraph": {
 				"dropcap": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -229,8 +229,8 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"horizontal": "min(20px, 5vw)",
-				"vertical": "min(20px, 5vw)"
+				"horizontal": "min(30px, 5vw)",
+				"vertical": "min(30px, 5vw)"
 			},
 			"paragraph": {
 				"dropcap": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -230,7 +230,7 @@
 			"gap": {
 				"baseline": "10px",
 				"horizontal": "min(20px, 5vw)",
-				"vertical": "min(30px, 5vw)"
+				"vertical": "min(20px, 5vw)"
 			},
 			"paragraph": {
 				"dropcap": {
@@ -415,6 +415,11 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(48px, 7vw), 64px)",
@@ -461,16 +466,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700,
-					"textTransform": "uppercase"
-				},
-				"color": {
-					"link": "var(--wp--custom--color--primary)"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -493,6 +488,16 @@
 					"fontStyle": "normal",
 					"fontWeight": "normal",
 					"lineHeight": "40px"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700,
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"link": "var(--wp--custom--color--primary)"
 				}
 			},
 			"core/navigation-link": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the spacing for Geologist so that the vertical and horizontal spacing is the same. We don't currently have a way to set responsive margins for the header, but I'm not sure we need it. With the variable set to min(30px, 5vw), on smaller devices 5vw will be used instead of the pixel value anyway.

Before:
![localhost_4759__p=371 (2)](https://user-images.githubusercontent.com/275961/135855369-41452987-b356-4029-92ed-9a235abb642b.png)

After:
![localhost_4759__p=371 (3)](https://user-images.githubusercontent.com/275961/135856009-39c685a6-eaec-4576-a9f5-d6d366615021.png)


#### Related issue(s):
https://github.com/Automattic/themes/issues/4687