### PR TITLE
Blockbase: remove unneeded styles for post template

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -677,8 +677,9 @@ p.has-drop-cap:not(:focus):first-letter {
 	display: none;
 }
 
-.wp-block-post-template .wp-block-post-featured-image {
-	line-height: 0;
+.wp-block-post-template {
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 .wp-block-pullquote.is-style-solid-color,

--- a/blockbase/sass/blocks/_post-template.scss
+++ b/blockbase/sass/blocks/_post-template.scss
@@ -1,6 +1,4 @@
 .wp-block-post-template {
-	// Needed until https://github.com/WordPress/gutenberg/pull/35273 is merged.
-	.wp-block-post-featured-image {
-		line-height: 0;
-	}
+	margin-top: 0;
+	margin-bottom: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The CSS removed by this PR has been [moved to GB](https://github.com/WordPress/gutenberg/pull/35273). This still needs to wait a bit before merging. To test, check that there's no gap between figure and image on a post template block:

<img width="972" alt="Screenshot 2021-10-08 at 17 41 16" src="https://user-images.githubusercontent.com/3593343/136585619-e339b1f2-727d-4ef3-a70e-2a047441bf9f.png">
