### PR TITLE
Skatepark: Increase menu spacing & style current menu item

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -130,6 +130,13 @@
 	font-size: var(--wp--preset--font-size--small);
 }
 
+.wp-block-navigation .wp-block-navigation-item.current-menu-item > a {
+	-webkit-text-decoration-line: underline;
+	        text-decoration-line: underline;
+	text-decoration-thickness: 0.2em;
+	text-underline-offset: 0.35em;
+}
+
 .wp-block-post-comments .reply a {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"}},"__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}},"__unstableSocialLinks":"social"} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/sass/blocks/_navigation.scss
+++ b/skatepark/sass/blocks/_navigation.scss
@@ -2,4 +2,12 @@
 //preventing mobile menu items (and sub-menu items) from having a different size value
 .wp-block-navigation {
 	font-size: var(--wp--preset--font-size--small);
+
+	.wp-block-navigation-item {
+		&.current-menu-item > a {
+			text-decoration-line: underline;
+			text-decoration-thickness: 0.2em;
+			text-underline-offset: 0.35em;
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR increases the space between the Skatepark menu items to match the mocks, and styles the current menu item:

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/1645628/139958456-deacb54b-311b-4dd0-8531-0871e2e06c3c.png)      | ![image](https://user-images.githubusercontent.com/1645628/139958400-9733eff1-9f4c-472e-9468-c5f7f5ce4974.png)       |

(The current menu item styling is dependent on GB 11.9, but nothing will break if this gets merged on our side sooner.)

#### Related issue(s):
Fixes #4963