### PR TITLE
Blockbase:  remove unneeded margin rules

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -902,10 +902,6 @@ p.wp-block-site-tagline {
 	text-align: var(--wp--custom--video--caption--text-align);
 }
 
-.wp-block-columns {
-	margin-bottom: unset;
-}
-
 .post-meta {
 	row-gap: var(--wp--custom--gap--baseline) !important;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -660,11 +660,6 @@ p.has-drop-cap:not(:focus):first-letter {
 	display: none;
 }
 
-.wp-block-post-template {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
 .wp-block-post-template .wp-block-post-featured-image {
 	line-height: 0;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -835,7 +835,6 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 }
 
 .wp-block-separator {
-	margin: var(--wp--custom--separator--margin);
 	opacity: var(--wp--custom--separator--opacity);
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -887,7 +887,6 @@ p.wp-block-site-tagline {
 
 .wp-block-table.is-style-stripes,
 .wp-block-table {
-	margin-bottom: 1em;
 	border-bottom: none;
 }
 

--- a/blockbase/sass/blocks/_columns.scss
+++ b/blockbase/sass/blocks/_columns.scss
@@ -1,6 +1,0 @@
-// TODO: This can be removed when Gutenberg no longer expresses opinion about the bottom margin of the block columns
-// or perhaps when the margins of blocks can be styled with the "style" portion of theme.json
-// See: https://github.com/WordPress/gutenberg/pull/34630
-.wp-block-columns {
-	margin-bottom: unset;
-}

--- a/blockbase/sass/blocks/_post-template.scss
+++ b/blockbase/sass/blocks/_post-template.scss
@@ -1,7 +1,4 @@
-// Needed until https://github.com/WordPress/gutenberg/pull/35193 is merged.
 .wp-block-post-template {
-	margin-top: 0;
-	margin-bottom: 0;
 	// Needed until https://github.com/WordPress/gutenberg/pull/35273 is merged.
 	.wp-block-post-featured-image {
 		line-height: 0;

--- a/blockbase/sass/blocks/_separator.scss
+++ b/blockbase/sass/blocks/_separator.scss
@@ -1,5 +1,4 @@
 .wp-block-separator {
-	margin: var(--wp--custom--separator--margin); // See https://github.com/WordPress/gutenberg/pull/30609 is merged
 	opacity: var(--wp--custom--separator--opacity); // Mirror controls that Gutenberg theme.css offers: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/separator/theme.scss - See: https://github.com/WordPress/gutenberg/issues/34637
 	&:not(.is-style-wide){
 		width: var(--wp--custom--separator--width); // See https://github.com/WordPress/gutenberg/issues/34638

--- a/blockbase/sass/blocks/_table.scss
+++ b/blockbase/sass/blocks/_table.scss
@@ -1,4 +1,3 @@
-// See https://github.com/WordPress/gutenberg/issues/31261
 .wp-block-table.is-style-stripes,
 .wp-block-table {
 	figcaption { // See https://github.com/WordPress/gutenberg/issues/34650
@@ -12,6 +11,5 @@
 		padding: calc(0.5*var(--wp--custom--gap--vertical)) calc(0.5*var(--wp--custom--gap--horizontal));
 	}
 
-	margin-bottom: 1em; // See https://github.com/WordPress/gutenberg/issues/34652
 	border-bottom: none;
 }

--- a/blockbase/sass/ponyfill.scss
+++ b/blockbase/sass/ponyfill.scss
@@ -29,5 +29,4 @@
 @import "blocks/file";
 @import "blocks/table";
 @import "blocks/video";
-@import "blocks/columns";
 @import "post/meta";

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -293,7 +293,6 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--gap--vertical) auto",
 				"width": "150px"
 			},
 			"table": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -284,7 +284,6 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--gap--vertical) auto",
 				"width": "150px"
 			},
 			"table": {

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -246,7 +246,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"horizontal": "min(32px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -469,7 +469,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--huge)"
 				},
 				"spacing": {
 					"padding": {

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -246,7 +246,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
 				"horizontal": "min(32px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -301,7 +301,6 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--gap--vertical) auto",
 				"width": "150px"
 			},
 			"table": {
@@ -470,7 +469,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"padding": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -340,7 +340,6 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--gap--vertical) auto",
 				"width": "150px"
 			},
 			"table": {

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -115,9 +115,6 @@
 						}
 					}
 				}
-			},
-			"separator": {
-				"margin": "calc( 9 * var(--wp--custom--gap--baseline) ) auto calc(2 * var(--wp--custom--gap--baseline) )"
 			}
 		},
 		"layout": {

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -279,7 +279,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"horizontal": "25px",
 				"vertical": "30px"
 			},
@@ -474,7 +474,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
-					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontSize": "var(--wp--preset--font-size--huge)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -279,7 +279,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
 				"horizontal": "25px",
 				"vertical": "30px"
 			},
@@ -334,8 +334,8 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "calc( 9 * var(--wp--custom--gap--baseline) ) auto calc(2 * var(--wp--custom--gap--baseline) )",
-				"width": "150px"
+				"width": "150px",
+				"margin": "calc( 9 * var(--wp--custom--gap--baseline) ) auto calc(2 * var(--wp--custom--gap--baseline) )"
 			},
 			"table": {
 				"figcaption": {
@@ -474,7 +474,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -334,8 +334,7 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"width": "150px",
-				"margin": "calc( 9 * var(--wp--custom--gap--baseline) ) auto calc(2 * var(--wp--custom--gap--baseline) )"
+				"width": "150px"
 			},
 			"table": {
 				"figcaption": {

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -199,9 +199,6 @@
 			},
 			"line-height": {
 				"body": 1.6
-			},
-			"separator": {
-				"margin": "calc( 0.5 * var(--wp--custom--gap--vertical) ) auto"
 			}
 		},
 		"layout": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -336,8 +336,7 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"width": "150px",
-				"margin": "calc( 0.5 * var(--wp--custom--gap--vertical) ) auto"
+				"width": "150px"
 			},
 			"table": {
 				"figcaption": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -281,7 +281,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "10px",
+				"baseline": "15px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -336,8 +336,8 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "calc( 0.5 * var(--wp--custom--gap--vertical) ) auto",
-				"width": "150px"
+				"width": "150px",
+				"margin": "calc( 0.5 * var(--wp--custom--gap--vertical) ) auto"
 			},
 			"table": {
 				"figcaption": {
@@ -493,7 +493,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				},
 				"spacing": {
 					"padding": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -281,7 +281,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},
@@ -493,7 +493,7 @@
 				},
 				"typography": {
 					"fontStyle": "italic",
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--huge)"
 				},
 				"spacing": {
 					"padding": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -295,7 +295,6 @@
 			},
 			"separator": {
 				"opacity": 1,
-				"margin": "var(--wp--custom--gap--vertical) auto",
 				"width": "150px"
 			},
 			"table": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes CSS that is no longer necessary after block gap was implemented. After gap was introduced, these rules were being overriden.

Check that the table and separator blocks look evenly separated from other blocks:


<img width="709" alt="Screenshot 2021-10-08 at 17 15 45" src="https://user-images.githubusercontent.com/3593343/136582417-6ff4277c-4a4b-4b08-8dbb-cd9790e741fe.png">

Same is happening for Post template block:

<img width="526" alt="Screenshot 2021-10-08 at 17 21 06" src="https://user-images.githubusercontent.com/3593343/136582465-90ba6666-05d8-419e-b860-a183f28c8589.png">

And with the columns block:

<img width="522" alt="Screenshot 2021-10-08 at 17 23 59" src="https://user-images.githubusercontent.com/3593343/136582991-de866c7b-6cde-48c5-bd5b-fe2006ce15fd.png">

