### PR TITLE
Blockbase + co: Fix navigation alignment

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -165,7 +165,6 @@ pre {
 
 .wp-site-blocks .site-header .wp-block-navigation {
 	flex-grow: 1;
-	justify-content: flex-end;
 }
 
 @media (max-width: 599px) {

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"fontSize":"tiny"} /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -8,7 +8,6 @@
 	}
 	.wp-block-navigation {
 		flex-grow: 1;
-		justify-content: flex-end;
 	}
 	// The blockGap is used HORIZONTALLY when the viewport is LARGE (in which case the value defined in theme.json is appropriate)
 	// It needs to be a different value then when the viewport is SMALL and the gap is used VERTICALLY

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->

--- a/geologist/inc/patterns/header-with-rounded-site-logo.php
+++ b/geologist/inc/patterns/header-with-rounded-site-logo.php
@@ -13,7 +13,7 @@ return array(
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo {"className":"is-style-rounded"} /-->
 	<!-- wp:site-title /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->',
 );

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

After https://github.com/WordPress/gutenberg/pull/35077 was merged the navigation for Blockbase, Quadrat, Geologist, and Videomaker were broken. This PR fixes this by applying the alignment correctly in the block markup and removing the unused CSS. The rest of the children were behaving correctly.

Before:

<img width="1298" alt="Screenshot 2021-10-06 at 16 25 47" src="https://user-images.githubusercontent.com/3593343/136222776-63ceaca9-32f8-435b-9197-441266ddcbf6.png">



After:

<img width="1300" alt="Screenshot 2021-10-06 at 16 25 21" src="https://user-images.githubusercontent.com/3593343/136222781-85bd6431-41f0-48f6-a949-2f08cff0cfa7.png">


We need to hold on to this PR before we merge because dotcom doesn't have the GB just yet.