### PR TITLE
Adjusted menu CSS to match recent changes in the block

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -473,21 +473,44 @@ ol {
 	padding-left: var(--wp--custom--list--spacing--padding--left);
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation .has-child .wp-block-navigation__submenu-container {
+	background-color: var(--wp--custom--color--background);
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
+}
+
+.wp-block-navigation.is-responsive:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
 	background-color: var(--wp--custom--color--background);
 	color: var(--wp--custom--color--foreground);
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation-link__content {
-	color: var(--wp--custom--color--foreground) !important;
-}
-
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	gap: 1rem;
-}
-
-.wp-block-navigation ul.wp-block-social-links {
+.wp-block-navigation.is-responsive ul.wp-block-social-links {
 	margin: 0;
+	gap: var(--wp--custom--gap--baseline);
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open {
+	font-size: var(--wp--preset--font-size--medium) !important;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation__container {
+	row-gap: 0.5rem !important;
+	align-items: flex-start !important;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation-item {
+	align-items: flex-start !important;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation__submenu-container {
+	font-size: var(--wp--preset--font-size--normal) !important;
+	padding-bottom: 0;
+	padding-left: var(--wp--custom--gap--horizontal) !important;
+	padding-top: 0.5rem;
+	row-gap: 0.5rem !important;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open ul.wp-block-social-links {
+	justify-content: flex-start;
 }
 
 p.has-drop-cap:not(:focus):first-letter {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -486,6 +486,10 @@ ol {
 	gap: 1rem;
 }
 
+.wp-block-navigation ul.wp-block-social-links {
+	margin: 0;
+}
+
 p.has-drop-cap:not(:focus):first-letter {
 	font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
 	font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -483,7 +483,7 @@ ol {
 }
 
 .wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	display: revert;
+	gap: 1rem;
 }
 
 p.has-drop-cap:not(:focus):first-letter {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -495,6 +495,8 @@ ol {
 .wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation__container {
 	row-gap: 0.5rem !important;
 	align-items: flex-start !important;
+	flex: unset;
+	padding-bottom: 0;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation-item {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -488,22 +488,22 @@ ol {
 	gap: var(--wp--custom--gap--baseline);
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open {
 	font-size: var(--wp--preset--font-size--medium) !important;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation__container {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {
 	row-gap: 0.5rem !important;
 	align-items: flex-start !important;
 	flex: unset;
 	padding-bottom: 0;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation-item {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
 	align-items: flex-start !important;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open .wp-block-navigation__submenu-container {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__submenu-container {
 	font-size: var(--wp--preset--font-size--normal) !important;
 	padding-bottom: 0;
 	padding-left: var(--wp--custom--gap--horizontal) !important;
@@ -511,7 +511,7 @@ ol {
 	row-gap: 0.5rem !important;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean.is-responsive .is-menu-open ul.wp-block-social-links {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
 	justify-content: flex-start;
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -482,7 +482,7 @@ ol {
 	color: var(--wp--custom--color--foreground) !important;
 }
 
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation-link__container {
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
 	display: revert;
 }
 

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -159,3 +159,8 @@ add_action(
 		);
 	}
 );
+
+/**
+ * Block Styles.
+ */
+require get_template_directory() . '/inc/block-styles.php';

--- a/blockbase/inc/block-styles.php
+++ b/blockbase/inc/block-styles.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Blockbase Theme: Block Styles
+ *
+ * @package Blockbase 
+ * @since 1.2.8
+ */
+
+if ( ! function_exists( 'blockbase_register_block_styles' ) ) :
+
+	function blockbase_register_block_styles() {
+
+		if ( function_exists( 'register_block_style' ) ) {
+
+			/**
+			 * Register block styles
+			 */
+			register_block_style(
+				'core/navigation',
+				array(
+					'name'         => 'blockbase-navigation-clean',
+					'label'        => __( 'Clean', 'blockbase' ),
+					'style_handle' => 'blockbase-navigation-clean',
+				)
+			);
+
+		}
+	}
+endif;
+
+add_action( 'after_setup_theme', 'blockbase_register_block_styles' );

--- a/blockbase/inc/block-styles.php
+++ b/blockbase/inc/block-styles.php
@@ -18,9 +18,9 @@ if ( ! function_exists( 'blockbase_register_block_styles' ) ) :
 			register_block_style(
 				'core/navigation',
 				array(
-					'name'         => 'blockbase-navigation-clean',
-					'label'        => __( 'Clean', 'blockbase' ),
-					'style_handle' => 'blockbase-navigation-clean',
+					'name'         => 'blockbase-navigation-improved-responsive',
+					'label'        => __( 'Improved Responsive Navigation', 'blockbase' ),
+					'style_handle' => 'blockbase-navigation-improved-responsive',
 				)
 			);
 

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -23,6 +23,8 @@
 		.wp-block-navigation__container {
 			row-gap: 0.5rem !important;
 			align-items: flex-start !important;
+			flex: unset;
+			padding-bottom: 0;
 		}
 		.wp-block-navigation-item {
 			align-items: flex-start !important;

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -17,7 +17,7 @@
 	}
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-clean {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive {
 	&.is-responsive .is-menu-open {
 		font-size: var(--wp--preset--font-size--medium) !important;
 		.wp-block-navigation__container {

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -1,19 +1,41 @@
 // See https://github.com/WordPress/gutenberg/issues/34648
-.wp-block-navigation.is-responsive {
-	.wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation {
+	// See https://github.com/WordPress/gutenberg/issues/34648
+	.has-child .wp-block-navigation__submenu-container {
 		background-color: var(--wp--custom--color--background);
-		color: var(--wp--custom--color--foreground);
+		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	}
-	.wp-block-navigation-link__content {
-		color: var(--wp--custom--color--foreground) !important;
-	}
-	.has-child .wp-block-navigation__submenu-container{
-		gap: 1rem;
+	&.is-responsive {
+		&:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
+			background-color: var(--wp--custom--color--background);
+			color: var(--wp--custom--color--foreground);
+		}
+		ul.wp-block-social-links {
+			margin: 0;
+			gap: var(--wp--custom--gap--baseline);
+		}
 	}
 }
 
-.wp-block-navigation {
-	ul.wp-block-social-links {
-		margin: 0;
+.wp-block-navigation.is-style-blockbase-navigation-clean {
+	&.is-responsive .is-menu-open {
+		font-size: var(--wp--preset--font-size--medium) !important;
+		.wp-block-navigation__container {
+			row-gap: 0.5rem !important;
+			align-items: flex-start !important;
+		}
+		.wp-block-navigation-item {
+			align-items: flex-start !important;
+		}
+		.wp-block-navigation__submenu-container {
+			font-size: var(--wp--preset--font-size--normal) !important;
+			padding-bottom: 0;
+			padding-left: var(--wp--custom--gap--horizontal) !important;
+			padding-top: 0.5rem;
+			row-gap: 0.5rem !important;
+		}
+		ul.wp-block-social-links {
+			justify-content: flex-start;
+		}
 	}
 }

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -7,7 +7,7 @@
 	.wp-block-navigation-link__content {
 		color: var(--wp--custom--color--foreground) !important;
 	}
-	.has-child .wp-block-navigation-link__container{
+	.has-child .wp-block-navigation__submenu-container{
 		display: revert;
 	}
 }

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -8,6 +8,6 @@
 		color: var(--wp--custom--color--foreground) !important;
 	}
 	.has-child .wp-block-navigation__submenu-container{
-		display: revert;
+		gap: 1rem;
 	}
 }

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -11,3 +11,9 @@
 		gap: 1rem;
 	}
 }
+
+.wp-block-navigation {
+	ul.wp-block-social-links {
+		margin: 0;
+	}
+}

--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -170,7 +170,7 @@ ul ul {
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open .wp-block-social-links {
 	position: absolute;
 	flex-direction: column;
-	padding-top: 12px;
+	padding-top: 36px;
 }
 
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),

--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -118,8 +118,7 @@ ul ul {
 	text-decoration: underline;
 }
 
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container .submenu-container,
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link__container {
+.wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	background-color: var(--wp--custom--color--background);
 	border-color: var(--wp--custom--color--tertiary);
 }
@@ -147,31 +146,31 @@ ul ul {
 	margin-right: 0;
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container {
-	margin-right: -19px;
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container {
+	gap: 0;
 	padding: 0 19px 0 0;
 	border-right: 1px solid var(--wp--custom--color--foreground);
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-navigation-item__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container .wp-block-navigation-item__content {
 	padding: 0;
 	font-size: var(--wp--custom--font-sizes--tiny);
 	line-height: 40px;
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation__container {
-	padding-top: 50px;
 	align-items: flex-end;
+	gap: 0;
+}
+
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open .wp-block-social-links {
+	position: absolute;
+	flex-direction: column;
+	padding-top: 12px;
 }
 
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),

--- a/geologist/sass/blocks/_navigation.scss
+++ b/geologist/sass/blocks/_navigation.scss
@@ -10,12 +10,9 @@
 		}
 	}
 	&:not(.has-background) {
-		.wp-block-navigation__container {
-			.submenu-container,
-			.wp-block-navigation-link__container {
-				background-color: var(--wp--custom--color--background);
-				border-color: var(--wp--custom--color--tertiary);
-			}
+		.wp-block-navigation__submenu-container {
+			background-color: var(--wp--custom--color--background);
+			border-color: var(--wp--custom--color--tertiary);
 		}
 	}
 
@@ -37,13 +34,12 @@
 					.wp-block-navigation-link__content {
 						margin-right: 0;
 					}
-					.submenu-container,
-					.wp-block-navigation-link__container{
-						margin-right: -19px;
+					.wp-block-navigation__submenu-container{
+						gap: 0;
 						padding: 0 19px 0 0;
 						border-right: 1px solid var(--wp--custom--color--foreground);
 						.wp-block-pages-list__item__link,
-						.wp-block-navigation-link__content {
+						.wp-block-navigation-item__content {
 							padding: 0;
 							font-size: var(--wp--custom--font-sizes--tiny);
 							line-height: 40px;
@@ -52,9 +48,15 @@
 				}
 			}
 			.wp-block-navigation__container{
-				padding-top: 50px;
 				align-items: flex-end;
+				gap: 0;
 			}
+		}
+		.wp-block-social-links {
+			position: absolute;
+			flex-direction: column;
+			padding-top: 12px;
 		}
 	}
 }
+

--- a/geologist/sass/blocks/_navigation.scss
+++ b/geologist/sass/blocks/_navigation.scss
@@ -55,8 +55,7 @@
 		.wp-block-social-links {
 			position: absolute;
 			flex-direction: column;
-			padding-top: 12px;
+			padding-top: 36px;
 		}
 	}
 }
-

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -3,6 +3,6 @@
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->
 <!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-<!-- wp:navigation {"textColor":"foreground-light","fontSize":"small","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -3,6 +3,6 @@
 <!-- wp:site-logo /-->
 <!-- wp:site-title /-->
 <!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -307,8 +307,7 @@ ul ul {
 	text-decoration: underline;
 }
 
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container .submenu-container,
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link__container {
+.wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	background-color: var(--wp--custom--color--background);
 	border-color: var(--wp--custom--color--tertiary);
 }

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -335,31 +335,31 @@ ul ul {
 	margin-right: 0;
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container {
-	margin-right: -19px;
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container {
+	gap: 0;
 	padding: 0 19px 0 0;
 	border-right: 1px solid var(--wp--custom--color--foreground);
 }
 
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .submenu-container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .submenu-container .wp-block-navigation-link__content,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-pages-list__item__link,
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation-link__container .wp-block-navigation-link__content {
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-navigation-item__content,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container .wp-block-pages-list__item__link,
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-link.has-child .wp-block-navigation__submenu-container .wp-block-navigation-item__content {
 	padding: 0;
 	font-size: var(--wp--custom--font-sizes--tiny);
 	line-height: 40px;
 }
 
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation__container {
-	padding-top: 50px;
 	align-items: flex-end;
+	gap: 0;
+}
+
+.wp-block-navigation .wp-block-social-links {
+	position: absolute;
+	flex-direction: column;
+	padding-top: 12px;
 }
 
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -356,7 +356,7 @@ ul ul {
 	gap: 0;
 }
 
-.wp-block-navigation .wp-block-social-links {
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open .wp-block-social-links {
 	position: absolute;
 	flex-direction: column;
 	padding-top: 12px;

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -359,7 +359,7 @@ ul ul {
 .wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open .wp-block-social-links {
 	position: absolute;
 	flex-direction: column;
-	padding-top: 12px;
+	padding-top: 36px;
 }
 
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -55,7 +55,7 @@
 		.wp-block-social-links {
 			position: absolute;
 			flex-direction: column;
-			padding-top: 12px;
+			padding-top: 36px;
 		}
 	}
 }

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -34,13 +34,12 @@
 					.wp-block-navigation-link__content {
 						margin-right: 0;
 					}
-					.submenu-container,
-					.wp-block-navigation-link__container{
-						margin-right: -19px;
+					.wp-block-navigation__submenu-container{
+						gap: 0;
 						padding: 0 19px 0 0;
 						border-right: 1px solid var(--wp--custom--color--foreground);
 						.wp-block-pages-list__item__link,
-						.wp-block-navigation-link__content {
+						.wp-block-navigation-item__content {
 							padding: 0;
 							font-size: var(--wp--custom--font-sizes--tiny);
 							line-height: 40px;
@@ -49,9 +48,14 @@
 				}
 			}
 			.wp-block-navigation__container{
-				padding-top: 50px;
 				align-items: flex-end;
+				gap: 0;
 			}
 		}
+	}
+	.wp-block-social-links {
+		position: absolute;
+		flex-direction: column;
+		padding-top: 12px;
 	}
 }

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -10,12 +10,9 @@
 		}
 	}
 	&:not(.has-background) {
-		.wp-block-navigation__container {
-			.submenu-container,
-			.wp-block-navigation-link__container {
-				background-color: var(--wp--custom--color--background);
-				border-color: var(--wp--custom--color--tertiary);
-			}
+		.wp-block-navigation__submenu-container {
+			background-color: var(--wp--custom--color--background);
+			border-color: var(--wp--custom--color--tertiary);
 		}
 	}
 

--- a/quadrat/sass/blocks/_navigation.scss
+++ b/quadrat/sass/blocks/_navigation.scss
@@ -52,10 +52,10 @@
 				gap: 0;
 			}
 		}
-	}
-	.wp-block-social-links {
-		position: absolute;
-		flex-direction: column;
-		padding-top: 12px;
+		.wp-block-social-links {
+			position: absolute;
+			flex-direction: column;
+			padding-top: 12px;
+		}
 	}
 }

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -157,19 +157,6 @@
 	text-underline-offset: 0.2em;
 }
 
-.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__container {
-	gap: 0 !important;
-	align-items: start !important;
-}
-
-.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-item {
-	align-items: start !important;
-}
-
-.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__submenu-container {
-	padding-top: 0 !important;
-}
-
 .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link {
 	font-family: var(--wp--preset--font-family--playfair-display);
 	font-size: 32px;
@@ -181,16 +168,6 @@
 	font-style: italic;
 	font-size: 24px;
 	line-height: 30px;
-}
-
-.wp-block-navigation__responsive-container:not(.has-modal-open) .wp-block-social-links {
-	flex-basis: 100%;
-}
-
-/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
-is passed all of the block attributes on the block definition in the template. */
-.wp-block-navigation__container {
-	justify-content: left;
 }
 
 .wp-block-post-comments #comments,

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -180,6 +180,10 @@ is passed all of the block attributes on the block definition in the template. *
 	justify-content: center;
 }
 
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
+	padding-left: 0 !important;
+}
+
 .wp-block-post-comments #comments,
 .wp-block-post-comments #reply-title {
 	font-style: italic;

--- a/seedlet-blocks/assets/theme.css
+++ b/seedlet-blocks/assets/theme.css
@@ -157,8 +157,21 @@
 	text-underline-offset: 0.2em;
 }
 
+.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__container {
+	gap: 0 !important;
+	align-items: start !important;
+}
+
+.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-item {
+	align-items: start !important;
+}
+
+.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__submenu-container {
+	padding-top: 0 !important;
+}
+
 .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation-link {
-	font-family: var(--wp--preset--font-family--headings);
+	font-family: var(--wp--preset--font-family--playfair-display);
 	font-size: 32px;
 	font-weight: 400;
 	line-height: 60px;
@@ -177,11 +190,7 @@
 /* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
 is passed all of the block attributes on the block definition in the template. */
 .wp-block-navigation__container {
-	justify-content: center;
-}
-
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	padding-left: 0 !important;
+	justify-content: left;
 }
 
 .wp-block-post-comments #comments,

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -1,18 +1,6 @@
 .wp-block-navigation__responsive-container {
 	&.has-modal-open {
-		.wp-block-navigation__container {
-			gap: 0 !important;
-			align-items: start !important;
-		}
-		.wp-block-navigation-item {
-			align-items: start !important;
-		}
-		.wp-block-navigation__submenu-container {
-			padding-top: 0 !important;
-		}
 		.wp-block-navigation-link {
-			//NOTE: We lost the ability to tap into "heading font family" when we "inverted" the mechanism of customizing fonts in universal themes.
-			//I'm unsure how to make this work as designed...
 			font-family: var(--wp--preset--font-family--playfair-display);
 			font-size: 32px;
 			font-weight: 400;
@@ -26,14 +14,4 @@
 			}
 		}
 	}
-
-	&:not(.has-modal-open) .wp-block-social-links {
-		flex-basis: 100%;
-	}
-}
-
-/* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
-is passed all of the block attributes on the block definition in the template. */
-.wp-block-navigation__container {
-	justify-content: left;
 }

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -1,9 +1,19 @@
 .wp-block-navigation__responsive-container {
 	&.has-modal-open {
+		.wp-block-navigation__container {
+			gap: 0 !important;
+			align-items: start !important;
+		}
+		.wp-block-navigation-item {
+			align-items: start !important;
+		}
+		.wp-block-navigation__submenu-container {
+			padding-top: 0 !important;
+		}
 		.wp-block-navigation-link {
 			//NOTE: We lost the ability to tap into "heading font family" when we "inverted" the mechanism of customizing fonts in universal themes.
 			//I'm unsure how to make this work as designed...
-			font-family: var(--wp--preset--font-family--headings);
+			font-family: var(--wp--preset--font-family--playfair-display);
 			font-size: 32px;
 			font-weight: 400;
 			line-height: 60px;
@@ -25,9 +35,5 @@
 /* NOTE: This can be removed when the rendering of the Navigation block, rendered with a Classic data source (by way of __unstableLocation),
 is passed all of the block attributes on the block definition in the template. */
 .wp-block-navigation__container {
-	justify-content: center;
-}
-
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	padding-left: 0 !important;
+	justify-content: left;
 }

--- a/seedlet-blocks/sass/blocks/_navigation.scss
+++ b/seedlet-blocks/sass/blocks/_navigation.scss
@@ -1,8 +1,8 @@
 .wp-block-navigation__responsive-container {
 	&.has-modal-open {
 		.wp-block-navigation-link {
-			//NOTE: For reasons I cannot explain... if I set this to use the --wp--preset--font-family--headings
-			//these values (which are what are set) are not respected in the modal.
+			//NOTE: We lost the ability to tap into "heading font family" when we "inverted" the mechanism of customizing fonts in universal themes.
+			//I'm unsure how to make this work as designed...
 			font-family: var(--wp--preset--font-family--headings);
 			font-size: 32px;
 			font-weight: 400;
@@ -26,4 +26,8 @@
 is passed all of the block attributes on the block definition in the template. */
 .wp-block-navigation__container {
 	justify-content: center;
+}
+
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
+	padding-left: 0 !important;
 }

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -126,7 +126,7 @@
 	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--gap--horizontal), var(--wp--custom--gap--horizontal) ));
 }
 
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation-link__container {
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
 	background-color: var(--wp--custom--color--background);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 }

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -126,9 +126,8 @@
 	padding-left: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ) + var(--wp--custom--gap--horizontal), var(--wp--custom--gap--horizontal) ));
 }
 
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	background-color: var(--wp--custom--color--background);
-	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
+.wp-block-navigation {
+	font-size: var(--wp--preset--font-size--small);
 }
 
 .wp-block-post-comments .reply a {

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"fontSize":"small","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/sass/blocks/_navigation.scss
+++ b/skatepark/sass/blocks/_navigation.scss
@@ -1,6 +1,6 @@
 // See https://github.com/WordPress/gutenberg/issues/34648
 .wp-block-navigation.is-responsive {
-	.has-child .wp-block-navigation-link__container {
+	.has-child .wp-block-navigation__submenu-container {
 		background-color: var(--wp--custom--color--background);
 		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	}

--- a/skatepark/sass/blocks/_navigation.scss
+++ b/skatepark/sass/blocks/_navigation.scss
@@ -1,7 +1,5 @@
-// See https://github.com/WordPress/gutenberg/issues/34648
-.wp-block-navigation.is-responsive {
-	.has-child .wp-block-navigation__submenu-container {
-		background-color: var(--wp--custom--color--background);
-		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
-	}
+//NOTE: Setting the font size as a block attributes forces ALL elements to have that font size
+//preventing mobile menu items (and sub-menu items) from having a different size value
+.wp-block-navigation {
+	font-size: var(--wp--preset--font-size--small);
 }

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -51,7 +51,7 @@ a:active {
 	align-items: flex-end;
 }
 
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation-link__container {
+.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
 	background-color: var(--wp--custom--color--background);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 }

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-clean","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -157,6 +157,12 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/navigation-link": {
+				"color": {
+					"background": "transparent",
+					"text": "var(--wp--custom--color--foreground)"
+				}
+			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -2,11 +2,3 @@
 .is-vertical.items-justified-right ul.wp-block-navigation__container {
 	align-items: flex-end;
 }
-
-// See https://github.com/WordPress/gutenberg/issues/34648
-.wp-block-navigation.is-responsive {
-	.has-child .wp-block-navigation__submenu-container {
-		background-color: var(--wp--custom--color--background);
-		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
-	}
-}

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -5,7 +5,7 @@
 
 // See https://github.com/WordPress/gutenberg/issues/34648
 .wp-block-navigation.is-responsive {
-	.has-child .wp-block-navigation-link__container {
+	.has-child .wp-block-navigation__submenu-container {
 		background-color: var(--wp--custom--color--background);
 		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	}

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -493,6 +493,12 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/navigation-link": {
+				"color": {
+					"background": "transparent",
+					"text": "var(--wp--custom--color--foreground)"
+				}
+			},
 			"core/post-terms": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Below are the mobile and desktop changes that I noticed were effected.  There may be other changes that I missed and didn't note below.  

Developed and tested on Gutenberg Trunk.  I'm unsure which commit (or version) the changes that broke the styles were introduced so I can't offer that for comparison. 

Quadrat Desktop Before:
<img src="https://user-images.githubusercontent.com/146530/136986046-fb16e268-f60c-4e1e-86b0-9674927cb296.png" width="300">

Quadrat Desktop After:
<img src="https://user-images.githubusercontent.com/146530/136977240-4f85dc40-467c-4d2a-ab5e-aee2ec4b2078.png" width="300">

Quadrat Mobile Before:
<img src="https://user-images.githubusercontent.com/146530/136986125-b1e1e7b7-c6aa-49be-9fd1-af6fa011dcc8.png" width="300">

Quadrat Mobile After:
<img src="https://user-images.githubusercontent.com/146530/136980468-aff8ba90-6019-426b-8067-c270e97106d0.png" width="300">

Geologist Desktop Before:
<img src="https://user-images.githubusercontent.com/146530/136977348-f0c1f5f8-2cbc-4ed6-b425-3d49e844aba3.png" width="300">

Geologist Desktop After:
<img src="https://user-images.githubusercontent.com/146530/136981104-958b7509-bacc-4dc4-b103-648ec34105a4.png" width="300">

Geologist Mobile Before:
<img src="https://user-images.githubusercontent.com/146530/136986202-eb0c6997-6f8d-4a5e-a982-5c150ff57af3.png" width="300">

Geologist Mobile After:
<img src="https://user-images.githubusercontent.com/146530/136981354-66e4ba4a-6c15-4033-b62a-8bf9408c5447.png" width="300">

Blockbase Mobile Before:
<img src="https://user-images.githubusercontent.com/146530/136986253-fc38fcd4-ff6a-4cdf-826e-3a3f91f7e22e.png" width="300">

Blockbase Mobile After:
<img src="https://user-images.githubusercontent.com/146530/136990038-db92fc8b-e5db-457b-b642-10f0dd8b9609.png" width="300">

Skatepark Desktop Before:
<img src="https://user-images.githubusercontent.com/146530/136986317-c63d4672-8ccf-4dff-9097-275f47d0f752.png" width="300">

Skatepark Desktop After:
<img src="https://user-images.githubusercontent.com/146530/136983047-a456573d-d622-433c-8f7d-2dcf0de9936d.png" width="300">

Seedlet Mobile Before:
<img src="https://user-images.githubusercontent.com/146530/136986401-c85d0212-0d8b-470a-bdff-046df183ce31.png" width="300">

Seedlet Mobile After:
<img src="https://user-images.githubusercontent.com/146530/136989768-887a2cea-89c5-49a9-849e-7f6e04ebcce8.png" width="300">



Adjusts menu stylin' CSS to fix recent changes in the navigation block

#### Related issue(s):
Fixes #4821