### PR TITLE
Blockbase: show message when the plugin is not active

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		register_nav_menus(
 			array(
 				'primary' => __( 'Primary Navigation', 'blockbase' ),
-				'social' => __( 'Social Navigation', 'blockbase' )
+				'social'  => __( 'Social Navigation', 'blockbase' ),
 			)
 		);
 
@@ -102,16 +102,16 @@ function blockbase_fonts_url() {
 		return '';
 	}
 
-	$font_families = [];
+	$font_families = array();
 	if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
-		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
+		foreach ( $theme_data['typography']['fontFamilies']['user'] as $font ) {
 			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
 		}
 	} else {
 		if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
-			foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
+			foreach ( $theme_data['typography']['fontFamilies']['theme'] as $font ) {
 				if ( ! empty( $font['google'] ) ) {
 					$font_families[] = $font['google'];
 				}
@@ -153,7 +153,7 @@ add_action(
 		wp_enqueue_script(
 			'wp-customize-nav-menu-refresh',
 			get_template_directory_uri() . '/inc/customizer/wp-customize-nav-menu-refresh.js',
-			[ 'customize-nav-menus' ],
+			array( 'customize-nav-menus' ),
 			wp_get_theme()->get( 'Version' ),
 			true
 		);
@@ -164,3 +164,5 @@ add_action(
  * Block Styles.
  */
 require get_template_directory() . '/inc/block-styles.php';
+
+require get_template_directory() . '/inc/require-gutenberg.php';

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">
 					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'textdomain' ); ?></p>
-					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'textdomain' ); ?></button></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'blockbase' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-success">
 					<p><?php esc_html_e( 'Congratulations! All steps required were completed. Enjoy your Full Site Editing experience.', 'blockbase' ); ?></p>

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -149,7 +149,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 
 					// Tweak the button.
 					jQuery( '.notice .require-gutenberg-install .button' )
-						.html( '<?php esc_html_e( 'Installing Gutenberg...', 'textdomain' ); ?>' )
+						.html( '<?php esc_html_e( 'Installing Gutenberg...', 'blockbase' ); ?>' )
 						.addClass( 'updating-message' )
 						.attr( 'aria-label', '<?php esc_attr_e( 'Installing Gutenberg...', 'textdomain' ); ?>' );
 

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 							// Remove previous errors.
 							jQuery( '.require-gutenberg-install .error' ).remove();
 							jQuery( '.require-gutenberg-install' )
-								.append( '<div class="error"><p><?php esc_html_e( 'An error occured:', 'textdomain' ); ?></p><p>' + e.message + '</p><p><?php esc_html_e( 'Please check your browser console for more details', 'textdomain' ); ?></p></div>' );
+								.append( '<div class="error"><p><?php esc_html_e( 'An error occured:', 'blockbase' ); ?></p><p>' + e.message + '</p><p><?php esc_html_e( 'Please check your browser console for more details', 'blockbase' ); ?></p></div>' );
 
 							console.log( e );
 						}

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Require Gutenberg
+ *
+ * @package WPThemes/Require-Gutenberg-FSE
+ * https://github.com/WordPress/theme-experiments/tree/master/require-gutenberg
+ *
+ */
+
+if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
+
+	/**
+	 * Init Gutenberg requirement.
+	 *
+	 * @since 1.0.0
+	 */
+	class WPThemes_Require_Gutenberg {
+
+		/**
+		 * Add hooks for this class.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return void
+		 */
+		public function run() {
+
+			// Make sure we have the plugin-checking functions we need.
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+
+			// Add the notice on wp admin.
+			add_action( 'admin_notices', array( $this, 'admin_notice' ) );
+
+			// Print scripts in the footer.
+			add_action( 'admin_footer', array( $this, 'the_script' ) );
+
+			// Print styles in the footer.
+			add_action( 'admin_footer', array( $this, 'the_styles' ) );
+
+			// Handle activating Gutenberg via AJAX.
+			add_action( 'wp_ajax_wpthemes_require_gutenberg_activate_plugin', array( $this, 'activate_plugin' ) );
+
+			// Add the notice on the frontend.
+			add_action( 'wp_loaded', array( $this, 'frontend_notice' ) );
+
+		}
+
+		/**
+		 * The admin notice.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+		public function admin_notice() {
+
+			// Figure out the current step we're on.
+			$active_step = false;
+			if ( ! $this->is_plugin_installed() ) {
+				$active_step = 'install';
+			} elseif ( ! $this->is_plugin_active() ) {
+				$active_step = 'activate';
+			}
+
+			// Early exit if there's nothing to do.
+			if ( ! $active_step ) {
+				return;
+			}
+			?>
+			<div class="notice notice-warning require-gutenberg-notice-wrapper notice-alt active-step-<?php echo esc_attr( $active_step ); ?>">
+				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'textdomain' ); ?></p>
+				<div class="require-gutenberg require-gutenberg-install">
+					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'textdomain' ); ?></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'textdomain' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
+				</div>
+				<div class="require-gutenberg require-gutenberg-activate">
+					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'textdomain' ); ?></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'textdomain' ); ?></button></p>
+				</div>
+				<div class="require-gutenberg require-gutenberg-success">
+					<p><?php esc_html_e( 'Congratulations! All steps required were completed. Enjoy your Full Site Editing experience.', 'textdomain' ); ?></p>
+				</div>
+			</div>
+			<?php
+		}
+
+		/**
+		 * The frontend notice.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+		public function frontend_notice() {
+			$active_plugin = false;
+			if ( $this->is_plugin_installed() && $this->is_plugin_active() ) {
+				$active_plugin = true;
+			}
+
+			// Early exit if there's nothing to do.
+			if ( $active_plugin ) {
+				return;
+			}
+
+			if ( ! is_admin() ) {
+				wp_die( 'This is an experimental theme and requires the Gutenberg plugin to be installed.' );
+			}
+		}
+
+		/**
+		 * Print styles for our notice.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+		public function the_styles() {
+			?>
+			<style>
+				.notice .require-gutenberg { position: relative; display: none; }
+				.notice.active-step-install .require-gutenberg-install { display: block; }
+				.notice.active-step-activate .require-gutenberg-activate { display: block; }
+				.notice.active-step-success .require-gutenberg-success { display: block; }
+				.notice .require-gutenberg:after { display: none; }
+			</style>
+			<?php
+		}
+
+		/**
+		 * Print script for our notice.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+		public function the_script() {
+			?>
+			<script>
+			wpThemesRequireGutenberg = {
+
+				/**
+				 * Install Gutenberg.
+				 */
+				installPlugin: function() {
+
+					// Tweak the button.
+					jQuery( '.notice .require-gutenberg-install .button' )
+						.html( '<?php esc_html_e( 'Installing Gutenberg...', 'textdomain' ); ?>' )
+						.addClass( 'updating-message' )
+						.attr( 'aria-label', '<?php esc_attr_e( 'Installing Gutenberg...', 'textdomain' ); ?>' );
+
+					// Install the plugin.
+					wp.updates.installPlugin( {
+						slug: 'gutenberg',
+						success: function() {
+
+							// Remove the "install" step.
+							jQuery( '.notice .require-gutenberg-install' ).remove();
+
+							// Switch classes and move on to the next step.
+							jQuery( '.require-gutenberg-notice-wrapper' )
+								.removeClass( 'active-step-install' )
+								.addClass( 'active-step-activate' );
+						},
+						error: function( e ) {
+
+							// Remove previous errors.
+							jQuery( '.require-gutenberg-install .error' ).remove();
+							jQuery( '.require-gutenberg-install' )
+								.append( '<div class="error"><p><?php esc_html_e( 'An error occured:', 'textdomain' ); ?></p><p>' + e.message + '</p><p><?php esc_html_e( 'Please check your browser console for more details', 'textdomain' ); ?></p></div>' );
+
+							console.log( e );
+						}
+					} );
+				},
+
+				/**
+				 * Activate the Gutenberg plugin.
+				 */
+				activatePlugin: function() {
+
+					// AJAX request to activate the plugin.
+					jQuery.get( ajaxurl, {
+						action: 'wpthemes_require_gutenberg_activate_plugin',
+						nonce: '<?php echo esc_html( wp_create_nonce( 'wpthemes_require_gutenberg' ) ); ?>'
+					}, function( response ) {
+						if ( 'success' === response ) {
+
+							// Remove the activate step.
+							jQuery( '.notice .require-gutenberg-activate' ).remove();
+
+							// Continue to next step.
+							jQuery( '.require-gutenberg-notice-wrapper' )
+								.removeClass( 'active-step-activate' )
+								.removeClass( 'notice-warning' )
+								.addClass( 'notice-success' )
+								.addClass( 'active-step-success' );
+						} else {
+
+							// There was an error.
+							jQuery( '.require-gutenberg-activate' )
+								.append( '<div class="error"><p><?php esc_html_e( 'An error occured', 'textdomain' ); ?>:</p><p><?php esc_html_e( 'Could not activate the plugin. Please go to the plugins page on your dashboard and manually activate the plugin.', 'textdomain' ); ?></p></div>' );
+						}
+					} );
+				},
+			}
+			</script>
+			<?php
+		}
+
+		/**
+		 * Check if the plugin is installed.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return bool
+		 */
+		public function is_plugin_installed() {
+			$plugins = get_plugins();
+			return isset( $plugins['gutenberg/gutenberg.php'] );
+		}
+
+		/**
+		 * Check if the plugin is active.
+		 *
+		 * @access public
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return bool
+		 */
+		public function is_plugin_active() {
+			return defined( 'GUTENBERG_VERSION' ) || is_plugin_active( 'gutenberg/gutenberg.php' );
+		}
+
+		/**
+		 * Activates the Gutenberg plugin.
+		 *
+		 * @access public
+		 *
+		 * @return void
+		 */
+		public function activate_plugin() {
+
+			// Early exit if the user doesn't have the capability to activate plugins.
+			if ( ! current_user_can( 'activate_plugins' ) ) {
+				wp_die();
+			}
+
+			// Security check.
+			check_ajax_referer( 'wpthemes_require_gutenberg', 'nonce' );
+
+			// Activate plugin.
+			$result = activate_plugin( 'gutenberg/gutenberg.php' );
+
+			// Plugin was successfully activated. Exit with success message.
+			if ( ! is_wp_error( $result ) ) {
+				wp_die( 'success' );
+			}
+
+			// Something went wrong, exit with error message.
+			wp_die( 'error' );
+		}
+	}
+}
+
+if ( ! function_exists( 'wpthemes_require_gutenberg_fse' ) ) {
+	/**
+	 * Load the Gutenberg requirement.
+	 *
+	 * @return void
+	 */
+	function wpthemes_require_gutenberg_fse() {
+
+		// Instantiate the object.
+		$init = new WPThemes_Require_Gutenberg();
+
+		// Run our actions.
+		$init->run();
+	}
+}
+
+// Run Gutenberg requirement.
+wpthemes_require_gutenberg_fse();

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 					jQuery( '.notice .require-gutenberg-install .button' )
 						.html( '<?php esc_html_e( 'Installing Gutenberg...', 'blockbase' ); ?>' )
 						.addClass( 'updating-message' )
-						.attr( 'aria-label', '<?php esc_attr_e( 'Installing Gutenberg...', 'textdomain' ); ?>' );
+						.attr( 'aria-label', '<?php esc_attr_e( 'Installing Gutenberg...', 'blockbase' ); ?>' );
 
 					// Install the plugin.
 					wp.updates.installPlugin( {

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'textdomain' ); ?></p>
 				<div class="require-gutenberg require-gutenberg-install">
 					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'textdomain' ); ?></p>
-					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'textdomain' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'blockbase' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">
 					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'blockbase' ); ?></p>

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-success">
-					<p><?php esc_html_e( 'Congratulations! All steps required were completed. Enjoy your Full Site Editing experience.', 'textdomain' ); ?></p>
+					<p><?php esc_html_e( 'Congratulations! All steps required were completed. Enjoy your Full Site Editing experience.', 'blockbase' ); ?></p>
 				</div>
 			</div>
 			<?php

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -222,8 +222,9 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 		 * @return bool
 		 */
 		public function is_plugin_installed() {
-			$plugins = get_plugins();
-			return isset( $plugins['gutenberg/gutenberg.php'] );
+			$plugins             = get_plugins();
+			$gutenberg_installed = ( false !== array_search( 'gutenberg', array_column( $plugins, 'TextDomain' ), true ) ) ? true : false;
+			return gutenberg_installed );
 		}
 
 		/**

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -203,7 +203,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 
 							// There was an error.
 							jQuery( '.require-gutenberg-activate' )
-								.append( '<div class="error"><p><?php esc_html_e( 'An error occured', 'textdomain' ); ?>:</p><p><?php esc_html_e( 'Could not activate the plugin. Please go to the plugins page on your dashboard and manually activate the plugin.', 'textdomain' ); ?></p></div>' );
+								.append( '<div class="error"><p><?php esc_html_e( 'An error occured', 'blockbase' ); ?>:</p><p><?php esc_html_e( 'Could not activate the plugin. Please go to the plugins page on your dashboard and manually activate the plugin.', 'blockbase' ); ?></p></div>' );
 						}
 					} );
 				},

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'blockbase' ); ?></p>
 				<div class="require-gutenberg require-gutenberg-install">
 					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'blockbase' ); ?></p>
-					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'blockbase' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'blockbase' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'blockbase' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">
 					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'blockbase' ); ?></p>

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -224,7 +224,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 		public function is_plugin_installed() {
 			$plugins             = get_plugins();
 			$gutenberg_installed = ( false !== array_search( 'gutenberg', array_column( $plugins, 'TextDomain' ), true ) ) ? true : false;
-			return gutenberg_installed );
+			return $gutenberg_installed;
 		}
 
 		/**

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'textdomain' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">
-					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'textdomain' ); ?></p>
+					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'blockbase' ); ?></p>
 					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'blockbase' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-success">

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 			<div class="notice notice-warning require-gutenberg-notice-wrapper notice-alt active-step-<?php echo esc_attr( $active_step ); ?>">
 				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'textdomain' ); ?></p>
 				<div class="require-gutenberg require-gutenberg-install">
-					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'textdomain' ); ?></p>
+					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'blockbase' ); ?></p>
 					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'blockbase' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">

--- a/blockbase/inc/require-gutenberg.php
+++ b/blockbase/inc/require-gutenberg.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 			}
 			?>
 			<div class="notice notice-warning require-gutenberg-notice-wrapper notice-alt active-step-<?php echo esc_attr( $active_step ); ?>">
-				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'textdomain' ); ?></p>
+				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'blockbase' ); ?></p>
 				<div class="require-gutenberg require-gutenberg-install">
 					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'blockbase' ); ?></p>
 					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'blockbase' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR fixes the error messages caused by uninstalling or deactivating GB with Blockbase or a child theme active. I'm including the [require Gutenberg](https://github.com/WordPress/theme-experiments/tree/master/require-gutenberg) script from the theme-experiments repo with a few modifications of my own.

![](https://cloudup.com/ccwN0OtaYXO+)

Now it shows an error message on wp admin that asks you to install or activate the plugin 

<img width="1139" alt="Screenshot 2021-11-04 at 10 44 31" src="https://user-images.githubusercontent.com/3593343/140292510-d574e8be-998a-481c-95f6-76a428b3f268.png">

And on the frontend it throws a generic error message instead of the fatal

<img width="1067" alt="Screenshot 2021-11-04 at 10 44 25" src="https://user-images.githubusercontent.com/3593343/140292582-1a474971-1358-4ed1-8819-a837cc334966.png">

There are other errors that will be silent if the plugin is not installed (theme.json properties or experimental blocks not working for example) so it's not just a matter of fixing the unchecked function on index.php

