### PR TITLE
set wide with to 'full width but with margins'

### DIFF
--- a/videomaker/child-theme.json
+++ b/videomaker/child-theme.json
@@ -108,7 +108,7 @@
 		},
 		"layout": {
 			"contentSize": "800px",
-			"wideSize": "1300px"
+			"wideSize": "100%"
 		},
 		"typography": {
 			"fontFamilies": [

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -312,7 +312,7 @@
 		},
 		"layout": {
 			"contentSize": "800px",
-			"wideSize": "1300px"
+			"wideSize": "100%"
 		},
 		"spacing": {
 			"blockGap": true,


### PR DESCRIPTION
Fixes: #4938

Changes wide with content to be "full width but with margins".

Before:
![image](https://user-images.githubusercontent.com/146530/139285785-84e835bb-e0bf-4824-a722-e6a437c68964.png)

After:
![image](https://user-images.githubusercontent.com/146530/139285707-2bf27091-83fa-4531-96b9-8015343f3da5.png)
