### PR TITLE
Videomaker: Update the single post template

### DIFF
--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -73,7 +73,6 @@ footer > .wp-block-group p {
 	margin-bottom: 0;
 }
 
-<<<<<<< HEAD
 .taxonomy-post_tag.wp-block-post-terms a {
 	background: var(--wp--custom--color--tertiary);
 	border-radius: 20px;
@@ -83,7 +82,8 @@ footer > .wp-block-group p {
 
 .taxonomy-post_tag.wp-block-post-terms .wp-block-post-terms__separator {
 	visibility: hidden;
-=======
+}
+
 .wp-block-post-navigation-link {
 	flex-grow: 1;
 }
@@ -95,7 +95,6 @@ footer > .wp-block-group p {
 
 .post-navigation-link-next {
 	text-align: right;
->>>>>>> Update to use next and prev post blocks
 }
 
 div.wp-block-query-pagination {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -85,8 +85,11 @@ footer > .wp-block-group p {
 	visibility: hidden;
 =======
 .wp-block-post-navigation-link {
-	border-top: 1px solid var(--wp--custom--color--primary);
 	flex-grow: 1;
+}
+
+.wp-block-post-navigation-link a {
+	border-top: 1px solid var(--wp--custom--color--primary);
 	padding-top: 10px;
 }
 

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -73,6 +73,7 @@ footer > .wp-block-group p {
 	margin-bottom: 0;
 }
 
+<<<<<<< HEAD
 .taxonomy-post_tag.wp-block-post-terms a {
 	background: var(--wp--custom--color--tertiary);
 	border-radius: 20px;
@@ -82,6 +83,16 @@ footer > .wp-block-group p {
 
 .taxonomy-post_tag.wp-block-post-terms .wp-block-post-terms__separator {
 	visibility: hidden;
+=======
+.wp-block-post-navigation-link {
+	border-top: 1px solid var(--wp--custom--color--primary);
+	flex-grow: 1;
+	padding-top: 10px;
+}
+
+.post-navigation-link-next {
+	text-align: right;
+>>>>>>> Update to use next and prev post blocks
 }
 
 div.wp-block-query-pagination {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -84,4 +84,20 @@ footer > .wp-block-group p {
 	visibility: hidden;
 }
 
+div.wp-block-query-pagination {
+	grid-template-areas: "prev next";
+	grid-template-columns: 1fr 1fr;
+}
+
+div.wp-block-query-pagination .wp-block-query-pagination-previous,
+div.wp-block-query-pagination .wp-block-query-pagination-next {
+	border-top: 1px solid var(--wp--custom--color--primary);
+	padding-top: 10px;
+	width: 100%;
+}
+
+div.wp-block-query-pagination .wp-block-query-pagination-next {
+	text-align: right;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -90,6 +90,7 @@ footer > .wp-block-group p {
 
 .wp-block-post-navigation-link a {
 	border-top: 1px solid var(--wp--custom--color--primary);
+	display: block;
 	padding-top: 10px;
 }
 

--- a/videomaker/block-templates/index.html
+++ b/videomaker/block-templates/index.html
@@ -23,8 +23,6 @@
 	<!-- wp:query-pagination -->
 	<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
 
-		<!-- wp:query-pagination-numbers /-->
-
 		<!-- wp:query-pagination-next /--></div>
 	<!-- /wp:query-pagination -->
 	</div>

--- a/videomaker/block-templates/page.html
+++ b/videomaker/block-templates/page.html
@@ -1,0 +1,28 @@
+<!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:post-title /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:template-part {"layout":{"inherit":true},"slug":"post-meta"} /-->
+
+	<!-- wp:group {"tagName":"main"} -->
+	<main class="wp-block-group">
+	<!-- wp:post-featured-image {"align":"full"} /-->
+
+	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	</main>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:spacer {"height":60} -->
+		<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+		<!-- wp:post-comments /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -18,6 +18,13 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+    <!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-next /-->
+    </div>
+	<!-- /wp:query-pagination -->
+
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -18,12 +18,17 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:query-pagination -->
-	<div class="wp-block-query-pagination">
-    <!-- wp:query-pagination-previous /-->
-	<!-- wp:query-pagination-next /-->
+
+    <!-- wp:spacer {"height":60} -->
+    <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+
+    <!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+    <div class="wp-block-group alignwide">
+        <!-- wp:post-navigation-link {"type":"previous"} /-->
+        <!-- wp:post-navigation-link /-->
     </div>
-	<!-- /wp:query-pagination -->
+    <!-- /wp:group -->
 
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/videomaker/sass/blocks/_post-navigation-link.scss
+++ b/videomaker/sass/blocks/_post-navigation-link.scss
@@ -3,6 +3,7 @@
 
 	a {
 		border-top: 1px solid var(--wp--custom--color--primary);
+		display: block;
 		padding-top: 10px;
 	}
 }

--- a/videomaker/sass/blocks/_post-navigation-link.scss
+++ b/videomaker/sass/blocks/_post-navigation-link.scss
@@ -1,0 +1,12 @@
+.wp-block-post-navigation-link {
+	flex-grow: 1;
+
+	a {
+		border-top: 1px solid var(--wp--custom--color--primary);
+		padding-top: 10px;
+	}
+}
+
+.post-navigation-link-next {
+	text-align: right;
+}

--- a/videomaker/sass/blocks/_query-pagination.scss
+++ b/videomaker/sass/blocks/_query-pagination.scss
@@ -1,0 +1,15 @@
+div.wp-block-query-pagination {
+	grid-template-areas: "prev next";
+	grid-template-columns: 1fr 1fr;
+
+	.wp-block-query-pagination-previous,
+	.wp-block-query-pagination-next {
+		border-top: 1px solid var(--wp--custom--color--primary);
+		padding-top: 10px;
+		width: 100%;
+	}
+
+	.wp-block-query-pagination-next {
+		text-align: right;
+	}
+}

--- a/videomaker/sass/theme.scss
+++ b/videomaker/sass/theme.scss
@@ -4,4 +4,5 @@
 @import "navigation";
 @import "templates/footer";
 @import "blocks/post-terms";
+@import "blocks/post-navigation-link";
 @import "blocks/query-pagination";

--- a/videomaker/sass/theme.scss
+++ b/videomaker/sass/theme.scss
@@ -4,3 +4,4 @@
 @import "navigation";
 @import "templates/footer";
 @import "blocks/post-terms";
+@import "blocks/query-pagination";


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This makes some changes to the single post template to match figma.

@beafialho do you think the next and previous buttons should go above or below the comment form?

Figma:
<img width="388" alt="Screenshot 2021-10-19 at 15 20 14" src="https://user-images.githubusercontent.com/275961/137929504-ba2e4d3e-79ab-4e03-ab14-4ce1c2ba988c.png">

This PR:
<img width="778" alt="Screenshot 2021-10-19 at 14 38 01" src="https://user-images.githubusercontent.com/275961/137929631-565b4e29-389f-4274-95bf-d49b8722ac43.png">




#### Related issue(s):
