### PR TITLE
Handle posts without titles

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -9,6 +9,7 @@
 	<!-- wp:post-title {"isLink":true} /-->
 	<!-- wp:post-featured-image {"isLink":true} /-->
 	<!-- wp:post-excerpt /-->
+	<!-- wp:template-part {"slug":"post-meta-icons","layout":{"inherit":true}} /-->
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->

--- a/kerr/block-templates/index.html
+++ b/kerr/block-templates/index.html
@@ -7,7 +7,7 @@
 	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:group -->
 		<div class="wp-block-group">
-		<!-- wp:post-date {"isLink":false,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+		<!-- wp:post-date {"isLink":true,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
 		<!-- wp:group {"layout":{"inherit":true}} -->
 		<div class="wp-block-group">

--- a/payton/block-templates/index.html
+++ b/payton/block-templates/index.html
@@ -16,7 +16,7 @@
 	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:group -->
 		<div class="wp-block-group">
-		<!-- wp:post-date {"isLink":false,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+		<!-- wp:post-date {"isLink":true,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
 		<!-- wp:group {"layout":{"inherit":true}} -->
 		<div class="wp-block-group">

--- a/quadrat/block-templates/index.html
+++ b/quadrat/block-templates/index.html
@@ -6,7 +6,7 @@
 	<!-- wp:post-template {"align":"wide"} -->
 		<!-- wp:group -->
 		<div class="wp-block-group">
-		<!-- wp:post-date {"isLink":false,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+		<!-- wp:post-date {"isLink":true,"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 		<!-- wp:post-title {"isLink":true, "level": 3, "textAlign":"center"} /-->
 		<!-- wp:group {"layout":{"inherit":true}} -->
 		<div class="wp-block-group">

--- a/russell/block-templates/index.html
+++ b/russell/block-templates/index.html
@@ -9,6 +9,7 @@
 	<!-- wp:post-title {"isLink":true} /-->
 	<!-- wp:post-featured-image {"isLink":true} /-->
 	<!-- wp:post-excerpt /-->
+	<!-- wp:template-part {"slug":"post-meta-icons","layout":{"inherit":true}} /-->
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This needs design input!

When posts don't have a title they need another way to access them from the index. Conventionally this is done with a link on the post date, so I have modified the following themes to add links on post date where it already exists (Quadrat, Payton and Kerr), and added a post meta to the index for themes that don't contain the date at all (Blockbase and Russell)

<img width="1440" alt="Screenshot 2021-10-27 at 12 31 22" src="https://user-images.githubusercontent.com/275961/139057496-975a1c5b-25af-47bc-8152-85c912995ec2.png">
<img width="1440" alt="Screenshot 2021-10-27 at 12 25 55" src="https://user-images.githubusercontent.com/275961/139057501-849c265c-9224-4dbb-8a82-77271de904b6.png">
<img width="1439" alt="Screenshot 2021-10-27 at 12 24 00" src="https://user-images.githubusercontent.com/275961/139057506-e4fa00fc-3aa8-4691-953c-3e170ff7eb6c.png">
<img width="1440" alt="Screenshot 2021-10-27 at 12 22 00" src="https://user-images.githubusercontent.com/275961/139057510-874af76c-a537-477e-854b-f3bc4e46a202.png">
<img width="1440" alt="Screenshot 2021-10-27 at 12 21 44" src="https://user-images.githubusercontent.com/275961/139057512-ba8701d3-db30-4daf-910d-9d7f5c05a6a5.png">
 