### PR TITLE
Add block pattern for labeled post links

### DIFF
--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -48,32 +48,7 @@
 <div class="wp-block-group"><!-- wp:post-comments /--></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"3em","bottom":"3em"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-top:3em;padding-bottom:3em">
-
-	<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
-	<hr class="wp-block-separator alignwide is-style-wide"/>
-	<!-- /wp:separator -->
-
-	<!-- wp:columns {"align":"wide","className":"next-prev-links"} -->
-	<div class="wp-block-columns alignwide next-prev-links">
-		<!-- wp:column {"style":{"spacing":{"padding":{"top":"1em","bottom":"1em"}}}} -->
-		<div class="wp-block-column" style="padding-top:1em;padding-bottom:1em">
-			<!-- wp:post-navigation-link {"type":"previous","showTitle":true} /-->
-		</div>
-		<!-- /wp:column -->
-		<!-- wp:column {"style":{"spacing":{"padding":{"top":"1em","bottom":"1em"}}}} -->
-		<div class="wp-block-column" style="padding-top:1em;padding-bottom:1em">
-			<!-- wp:post-navigation-link {"textAlign":"right","showTitle":true} /-->
-		</div>
-		<!-- /wp:column -->
-	</div>
-	<!-- /wp:columns -->
-
-	<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
-	<hr class="wp-block-separator alignwide is-style-wide"/>
-	<!-- /wp:separator -->
-</div>
-<!-- /wp:group -->
+<!-- wp:pattern {"slug":"skatepark/post-navigation-labeled"} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->
+<!-- /wp:group -->

--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -51,4 +51,3 @@
 <!-- wp:pattern {"slug":"skatepark/post-navigation-labeled"} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->
-<!-- /wp:group -->

--- a/skatepark/inc/block-patterns.php
+++ b/skatepark/inc/block-patterns.php
@@ -27,6 +27,7 @@ if ( ! function_exists( 'skatepark_register_block_patterns' ) ) :
 				'two-columns-of-text',
 				'paragraph-with-quote',
 				'columns-in-container',
+				'post-navigation-labeled'
 			);
 
 			foreach ( $block_patterns as $block_pattern ) {

--- a/skatepark/inc/patterns/post-navigation-labeled.php
+++ b/skatepark/inc/patterns/post-navigation-labeled.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Post Navigation Links.
+ *
+ * @package Skatepark
+ */
+
+return array(
+	'title'      => __( 'Post Navigation Links', 'skatepark' ),
+	'categories' => array( 'skatepark' ),
+	'content'    => '
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"3em","bottom":"3em"}}},"layout":{"inherit":true}} -->
+<div class="wp-block-group" style="padding-top:3em;padding-bottom:3em">
+
+	<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
+	<hr class="wp-block-separator alignwide is-style-wide"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:columns {"align":"wide","className":"next-prev-links"} -->
+	<div class="wp-block-columns alignwide next-prev-links">
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"1em","bottom":"1em"}}}} -->
+		<div class="wp-block-column" style="padding-top:1em;padding-bottom:1em">
+			<!-- wp:paragraph {"align":"left","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"800","fontSize":"14px","letterSpacing":"0.1em"},"spacing":{"margins":{"top":"0px", "bottom":"0px"}}}} -->
+			<p class="has-text-align-left" id="next-post" style="font-size:14px;font-style:normal;font-weight:800;text-transform:uppercase;letter-spacing:0.1em;margin-top:0px;margin-bottom:0px;">' . esc_html__( 'previous post', 'skatepark' ) . '</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"style":{"typography":{"fontSize":"14px"}}} /-->
+		</div>
+		<!-- /wp:column -->
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"1em","bottom":"1em"}}}} -->
+		<div class="wp-block-column" style="padding-top:1em;padding-bottom:1em">
+			<!-- wp:paragraph {"align":"right","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"800","fontSize":"14px","letterSpacing":"0.1em"},"spacing":{"margins":{"top":"0px", "bottom":"0px"}}}} -->
+			<p class="has-text-align-right" id="next-post" style="font-size:14px;font-style:normal;font-weight:800;text-transform:uppercase;letter-spacing:0.1em;margin-top:0px;margin-bottom:0px;">' . esc_html__( 'next post', 'skatepark' ) . '</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:post-navigation-link {"textAlign":"right","showTitle":true,"style":{"typography":{"fontSize":"14px"}}} /-->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
+	<hr class="wp-block-separator alignwide is-style-wide"/>
+	<!-- /wp:separator -->
+</div>
+<!-- /wp:group -->
+',
+);


### PR DESCRIPTION
Refactors design of the post links and moves them to a block pattern for localization.

Fixes #4977 

Before:
![image](https://user-images.githubusercontent.com/146530/141196454-8dd25c2e-fdf1-4618-af7a-3c51134ccc81.png)

After:
![image](https://user-images.githubusercontent.com/146530/141196406-897a2101-3d5c-4baa-8776-c165b4982621.png)
