### PR TITLE
Fix ignored link color

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -475,7 +475,7 @@ ol {
 	display: revert;
 }
 
-p.has-text-color a {
+p.has-text-color:not(.has-link-color) a {
 	color: var(--wp--style--color--link, var(--wp--custom--color--primary));
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Make style rule for paragraph links with custom text color not apply when the paragraph also has a custom link color set.

#### Related issue(s):

#4776
