### PR TITLE
Update style.css

### DIFF
--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -11,7 +11,7 @@ Version: 1.2.14
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Text Domain: blockbase
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 Blockbase WordPress Theme, (C) 2021 Automattic, Inc.
 Blockbase is distributed under the terms of the GNU GPL.

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: geologist
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: mayland-blocks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/payton/style.css
+++ b/payton/style.css
@@ -12,6 +12,6 @@ License: GNU General Public License v2 or later
 License URI:
 Template: blockbase
 Text Domain: payton
-Tags:
+Tags:auto-loading-homepage
 
 */

--- a/payton/style.css
+++ b/payton/style.css
@@ -12,6 +12,6 @@ License: GNU General Public License v2 or later
 License URI:
 Template: blockbase
 Text Domain: payton
-Tags:auto-loading-homepage
+Tags: editor-style, auto-loading-homepage
 
 */

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: quadrat
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/russell/style.css
+++ b/russell/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: russell
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 Russell WordPress Theme, (C) 2021 Automattic, Inc.
 Russell is distributed under the terms of the GNU GPL.

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: seedlet-blocks
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 Seedlet Blocks WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet Blocks is distributed under the terms of the GNU GPL.

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: skatepark
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/videomaker/style.css
+++ b/videomaker/style.css
@@ -12,6 +12,6 @@ License: GNU General Public License v2 or later
 License URI: 
 Template: blockbase
 Text Domain: videomaker
-Tags: 
+Tags: auto-loading-homepage
 
 */

--- a/videomaker/style.css
+++ b/videomaker/style.css
@@ -12,6 +12,6 @@ License: GNU General Public License v2 or later
 License URI: 
 Template: blockbase
 Text Domain: videomaker
-Tags: auto-loading-homepage
+Tags: editor-style, auto-loading-homepage
 
 */

--- a/zoologist/style.css
+++ b/zoologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: zoologist
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 Zoologist WordPress Theme, (C) 2021 Automattic, Inc.
 Zoologist is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds auto-loading-homepage tag to stylesheet. Fixes homepage switching on WordPress.com

Themes:
- Blockbase
- Geologist
- Mayland Blocks
- Payton
- Quadrat
- Russell
- Seedlet Blocks
- Skatepark
- Videomaker
- Zoologist


#### Related issue(s):

None.