### PR TITLE
Blockbase: Make the heading gap a variable

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -156,7 +156,6 @@ pre {
 .wp-site-blocks .site-header {
 	justify-content: start;
 	overflow: inherit;
-	padding-top: var(--wp--custom--gap--vertical);
 }
 
 .wp-site-blocks .site-header .wp-block-site-title a {
@@ -331,23 +330,9 @@ button:focus {
 	outline-offset: 2px;
 }
 
-input.wp-block-search__input::placeholder,
-input[type="text"]::placeholder,
-input[type="email"]::placeholder,
-input[type="url"]::placeholder,
-input[type="password"]::placeholder,
-input[type="search"]::placeholder,
-input[type="number"]::placeholder,
-input[type="tel"]::placeholder,
-input[type="range"]::placeholder,
-input[type="date"]::placeholder,
-input[type="month"]::placeholder,
-input[type="week"]::placeholder,
-input[type="time"]::placeholder,
-input[type="datetime"]::placeholder,
-input[type="datetime-local"]::placeholder,
-input[type="color"]::placeholder,
-textarea::placeholder {
+input[type="checkbox"]::placeholder,
+input[type="submit"]::placeholder,
+button::placeholder {
 	color: var(--wp--custom--form--color--text);
 	opacity: 0.66;
 }

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}}} -->
-<div class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"fontSize":"tiny"} /-->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"80px"}}}} -->
-<div class="wp-block-group site-header" style="padding-bottom:80px">
+<!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}}} -->
+<div class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"fontSize":"tiny"} /-->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -4,5 +4,5 @@
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"fontSize":"tiny"} /-->
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
-</div>
+</header>
 <!-- /wp:group -->

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -1,7 +1,6 @@
 .wp-site-blocks .site-header {
 	justify-content: start;
 	overflow: inherit;
-	padding-top: var(--wp--custom--gap--vertical);
 
 	.wp-block-site-title a {
 		text-decoration: none;

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -239,9 +239,16 @@
 			},
 			"gap": {
 				"baseline": "15px",
-				"header": "80px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "80px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -239,6 +239,7 @@
 			},
 			"gap": {
 				"baseline": "15px",
+				"header": "80px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header","layout":{"type":"flex"}} -->
-<header class="wp-block-group site-header" style="padding-bottom:90px">
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header","layout":{"type":"flex"}} -->
-<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -118,9 +118,15 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "90px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "90px"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -118,6 +118,7 @@
 			},
 			"gap": {
 				"baseline": "10px",
+				"header": "90px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -229,9 +229,16 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "90px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "90px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -229,6 +229,7 @@
 			},
 			"gap": {
 				"baseline": "10px",
+				"header": "90px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header","layout":{"type":"flex"}} -->
-<div class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->
 <!-- wp:site-tagline {"fontSize":"tiny"} /-->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -5,5 +5,5 @@
 <!-- wp:site-tagline {"fontSize":"tiny"} /-->
 <!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
-</div>
+</header>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"32px"}}},"className":"site-header","layout":{"type":"flex"}} -->
-<div class="wp-block-group site-header" style="padding-bottom:32px">
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<div class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->
 <!-- wp:site-tagline {"fontSize":"tiny"} /-->

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -79,6 +79,7 @@
 				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"gap": {
+				"header": "32px",
 				"horizontal": "min(32px, 5vw)"
 			},
 			"width": {

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -80,8 +80,14 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "32px",
 				"horizontal": "min(32px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "32px"
+					}
+				}
 			},
 			"width": {
 				"default": "750px",

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -79,6 +79,7 @@
 				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"gap": {
+				"baseline": "10px",
 				"header": "32px",
 				"horizontal": "min(32px, 5vw)"
 			},

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -247,9 +247,16 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "32px",
 				"horizontal": "min(32px, 5vw)",
 				"vertical": "min(30px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "32px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {
@@ -492,12 +499,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": 700
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -518,6 +519,12 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": 700
 				}
 			}
 		},

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -246,7 +246,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"header": "32px",
 				"horizontal": "min(32px, 5vw)",
 				"vertical": "min(30px, 5vw)"

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -246,7 +246,8 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
+				"header": "32px",
 				"horizontal": "min(32px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -443,6 +444,11 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--poppins)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
@@ -465,7 +471,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"padding": {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -502,6 +502,7 @@ input[type="submit"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input[type="checkbox"],
 textarea {
 	font-size: var(--wp--preset--font-size--normal);
 }

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:170px">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -32,6 +32,11 @@
 			]
 		},
 		"custom": {
+			"body": {
+				"typography": {
+					"lineHeight": 1.7
+				}
+			},
 			"button": {
 				"border": {
 					"color": "var(--wp--custom--color--foreground)",
@@ -157,10 +162,10 @@
 			"fontSizes": {
 				"tiny": "16px"
 			},
-			"body": {
-				"typography": {
-					"lineHeight": 1.7
-				}
+			"gap": {
+				"header": "170px",
+				"horizontal": "min(34px, 5vw)",
+				"vertical": "min(34px, 5vw)"
 			},
 			"heading": {
 				"typography": {

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -164,9 +164,15 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "170px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "170px"
+					}
+				}
 			},
 			"heading": {
 				"typography": {

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -163,6 +163,7 @@
 				"tiny": "16px"
 			},
 			"gap": {
+				"baseline": "10px",
 				"header": "170px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -285,9 +285,16 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "170px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "170px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {
@@ -523,16 +530,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700,
-					"textTransform": "uppercase"
-				},
-				"color": {
-					"link": "var(--wp--custom--color--primary)"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -555,6 +552,16 @@
 					"fontStyle": "normal",
 					"fontWeight": "normal",
 					"lineHeight": "40px"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700,
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"link": "var(--wp--custom--color--primary)"
 				}
 			},
 			"core/navigation-link": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -284,7 +284,8 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
+				"header": "80px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"
 			},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -285,7 +285,7 @@
 			},
 			"gap": {
 				"baseline": "15px",
-				"header": "80px",
+				"header": "170px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"
 			},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -284,7 +284,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"header": "170px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,9 +1,5 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
-
-<!-- wp:spacer {"height":60} -->
-<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}}} -->
+<header class="wp-block-group" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 
 <!-- wp:site-logo {"align":"center","width":128} /-->
 

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,3 +1,6 @@
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}}} -->
+<header class="wp-block-group" style="padding-bottom:var(--wp--custom--gap--header)">
+
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -11,6 +14,5 @@
 <!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary"} -->
 <!-- /wp:navigation -->
 
-<!-- wp:spacer {"height":60} -->
-<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+</header>
+<!-- /wp:group -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 
 <!-- wp:spacer {"height":60} -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}}} -->
-<header class="wp-block-group" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -110,7 +110,8 @@
 			"header": {
 				"spacing": {
 					"padding": {
-						"bottom": "60px"
+						"top": "80px",
+						"bottom": "80px"
 					}
 				}
 			},

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -103,6 +103,7 @@
 				}
 			},
 			"gap": {
+				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"
 			},

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -103,7 +103,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -104,9 +104,15 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "60px"
+					}
+				}
 			},
 			"pullquote": {
 				"citation": {

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -103,6 +103,7 @@
 				}
 			},
 			"gap": {
+				"baseline": "15px",
 				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -280,9 +280,16 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "60px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {
@@ -518,15 +525,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700
-				},
-				"color": {
-					"link": "var(--wp--custom--color--primary)"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -547,6 +545,15 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700
+				},
+				"color": {
+					"link": "var(--wp--custom--color--primary)"
 				}
 			}
 		},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -279,7 +279,8 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
+				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"
 			},
@@ -467,9 +468,14 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},
@@ -582,7 +588,7 @@
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"margin": {
@@ -596,7 +602,7 @@
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				},
 				"spacing": {
 					"margin": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -286,8 +286,8 @@
 			"header": {
 				"spacing": {
 					"padding": {
-						"bottom": "60px",
-						"top": "var(--wp--custom--gap--vertical)"
+						"bottom": "80px",
+						"top": "80px"
 					}
 				}
 			},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -279,7 +279,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"header": "60px",
 				"horizontal": "25px",
 				"vertical": "30px"

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,5 +1,6 @@
-<!-- wp:group { "layout":{"type":"flex"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"layout":{"type":"flex"}} -->
+<header class="wp-block-group" style="padding-bottom:var(--wp--custom--gap--header)">
+
 <!-- wp:group {"className":"site-brand"} -->
 <div class="wp-block-group site-brand">
 <!-- wp:site-logo /-->
@@ -14,7 +15,5 @@
 <!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
 
 
-</div>
-<!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"layout":{"type":"flex"}} -->
-<header class="wp-block-group" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 
 <!-- wp:group {"className":"site-brand"} -->
 <div class="wp-block-group site-brand">

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top":"var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 
 <!-- wp:group {"className":"site-brand"} -->
@@ -14,6 +14,8 @@
 
 <!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"social"} --><!-- /wp:navigation -->
 
-
 </div>
+<!-- /wp:group -->
+
+</header>
 <!-- /wp:group -->

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"4em","bottom":"2.5em"}}},"layout":{"inherit":true}} -->
-<main class="wp-block-group" style="padding-top:4em;padding-bottom:2.5em">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"2.5em"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-bottom:2.5em">
 	<!-- wp:query-title {"type":"archive","align":"wide"} /-->
 	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
 	<div class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/skatepark/block-templates/page.html
+++ b/skatepark/block-templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"4em"}}}} -->
-<div class="wp-block-group" style="padding-top:4em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"5em"}}}} -->

--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"4em"}}}} -->
-<div class="wp-block-group" style="padding-top:4em"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"align":"wide"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main"} -->

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -186,6 +186,7 @@
 				"tiny": "16px"
 			},
 			"gap": {
+				"baseline": "10px",
 				"header": "4em"
 			},
 			"heading": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -186,8 +186,14 @@
 				"tiny": "16px"
 			},
 			"gap": {
-				"baseline": "10px",
-				"header": "4em"
+				"baseline": "10px"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "4em"
+					}
+				}
 			},
 			"heading": {
 				"typography": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -185,6 +185,9 @@
 			"fontSizes": {
 				"tiny": "16px"
 			},
+			"gap": {
+				"header": "4em"
+			},
 			"heading": {
 				"typography": {
 					"fontWeight": "700"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -281,7 +281,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"header": "4em",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -282,9 +282,16 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "4em",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "4em",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {
@@ -515,14 +522,6 @@
 					"width": "0 0 3px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": 900,
-					"letterSpacing": "0.05em",
-					"textTransform": "uppercase"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -543,6 +542,14 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": 900,
+					"letterSpacing": "0.05em",
+					"textTransform": "uppercase"
 				}
 			},
 			"core/cover": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -281,7 +281,8 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
+				"header": "4em",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -464,16 +465,16 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "1em"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontSize": "min(max(48px, 7vw), 72px)",
 					"lineHeight": 1.2,
 					"fontWeight": "700"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "1em"
-					}
 				}
 			},
 			"core/post-date": {
@@ -493,7 +494,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"padding": {

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:170px">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--header)"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--gap--header)">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--header--spacing--padding--bottom)","top","var(--wp--custom--header--spacing--padding--top)"}}},"className":"site-header"} -->
+<header class="wp-block-group site-header" style="padding-bottom:var(--wp--custom--header--spacing--padding--bottom);padding-top:var(--wp--custom--header--spacing--padding--top);">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -103,6 +103,13 @@
 			"gap": {
 				"baseline": "10px",
 				"header": "170px"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "170px"
+					}
+				}
 			}
 		},
 		"layout": {

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -99,11 +99,11 @@
 			],
 			"fontSizes": {
 				"tiny": "16px"
+			},
+			"gap": {
+				"baseline": "10px",
+				"header": "170px"
 			}
-		},
-		"gap": {
-			"baseline": "10px",
-			"header": "170px"
 		},
 		"layout": {
 			"contentSize": "800px",

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -101,6 +101,10 @@
 				"tiny": "16px"
 			}
 		},
+		"gap": {
+			"baseline": "10px",
+			"header": "170px"
+		},
 		"layout": {
 			"contentSize": "800px",
 			"wideSize": "1300px"

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -241,9 +241,17 @@
 			},
 			"gap": {
 				"baseline": "10px",
-				"header": "170px",
 				"horizontal": "min(30px, 5vw)",
-				"vertical": "min(30px, 5vw)"
+				"vertical": "min(30px, 5vw)",
+				"header": "170px"
+			},
+			"header": {
+				"spacing": {
+					"padding": {
+						"bottom": "170px",
+						"top": "var(--wp--custom--gap--vertical)"
+					}
+				}
 			},
 			"paragraph": {
 				"dropcap": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -241,6 +241,7 @@
 			},
 			"gap": {
 				"baseline": "15px",
+				"header": "80px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -466,13 +467,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700,
-					"textTransform": "uppercase"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -493,6 +487,13 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700,
+					"textTransform": "uppercase"
 				}
 			},
 			"core/post-terms": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -240,8 +240,8 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
-				"header": "80px",
+				"baseline": "10px",
+				"header": "170px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -367,10 +367,6 @@
 					"slug": "huge"
 				}
 			]
-		},
-		"gap": {
-			"baseline": "10px",
-			"header": "170px"
 		}
 	},
 	"styles": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -367,6 +367,10 @@
 					"slug": "huge"
 				}
 			]
+		},
+		"gap": {
+			"baseline": "10px",
+			"header": "170px"
 		}
 	},
 	"styles": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds a new variable to custom, making the gap between the header and the content a value which can be configured using theme.json. In the future we hope that we'll be able to inherit the markup for headers from the parent theme, so that child themes can customize this gap without needing to create a new header.html file.

The look of the themes should be unchanged.
