### PR TITLE
dotorg package script: remove tags for themes that don't build their css

### DIFF
--- a/package-dotorg.sh
+++ b/package-dotorg.sh
@@ -4,6 +4,11 @@ if [[ "$1" != "" ]]; then
 	find $THEME/assets/sass/*.scss -type f -exec sed -i '' 's/-wpcom//g' {} \; 
 	find $THEME/assets/sass/*.scss -type f -exec sed -i '' 's/, auto-loading-homepage//g' {} \; 
 	find $THEME/assets/sass/*.scss -type f -exec sed -i '' 's/, jetpack-global-styles//g' {} \; 
+
+	find $THEME/style.css -type f -exec sed -i '' 's/-wpcom//g' {} \; 
+	find $THEME/style.css -type f -exec sed -i '' 's/, auto-loading-homepage//g' {} \; 
+	find $THEME/style.css -type f -exec sed -i '' 's/, jetpack-global-styles//g' {} \; 
+
 	cd $THEME && npm run build;
 	mkdir $THEME;
 	rsync -avz --include='theme.json' --exclude $THEME --exclude-from '../dotorg-exclude.txt' ./ $THEME


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The script removes the tags only on sass files. This worked fine for Varia based themes, but Blockbase children don't have the tags on the sass files, just the CSS file

This change removes the tags from the CSS files as well

