### PR TITLE
renamed a couple of functions from 'newtheme' to 'geologist'

### DIFF
--- a/blockbase/create-child.js
+++ b/blockbase/create-child.js
@@ -58,7 +58,7 @@ const functions_php = `<?php
 /**
  * Add Editor Styles
  */
-function newtheme_editor_styles() {
+function {newtheme}_editor_styles() {
 	// Enqueue editor styles.
 	add_editor_style(
 		array(
@@ -66,16 +66,16 @@ function newtheme_editor_styles() {
 		)
 	);
 }
-add_action( 'after_setup_theme', 'newtheme_editor_styles' );
+add_action( 'after_setup_theme', '{newtheme}_editor_styles' );
 
 /**
  *
  * Enqueue scripts and styles.
  */
-function newtheme_scripts() {
-	wp_enqueue_style( 'newtheme-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array('blockbase-ponyfill'), wp_get_theme()->get( 'Version' ) );
+function {newtheme}_scripts() {
+	wp_enqueue_style( '{newtheme}-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blockbase-ponyfill' ), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'wp_enqueue_scripts', 'newtheme_scripts' );
+add_action( 'wp_enqueue_scripts', '{newtheme}_scripts' );
 
 `;
 

--- a/geologist/functions.php
+++ b/geologist/functions.php
@@ -3,7 +3,7 @@
 /**
  * Add Editor Styles
  */
-function newtheme_editor_styles() {
+function geologist_editor_styles() {
 	// Enqueue editor styles.
 	add_editor_style(
 		array(
@@ -11,16 +11,16 @@ function newtheme_editor_styles() {
 		)
 	);
 }
-add_action( 'after_setup_theme', 'newtheme_editor_styles' );
+add_action( 'after_setup_theme', 'geologist_editor_styles' );
 
 /**
  *
  * Enqueue scripts and styles.
  */
-function newtheme_scripts() {
-	wp_enqueue_style( 'newtheme-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array('blockbase-ponyfill'), wp_get_theme()->get( 'Version' ) );
+function geologist_scripts() {
+	wp_enqueue_style( 'geologist-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array('blockbase-ponyfill'), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'wp_enqueue_scripts', 'newtheme_scripts' );
+add_action( 'wp_enqueue_scripts', 'geologist_scripts' );
 
 /**
  * Block Patterns.


### PR DESCRIPTION
Seems either the theme was initially generated with the name 'newtheme', the script didn't change those values, copypasta error or something else.

I'm not sure if this was the 'namespacing' problems noted in #4812 but it's the only instance I could find that didn't seem correct.