### PR TITLE
Added a dotorg deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+deploy/
 twentynineteen/
 theme-dev-utils/
 theme-dev-utils

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Make sure SVN credentials and project slug are set
+if [[ -z "$SVN_USERNAME" ]]; then
+	echo "Set the SVN_USERNAME secret"
+	exit 1
+fi
+
+if [[ -z "$SVN_PASSWORD" ]]; then
+	echo "Set the SVN_PASSWORD secret"
+	exit 1
+fi
+
+rm -rf ./deploy
+
+# Look into all the subfolders
+for THEME_SLUG in */ ; do
+
+	# And for those that have a package.json file...
+	if test -f "./${THEME_SLUG}/package.json"; then
+
+		THEME_VERSION=$(cat ./${THEME_SLUG}/package.json \
+		  | grep version \
+		  | head -1 \
+		  | awk -F: '{ print $2 }' \
+		  | sed 's/[",]//g' \
+		  | sed 's/-wpcom//g' \
+		  | tr -d '[[:space:]]')
+
+		# TODO: This does take into account the -wpcom appended to some theme versions.
+		# Ideally that can be removed from all of the themes versioning in this repository.
+		# I'm not convinced it's helpful...
+
+		printf "\n\nAttempting to deploy theme ${THEME_SLUG} version ${THEME_VERSION}\n"
+
+		SVN_URL="https://themes.svn.wordpress.org/${THEME_SLUG}/"
+		SVN_DIR="$PWD/deploy/${THEME_SLUG}"
+
+		svn checkout --depth immediates "$SVN_URL" "$SVN_DIR" --no-auth-cache --non-interactive > /dev/null
+
+		if [ ! -d "$SVN_DIR" ]; then
+			echo "No theme by that slug to be checked out. Probably not a theme.  Moving on."
+			continue;
+		fi
+
+		if [ -d "$SVN_DIR/$THEME_VERSION" ]; then
+			rm -rf $SVN_DIR
+			echo "Release already exists.  Moving on."
+			continue;
+		fi
+
+		echo "➤ Copying theme '${THEME_SLUG}' version '${THEME_VERSION}' to svn repository... "
+		rsync -rc --include='./$THEME_SLUG/theme.json' --exclude-from './dotorg-exclude.txt' ./$THEME_SLUG/ $SVN_DIR/$THEME_VERSION
+
+		# Remove -wpcom from versoning
+		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/-wpcom//g' {} \; 
+
+		# Remove the wpcom-specific tags used in some themes
+		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, auto-loading-homepage//g' {} \; 
+		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, jetpack-global-styles//g' {} \; 
+
+		# Add the version to SVN
+		svn add $SVN_DIR --force > /dev/null
+
+		echo "➤ Committing files..."
+		# svn commit -m "Update to version ${THEME_VERSION} from GitHub" --no-auth-cache --non-interactive  --username ${SVN_USERNAME} --password ${SVN_PASSWORD}
+
+	fi
+done

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -71,5 +71,5 @@ for THEME_SLUG in ${THEMES_TO_DEPLOY[@]} ; do
 	svn add $SVN_DIR --force > /dev/null
 
 	echo "➤ Committing files..."
-	# svn commit -m "Update to version ${THEME_VERSION} from GitHub" --no-auth-cache --non-interactive  --username ${SVN_USERNAME} --password ${SVN_PASSWORD}
+	svn commit $SVN_DIR -m "Update to version ${THEME_VERSION} from GitHub" --no-auth-cache --non-interactive  --username ${SVN_USERNAME} --password ${SVN_PASSWORD}
 done

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -13,57 +13,63 @@ fi
 
 rm -rf ./deploy
 
-# Look into all the subfolders
-for THEME_SLUG in */ ; do
+# Look into all the themes we expect to deploy
 
-	# And for those that have a style.css file...
-	if test -f "./${THEME_SLUG}/style.css"; then
+declare -a THEMES_TO_DEPLOY=(
+	"blockbase" 
+	"zoologist"
+	"geologist"
+	"mayland-blocks"
+	"quadrat"
+	"skatepark"
+	"seedlet-blocks"
+)
 
-		THEME_VERSION=$(cat ./${THEME_SLUG}/style.css \
-		  | grep Version \
-		  | head -1 \
-		  | awk -F: '{ print $2 }' \
-		  | sed 's/[",]//g' \
-		  | sed 's/-wpcom//g' \
-		  | tr -d '[[:space:]]')
+for THEME_SLUG in ${THEMES_TO_DEPLOY[@]} ; do
 
-		# TODO: This does take into account the -wpcom appended to some theme versions.
-		# Ideally that can be removed from all of the themes versioning in this repository.
-		# I'm not convinced it's helpful...
+	THEME_VERSION=$(cat ./${THEME_SLUG}/style.css \
+	  | grep Version \
+	  | head -1 \
+	  | awk -F: '{ print $2 }' \
+	  | sed 's/[",]//g' \
+	  | sed 's/-wpcom//g' \
+	  | tr -d '[[:space:]]')
 
-		printf "\n\nAttempting to deploy theme ${THEME_SLUG} version ${THEME_VERSION}\n"
+	# TODO: This does take into account the -wpcom appended to some theme versions.
+	# Ideally that can be removed from all of the themes versioning in this repository.
+	# I'm not convinced it's helpful...
 
-		SVN_URL="https://themes.svn.wordpress.org/${THEME_SLUG}/"
-		SVN_DIR="$PWD/deploy/${THEME_SLUG}"
+	printf "\n\nAttempting to deploy theme ${THEME_SLUG} version ${THEME_VERSION}\n"
 
-		svn checkout --depth immediates "$SVN_URL" "$SVN_DIR" --no-auth-cache --non-interactive > /dev/null
+	SVN_URL="https://themes.svn.wordpress.org/${THEME_SLUG}/"
+	SVN_DIR="$PWD/deploy/${THEME_SLUG}"
 
-		if [ ! -d "$SVN_DIR" ]; then
-			echo "No theme by that slug to be checked out. Probably not a theme.  Moving on."
-			continue;
-		fi
+	svn checkout --depth immediates "$SVN_URL" "$SVN_DIR" --no-auth-cache --non-interactive > /dev/null
 
-		if [ -d "$SVN_DIR/$THEME_VERSION" ]; then
-			rm -rf $SVN_DIR
-			echo "Release already exists.  Moving on."
-			continue;
-		fi
-
-		echo "➤ Copying theme '${THEME_SLUG}' version '${THEME_VERSION}' to svn repository... "
-		rsync -rc --include=theme.json --exclude-from './dotorg-exclude.txt' ./$THEME_SLUG/ $SVN_DIR/$THEME_VERSION
-
-		# Remove -wpcom from versoning
-		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/-wpcom//g' {} \; 
-
-		# Remove the wpcom-specific tags used in some themes
-		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, auto-loading-homepage//g' {} \; 
-		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, jetpack-global-styles//g' {} \; 
-
-		# Add the version to SVN
-		svn add $SVN_DIR --force > /dev/null
-
-		echo "➤ Committing files..."
-		# svn commit -m "Update to version ${THEME_VERSION} from GitHub" --no-auth-cache --non-interactive  --username ${SVN_USERNAME} --password ${SVN_PASSWORD}
-
+	if [ ! -d "$SVN_DIR" ]; then
+		echo "No theme by that slug to be checked out. Probably not a theme.  Moving on."
+		continue;
 	fi
+
+	if [ -d "$SVN_DIR/$THEME_VERSION" ]; then
+		rm -rf $SVN_DIR
+		echo "Release already exists.  Moving on."
+		continue;
+	fi
+
+	echo "➤ Copying theme '${THEME_SLUG}' version '${THEME_VERSION}' to svn repository... "
+	rsync -rc --include=theme.json --exclude-from './dotorg-exclude.txt' ./$THEME_SLUG/ $SVN_DIR/$THEME_VERSION
+
+	# Remove -wpcom from versoning
+	find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/-wpcom//g' {} \; 
+
+	# Remove the wpcom-specific tags used in some themes
+	find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, auto-loading-homepage//g' {} \; 
+	find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/, jetpack-global-styles//g' {} \; 
+
+	# Add the version to SVN
+	svn add $SVN_DIR --force > /dev/null
+
+	echo "➤ Committing files..."
+	# svn commit -m "Update to version ${THEME_VERSION} from GitHub" --no-auth-cache --non-interactive  --username ${SVN_USERNAME} --password ${SVN_PASSWORD}
 done

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -16,11 +16,11 @@ rm -rf ./deploy
 # Look into all the subfolders
 for THEME_SLUG in */ ; do
 
-	# And for those that have a package.json file...
-	if test -f "./${THEME_SLUG}/package.json"; then
+	# And for those that have a style.css file...
+	if test -f "./${THEME_SLUG}/style.css"; then
 
-		THEME_VERSION=$(cat ./${THEME_SLUG}/package.json \
-		  | grep version \
+		THEME_VERSION=$(cat ./${THEME_SLUG}/style.css \
+		  | grep Version \
 		  | head -1 \
 		  | awk -F: '{ print $2 }' \
 		  | sed 's/[",]//g' \

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -50,7 +50,7 @@ for THEME_SLUG in */ ; do
 		fi
 
 		echo "➤ Copying theme '${THEME_SLUG}' version '${THEME_VERSION}' to svn repository... "
-		rsync -rc --include='./$THEME_SLUG/theme.json' --exclude-from './dotorg-exclude.txt' ./$THEME_SLUG/ $SVN_DIR/$THEME_VERSION
+		rsync -rc --include=theme.json --exclude-from './dotorg-exclude.txt' ./$THEME_SLUG/ $SVN_DIR/$THEME_VERSION
 
 		# Remove -wpcom from versoning
 		find $SVN_DIR/$THEME_VERSION/style.css -type f -exec sed -i '' 's/-wpcom//g' {} \; 


### PR DESCRIPTION
This is the first step to automating theme releases to dotorg.

This script can be ran manually, could be integrated into the manual deploy process, or handled by a github action.

For this change we are evaluating running it manually.

To test:
From the root of the project execute the script.  Note that the script needs to have the SVN_USERNAME and SVN_PASSWORD variables set.  Example:
```
%> SVN_USERNAME=test SVN_PASSWORD='test' ./deploy-dotorg.sh
```

Note that legit credentials aren't necessary since the script doesn't actually commit the change (yet).  Once [this line](https://github.com/Automattic/themes/compare/deploy/dotorg?expand=1#diff-8b2f23c53ecb2badc86c5f0f6d2083fa76616033bf4a04f65600ab36ba30527aR66) is uncommented legit credentials will be necessary.

Once the script has completed you will notice that there is a new `/deploy` folder in which you will find a subfolder with the theme slug that will be deployed.  In that folder you will see (empty) subfolders of ALL released versions, the latest of which will have the newly added version.

The script cycles through ALL folders and operates on those that have a package.json file.
If the version in that file doesn't already have a matching version in SVN it creates one, copies the resources for that theme into it (excluding those noted in `dotorg-exclude.txt`) and does a few minor transformations on the resulting files (removing wpcom-specific tags from style.css, etc).

Once we have verified that all of the information in the generated theme folders is correct (and any wpcom>wporg transformations are correct) we can re-run the script with the "commit" line uncommented and all of the themes will be updated in SVN deploying a new version of the theme.

All done!
