### PR TITLE
fixed spacing issues on post title

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -180,10 +180,13 @@
 	margin-bottom: 0;
 }
 
-h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
+h1.wp-block-post-title {
+	margin-bottom: calc(var(--wp--custom--gap--vertical) * 3);
+}
+
+body:not(.has-featured-image) h1.wp-block-post-title {
 	border-bottom: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
 	padding-bottom: calc(var(--wp--custom--gap--vertical) * 3);
-	margin-bottom: 0;
 }
 
 .is-root-container,

--- a/skatepark/sass/blocks/_post-title.scss
+++ b/skatepark/sass/blocks/_post-title.scss
@@ -1,6 +1,9 @@
-h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
-	border-bottom: var(--wp--custom--form--border--width)
-		var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
-	padding-bottom: calc(var(--wp--custom--gap--vertical) * 3);
-	margin-bottom: 0;
+h1.wp-block-post-title {
+	//can be removed after https://github.com/WordPress/gutenberg/pull/35684 lands
+	margin-bottom: calc(var(--wp--custom--gap--vertical) * 3);
+	body:not(.has-featured-image) &{
+		border-bottom: var(--wp--custom--form--border--width)
+			var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
+		padding-bottom: calc(var(--wp--custom--gap--vertical) * 3);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR changes the post title CSS to better fit the design both with and without featured image on posts and pages:

**Post/page with image:**
Before | After
--- | ---
<img width="1464" alt="Screenshot 2021-10-18 at 11 27 54" src="https://user-images.githubusercontent.com/3593343/137705439-4c6eee70-f39b-4ea8-8587-48e812e676ab.png"> | <img width="1419" alt="Screenshot 2021-10-18 at 11 27 40" src="https://user-images.githubusercontent.com/3593343/137705446-b343df41-a534-42e8-a71c-5ddd16ee8a13.png">

**Post/page without image:**
Before | After
--- | ---
<img width="1413" alt="Screenshot 2021-10-18 at 11 28 02" src="https://user-images.githubusercontent.com/3593343/137705428-d0ba026d-083b-48ee-91a1-c45af2bd0af3.png"> | <img width="1390" alt="Screenshot 2021-10-18 at 11 27 33" src="https://user-images.githubusercontent.com/3593343/137705455-f99f1846-7343-417e-9599-aaf23fbf122f.png">

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4791