### PR TITLE
Blockbase: Remove .nocomments fix

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -667,10 +667,6 @@ p.has-drop-cap:not(:focus):first-letter {
 	margin-bottom: var(--wp--custom--gap--baseline);
 }
 
-.wp-block-post-comments .nocomments {
-	display: none;
-}
-
 .wp-block-post-template {
 	margin-top: 0;
 	margin-bottom: 0;

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -156,9 +156,4 @@
 		font-size: var(--wp--preset--font-size--small);
 		margin-bottom: var(--wp--custom--gap--baseline);
 	}
-
-	// Needed until we have the option to hide this message via the block.
-	.nocomments {
-		display: none;
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->
### Do no merge until Gutenberg 11.9.0 is on wpcom

#### Changes proposed in this Pull Request:
Now that https://github.com/WordPress/gutenberg/pull/35743 has been merged, I believe we can remove the rule for hiding the `.nocomments` container.

To test, make sure the 'comments are closed' message still doesn't appear if there are no comments and comments are closed. (With the GB PR, this container won't render at all.)