### PR TITLE
Payton: Fix query pagination containers

### DIFF
--- a/payton/block-templates/index.html
+++ b/payton/block-templates/index.html
@@ -30,11 +30,10 @@
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
-	<div class="wp-block-query-pagination alignwide">
-	<!-- wp:query-pagination-previous /-->
-	<!-- wp:query-pagination-numbers /-->
-	<!-- wp:query-pagination-next /-->
-	</div><!-- /wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
 </main>
 <!-- /wp:query -->
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes markup in the query pagination container that is no longer required by Gutenberg.

Before:
<img width="1018" alt="Screenshot 2021-10-22 at 20 15 11" src="https://user-images.githubusercontent.com/275961/138511355-96cd687a-671e-4aaf-bfcf-1f464a909f0f.png">

After:
<img width="1288" alt="Screenshot 2021-10-22 at 20 15 41" src="https://user-images.githubusercontent.com/275961/138511374-cfcffabd-75dd-42fd-8ae4-e989756f96da.png">


