### PR TITLE
Blockbase: Add theme.json meta data

### DIFF
--- a/blockbase/create-child.js
+++ b/blockbase/create-child.js
@@ -1,4 +1,6 @@
 const child_theme_json = `{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"settings": {
 		"custom": {}
 	},

--- a/geologist/child-theme.json
+++ b/geologist/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"customTemplates": [
 		{
 			"name": "page-without-title",

--- a/mayland-blocks/child-theme.json
+++ b/mayland-blocks/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"templateParts": [
 		{
 			"name": "header",

--- a/quadrat/child-theme.json
+++ b/quadrat/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"customTemplates": [
 		{
 			"name": "page-without-title",

--- a/seedlet-blocks/child-theme.json
+++ b/seedlet-blocks/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"templateParts": [
 		{
 			"name": "header",

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"settings": {
 		"color": {
 			"gradients": [],

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
 	"settings": {
 		"color": {
 			"palette": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Once child theme's theme.json inherit from the parent theme.json, they will need a version and schema defining on them. There's no harm in adding this now ready for that change.

Hopefully this also makes it easier to edit these files as they will have better syntax highlighting.
