### PR TITLE
Blockbase: search block font size

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -782,7 +782,6 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 }
 
 .wp-block-search .wp-block-search__input {
-	line-height: var(--wp--custom--button--typography--line-height);
 	padding: var(--wp--custom--form--padding);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 }

--- a/blockbase/sass/blocks/_search.scss
+++ b/blockbase/sass/blocks/_search.scss
@@ -14,7 +14,6 @@
 	}
 
 	.wp-block-search__input {
-		line-height: var(--wp--custom--button--typography--line-height);
 		padding: var(--wp--custom--form--padding);
 		border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	}

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -450,6 +450,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -452,7 +452,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -452,7 +452,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -456,7 +456,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -454,6 +454,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -456,7 +456,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -479,6 +479,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -481,7 +481,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -481,7 +481,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/payton/theme.json
+++ b/payton/theme.json
@@ -463,6 +463,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"
@@ -473,23 +478,11 @@
 					"width": "0 0 1px 0"
 				}
 			},
-			"core/site-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": 700
-				}
-			},
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",
 					"style": "solid",
 					"width": "0 0 0 1px"
-				},
-				"citation": {
-					"typography": {
-						"fontSize": "var(--wp--custom--font-sizes--tiny)",
-						"fontWeight": "400"
-					}
 				},
 				"spacing": {
 					"padding": {
@@ -499,6 +492,13 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontStyle": "normal"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": "700",
+					"textDecoration": "none"
 				}
 			}
 		},
@@ -598,7 +598,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "0.5em"
+			"blockGap": "1em"
 		},
 		"typography": {
 			"lineHeight": "var(--wp--custom--body--typography--line-height)",

--- a/payton/theme.json
+++ b/payton/theme.json
@@ -465,7 +465,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/payton/theme.json
+++ b/payton/theme.json
@@ -465,7 +465,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -512,7 +512,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -512,7 +512,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -510,6 +510,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/russell/theme.json
+++ b/russell/theme.json
@@ -461,7 +461,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/russell/theme.json
+++ b/russell/theme.json
@@ -459,6 +459,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/russell/theme.json
+++ b/russell/theme.json
@@ -461,7 +461,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -517,7 +517,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -515,6 +515,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "#EFEFEF"

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -517,7 +517,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -504,7 +504,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -504,7 +504,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -502,6 +502,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -453,6 +453,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -455,7 +455,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -455,7 +455,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -457,7 +457,7 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--custom--button--typography--font-size)",
 					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -455,6 +455,11 @@
 					}
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--custom--color--foreground)"

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -457,7 +457,8 @@
 			},
 			"core/search": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"lineHeight": "var(--wp--custom--body--typography--line-height)"
 				}
 			},
 			"core/separator": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR https://github.com/WordPress/gutenberg/pull/35723 is about to be merged and it will affect all Blockbase themes. Previously, applying font-size to the search block via theme.json didn't work, after the GB PR is merged it will start working. Before the PR, the search block on all BB themes was simply applying the browser default rules for inputs (about 13.333px on FF). I decided on using --wp--preset--font-size--small instead, it will make the block look a little bit bigger don't he themes but I think it makes it more consistent with the rest of the elements of the theme than the random browser size.

I'm also changing the line-height so that the difference in size is not as big.

Skatepark 

Before | After
--- | ---
<img width="728" alt="Screenshot 2021-10-19 at 13 01 22" src="https://user-images.githubusercontent.com/3593343/137897655-48569471-b7b4-419c-ae3b-290e2d74d9b3.png"> | <img width="742" alt="Screenshot 2021-10-19 at 13 06 08" src="https://user-images.githubusercontent.com/3593343/137897648-f3917d6b-b216-4d03-99b3-79a6970a6f0d.png">

After the related PR is merged, the font size of the block will inherit directly from the body font, which will be much bigger than this.

@kjellr @beafialho @melchoyce I'm tagging you since this will introduce a slight visual change.

#### Related issue(s):

https://github.com/WordPress/gutenberg/pull/35723