### PR TITLE
Quadrat: removed the utility class from block patterns and instead used margin

### DIFF
--- a/quadrat/inc/patterns/latest-episodes.php
+++ b/quadrat/inc/patterns/latest-episodes.php
@@ -15,8 +15,8 @@ return array(
 	<figure class="wp-block-image size-large image-no-margin mb-0"><img src="' . get_stylesheet_directory_uri() . '/assets/illustrations/screen-usage.jpeg" alt="' . esc_attr__( 'Illustration of a woman working on a laptop.', 'quadrat' ) . '" class="wp-image-1438"/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
+	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim" style="margin-top:0;padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
 	<h3 class="has-primary-color has-text-color">' . esc_html__( 'Episode 1: How Screens Affect Hormones', 'quadrat' ) . '</h3>
 	<!-- /wp:heading -->
 
@@ -33,8 +33,8 @@ return array(
 	<figure class="wp-block-image size-large image-no-margin mb-0"><img src="' . get_stylesheet_directory_uri() . '/assets/illustrations/leadership.jpeg" alt="' . esc_attr__( 'Illustration of a woman climbing steps.', 'quadrat' ) . '" class="wp-image-1439"/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
+	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim" style="margin-top:0;padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"primary"} -->
 	<h3 class="has-primary-color has-text-color">' . esc_html__( 'Episode 2: Female Leaders, Where Are They?', 'quadrat' ) . '</h3>
 	<!-- /wp:heading -->
 

--- a/quadrat/inc/patterns/query-episodes.php
+++ b/quadrat/inc/patterns/query-episodes.php
@@ -14,8 +14,8 @@ return array(
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"className":"vertical-query-pattern","layout":{"inherit":false}} -->
 	<div class="wp-block-group vertical-query-pattern" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /-->
 
-	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0" style="padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
+	<!-- wp:cover {"overlayColor":"tertiary","minHeight":360,"style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"30px","right":"40px","bottom":"20px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim" style="margin-top:0;padding-top:30px;padding-right:40px;padding-bottom:20px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
 
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
 	<!-- /wp:cover --></div>
@@ -30,8 +30,8 @@ return array(
 
 	<!-- wp:post-featured-image {"className":"image-no-margin mb-0"} /-->
 
-	<!-- wp:cover {"className":"horizontal-query-pattern","overlayColor":"tertiary","minHeight":360,"className":"mt-0","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}}} -->
-	<div class="wp-block-cover has-tertiary-background-color has-background-dim mt-0 horizontal-query-pattern" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container">
+	<!-- wp:cover {"className":"horizontal-query-pattern","overlayColor":"tertiary","minHeight":360,"style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}}} -->
+	<div class="wp-block-cover has-tertiary-background-color has-background-dim horizontal-query-pattern" style="margin-top:0;padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px;min-height:360px"><div class="wp-block-cover__inner-container">
 	<!-- wp:post-title {"isLink":true,"linkTarget":"_blank","textColor":"primary"} /-->
 	<!-- wp:post-excerpt {"textColor":"primary","fontSize":"small"} /--></div></div>
 	<!-- /wp:cover -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the utility class `mt-0` from Quadrat's patterns (I hesitate to remove it from Blockbase's CSS in case other users are using it on their themes) and I am using GB margin instead. I was under the impression that only Group blocks supported margins but it appears that is [no longer the case](https://github.com/WordPress/gutenberg/issues/28356#issuecomment-943929002). Hopefully, this can help solve the issues over at https://github.com/Automattic/wp-calypso/issues/56833

To test, check that there's no gap between the darker block and the images on the Latest episodes and Query episodes patterns.

<img width="1174" alt="Screenshot 2021-10-15 at 09 46 36" src="https://user-images.githubusercontent.com/3593343/137451636-53eea1f2-353b-4175-a3f5-380c168c7e2b.png">

