### PR TITLE
Quadrat: Allow long titles to wrap the same way on post pages and on the index

### DIFF
--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -2,13 +2,17 @@
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <main class="wp-block-query">
-	<!-- wp:post-template -->
-		<!-- wp:group {"layout":{"inherit":true}} -->
+	<!-- wp:post-template {"align":"wide"} -->
+		<!-- wp:group -->
 		<div class="wp-block-group">
 		<!-- wp:post-date {"isLink":false,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
 		<!-- wp:post-featured-image {"isLink":true} /-->
 		<!-- wp:post-excerpt /-->
+		</div>
+		<!-- /wp:group -->
 		<!-- wp:spacer {"height":60} -->
 		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -6,9 +6,6 @@
 	<div style="height:27px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
-	<!-- wp:spacer {"height":30} -->
-	<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
 	<!-- wp:post-featured-image {"align":"wide"} /-->
 </div>
 <!-- /wp:group -->

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -13,9 +13,6 @@
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide"} /-->
-		<!-- wp:spacer {"height":30} -->
-		<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
 		<!-- wp:post-featured-image {"align":"wide"} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
This keeps the look of the page titles the same on the post/page templates and the index template.

One side effect is that the featured image is in a different place on each page. Which one is correct?

Also, should we make this change in Geologist?

Post:
<img width="1440" alt="Screenshot 2021-10-06 at 16 21 27" src="https://user-images.githubusercontent.com/275961/136233941-df47c102-ed4b-4af7-a123-56e1864deb99.png">

Index:
<img width="1440" alt="Screenshot 2021-10-06 at 16 21 37" src="https://user-images.githubusercontent.com/275961/136233930-40af6f83-ce50-46d3-b516-bb6dd9c9777c.png">


