### PR TITLE
Refactor Paragraph margin rules for consistent, non block-gap values

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -221,9 +221,9 @@ body.admin-bar .wp-site-blocks {
 
 p.wp-block.wp-block-paragraph,
 *[class^="wp-container"] > * + p,
+*[class^="wp-container"] > p + *,
 p {
 	margin-top: 1em;
-	margin-bottom: 1em;
 }
 
 .image-no-margin {

--- a/blockbase/sass/base/_text.scss
+++ b/blockbase/sass/base/_text.scss
@@ -1,7 +1,7 @@
 // Needed until https://github.com/WordPress/gutenberg/issues/35267 is resolved.
 p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
 *[class^="wp-container"] > * + p,
+*[class^="wp-container"] > p + *,
 p {
 	margin-top: 1em;
-	margin-bottom: 1em;
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This change:
* Removes the bottom margin from paragraphs
* Adjusts the top-margin of any element that FOLLOWS a paragraph to be the "paragraph gap" size.

Thus the "paragraph gap" rules are as such:
```
Inside any wp-container,
Any paragraph element that IS NOT THE FIRST thing and
Any element immediately after a paragraph element
use paragraph gap rules
```

This allows us to define the paragraph gap rules differently than the general block-gap rules and those rules will be followed on both sides of the paragraph.

Before:
![image](https://user-images.githubusercontent.com/146530/138897352-ff32403e-4ab7-4ad4-b85b-f9aecfbb45b3.png)

(note that: the gap above the top of the group is 30px while the gap below is 1em)
After:

![image](https://user-images.githubusercontent.com/146530/138897243-729c9626-c1b1-43d5-8698-d94aa7aa0fee.png)
(note that: the gap above and below the group is 1em)

The gap between the bottom button and image remains 30px.

#### Related issue(s):
Closes: #4851