### PR TITLE
Blockbase: Remove unnecessary normalize code

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -3,18 +3,8 @@
  * - Reset the browser
  */
 body {
-	margin: 0;
-	padding: 0;
-}
-
-body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-}
-
-img {
-	height: auto;
-	max-width: 100%;
 }
 
 * {
@@ -331,23 +321,9 @@ button:focus {
 	outline-offset: 2px;
 }
 
-input.wp-block-search__input::placeholder,
-input[type="text"]::placeholder,
-input[type="email"]::placeholder,
-input[type="url"]::placeholder,
-input[type="password"]::placeholder,
-input[type="search"]::placeholder,
-input[type="number"]::placeholder,
-input[type="tel"]::placeholder,
-input[type="range"]::placeholder,
-input[type="date"]::placeholder,
-input[type="month"]::placeholder,
-input[type="week"]::placeholder,
-input[type="time"]::placeholder,
-input[type="datetime"]::placeholder,
-input[type="datetime-local"]::placeholder,
-input[type="color"]::placeholder,
-textarea::placeholder {
+input[type="checkbox"]::placeholder,
+input[type="submit"]::placeholder,
+button::placeholder {
 	color: var(--wp--custom--form--color--text);
 	opacity: 0.66;
 }

--- a/blockbase/sass/base/_normalize.scss
+++ b/blockbase/sass/base/_normalize.scss
@@ -1,20 +1,7 @@
-
-// Remove the margin in all browsers.
-body {
-  margin: 0;
-  padding: 0;
-}
-
 // Smooth out the fonts
 body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-}
-
-// Needed until https://github.com/WordPress/gutenberg/pull/27518/ is merged.
-img {
-	height: auto;
-	max-width: 100%;
 }
 
 * {
@@ -22,5 +9,5 @@ img {
 }
 
 pre {
-	overflow: scroll;	
+	overflow: scroll;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/pull/35421 and https://github.com/WordPress/gutenberg/pull/30092 have merged we can remove some stuff from the Blockbase normalize file.

To test, make sure that the body still has no margin and padding, and that no images are stretched.
