### PR TITLE
Videomaker: Reduce header spacing on header-footer-only template

### DIFF
--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
-<header class="wp-block-group site-header" style="padding-bottom:170px">
+<!-- wp:group {"tagName":"header","layout":{"type":"flex"},"className":"site-header"} -->
+<header class="wp-block-group site-header">
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline /-->

--- a/videomaker/block-templates/header-footer-only.html
+++ b/videomaker/block-templates/header-footer-only.html
@@ -1,4 +1,9 @@
-<!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"50px"}}},"className":"site-header","layout":{"type":"flex"}} -->
+<header class="wp-block-group site-header" style="padding-bottom:50px"><!-- wp:site-logo /-->
+    <!-- wp:site-title /-->
+    <!-- wp:site-tagline /-->
+    <!-- wp:navigation {"itemsJustification":"right","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive"} /--></header>
+<!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">

--- a/videomaker/block-templates/header-footer-only.html
+++ b/videomaker/block-templates/header-footer-only.html
@@ -1,12 +1,7 @@
-<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"50px"}}},"className":"site-header","layout":{"type":"flex"}} -->
-<header class="wp-block-group site-header" style="padding-bottom:50px"><!-- wp:site-logo /-->
-    <!-- wp:site-title /-->
-    <!-- wp:site-tagline /-->
-    <!-- wp:navigation {"itemsJustification":"right","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive"} /--></header>
-<!-- /wp:group -->
+<!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main"} -->
-<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var(--wp--custom--gap--vertical)"}}}} -->
+<main class="wp-block-group" style="margin-top: var(--wp--custom--gap--vertical)">
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>

--- a/videomaker/block-templates/index.html
+++ b/videomaker/block-templates/index.html
@@ -1,5 +1,9 @@
 <!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
 
+<!-- wp:spacer {"height":170} -->
+<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">
 <!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"100px"}}}} /-->

--- a/videomaker/block-templates/page.html
+++ b/videomaker/block-templates/page.html
@@ -1,5 +1,9 @@
 <!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
 
+<!-- wp:spacer {"height":170} -->
+<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:post-title /-->

--- a/videomaker/block-templates/search.html
+++ b/videomaker/block-templates/search.html
@@ -1,5 +1,9 @@
 <!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
 
+<!-- wp:spacer {"height":170} -->
+<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-group">
 

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -1,5 +1,9 @@
 <!-- wp:template-part {"area":"header","slug":"header","tagName":"header"} /-->
 
+<!-- wp:spacer {"height":170} -->
+<div style="height:170px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 <!-- wp:post-title /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR changes the bottom padding on the header from `170px` to `50px` on the header-footer-only template.

I did this by replacing the header template part reference with the contents of the header and then changing the padding. I'm not sure if this is the best way..

Before:
![image](https://user-images.githubusercontent.com/1645628/139057615-19f611c1-ecf2-4146-af67-94ecefcfa9e7.png)

After:
![image](https://user-images.githubusercontent.com/1645628/139057553-85a7ae1c-4b85-4f44-994a-89c9d1d15429.png)

#### Related issue(s):
Fixes #4871