### PR TITLE
Skatepark: Fix multiline tags and categories

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -914,6 +914,7 @@ p.wp-block-site-tagline {
 .is-style-post-category-icon,
 .is-style-post-tag-icon {
 	display: flex;
+	flex-wrap: wrap;
 }
 
 .is-style-post-author-icon:before,

--- a/blockbase/sass/base/_mixins.scss
+++ b/blockbase/sass/base/_mixins.scss
@@ -15,6 +15,7 @@
 
 @mixin post-meta-icon {
 	display: flex;
+	flex-wrap: wrap;
 	&:before {
 		align-self: center;
 		content: '';

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -470,7 +470,12 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 .post-meta .is-style-post-date-icon,
 .post-meta .is-style-post-category-icon,
 .post-meta .is-style-post-tag-icon {
+	flex-wrap: wrap;
 	margin-bottom: 0.5em;
+	overflow-wrap: normal;
+	padding-left: calc( 18px + var(--wp--custom--gap--baseline));
+	position: relative;
+	word-break: normal;
 }
 
 .is-style-post-date-icon:before,
@@ -478,6 +483,9 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 .is-style-post-tag-icon:before {
 	height: 18px;
 	width: 18px;
+	position: absolute;
+	left: 0;
+	top: 0;
 }
 
 .is-style-post-date-icon:before {

--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -470,7 +470,6 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 .post-meta .is-style-post-date-icon,
 .post-meta .is-style-post-category-icon,
 .post-meta .is-style-post-tag-icon {
-	flex-wrap: wrap;
 	margin-bottom: 0.5em;
 	overflow-wrap: normal;
 	padding-left: calc( 18px + var(--wp--custom--gap--baseline));
@@ -485,7 +484,7 @@ a:not(.ab-item):not(.screen-reader-shortcut):focus {
 	width: 18px;
 	position: absolute;
 	left: 0;
-	top: 0;
+	top: 3px;
 }
 
 .is-style-post-date-icon:before {

--- a/skatepark/sass/elements/_post-meta.scss
+++ b/skatepark/sass/elements/_post-meta.scss
@@ -7,9 +7,13 @@
 	.is-style-post-date-icon,
 	.is-style-post-category-icon,
 	.is-style-post-tag-icon {
+		flex-wrap: wrap;
 		margin-bottom: 0.5em;
+		overflow-wrap: normal;
+		padding-left: calc( 18px + var(--wp--custom--gap--baseline));
+		position: relative;
+		word-break: normal;
 	}
-
 }
 
 .is-style-post-date-icon,
@@ -18,6 +22,9 @@
 	&:before {
 		height: 18px;
 		width: 18px;
+		position: absolute;
+		left: 0;
+		top: 0;
 	}
 }
 

--- a/skatepark/sass/elements/_post-meta.scss
+++ b/skatepark/sass/elements/_post-meta.scss
@@ -7,7 +7,6 @@
 	.is-style-post-date-icon,
 	.is-style-post-category-icon,
 	.is-style-post-tag-icon {
-		flex-wrap: wrap;
 		margin-bottom: 0.5em;
 		overflow-wrap: normal;
 		padding-left: calc( 18px + var(--wp--custom--gap--baseline));
@@ -24,7 +23,7 @@
 		width: 18px;
 		position: absolute;
 		left: 0;
-		top: 0;
+		top: 3px;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR ensures that the tags and categories on Skatepark line up horizontally, without any gaps. I'm not sure if I've done this in the best way. I tried to only use `flex` properties but I didn't get very far..

I've also slightly increased the gap between the icon and the text, as I noticed it was slightly bigger on the design.

Before:
![image](https://user-images.githubusercontent.com/1645628/141323903-7c7a6d0a-cd7e-4e4a-81b0-3741a146d361.png)

After:
![image](https://user-images.githubusercontent.com/1645628/141323829-a22f4f40-4cdb-4093-b30c-16b298f1657e.png)

#### Related issue(s):
Closes #4979