### PR TITLE
Videomaker: Navigation styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -476,7 +476,7 @@ ol {
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open {
-	font-size: var(--wp--preset--font-size--medium) !important;
+	font-size: var(--wp--preset--font-size--medium);
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -480,22 +480,22 @@ ol {
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {
-	row-gap: 0.5rem !important;
-	align-items: flex-start !important;
+	row-gap: 0.5rem;
+	align-items: flex-start;
 	flex: unset;
 	padding-bottom: 0;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
-	align-items: flex-start !important;
+	align-items: flex-start;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__submenu-container {
-	font-size: var(--wp--preset--font-size--normal) !important;
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content .has-child .wp-block-navigation__submenu-container {
+	font-size: var(--wp--preset--font-size--normal);
 	padding-bottom: 0;
-	padding-left: var(--wp--custom--gap--horizontal) !important;
+	padding-left: var(--wp--custom--gap--horizontal);
 	padding-top: 0.5rem;
-	row-gap: 0.5rem !important;
+	row-gap: 0.5rem;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -19,7 +19,7 @@
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive {
 	&.is-responsive .is-menu-open {
-		font-size: var(--wp--preset--font-size--medium) !important;
+		font-size: var(--wp--preset--font-size--medium);
 
 		.wp-block-navigation__container {
 			row-gap: 0.5rem;

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -20,22 +20,27 @@
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive {
 	&.is-responsive .is-menu-open {
 		font-size: var(--wp--preset--font-size--medium) !important;
+
 		.wp-block-navigation__container {
-			row-gap: 0.5rem !important;
-			align-items: flex-start !important;
+			row-gap: 0.5rem;
+			align-items: flex-start;
 			flex: unset;
 			padding-bottom: 0;
 		}
+
 		.wp-block-navigation-item {
-			align-items: flex-start !important;
+			align-items: flex-start;
 		}
-		.wp-block-navigation__submenu-container {
-			font-size: var(--wp--preset--font-size--normal) !important;
-			padding-bottom: 0;
-			padding-left: var(--wp--custom--gap--horizontal) !important;
-			padding-top: 0.5rem;
-			row-gap: 0.5rem !important;
+		.wp-block-navigation__responsive-container-content .has-child { // Needed for specificity to beat the navigation block CSS
+			.wp-block-navigation__submenu-container {
+				font-size: var(--wp--preset--font-size--normal);
+				padding-bottom: 0;
+				padding-left: var(--wp--custom--gap--horizontal);
+				padding-top: 0.5rem;
+				row-gap: 0.5rem;
+			}
 		}
+
 		ul.wp-block-social-links {
 			justify-content: flex-start;
 		}

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -66,14 +66,12 @@ div.post-meta a {
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {
 	align-items: center !important;
+	row-gap: 1rem !important;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
 	align-items: center !important;
-}
-
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child > a {
-	text-decoration: underline;
+	row-gap: 0.5rem;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -71,11 +71,17 @@ div.post-meta a {
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
 	align-items: center !important;
-	row-gap: 0.5rem;
+	row-gap: 0.8rem;
+}
+
+
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content {
+	justify-content: space-between;
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
 	justify-content: center;
+	padding-bottom: calc( var(--wp--custom--gap--vertical) * 2);
 }
 
 footer > .wp-block-group {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -75,6 +75,15 @@ div.post-meta a {
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
 	justify-content: center;
 }
+
+.wp-block-navigation__container .wp-block-navigation-item.current-menu-item > a {
+	text-decoration: underline;
+}
+
+.wp-block-navigation__container .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
+	display: none;
+}
+
 footer > .wp-block-group {
 	align-items: center;
 	justify-content: space-between;

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -72,16 +72,12 @@ div.post-meta a {
 	align-items: center !important;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
-	justify-content: center;
-}
-
-.wp-block-navigation__container .wp-block-navigation-item.current-menu-item > a {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child > a {
 	text-decoration: underline;
 }
 
-.wp-block-navigation__container .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
-	display: none;
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
+	justify-content: center;
 }
 
 footer > .wp-block-group {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -64,34 +64,34 @@ div.post-meta a {
 	align-items: flex-end;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {
-	align-items: center !important;
-	row-gap: 1rem !important;
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__container {
+	align-items: center;
+	row-gap: 1rem;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
-	align-items: center !important;
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item {
+	align-items: center;
 	row-gap: 0.8rem;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.current-menu-item > a {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item.current-menu-item > a {
 	text-decoration: underline;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child .wp-block-navigation__submenu-container {
-	padding-left: 0 !important;
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item.has-child .wp-block-navigation__submenu-container {
+	padding-left: 0;
 	padding-right: 0;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
 	display: none;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content {
 	justify-content: space-between;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container ul.wp-block-social-links {
 	justify-content: center;
 	padding-bottom: calc( var(--wp--custom--gap--vertical) * 2);
 }

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -64,6 +64,14 @@ div.post-meta a {
 	align-items: flex-end;
 }
 
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__container {
+	align-items: center !important;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item {
+	align-items: center !important;
+}
+
 footer > .wp-block-group {
 	align-items: center;
 	justify-content: space-between;

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -83,10 +83,6 @@ div.post-meta a {
 	padding-right: 0;
 }
 
-.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
-	display: none;
-}
-
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content {
 	justify-content: space-between;
 }

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -78,6 +78,11 @@ div.post-meta a {
 	text-decoration: underline;
 }
 
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child .wp-block-navigation__submenu-container {
+	padding-left: 0 !important;
+	padding-right: 0;
+}
+
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
 	display: none;
 }

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -74,6 +74,13 @@ div.post-meta a {
 	row-gap: 0.8rem;
 }
 
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.current-menu-item > a {
+	text-decoration: underline;
+}
+
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation-item.has-child:not(.current-menu-item) .wp-block-navigation__submenu-container {
+	display: none;
+}
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content {
 	justify-content: space-between;

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -72,6 +72,9 @@ div.post-meta a {
 	align-items: center !important;
 }
 
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive.is-responsive .is-menu-open ul.wp-block-social-links {
+	justify-content: center;
+}
 footer > .wp-block-group {
 	align-items: center;
 	justify-content: space-between;

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -155,11 +155,6 @@
 					"fontFamily": "var(--wp--preset--font-family--inter)"
 				}
 			},
-			"core/navigation": {
-				"typography": {
-					"textTransform": "uppercase"
-				}
-			},
 			"core/navigation-link": {
 				"color": {
 					"background": "transparent",

--- a/videomaker/inc/patterns/background-video.php
+++ b/videomaker/inc/patterns/background-video.php
@@ -17,7 +17,7 @@ return array(
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
 	<div class="wp-block-column is-vertically-aligned-center">
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /-->
 	</div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->

--- a/videomaker/inc/patterns/full-width-homepage.php
+++ b/videomaker/inc/patterns/full-width-homepage.php
@@ -15,7 +15,7 @@ return array(
 	<!-- /wp:column -->
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /--></div>
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 

--- a/videomaker/inc/patterns/header-description-and-grid-of-projects.php
+++ b/videomaker/inc/patterns/header-description-and-grid-of-projects.php
@@ -19,7 +19,7 @@ return array(
 		<h3 style="font-weight:300">' . esc_html__( 'Jonah is Creative Director of Hano, a production studio that specializes in combining storytelling with visual design.', 'videomaker' ) . '</h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"primary"} /-->
+		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 		</div>
 		<!-- /wp:column -->

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -16,6 +16,12 @@
 			&.current-menu-item > a {
 				text-decoration: underline;
 			}
+			&.has-child {
+				.wp-block-navigation__submenu-container {
+					padding-left: 0 !important;
+					padding-right: 0;
+				}
+			}
 			&.has-child:not(.current-menu-item) {
 				.wp-block-navigation__submenu-container {
 					display: none;

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -4,27 +4,31 @@
 }
 
 .wp-block-navigation.is-style-blockbase-navigation-improved-responsive {
-	&.is-responsive .is-menu-open {
+	&.is-responsive .is-menu-open.wp-block-navigation__responsive-container {
 		.wp-block-navigation__container {
-			align-items: center !important;
-			row-gap: 1rem !important;
+			align-items: center;
+			row-gap: 1rem;
 		}
-		.wp-block-navigation-item {
-			align-items: center !important;
-			row-gap: 0.8rem;
 
-			&.current-menu-item > a {
-				text-decoration: underline;
-			}
-			&.has-child {
-				.wp-block-navigation__submenu-container {
-					padding-left: 0 !important;
-					padding-right: 0;
+		.wp-block-navigation__responsive-container-content { // Needed for specificity to beat the navigation block CSS
+			.wp-block-navigation-item {
+				align-items: center;
+				row-gap: 0.8rem;
+
+				&.current-menu-item > a {
+					text-decoration: underline;
 				}
-			}
-			&.has-child:not(.current-menu-item) {
-				.wp-block-navigation__submenu-container {
-					display: none;
+
+				&.has-child {
+					.wp-block-navigation__submenu-container {
+						padding-left: 0;
+						padding-right: 0;
+					}
+				}
+				&.has-child:not(.current-menu-item) {
+					.wp-block-navigation__submenu-container {
+						display: none;
+					}
 				}
 			}
 		}

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -10,22 +10,13 @@
 		}
 		.wp-block-navigation-item {
 			align-items: center !important;
+
+			&.has-child > a {
+				text-decoration: underline;
+			}
 		}
 		ul.wp-block-social-links {
 			justify-content: center;
-		}
-	}
-}
-
-.wp-block-navigation__container {
-	.wp-block-navigation-item {
-		&.current-menu-item > a {
-			text-decoration: underline;
-		}
-		&.has-child:not(.current-menu-item) {
-			.wp-block-navigation__submenu-container {
-				display: none;
-			}
 		}
 	}
 }

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -2,3 +2,14 @@
 .is-vertical.items-justified-right ul.wp-block-navigation__container {
 	align-items: flex-end;
 }
+
+.wp-block-navigation.is-style-blockbase-navigation-improved-responsive {
+	&.is-responsive .is-menu-open {
+		.wp-block-navigation__container {
+			align-items: center !important;
+		}
+		.wp-block-navigation-item {
+			align-items: center !important;
+		}
+	}
+}

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -7,13 +7,11 @@
 	&.is-responsive .is-menu-open {
 		.wp-block-navigation__container {
 			align-items: center !important;
+			row-gap: 1rem !important;
 		}
 		.wp-block-navigation-item {
 			align-items: center !important;
-
-			&.has-child > a {
-				text-decoration: underline;
-			}
+			row-gap: 0.5rem;
 		}
 		ul.wp-block-social-links {
 			justify-content: center;

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -11,5 +11,8 @@
 		.wp-block-navigation-item {
 			align-items: center !important;
 		}
+		ul.wp-block-social-links {
+			justify-content: center;
+		}
 	}
 }

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -16,3 +16,16 @@
 		}
 	}
 }
+
+.wp-block-navigation__container {
+	.wp-block-navigation-item {
+		&.current-menu-item > a {
+			text-decoration: underline;
+		}
+		&.has-child:not(.current-menu-item) {
+			.wp-block-navigation__submenu-container {
+				display: none;
+			}
+		}
+	}
+}

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -11,10 +11,14 @@
 		}
 		.wp-block-navigation-item {
 			align-items: center !important;
-			row-gap: 0.5rem;
+			row-gap: 0.8rem;
+
+		.wp-block-navigation__responsive-container-content {
+			justify-content: space-between;
 		}
 		ul.wp-block-social-links {
 			justify-content: center;
+			padding-bottom: calc( var(--wp--custom--gap--vertical) * 2 );
 		}
 	}
 }

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -25,11 +25,6 @@
 						padding-right: 0;
 					}
 				}
-				&.has-child:not(.current-menu-item) {
-					.wp-block-navigation__submenu-container {
-						display: none;
-					}
-				}
 			}
 		}
 		.wp-block-navigation__responsive-container-content {

--- a/videomaker/sass/_navigation.scss
+++ b/videomaker/sass/_navigation.scss
@@ -13,6 +13,15 @@
 			align-items: center !important;
 			row-gap: 0.8rem;
 
+			&.current-menu-item > a {
+				text-decoration: underline;
+			}
+			&.has-child:not(.current-menu-item) {
+				.wp-block-navigation__submenu-container {
+					display: none;
+				}
+			}
+		}
 		.wp-block-navigation__responsive-container-content {
 			justify-content: space-between;
 		}

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -411,8 +411,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"textTransform": "uppercase"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR tweaks the Videomaker navigation styles to match the Figma designs.

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/1645628/138068091-7b0f16e1-031f-4f1a-8ecc-743fceb5dedd.png)     | ![image](https://user-images.githubusercontent.com/1645628/138067811-6fedaf56-3985-4bfc-b3ab-ca8c9cacaf71.png)     |

It looks like GB doesn't pull through the `current-menu-item` class, so we're not able to style the active menu item differently at the moment. I've made a change to the navigation attributes PR on GB that fixes this, so it's possible to test on this branch: https://github.com/WordPress/gutenberg/pull/35634. 

Without the GB PR, I think we'll need to remove the submenu styles. At the moment I've hidden all child menu items unless the parent is the current menu item, which means they'll be hidden by default without the `current-menu-item` class. Let me know if you want me to remove these now - or maybe comment them out while we wait for a fix?

I've made sure the menus in the patterns are still uppercase by adding an inline style to the nav blocks in the patterns.

I've also only styled the responsive menu, as it looks like Videomaker should always use the responsive menu when this can be merged: https://github.com/Automattic/themes/pull/4832

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/4651