### PR TITLE
Blockbase: Update the stacking of site title and tagline in Blockbase and co

### DIFF
--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"80px"}}}} -->
 <div class="wp-block-group site-header" style="padding-bottom:80px">
 	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/kerr/block-template-parts/header.html
+++ b/kerr/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"40px"}}}} -->
 <div class="wp-block-group site-header" style="padding-bottom:40px">
 	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -1,8 +1,13 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"32px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <div class="wp-block-group site-header" style="padding-bottom:32px">
 <!-- wp:site-logo /-->
-<!-- wp:site-title /-->
-<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+<!-- wp:group -->
+<div class="wp-block-group">
+	<!-- wp:site-title /-->
+	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:170px">
 	<!-- wp:site-logo /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/russell/block-template-parts/header.html
+++ b/russell/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"className":"site-header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"40px"}}}} -->
 <div class="wp-block-group site-header" style="padding-bottom:40px">
 	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->

--- a/zoologist/block-template-parts/header.html
+++ b/zoologist/block-template-parts/header.html
@@ -1,8 +1,14 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"120px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <header class="wp-block-group site-header" style="padding-bottom:120px">
 	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the way that site title and site tagline blocks stack in the header. I realised we could do this easily without any CSS. I think this is preferable as it will give a lot more space to the navigation before it stacks.

Blockbase:
<img width="801" alt="Screenshot 2021-10-28 at 08 43 48" src="https://user-images.githubusercontent.com/275961/139213589-12094a04-90da-4f7b-a29e-63998c54eed8.png">

Quadrat:
<img width="797" alt="Screenshot 2021-10-28 at 08 44 43" src="https://user-images.githubusercontent.com/275961/139213598-e8335e1c-2fd0-4d83-a002-d9ee55162671.png">

Geologist:
<img width="799" alt="Screenshot 2021-10-28 at 08 52 35" src="https://user-images.githubusercontent.com/275961/139213614-eb76fd9d-93a9-43f1-856e-2e53e9a9d008.png">

Zoologist:
<img width="800" alt="Screenshot 2021-10-28 at 09 06 30" src="https://user-images.githubusercontent.com/275961/139213844-67a7b0dd-faba-4cc4-8273-cb4478c1ad62.png">


Mayland blocks:
<img width="801" alt="Screenshot 2021-10-28 at 08 53 45" src="https://user-images.githubusercontent.com/275961/139213698-74b18321-f7b3-4061-941e-9ddf60838f8a.png">

Russell:
<img width="800" alt="Screenshot 2021-10-28 at 08 55 11" src="https://user-images.githubusercontent.com/275961/139213736-6bcc2193-c37a-4fca-8663-7ca602129954.png">

Kerr:
<img width="799" alt="Screenshot 2021-10-28 at 08 52 54" src="https://user-images.githubusercontent.com/275961/139213712-bbb073a4-4b48-4102-a4b2-c8da92a0b58c.png">


#### Related issue(s):
https://github.com/Automattic/themes/issues/4881