### PR TITLE
fixed wrong font sizes for the theme

### DIFF
--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -184,7 +184,7 @@
 				}
 			},
 			"fontSizes": {
-				"tiny": "16px"
+				"tiny": "14px"
 			},
 			"gap": {
 				"baseline": "10px"
@@ -372,7 +372,7 @@
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
-					"fontSize": "14px",
+					"fontSize": "var(--wp--custom--font-sizes--tiny)",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
 					"lineHeight": "1.3",

--- a/skatepark/child-theme.json
+++ b/skatepark/child-theme.json
@@ -352,7 +352,7 @@
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
 					"lineHeight": "1.3",
@@ -372,7 +372,7 @@
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
-					"fontSize": "var(--wp--custom--font-sizes--tiny)",
+					"fontSize": "14px",
 					"fontWeight": "900",
 					"letterSpacing": "0.1em",
 					"lineHeight": "1.3",

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -611,7 +611,7 @@
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": "1.3",
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase"
 				},
@@ -643,7 +643,7 @@
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": "1.3",
-					"fontSize": "var(--wp--custom--font-sizes--tiny)",
+					"fontSize": "14px",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase"
 				},

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -188,7 +188,7 @@
 				}
 			],
 			"fontSizes": {
-				"tiny": "16px"
+				"tiny": "14px"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--gap--horizontal) )",
@@ -643,7 +643,7 @@
 					"fontFamily": "var(--wp--preset--font-family--red-hat-display)",
 					"fontWeight": "900",
 					"lineHeight": "1.3",
-					"fontSize": "14px",
+					"fontSize": "var(--wp--custom--font-sizes--tiny)",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase"
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I went through Skatepark's font sizes again and compared them to the designs, some were wrong after we refactored Blockbase's font sizes to fit Gutenberg name conventions. 

I tested with this markup:
```

<!-- wp:heading {"level":1} -->
<h1 id="heading-1">Heading 1</h1>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2 id="heading-1">Heading 2</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3 id="heading-1">Heading 3</h3>
<!-- /wp:heading -->

<!-- wp:heading {"level":4} -->
<h4 id="heading-1">Heading 4</h4>
<!-- /wp:heading -->

<!-- wp:heading {"level":5} -->
<h5 id="heading-1">Heading 5</h5>
<!-- /wp:heading -->

<!-- wp:heading {"level":6} -->
<h6 id="heading-1">Heading 6</h6>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"huge"} -->
<p class="has-huge-font-size">Paragraph Extra large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"large"} -->
<p class="has-large-font-size">Paragraph Large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"medium"} -->
<p class="has-medium-font-size">Paragraph Medium</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"normal"} -->
<p class="has-normal-font-size">Paragraph Normal</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"small"} -->
<p class="has-small-font-size">Paragraph Small</p>
<!-- /wp:paragraph -->
```

<img width="649" alt="Screenshot 2021-10-28 at 12 08 34" src="https://user-images.githubusercontent.com/3593343/139235751-d79c8200-06a5-409f-98bd-bcf53e51d6cc.png">


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4689