### PR TITLE
Blockbase: Allow themes to inherit core gradients unless they define their own

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -37,7 +37,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -11,7 +11,6 @@
 	],
 	"settings": {
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -45,7 +45,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -19,7 +19,6 @@
 	],
 	"settings": {
 		"color": {
-			"gradients": [ ],
 			"palette": [
 				{
 					"slug": "foreground",

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -45,7 +45,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "foreground",

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -11,7 +11,6 @@
 	],
 	"settings": {
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -45,7 +45,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -41,6 +41,33 @@
 			"customWidth": true
 		},
 		"color": {
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#3C8067",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#336D58",
+					"name": "Secondary"
+				},
+				{
+					"slug": "foreground",
+					"color": "#333333",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#ffffff",
+					"name": "Background"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#FAFBF6",
+					"name": "tertiary"
+				}
+			],
 			"gradients": [
 				{
 					"slug": "hard-diagonal",
@@ -77,33 +104,6 @@
 				{
 					"slug": "stripe",
 					"gradient": "linear-gradient(to bottom, transparent 20%, #3C8067 20%, #3C8067 80%, transparent 80%)"
-				}
-			],
-			"palette": [
-				{
-					"slug": "primary",
-					"color": "#3C8067",
-					"name": "Primary"
-				},
-				{
-					"slug": "secondary",
-					"color": "#336D58",
-					"name": "Secondary"
-				},
-				{
-					"slug": "foreground",
-					"color": "#333333",
-					"name": "Foreground"
-				},
-				{
-					"slug": "background",
-					"color": "#ffffff",
-					"name": "Background"
-				},
-				{
-					"slug": "tertiary",
-					"color": "#FAFBF6",
-					"name": "tertiary"
 				}
 			]
 		},

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -1,7 +1,6 @@
 {
 	"settings": {
 		"color": {
-			"gradients": [],
 			"duotone": [
                 {
                     "colors": [ "#000", "#B9FB9C" ],

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -37,7 +37,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "primary",

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -37,7 +37,6 @@
 			"customWidth": true
 		},
 		"color": {
-			"gradients": [],
 			"palette": [
 				{
 					"slug": "foreground",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
By defining gradients as an empty array, we disable the default gradients. This removes that definition, allowing Blockbase themes to use the core gradients, unless they supply their own.
