### PR TITLE
Geologist: Remove blockTypes from Geologist patterns

### DIFF
--- a/geologist/inc/patterns/authors.php
+++ b/geologist/inc/patterns/authors.php
@@ -8,7 +8,6 @@
 return array(
 	'title'      => __( 'Authors', 'geologist' ),
 	'categories' => array( 'geologist' ),
-	'blockTypes' => array( 'core/post-author' ),
 	'content'    => '<!-- wp:paragraph -->
 	<p>' . esc_html__( 'About the Authors:', 'geologist' ) . '</p>
 	<!-- /wp:paragraph -->

--- a/geologist/inc/patterns/email-updates-large.php
+++ b/geologist/inc/patterns/email-updates-large.php
@@ -8,7 +8,6 @@
 return array(
 	'title'      => __( 'Email Updates (Large)', 'geologist' ),
 	'categories' => array( 'geologist' ),
-	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:heading {"level":3} -->
 	<h3>' . esc_html__( 'Our newsletter rocks! Sign up here to receive every post in your inbox.', 'geologist' ) . '</h3>
 	<!-- /wp:heading -->

--- a/geologist/inc/patterns/email-updates-small.php
+++ b/geologist/inc/patterns/email-updates-small.php
@@ -8,7 +8,6 @@
 return array(
 	'title'      => __( 'Email Updates (small)', 'geologist' ),
 	'categories' => array( 'geologist' ),
-	'blockTypes' => array( 'jetpack/subscriptions' ),
 	'content'    => '<!-- wp:paragraph --><p>' . esc_html__( 'Receive every post in your inbox.', 'geologist' ) . '</p><!-- /wp:paragraph -->
 	<!-- wp:jetpack/subscriptions -->
 	<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" custom_font_size="16px" custom_border_radius="0" custom_border_weight="1" custom_padding="15" custom_spacing="10" submit_button_classes="" email_field_classes="" show_only_email_and_button="true"]</div>

--- a/geologist/inc/patterns/image-feature.php
+++ b/geologist/inc/patterns/image-feature.php
@@ -8,7 +8,6 @@
 return array(
 	'title'      => __( 'Image feature', 'geologist' ),
 	'categories' => array( 'geologist' ),
-	'blockTypes' => array( 'core/image', 'core/columns' ),
 	'content'    => '<!-- wp:image {"align":"wide","sizeSlug":"large"} -->
 	<figure class="wp-block-image alignwide size-large"><img src="' . get_stylesheet_directory_uri() . '/assets/images/gem.jpeg" alt=""/></figure>
 	<!-- /wp:image -->

--- a/geologist/inc/patterns/introduction.php
+++ b/geologist/inc/patterns/introduction.php
@@ -8,7 +8,6 @@
 return array(
 	'title'      => __( 'Introduction', 'geologist' ),
 	'categories' => array( 'geologist' ),
-	'blockTypes' => array( 'core/cover', 'core/header' ),
 	'content'    => '<!-- wp:heading {"level":3} -->
 	<h3>' . esc_html__( "Geologist is a blog dedicated to everything buried under the earth's surface.", 'geologist' ) . '</h3>
 	<!-- /wp:heading -->',


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes `blockTypes` from some of the Geologist themes - this should be used to present variations of block templates, which these aren't.

#### Related issue(s):
