### PR TITLE
Blockbase: Update the query pagination block markup

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -17,11 +17,11 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-previous /-->
 
 		<!-- wp:query-pagination-numbers /-->
 
-		<!-- wp:query-pagination-next /--></div>
+		<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:group -->

--- a/geologist/block-templates/index.html
+++ b/geologist/block-templates/index.html
@@ -16,9 +16,9 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -20,9 +20,9 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -12,11 +12,9 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
-		<div class="wp-block-query-pagination alignwide">
-			<!-- wp:query-pagination-previous /-->
-			<!-- wp:query-pagination-numbers /-->
-			<!-- wp:query-pagination-next /-->
-		</div>
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 
 	<!-- /wp:query -->

--- a/quadrat/inc/patterns/query-diamond.php
+++ b/quadrat/inc/patterns/query-diamond.php
@@ -31,9 +31,9 @@ return array(
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 
 	</div>

--- a/russell/block-templates/index.html
+++ b/russell/block-templates/index.html
@@ -17,11 +17,11 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-previous /-->
 
 		<!-- wp:query-pagination-numbers /-->
 
-		<!-- wp:query-pagination-next /--></div>
+		<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:group -->

--- a/skatepark/block-templates/index.html
+++ b/skatepark/block-templates/index.html
@@ -21,11 +21,11 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 
 	<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination --></div>
 	<!-- /wp:query -->
 

--- a/skatepark/inc/patterns/blog-posts.php
+++ b/skatepark/inc/patterns/blog-posts.php
@@ -26,11 +26,11 @@ return array(
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 
 	<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination --></div>
 	<!-- /wp:query -->',
 );

--- a/videomaker/block-templates/index.html
+++ b/videomaker/block-templates/index.html
@@ -21,9 +21,8 @@
 
 	<div class="wp-block-group">
 	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
-
-		<!-- wp:query-pagination-next /--></div>
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:group -->

--- a/zoologist/block-templates/index.html
+++ b/zoologist/block-templates/index.html
@@ -16,9 +16,9 @@
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
 	<!-- wp:query-pagination {"align":"wide"} -->
-	<div class="wp-block-query-pagination alignwide"><!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next /--></div>
+	<!-- wp:query-pagination-next /-->
 	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since https://github.com/WordPress/gutenberg/pull/35092 merged, the Query Pagination block doesn't have any markup. This removes the extra wrappers. We can't merge it until this version of GB ships on dotcom.

To test, run the latest GB and check that the query pagination block still looks ok.

#### Related issue(s):
https://github.com/WordPress/gutenberg/pull/35092

Closes #4886