### PR TITLE
Blockbase: Use new attributes for navigation block

### DIFF
--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/kerr/block-template-parts/header.html
+++ b/kerr/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,6 +1,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"32px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <div class="wp-block-group site-header" style="padding-bottom:32px">
 <!-- wp:site-logo /-->
+
 <!-- wp:group -->
 <div class="wp-block-group">
 	<!-- wp:site-title /-->
@@ -8,6 +9,6 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/payton/block-template-parts/header.html
+++ b/payton/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"10px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-top:10px">
-	<!-- wp:navigation {"itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontFamily":"var:preset|font-family|overpass"}},"fontSize":"small"} -->
+	<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","style":{"typography":{"fontFamily":"var:preset|font-family|overpass"}},"fontSize":"small"} -->
 	<!-- /wp:navigation -->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}}} -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/russell/block-template-parts/header.html
+++ b/russell/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,11 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
+<<<<<<< HEAD
 <!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+=======
+<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+>>>>>>> Use new attributes for navigation block
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,11 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<<<<<<< HEAD
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"center","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
-=======
-<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
->>>>>>> Use new attributes for navigation block
+<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}},"__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}},"__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -7,6 +7,6 @@
 		<!-- wp:site-tagline /-->
 	</div>
 	<!-- /wp:group -->
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"always","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/zoologist/block-template-parts/header.html
+++ b/zoologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When https://github.com/WordPress/gutenberg/pull/35568/ merges we will need to update the attributes of the navigation block from:

`"isResponsive": true`

to:

`"overlayMenu":"mobile"`.

Except in videomaker where it should be:
`"overlayMenu":"always"`.

#### Related issue(s):
https://github.com/WordPress/gutenberg/pull/35568/