### PR TITLE
Blockbase: Fix warning when we try to set properties on arrays

### DIFF
--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -18,6 +18,10 @@ function set_settings_array( $target, $array, $value ) {
 			$current->{ $key } = (object) array();
 		}
 		$current =& $current->{ $key };
+
+		// Cast to an object in the case where it's been set as an array.
+		$current = (object) $current;
+
 		$key     = array_shift( $array );
 	}
 	$current->{ $key } = $value;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Sometimes the settings in theme.json are arrays not objects. This converts them to objects so that we can set properties on them.

#### Related issue(s):
Fixes #4970