### PR TITLE
Skatepark: apply caption block styles only to non gallery block images

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -269,17 +269,17 @@ h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	--wp--custom--button--spacing--padding--bottom: 0.5em;
 }
 
-.is-style-skatepark-aside-caption {
+:not(.wp-block-gallery) > .is-style-skatepark-aside-caption {
 	align-items: center;
 	display: flex;
 	flex-direction: column;
 }
 
-.is-style-skatepark-aside-caption img {
+:not(.wp-block-gallery) > .is-style-skatepark-aside-caption img {
 	justify-self: center;
 }
 
-.is-style-skatepark-aside-caption figcaption {
+:not(.wp-block-gallery) > .is-style-skatepark-aside-caption figcaption {
 	align-self: flex-end;
 	border-top: 3px solid var(--wp--preset--color--primary);
 	font-size: var(--wp--preset--font-size--small);
@@ -290,7 +290,7 @@ h1.wp-block-post-title:not(.has-featured-image .wp-block-post-title) {
 	text-align: left;
 }
 
-.is-style-skatepark-aside-caption.alignfull figcaption {
+:not(.wp-block-gallery) > .is-style-skatepark-aside-caption.alignfull figcaption {
 	margin-left: var(--wp--custom--gap--horizontal);
 	margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--gap--horizontal) ));
 }

--- a/skatepark/sass/block-styles/_image-caption.scss
+++ b/skatepark/sass/block-styles/_image-caption.scss
@@ -1,25 +1,27 @@
 .is-style-skatepark-aside-caption {
-	align-items: center;
-	display: flex;
-	flex-direction: column;
+	:not(.wp-block-gallery) > & {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
 
-	img {
-		justify-self: center;
-	}
+		img {
+			justify-self: center;
+		}
 
-	figcaption {
-		align-self: flex-end;
-		border-top: 3px solid var(--wp--preset--color--primary);
-		font-size: var(--wp--preset--font-size--small);
-		margin-bottom: 0;
-		margin-top: 20px;
-		padding-top: 20px;
-		max-width: 455px;
-		text-align: left;
-	}
+		figcaption {
+			align-self: flex-end;
+			border-top: 3px solid var(--wp--preset--color--primary);
+			font-size: var(--wp--preset--font-size--small);
+			margin-bottom: 0;
+			margin-top: 20px;
+			padding-top: 20px;
+			max-width: 455px;
+			text-align: left;
+		}
 
-	&.alignfull figcaption {
-		margin-left: var(--wp--custom--gap--horizontal);
-		margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--gap--horizontal) ) );
+		&.alignfull figcaption {
+			margin-left: var(--wp--custom--gap--horizontal);
+			margin-right: calc( max( 0.5 * ( 100% - var(--wp--custom--layout--wide-size) ), var(--wp--custom--gap--horizontal) ) );
+		}
 	}
 }

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -512,6 +512,14 @@
 					"width": "0 0 3px 0"
 				}
 			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": 900,
+					"letterSpacing": "0.05em",
+					"textTransform": "uppercase"
+				}
+			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
@@ -532,14 +540,6 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": 900,
-					"letterSpacing": "0.05em",
-					"textTransform": "uppercase"
 				}
 			},
 			"core/cover": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR applies the caption styles only to non gallery block image blocks. I couldn't make it work turning `is_default` to false [on the block style](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/#register_block_style) so I went the CSS route. that way the block style can still be the default one for image blocks outside the gallery block.

Before | After
--- | ---
<img width="713" alt="Screenshot 2021-10-18 at 11 45 14" src="https://user-images.githubusercontent.com/3593343/137719411-83a642ed-5b56-4fe0-ad35-e05a3aea95ef.png"> | <img width="732" alt="Screenshot 2021-10-18 at 11 45 01" src="https://user-images.githubusercontent.com/3593343/137719418-ea75efed-de01-4fa9-90bc-d141596c2c37.png">

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4741
