### PR TITLE
Quadrat: Ensure that the position of the post title is the same on all pages

### DIFF
--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -3,6 +3,8 @@
 <!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <main class="wp-block-query">
 	<!-- wp:post-template -->
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
 		<!-- wp:post-date {"isLink":false,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
 		<!-- wp:post-featured-image {"isLink":true} /-->
@@ -10,6 +12,8 @@
 		<!-- wp:spacer {"height":60} -->
 		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -2,6 +2,9 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
+	<!-- wp:spacer {"height":27} -->
+	<div style="height:27px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
 	<!-- wp:spacer {"height":30} -->
 	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -3,8 +3,8 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}, "style":{"spacing":{"padding":"50px"}}} -->
-	<div style="padding:50px" class="wp-block-group post-meta">
+	<!-- wp:group {"className":"post-meta","layout":{"type":"flex"}} -->
+	<div class="wp-block-group post-meta">
 		<!-- wp:post-date {"textAlign":"center","isLink":true,"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-terms {"term":"category","textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	</div>

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -174,6 +174,7 @@
 				"body": 1.7
 			},
 			"gap": {
+				"baseline": "10px",
 				"horizontal": "min(34px, 5vw)",
 				"vertical": "min(34px, 5vw)"
 			},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -471,6 +471,11 @@
 				}
 			},
 			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "min(max(48px, 7vw), 80px)",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the header for Quadrat so that the Post/Page title is the same on the index, single and page templates.

An alternative to https://github.com/Automattic/themes/pull/4771, which I think is a bit simpler. If this is preferred then I can make the same changes to Geologist too.

After:
![localhost_4759__page_id=2 preview_id=2 preview_nonce=01dd0db364 preview=true](https://user-images.githubusercontent.com/275961/135911234-9ede483d-f9f3-4bdc-b936-0ac0efb6ef5e.png)
![localhost_4759__p=167 (1)](https://user-images.githubusercontent.com/275961/135911248-86648d70-ed80-4508-a335-db857d6180de.png)
![localhost_4759__paged=8](https://user-images.githubusercontent.com/275961/135911251-8c46ffc7-d91a-4554-bd43-9768754728d0.png)



#### Related issue(s):
https://github.com/Automattic/themes/issues/4757