### PR TITLE
Fixed null-ref error when previewing colors for any theme but Skatepark

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors-preview.js
+++ b/blockbase/inc/customizer/wp-customize-colors-preview.js
@@ -25,7 +25,7 @@ function blockBaseUpdateColorsPreview( palette ) {
 	);
 	styleElement.innerHTML = innerHTML;
 
-	if ( userColorDuotone ) {
+	if ( window.userColorDuotone ) {
 		const colors = palette.map( ( paletteItem ) => paletteItem.color );
 		//we are inverting the order when we have a darker background so that duotone looks good.
 		colors.sort( ( first, second ) => {


### PR DESCRIPTION
The PR [enabling Duotone customizations](https://github.com/Automattic/themes/pull/4740) via the customizer seems to have introduced a null-ref error.  It's checking for the existence of a global variable so I thought the original code was fine but Chrome was throwing an error and made color customization previews stop working.

To reproduce try to change the colors in Blockbase.  Note the console error.

This change fixes that by referencing `window.` where the variable actually resides.