### PR TITLE
Revert the header change for Quadrat, Geologist and Zoologist

### DIFF
--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -1,14 +1,8 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"90px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo /-->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-		<!-- wp:site-title /-->
-		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	</div>
-	<!-- /wp:group -->
-
+	<!-- wp:site-title /-->
+	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -1,14 +1,8 @@
 <!-- wp:group {"tagName":"header","layout":{"type":"flex"},"style":{"spacing":{"padding":{"bottom":"170px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-bottom:170px">
 	<!-- wp:site-logo /-->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	</div>
-	<!-- /wp:group -->
-
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->

--- a/zoologist/block-template-parts/header.html
+++ b/zoologist/block-template-parts/header.html
@@ -1,14 +1,8 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"bottom":"120px"}}},"className":"site-header","layout":{"type":"flex"}} -->
 <header class="wp-block-group site-header" style="padding-bottom:120px">
 	<!-- wp:site-logo /-->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-		<!-- wp:site-title /-->
-		<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	</div>
-	<!-- /wp:group -->
-
+	<!-- wp:site-title /-->
+	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
 	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This reverts the change for Quadrat, Geologist and Zoologist which moves the tagline onto a new line:


<img width="1440" alt="Screenshot 2021-10-29 at 21 36 48" src="https://user-images.githubusercontent.com/275961/139498846-26d1d66a-5be9-4b5a-9400-683aaaaba46c.png">
