### PR TITLE
Videomaker: Align footer credits block

### DIFF
--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -140,6 +140,10 @@ footer > .wp-block-group p {
 	margin-bottom: 0;
 }
 
+footer > .wp-block-group .footer-credit {
+	align-self: flex-end;
+}
+
 .post-tags-container .taxonomy-post_tag.wp-block-post-terms {
 	display: flex;
 	flex-wrap: wrap;

--- a/videomaker/block-template-parts/footer.html
+++ b/videomaker/block-template-parts/footer.html
@@ -5,8 +5,8 @@
 	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer"} --><!-- /wp:navigation -->
 	</div>
 	<!-- /wp:group -->
-	<!-- wp:group -->
-	<div class="wp-block-group">
+	<!-- wp:group {"className":"footer-credit"} -->
+	<div class="wp-block-group footer-credit">
 		<!-- wp:paragraph {"fontSize":"small"} -->
 		<p class="has-small-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
 		<!-- /wp:paragraph -->

--- a/videomaker/sass/templates/_footer.scss
+++ b/videomaker/sass/templates/_footer.scss
@@ -4,4 +4,8 @@ footer > .wp-block-group {
 	p {
 		margin-bottom: 0;
 	}
+
+	.footer-credit {
+		align-self: flex-end;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Small PR to align the footer credits block to the bottom of the footer.

![Screenshot 2021-11-15 at 20 25 42](https://user-images.githubusercontent.com/1645628/141852879-bead63ae-0840-4023-9604-0caee1180d13.png)

I did this with CSS and a custom class in order to only target the footer credits block, I'm not sure if there's another way to do this that involves changing/adding less code..

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/4962