### PR TITLE
Videomaker: Fix header navigation alignment

### DIFF
--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -1,8 +1,12 @@
 <!-- wp:group {"align":"wide","tagName":"header","layout":{"type":"flex"},"className":"site-header"} -->
 <header class="wp-block-group alignwide site-header">
-	<!-- wp:site-logo /-->
-	<!-- wp:site-title /-->
-	<!-- wp:site-tagline /-->
+	<!-- wp:group {"layout":{"type":"flex"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-logo /-->
+		<!-- wp:site-title /-->
+		<!-- wp:site-tagline /-->
+	</div>
+	<!-- /wp:group -->
 	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR corrects the alignment of the header navigation:

![image](https://user-images.githubusercontent.com/1645628/139961682-c09d55a2-04aa-43d8-a518-d7059880761c.png)

It looks like the tagline is already 16px font size - it's set to `var(--wp--preset--font-size--small)`, which is 16px. Let me know if this still doesn't look right.

#### Related issue(s):
Fixes #4951