### PR TITLE
Videomaker: Update tag styles

### DIFF
--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -64,11 +64,6 @@ div.post-meta a {
 	align-items: flex-end;
 }
 
-.wp-block-navigation.is-responsive .has-child .wp-block-navigation__submenu-container {
-	background-color: var(--wp--custom--color--background);
-	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--preset--color--primary);
-}
-
 footer > .wp-block-group {
 	align-items: center;
 	justify-content: space-between;
@@ -76,6 +71,17 @@ footer > .wp-block-group {
 
 footer > .wp-block-group p {
 	margin-bottom: 0;
+}
+
+.taxonomy-post_tag.wp-block-post-terms a {
+	background: var(--wp--custom--color--tertiary);
+	border-radius: 20px;
+	font-weight: 600;
+	padding: 10px 20px;
+}
+
+.taxonomy-post_tag.wp-block-post-terms .wp-block-post-terms__separator {
+	visibility: hidden;
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/videomaker/block-template-parts/post-meta.html
+++ b/videomaker/block-template-parts/post-meta.html
@@ -5,6 +5,6 @@
 	<p>/</p>
 	<!-- /wp:paragraph -->
     <!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-    <!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 </div>
 <!-- /wp:group -->
+<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->

--- a/videomaker/block-templates/index.html
+++ b/videomaker/block-templates/index.html
@@ -9,9 +9,7 @@
 	<!-- wp:post-featured-image {"isLink":true} /-->
 	<!-- wp:post-excerpt /-->
 
-	<!-- wp:group {"layout":{"type":"flex"}} -->
-	<div class="wp-block-group"><!-- wp:post-date /-->/<!-- wp:post-terms {"term":"category"} /--></div>
-	<!-- /wp:group -->
+	<!-- wp:template-part {"slug":"post-meta"} /-->
 
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -55,7 +55,7 @@
 				"background": "var(--wp--preset--color--background)",
 				"primary": "var(--wp--preset--color--foreground)",
 				"secondary": "var(--wp--preset--color--foreground)",
-				"tertiary": "var(--wp--preset--color--background)"
+				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"colorPalettes": [
 				{

--- a/videomaker/sass/blocks/_post-terms.scss
+++ b/videomaker/sass/blocks/_post-terms.scss
@@ -1,0 +1,12 @@
+.taxonomy-post_tag.wp-block-post-terms {
+	a {
+		background: var(--wp--custom--color--tertiary);
+		border-radius: 20px;
+		font-weight: 600;
+		padding: 10px 20px;
+	}
+
+	.wp-block-post-terms__separator {
+		visibility: hidden;
+	}
+}

--- a/videomaker/sass/theme.scss
+++ b/videomaker/sass/theme.scss
@@ -3,3 +3,4 @@
 @import "meta";
 @import "navigation";
 @import "templates/footer";
+@import "blocks/post-terms";

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -103,7 +103,7 @@
 				"background": "var(--wp--preset--color--background)",
 				"primary": "var(--wp--preset--color--foreground)",
 				"secondary": "var(--wp--preset--color--foreground)",
-				"tertiary": "var(--wp--preset--color--background)"
+				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"colorPalettes": [
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds CSS for Post Tags to match the Figma file.

Figma
<img width="742" alt="Screenshot 2021-10-19 at 12 20 54" src="https://user-images.githubusercontent.com/275961/137899596-34341d37-f26b-450a-a843-bd59b8c28ae1.png">

This PR
<img width="463" alt="Screenshot 2021-10-19 at 12 21 44" src="https://user-images.githubusercontent.com/275961/137899718-90175bc2-8739-4273-9cac-8c30d6c2361e.png">

#### Related issue(s):
https://github.com/Automattic/themes/issues/4844