### PR TITLE
Updated tested version of wordpress for all blockbase themes

### DIFF
--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Blockbase is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 1.2.9
 License: GNU General Public License v2 or later

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 1.0.3
 License: GNU General Public License v2 or later

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 2.1.7
 License: GNU General Public License v2 or later

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 1.1.12
 License: GNU General Public License v2 or later

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column block-based theme.
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 2.1.7
 License: GNU General Public License v2 or later

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Skatepark is a bold and exciting WordPress theme designed for modern events and organizations. With its simple but vivid color default scheme, duotone support, and playful grid, Skatepark is a theme designed for work and play. Customize its colors or try out different font pairings to create your own unique look and feel.
 Requires at least: 5.7.2
-Tested up to: 5.7.2
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 1.0.6
 License: GNU General Public License v2 or later

--- a/videomaker/style.css
+++ b/videomaker/style.css
@@ -5,7 +5,7 @@ Author:
 Author URI: 
 Description: 
 Requires at least: 5.7
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.7
 Version: 0.0.9
 License: GNU General Public License v2 or later


### PR DESCRIPTION
I'm not sure what process is needed to officially have the themes tested in a WP version but I've been using 5.8 locally to develop as long as it's been released so I feel comfortable saying it's a go...

Fixes part of #4812
