### PR TITLE
Blockbase: Fix header alignment

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -154,6 +154,7 @@ pre {
 }
 
 .wp-site-blocks .site-header {
+	align-items: baseline;
 	justify-content: start;
 	overflow: inherit;
 	padding-top: var(--wp--custom--gap--vertical);

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -174,6 +174,10 @@ pre {
 	}
 }
 
+.wp-site-blocks .site-header .wp-block-site-logo {
+	align-self: center;
+}
+
 @media (max-width: 599px) {
 	.wp-site-blocks .site-header .wp-block-site-logo {
 		flex-basis: 100%;

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -16,6 +16,7 @@
 		gap: 2px;
 	}
 	.wp-block-site-logo {
+		align-self: center;
 
 		@include break-small-only(){
 			flex-basis: 100%;

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -1,4 +1,5 @@
 .wp-site-blocks .site-header {
+	align-items: baseline;
 	justify-content: start;
 	overflow: inherit;
 	padding-top: var(--wp--custom--gap--vertical);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This ensures that the text in the blockbase header is aligned to the baseline even if the font sizes are different:

Before:
<img width="783" alt="Screenshot 2021-10-04 at 17 16 56" src="https://user-images.githubusercontent.com/275961/135887697-2d4c3eed-53ff-4fed-b67a-db974aa18cc6.png">
<img width="827" alt="Screenshot 2021-10-04 at 17 16 02" src="https://user-images.githubusercontent.com/275961/135887699-af925892-f88b-4fac-87ce-95f121dea9f6.png">

After:
<img width="763" alt="Screenshot 2021-10-04 at 17 14 58" src="https://user-images.githubusercontent.com/275961/135887715-8bb92697-1d18-476e-87da-b1ce393c38fd.png">
<img width="757" alt="Screenshot 2021-10-04 at 17 14 37" src="https://user-images.githubusercontent.com/275961/135887717-596d7d4f-cf8c-4563-87d7-5ab30c2f666c.png">



