### PR TITLE
Add empty blockbase child

### DIFF
--- a/empty-blockbase-child/functions.php
+++ b/empty-blockbase-child/functions.php
@@ -2,7 +2,7 @@
 /**
  * Add Editor Styles
  */
-function typewriter_editor_styles() {
+function empty_blockbase_child_editor_styles() {
 	// Enqueue editor styles.
 	add_editor_style(
 		array(
@@ -10,13 +10,13 @@ function typewriter_editor_styles() {
 		)
 	);
 }
-add_action( 'after_setup_theme', 'typewriter_editor_styles' );
+add_action( 'after_setup_theme', 'empty_blockbase_child_editor_styles' );
 
 /**
  *
  * Enqueue scripts and styles.
  */
-function typewriter_scripts() {
-	wp_enqueue_style( 'typewriter-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blockbase-ponyfill' ), wp_get_theme()->get( 'Version' ) );
+function empty_blockbase_child_scripts() {
+	wp_enqueue_style( 'empty_blockbase_child-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blockbase-ponyfill' ), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'wp_enqueue_scripts', 'typewriter_scripts' );
+add_action( 'wp_enqueue_scripts', 'empty_blockbase_child_scripts' );

--- a/empty-blockbase-child/functions.php
+++ b/empty-blockbase-child/functions.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Add Editor Styles
+ */
+function typewriter_editor_styles() {
+	// Enqueue editor styles.
+	add_editor_style(
+		array(
+			'/assets/theme.css',
+		)
+	);
+}
+add_action( 'after_setup_theme', 'typewriter_editor_styles' );
+
+/**
+ *
+ * Enqueue scripts and styles.
+ */
+function typewriter_scripts() {
+	wp_enqueue_style( 'typewriter-styles', get_stylesheet_directory_uri() . '/assets/theme.css', array( 'blockbase-ponyfill' ), wp_get_theme()->get( 'Version' ) );
+}
+add_action( 'wp_enqueue_scripts', 'typewriter_scripts' );

--- a/empty-blockbase-child/style.css
+++ b/empty-blockbase-child/style.css
@@ -1,0 +1,16 @@
+/*
+Theme Name: Empty Blockbase Child
+Theme URI:
+Author: Automattic
+Author URI: https://automattic.com
+Description: An empty Blockbase child theme
+Requires at least: 5.8
+Tested up to: 5.8
+Requires PHP: 5.7
+Version: 0.0.1
+License: GNU General Public License v2 or later
+License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
+Template: blockbase
+Text Domain: empty-blockbase-child
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+*/

--- a/empty-blockbase-child/theme.json
+++ b/empty-blockbase-child/theme.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json.schemastore.org/theme-v1.json",
+    "version": 1
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This creates a new empty blockbase child theme. This might be useful for people building a simple theme on top of blockbase as it avoids duplicating things that can be inherited from the parent theme. At the moment, even with this theme all the templates are duplicated.... 

To test, switch to this theme, and then try creating a child theme using the create blockbase theme plugin: https://github.com/Automattic/create-blockbase-theme

