### PR TITLE
Geologist: Make vertical position of the post title consistent

### DIFF
--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -374,8 +374,4 @@ textarea:focus {
 	content: ",";
 }
 
-.wp-block-query .wp-block-post-featured-image {
-	margin-top: calc( var(--wp--custom--gap--vertical) / 2);
-}
-
 /*# sourceMappingURL=theme.css.map */

--- a/geologist/block-templates/index.html
+++ b/geologist/block-templates/index.html
@@ -3,6 +3,8 @@
 <!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <main class="wp-block-query">
 	<!-- wp:post-template -->
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"left"} /-->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
@@ -10,6 +12,8 @@
 		<!-- wp:spacer {"height":120} -->
 		<div style="height:120px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide"} -->
 	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->

--- a/geologist/sass/templates/_query.scss
+++ b/geologist/sass/templates/_query.scss
@@ -1,5 +1,0 @@
-.wp-block-query {
-	.wp-block-post-featured-image {
-		margin-top: calc( var(--wp--custom--gap--vertical) / 2 );
-	}
-}

--- a/geologist/sass/theme.scss
+++ b/geologist/sass/theme.scss
@@ -18,4 +18,3 @@
 @import "elements/forms";
 @import "templates/index";
 @import "templates/meta";
-@import "templates/query";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This makes the vertical position of the Post Title consistent in the index and post templates:

Index:
<img width="932" alt="Screenshot 2021-10-06 at 14 46 09" src="https://user-images.githubusercontent.com/275961/136215236-cd3ea5fb-3430-495f-9cbc-6781e9feec1d.png">

Post:
<img width="935" alt="Screenshot 2021-10-06 at 14 45 58" src="https://user-images.githubusercontent.com/275961/136215269-fe75c49f-35d3-4e4e-a1c6-e8fb4fde26d0.png">

The featured image is also slightly off - if you can decide which position is better, I can match that up too.


#### Related issue(s):
https://github.com/Automattic/themes/issues/4758