### PR TITLE
Videomaker: Fix post meta spacing

### DIFF
--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -101,6 +101,9 @@
 			],
 			"fontSizes": {
 				"tiny": "16px"
+			},
+			"gap": {
+				"baseline": "10px"
 			}
 		},
 		"layout": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -240,7 +240,7 @@
 				}
 			},
 			"gap": {
-				"baseline": "15px",
+				"baseline": "10px",
 				"horizontal": "min(30px, 5vw)",
 				"vertical": "min(30px, 5vw)"
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The spacing around post meta should be smaller.

Before:
<img width="409" alt="Screenshot 2021-10-12 at 15 04 48" src="https://user-images.githubusercontent.com/275961/136971589-f7dee494-9b26-4afe-b891-896397384c19.png">

After:
<img width="383" alt="Screenshot 2021-10-12 at 15 04 12" src="https://user-images.githubusercontent.com/275961/136971572-8b71c0a3-834c-4106-ad35-7182d0901471.png">

