### PR TITLE
Videomaker: Change videos in patterns to point to VideoPress

### DIFF
--- a/videomaker/inc/patterns/full-width-homepage.php
+++ b/videomaker/inc/patterns/full-width-homepage.php
@@ -19,7 +19,9 @@ return array(
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 
-	<!-- wp:video {"align":"wide","className":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video alignwide wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"></video></figure>
-	<!-- /wp:video -->',
+	<!-- wp:embed {"url":"https://videopress.com/v/bjvmxiQS","type":"video","providerNameSlug":"videopress","responsive":true,"align":"wide","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed alignwide is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/bjvmxiQS
+	</div></figure>
+	<!-- /wp:embed -->',
 );

--- a/videomaker/inc/patterns/header-description-and-grid-of-projects.php
+++ b/videomaker/inc/patterns/header-description-and-grid-of-projects.php
@@ -33,25 +33,31 @@ return array(
 		<!-- wp:column {"width":"30%"} -->
 		<div class="wp-block-column" style="flex-basis:30%">
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/bjvmxiQS","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/bjvmxiQS
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'Man Working at Dawn', 'videomaker' ) . '</h4>
 		<!-- /wp:heading -->
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/QnM8BRgT","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/QnM8BRgT
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'The Tale of The Three Cocktails', 'videomaker' ) . '</h4>
 		<!-- /wp:heading -->
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/pacific.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/Ubk3Xl86","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/Ubk3Xl86
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'Is This The Pacific?', 'videomaker' ) . '</h4>
@@ -63,25 +69,31 @@ return array(
 		<!-- wp:column {"width":"30%"} -->
 		<div class="wp-block-column" style="flex-basis:30%">
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/z4N1oaIj","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/z4N1oaIj
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'Boats', 'videomaker' ) . '</h4>
 		<!-- /wp:heading -->
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/ma3Uz3AE","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/ma3Uz3AE
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'Plenty of Fish In The Sea', 'videomaker' ) . '</h4>
 		<!-- /wp:heading -->
 
-		<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/i-love-you.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-		<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/i-love-you.mp4"></video></figure>
-		<!-- /wp:video -->
+		<!-- wp:embed {"url":"https://videopress.com/v/e7QDnuzH","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+		<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		https://videopress.com/v/e7QDnuzH
+		</div></figure>
+		<!-- /wp:embed -->
 
 		<!-- wp:heading {"level":4} -->
 		<h4>' . esc_html__( 'I Love You', 'videomaker' ) . '</h4>

--- a/videomaker/inc/patterns/header-names-list-and-grid.php
+++ b/videomaker/inc/patterns/header-names-list-and-grid.php
@@ -31,9 +31,11 @@ return array(
 	<!-- wp:column {"width":"60%"} -->
 	<div class="wp-block-column" style="flex-basis:60%">
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/z4N1oaIj","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/z4N1oaIj
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:heading {"level":3,"style":{"typography":{"fontWeight":"700"}},"fontSize":"normal"} -->
 	<h3 class="has-normal-font-size" style="font-weight:700">' . esc_html__( 'Boats', 'videomaker' ) . '</h3>

--- a/videomaker/inc/patterns/pattern-grid.php
+++ b/videomaker/inc/patterns/pattern-grid.php
@@ -10,9 +10,13 @@ return array(
 	'categories' => array( 'videomaker' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"></video></figure>
-	<!-- /wp:video -->
+	<div class="wp-block-column">
+
+	<!-- wp:embed {"url":"https://videopress.com/v/bjvmxiQS","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/bjvmxiQS
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'Man Working at Dawn', 'videomaker' ) . '</h4>
@@ -20,9 +24,11 @@ return array(
 
 	<!-- wp:template-part {"slug":"post-meta","theme":"' . get_stylesheet() . '"} /-->
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/QnM8BRgT","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/QnM8BRgT
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'The Tale of The Three Cocktails', 'videomaker' ) . '</h4>
@@ -34,9 +40,13 @@ return array(
 	<!-- /wp:column -->
 
 	<!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"></video></figure>
-	<!-- /wp:video -->
+	<div class="wp-block-column">
+
+	<!-- wp:embed {"url":"https://videopress.com/v/z4N1oaIj","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/z4N1oaIj
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'Boats', 'videomaker' ) . '</h4>
@@ -44,9 +54,11 @@ return array(
 
 	<!-- wp:template-part {"slug":"post-meta","theme":"' . get_stylesheet() . '"} /-->
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/ma3Uz3AE","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/ma3Uz3AE
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:heading {"level":4} -->
 	<h4>' . esc_html__( 'Plenty of Fish In The Sea', 'videomaker' ) . '</h4>

--- a/videomaker/inc/patterns/pattern-offset-project-grid.php
+++ b/videomaker/inc/patterns/pattern-offset-project-grid.php
@@ -12,9 +12,11 @@ return array(
 	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
 	<div class="wp-block-column" style="flex-basis:60%">
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/bjvmxiQS","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/bjvmxiQS
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:group -->
 	<div class="wp-block-group">
@@ -33,9 +35,11 @@ return array(
 	<div style="height:290px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/z4N1oaIj","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/z4N1oaIj
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:group -->
 	<div class="wp-block-group">
@@ -64,9 +68,11 @@ return array(
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/cocktails.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/QnM8BRgT","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/QnM8BRgT
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:group -->
 	<div class="wp-block-group">
@@ -97,9 +103,11 @@ return array(
 	<div style="height:385px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/pacific.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/pacific.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/Ubk3Xl86","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/Ubk3Xl86
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:group --><div class="wp-block-group">
 	<!-- wp:heading {"level":4} -->
@@ -114,10 +122,12 @@ return array(
 
 	<!-- wp:column {"width":"60%"} -->
 	<div class="wp-block-column" style="flex-basis:60%">
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/fish.mp4"></video></figure>
-	<!-- /wp:video -->
 
+	<!-- wp:embed {"url":"https://videopress.com/v/ma3Uz3AE","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/ma3Uz3AE
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:group -->
 	<div class="wp-block-group">

--- a/videomaker/inc/patterns/pattern-two-posts-with-excerpt.php
+++ b/videomaker/inc/patterns/pattern-two-posts-with-excerpt.php
@@ -11,9 +11,12 @@ return array(
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column {"width":"80%"} -->
 	<div class="wp-block-column" style="flex-basis:80%">
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"} -->
-	<figure class="wp-block-video"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/digging.mp4"></video></figure>
-	<!-- /wp:video -->
+
+	<!-- wp:embed {"url":"https://videopress.com/v/bjvmxiQS","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/bjvmxiQS
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:columns -->
 	<div class="wp-block-columns"><!-- wp:column -->
@@ -57,9 +60,11 @@ return array(
 	<!-- wp:column {"width":"80%"} -->
 	<div class="wp-block-column" style="flex-basis:80%">
 
-	<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"} -->
-	<figure class="wp-block-video"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/boats.mp4"></video></figure>
-	<!-- /wp:video -->
+	<!-- wp:embed {"url":"https://videopress.com/v/z4N1oaIj","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/z4N1oaIj
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:columns -->
 	<div class="wp-block-columns"><!-- wp:column -->

--- a/videomaker/inc/patterns/post-i-love-you.php
+++ b/videomaker/inc/patterns/post-i-love-you.php
@@ -8,9 +8,11 @@
 return array(
 	'title'      => __( 'Post: I Love You', 'videomaker' ),
 	'categories' => array( 'videomaker' ),
-	'content'    => '<!-- wp:video {"src":"' . get_stylesheet_directory_uri() . '/assets/videos/i-love-you.mp4","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
-	<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><video controls src="' . get_stylesheet_directory_uri() . '/assets/videos/i-love-you.mp4"></video></figure>
-	<!-- /wp:video -->
+	'content'    => '<!-- wp:embed {"url":"https://videopress.com/v/e7QDnuzH","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+	<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+	https://videopress.com/v/e7QDnuzH
+	</div></figure>
+	<!-- /wp:embed -->
 
 	<!-- wp:post-terms {"term":"post_tag"} /-->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This updates all the patterns in Videomaker to use VideoPress videos rather than local ones. This means that they load with a big playback button.

#### Related issue(s):
Fixes #4884 and #4882