### PR TITLE
Videomaker: Add videomaker as a blockbase child

### DIFF
--- a/blockbase/rebuild-child-themes.sh
+++ b/blockbase/rebuild-child-themes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a ChildThemes=( "mayland-blocks" "seedlet-blocks" "quadrat" "skatepark" "geologist" )
+declare -a ChildThemes=( "mayland-blocks" "seedlet-blocks" "quadrat" "skatepark" "geologist" "videomaker" )
 
 for child in ${ChildThemes[@]}; do
 	cd '../'${child}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Makes videomaker a blockbase child.

To test, run `npm run build:all` from inside blockbase and confirm that videomaker gets rebuilt.

#### Related issue(s):
