### PR TITLE
Videomaker: Use the system font for pagination arrows

### DIFF
--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -179,4 +179,8 @@ div.wp-block-query-pagination .wp-block-query-pagination-next {
 	text-align: right;
 }
 
+div.wp-block-query-pagination .is-arrow-arrow {
+	font-family: var(--wp--preset--font-family--system-font);
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -117,6 +117,11 @@
 					"slug": "inter",
 					"name": "Inter",
 					"google": "family=Inter:wght@100..900"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-font",
+					"name": "System Font"
 				}
 			],
 			"fontSizes": [

--- a/videomaker/sass/blocks/_query-pagination.scss
+++ b/videomaker/sass/blocks/_query-pagination.scss
@@ -12,4 +12,8 @@ div.wp-block-query-pagination {
 	.wp-block-query-pagination-next {
 		text-align: right;
 	}
+
+	.is-arrow-arrow {
+		font-family: var(--wp--preset--font-family--system-font);
+	}
 }

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -335,6 +335,11 @@
 					"slug": "inter",
 					"name": "Inter",
 					"google": "family=Inter:wght@100..900"
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-font",
+					"name": "System Font"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Updates the fonts for the arrows in Query Pagination to be the system font:
<img width="717" alt="Screenshot 2021-10-28 at 13 36 40" src="https://user-images.githubusercontent.com/275961/139256381-d15e63b0-1941-461f-8231-cf5210834972.png">

As per https://github.com/Automattic/themes/pull/4909