### PR TITLE
Quadrat + Geologist: fix query loop not working

### DIFF
--- a/geologist/block-templates/index.html
+++ b/geologist/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<!-- wp:query {"tagName":"main","layout":{"inherit":true},"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <main class="wp-block-query">
 	<!-- wp:post-template -->
 		<!-- wp:group {"layout":{"inherit":true}} -->

--- a/geologist/block-templates/search.html
+++ b/geologist/block-templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":5,"isLink":true} /-->

--- a/geologist/inc/patterns/two-featured-posts.php
+++ b/geologist/inc/patterns/two-featured-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Two featured posts', 'geologist' ),
 	'categories' => array( 'geologist' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"queryId":14,"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":2}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":2}} -->
 	<div class="wp-block-query"><!-- wp:post-template -->
 	<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/mayland-blocks/block-templates/index.html
+++ b/mayland-blocks/block-templates/index.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-group">
 
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <div class="wp-block-query">
 <!-- wp:post-template -->
 <!-- wp:post-title {"isLink":true} /-->

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"inherit":true},"queryId":1,"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+<!-- wp:query {"tagName":"main","layout":{"inherit":true},"query":{"perPage":5,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <main class="wp-block-query">
 	<!-- wp:post-template -->
 		<!-- wp:group {"layout":{"inherit":true}} -->

--- a/quadrat/block-templates/search.html
+++ b/quadrat/block-templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":5,"isLink":true} /-->

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <div class="wp-block-query">
 <!-- wp:post-template -->
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->

--- a/skatepark/block-templates/search.html
+++ b/skatepark/block-templates/search.html
@@ -9,7 +9,7 @@
 		<div style="height:45px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 	<!-- wp:post-template -->
 
 		<!-- wp:post-title {"level":3,"isLink":true} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

On Geologist and Quadrat we've encountered a bug when the gutenberg-edge sticker is applied to a site on dotcom. To reproduce this go to either of the demo sites and check the blog page while the sticker is active, you will see something like this:

<img width="1668" alt="Screenshot 2021-10-08 at 09 39 36" src="https://user-images.githubusercontent.com/3593343/136517584-2abc3212-98bd-48fd-ae1c-4ff2ca495bec.png">

This is caused by a duplicated id in the query block apparently. Since that id is not needed by the markup to function, I've removed all instances of it on our themes. The problem this unveils is that now that the themes are activated, those that had this markup applied via headstart will not receive this fix. My test site wasn't fixed by this PR, while the demo site was:

<img width="1666" alt="Screenshot 2021-10-08 at 09 38 16" src="https://user-images.githubusercontent.com/3593343/136517882-aac76fe7-a647-4bf9-92dc-79b7d8379f9a.png">

I'm going to fix the headstart file so that it doesn't happen in the future but this is a problem we'll encounter in the future with any changes that we make to the markup and it's going to be a tough one.