### PR TITLE
blockbase checkbox for duotone

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -1,3 +1,13 @@
+var enabledDuotone = duotoneVars[ 'duotoneControl' ] === '1' ? true : false;
+
+wp.customize( 'duotone_control', ( value ) => {
+	value.bind( ( newValue ) => {
+		enabledDuotone = newValue;
+		toggleDuotoneFilter( '#wp-duotone-default-filter', enabledDuotone );
+		toggleDuotoneFilter( '#wp-duotone-custom-filter', enabledDuotone );
+	} );
+} );
+
 if ( userColorPalette && userColorSectionKey ) {
 	// For each of the palette items add a listener
 	userColorPalette.forEach( ( paletteItem ) => {
@@ -6,6 +16,7 @@ if ( userColorPalette && userColorSectionKey ) {
 			value.bind( ( newValue ) => {
 				paletteItem.color = newValue;
 				blockBaseUpdateColorsPreview( userColorPalette );
+				console.log( userColorPalette );
 			} );
 		} );
 	} );
@@ -47,27 +58,51 @@ function blockBaseUpdateColorsPreview( palette ) {
 
 function updateDuotoneFilter( filterID, colors ) {
 	if ( document.querySelector( filterID ) ) {
-		if ( duotoneVars[ 'duotoneControl' ] !== 1 ) {
-			//This effectively disables the duotone filter
-			document
-				.querySelector( filterID + ' feColorMatrix' )
-				.setAttribute( 'values', '0' );
+		toggleDuotoneFilter( filterID, enabledDuotone );
+		document
+			.querySelector( filterID + ' feFuncR' )
+			.setAttribute( 'tableValues', colors.r.join( ' ' ) );
+		document
+			.querySelector( filterID + ' feFuncG' )
+			.setAttribute( 'tableValues', colors.g.join( ' ' ) );
+		document
+			.querySelector( filterID + ' feFuncB' )
+			.setAttribute( 'tableValues', colors.b.join( ' ' ) );
+	}
+}
 
-			if ( document.querySelector( filterID + ' feComponentTransfer' ) ) {
-				document
-					.querySelector( filterID + ' feComponentTransfer' )
-					.remove();
-			}
-		} else {
+function toggleDuotoneFilter( filterID, enable ) {
+	console.log( enable );
+	//This effectively disables the duotone filter
+	if ( document.querySelector( filterID ) ) {
+		let colorMatrix = document.querySelector( filterID + ' feColorMatrix' );
+		let matrixValues = '';
+		if ( enable ) {
+			matrixValues = colorMatrix.getAttribute( 'oldValues' );
+			colorMatrix.setAttribute( 'values', matrixValues );
+			colorMatrix.setAttribute( 'oldValues', '' );
 			document
 				.querySelector( filterID + ' feFuncR' )
-				.setAttribute( 'tableValues', colors.r.join( ' ' ) );
+				.setAttribute( 'type', 'table' );
 			document
 				.querySelector( filterID + ' feFuncG' )
-				.setAttribute( 'tableValues', colors.g.join( ' ' ) );
+				.setAttribute( 'type', 'table' );
 			document
 				.querySelector( filterID + ' feFuncB' )
-				.setAttribute( 'tableValues', colors.b.join( ' ' ) );
+				.setAttribute( 'type', 'table' );
+		} else {
+			matrixValues = colorMatrix.getAttribute( 'values' );
+			colorMatrix.setAttribute( 'oldValues', matrixValues );
+			colorMatrix.setAttribute( 'values', '' );
+			document
+				.querySelector( filterID + ' feFuncR' )
+				.setAttribute( 'type', 'identity' );
+			document
+				.querySelector( filterID + ' feFuncG' )
+				.setAttribute( 'type', 'identity' );
+			document
+				.querySelector( filterID + ' feFuncB' )
+				.setAttribute( 'type', 'identity' );
 		}
 	}
 }

--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -25,7 +25,7 @@ function blockBaseUpdateColorsPreview( palette ) {
 	);
 	styleElement.innerHTML = innerHTML;
 
-	if ( window.userColorDuotone ) {
+	if ( duotoneVars[ 'userColorDuotone' ] ) {
 		const colors = palette.map( ( paletteItem ) => paletteItem.color );
 		//we are inverting the order when we have a darker background so that duotone looks good.
 		colors.sort( ( first, second ) => {
@@ -47,6 +47,16 @@ function blockBaseUpdateColorsPreview( palette ) {
 
 function updateDuotoneFilter( filterID, colors ) {
 	if ( document.querySelector( filterID ) ) {
+		if ( duotoneVars[ 'duotoneControl' ] !== 1 ) {
+			//This effectively disables the duotone filter
+			document
+				.querySelector( filterID + ' feColorMatrix' )
+				.setAttribute( 'values', '0' );
+			document
+				.querySelector( filterID + ' feComponentTransfer' )
+				.remove();
+		}
+
 		document
 			.querySelector( filterID + ' feFuncR' )
 			.setAttribute( 'tableValues', colors.r.join( ' ' ) );

--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -16,7 +16,6 @@ if ( userColorPalette && userColorSectionKey ) {
 			value.bind( ( newValue ) => {
 				paletteItem.color = newValue;
 				blockBaseUpdateColorsPreview( userColorPalette );
-				console.log( userColorPalette );
 			} );
 		} );
 	} );
@@ -72,15 +71,19 @@ function updateDuotoneFilter( filterID, colors ) {
 }
 
 function toggleDuotoneFilter( filterID, enable ) {
-	console.log( enable );
 	//This effectively disables the duotone filter
 	if ( document.querySelector( filterID ) ) {
 		let colorMatrix = document.querySelector( filterID + ' feColorMatrix' );
 		let matrixValues = '';
 		if ( enable ) {
 			matrixValues = colorMatrix.getAttribute( 'oldValues' );
-			colorMatrix.setAttribute( 'values', matrixValues );
-			colorMatrix.setAttribute( 'oldValues', '' );
+			if (
+				colorMatrix.hasAttribute( 'oldValues' ) &&
+				matrixValues !== ''
+			) {
+				colorMatrix.setAttribute( 'values', matrixValues );
+				colorMatrix.setAttribute( 'oldValues', '' );
+			}
 			document
 				.querySelector( filterID + ' feFuncR' )
 				.setAttribute( 'type', 'table' );
@@ -92,8 +95,10 @@ function toggleDuotoneFilter( filterID, enable ) {
 				.setAttribute( 'type', 'table' );
 		} else {
 			matrixValues = colorMatrix.getAttribute( 'values' );
-			colorMatrix.setAttribute( 'oldValues', matrixValues );
-			colorMatrix.setAttribute( 'values', '' );
+			if ( colorMatrix.hasAttribute( 'values' ) && matrixValues !== '' ) {
+				colorMatrix.setAttribute( 'oldValues', matrixValues );
+				colorMatrix.setAttribute( 'values', '' );
+			}
 			document
 				.querySelector( filterID + ' feFuncR' )
 				.setAttribute( 'type', 'identity' );

--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -52,20 +52,23 @@ function updateDuotoneFilter( filterID, colors ) {
 			document
 				.querySelector( filterID + ' feColorMatrix' )
 				.setAttribute( 'values', '0' );
-			document
-				.querySelector( filterID + ' feComponentTransfer' )
-				.remove();
-		}
 
-		document
-			.querySelector( filterID + ' feFuncR' )
-			.setAttribute( 'tableValues', colors.r.join( ' ' ) );
-		document
-			.querySelector( filterID + ' feFuncG' )
-			.setAttribute( 'tableValues', colors.g.join( ' ' ) );
-		document
-			.querySelector( filterID + ' feFuncB' )
-			.setAttribute( 'tableValues', colors.b.join( ' ' ) );
+			if ( document.querySelector( filterID + ' feComponentTransfer' ) ) {
+				document
+					.querySelector( filterID + ' feComponentTransfer' )
+					.remove();
+			}
+		} else {
+			document
+				.querySelector( filterID + ' feFuncR' )
+				.setAttribute( 'tableValues', colors.r.join( ' ' ) );
+			document
+				.querySelector( filterID + ' feFuncG' )
+				.setAttribute( 'tableValues', colors.g.join( ' ' ) );
+			document
+				.querySelector( filterID + ' feFuncB' )
+				.setAttribute( 'tableValues', colors.b.join( ' ' ) );
+		}
 	}
 }
 

--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -1,4 +1,8 @@
-var enabledDuotone = duotoneVars[ 'duotoneControl' ] === '1' ? true : false;
+var enabledDuotone = false;
+
+if ( window.duotoneVars ) {
+	enabledDuotone = duotoneVars[ 'duotoneControl' ] === '1' ? true : false;
+}
 
 wp.customize( 'duotone_control', ( value ) => {
 	value.bind( ( newValue ) => {

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -138,7 +138,6 @@ class GlobalStylesColorCustomizer {
 	}
 
 	function register_duotone_controls( $wp_customize ) {
-
 		$wp_customize->add_setting(
 			'duotone_control',
 			array(

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -22,7 +22,14 @@ class GlobalStylesColorCustomizer {
 		wp_localize_script( 'customizer-preview-color', 'userColorPalette', $this->user_color_palette );
 		if ( $this->theme_duotone_settings ) {
 			wp_enqueue_script( 'colord', get_template_directory_uri() . '/inc/customizer/vendors/colord.min.js' );
-			wp_localize_script( 'customizer-preview-color', 'userColorDuotone', $this->theme_duotone_settings );
+			wp_localize_script(
+				'customizer-preview-color',
+				'duotoneVars',
+				array(
+					'userColorDuotone' => $this->theme_duotone_settings,
+					'duotoneControl'   => get_theme_mod( 'duotone_control' ),
+				)
+			);
 		}
 	}
 
@@ -137,6 +144,7 @@ class GlobalStylesColorCustomizer {
 			array(
 				'default'    => true,
 				'capability' => 'edit_theme_options',
+				'transport'  => 'postMessage', // We need this to stop the page refreshing.
 			)
 		);
 

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -213,7 +213,7 @@ class GlobalStylesColorCustomizer {
 		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
 
 		// Only reset the palette if the setting exists, otherwise the whole settings array gets destroyed.
-		if ( property_exists( $user_theme_json_post_content, 'settings' ) && property_exists( $user_theme_json_post_content->settings, 'color' ) && property_exists( $user_theme_json_post_content->settings->color, 'palette' ) ) {
+		if ( property_exists( $user_theme_json_post_content, 'settings' ) && is_object( $user_theme_json_post_content->settings ) && property_exists( $user_theme_json_post_content->settings, 'color' ) && property_exists( $user_theme_json_post_content->settings->color, 'palette' ) ) {
 			// Start with reset palette settings.
 			unset( $user_theme_json_post_content->settings->color->palette );
 		}
@@ -231,10 +231,10 @@ class GlobalStylesColorCustomizer {
 
 			//we set all blocks to use no duotone filter when the checkbox is unchecked
 			if ( ! $this->enable_duotone ) {
-				//$this->update_blocks_duotone_filter( 'none', $user_theme_json_post_content );
+				$this->update_blocks_duotone_filter( 'none', $user_theme_json_post_content );
 			}
 
-			if ( $this->theme_duotone_settings && null !== $primary_key && null !== $background_key && 1 === $this->enable_duotone ) {
+			if ( $this->theme_duotone_settings && -1 < $primary_key && -1 < $background_key && $this->enable_duotone ) {
 
 				$primary    = $this->user_color_palette[ $primary_key ];
 				$background = $this->user_color_palette[ $background_key ];

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -143,7 +143,7 @@ class GlobalStylesColorCustomizer {
 			array(
 				'default'           => true,
 				'capability'        => 'edit_theme_options',
-				'sanitize_callback' => array( __CLASS__, 'sanitize_boolean' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
 				'transport'         => 'postMessage', // We need this to stop the page refreshing.
 			)
 		);
@@ -153,7 +153,7 @@ class GlobalStylesColorCustomizer {
 			array(
 				'type'    => 'checkbox',
 				'section' => $this->section_key,
-				'label'   => __( 'Apply these colors to the theme\'s images', 'blockbase' ),
+				'label'   => __( 'Enable duotone', 'blockbase' ),
 			)
 		);
 
@@ -310,17 +310,6 @@ class GlobalStylesColorCustomizer {
 			}
 		}
 		return true;
-	}
-
-	/*
-	* Sanitize a boolean value
-	*/
-	function sanitize_boolean( $input ) {
-		if ( is_bool( $input ) ) {
-			return $input;
-		} else {
-			return true;
-		}
 	}
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->
### Do not Merge
Can be merged once this issue has been brought in and has landed on wpcom : https://github.com/WordPress/gutenberg/pull/36236

#### Changes proposed in this Pull Request:

This PR adds a checkbox for themes that have duotone support that allows the user to turn it off for any blocks that have it set in theme.json directly from the customizer.

<img width="1255" alt="Screenshot 2021-11-04 at 13 12 33" src="https://user-images.githubusercontent.com/3593343/140311555-cc25a2b3-ff3e-41b4-8110-cdc388018919.png">

There are two known issues with this approach:

- If we uncheck the duotone checkbox and reload the customizer page and check it back again, the preview will not show the filter (but it will work in the frontend). There's no easy way around this because when the filter is off we don't know which selectors to apply it back on.
- On non dev environments (with no debug settings on) the transient cache from Gutenberg removes the SVG filters, Ben has [opened an issue upstream](https://github.com/WordPress/gutenberg/issues/36208) but this effectively breaks the duotone filters in the frontend. That's happening regardless of this PR too, we just uncovered that while testing this.
EDIT: the cache issue is solved by https://github.com/WordPress/gutenberg/pull/36236

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/4434