### PR TITLE
Quadrat + Geologist: Remove invalid site-logo rule

### DIFF
--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -353,13 +353,6 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontWeight": "400"
-		},
-		"core/site-logo": {
-			"spacing": {
-				"padding": {
-					"left": "35px"
-				}
-			}
 		}
 	}
 }

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -630,13 +630,6 @@
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
-		},
-		"core/site-logo": {
-			"spacing": {
-				"padding": {
-					"left": "35px"
-				}
-			}
 		}
 	}
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -502,6 +502,7 @@ input[type="submit"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
+input[type="checkbox"],
 textarea {
 	font-size: var(--wp--preset--font-size--normal);
 }

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -408,13 +408,6 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontWeight": "400"
-		},
-		"core/site-logo": {
-			"spacing": {
-				"padding": {
-					"left": "35px"
-				}
-			}
 		}
 	}
 }

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -522,16 +522,6 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700,
-					"textTransform": "uppercase"
-				},
-				"color": {
-					"link": "var(--wp--custom--color--primary)"
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -554,6 +544,16 @@
 					"fontStyle": "normal",
 					"fontWeight": "normal",
 					"lineHeight": "40px"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": 700,
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"link": "var(--wp--custom--color--primary)"
 				}
 			},
 			"core/navigation-link": {
@@ -686,13 +686,6 @@
 			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 			"fontSize": "var(--wp--preset--font-size--normal)",
 			"fontWeight": "400"
-		},
-		"core/site-logo": {
-			"spacing": {
-				"padding": {
-					"left": "35px"
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
This was added in https://github.com/Automattic/themes/pull/3776 originally, but it's in the wrong place in the file and doesn't seem to do anything, so I think we can just remove it.

To test, make sure that the header with a logo looks the same:
<img width="359" alt="Screenshot 2021-10-07 at 16 22 30" src="https://user-images.githubusercontent.com/275961/136414874-4ce2e4f9-3731-4d18-92ac-0e6c9a2dd438.png">
<img width="931" alt="Screenshot 2021-10-07 at 16 22 22" src="https://user-images.githubusercontent.com/275961/136414876-206db259-d028-414b-9143-723b7b865b33.png">

