### PR TITLE
Videomaker: Make footer group block align wide

### DIFF
--- a/videomaker/block-template-parts/footer.html
+++ b/videomaker/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","layout":{"type":"flex"},"style":{"spacing":{"padding":{"top":"170px","right":"var(--wp--custom--gap--horizontal","bottom":"var(--wp--custom--gap--horizontal","left":"var(--wp--custom--gap--horizontal"}}}} -->
-<div class="wp-block-group alignfull" style="padding-top: 170px; padding-right: var(--wp--custom--gap--horizontal);padding-bottom: var(--wp--custom--gap--horizontal);padding-left: var(--wp--custom--gap--horizontal);">
+<!-- wp:group {"align":"wide","layout":{"type":"flex"},"style":{"spacing":{"padding":{"top":"170px","bottom":"var(--wp--custom--gap--horizontal"}}}} -->
+<div class="wp-block-group alignwide" style="padding-top: 170px;padding-bottom: var(--wp--custom--gap--horizontal);">
 	<!-- wp:group -->
 	<div class="wp-block-group">
 	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer"} --><!-- /wp:navigation -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR changes the footer group block width to align wide rather than align full. I've also removed the left and right padding as I don't think we need it with align wide.

![image](https://user-images.githubusercontent.com/1645628/141855494-078a59a8-93ae-41ad-8abc-76694c122923.png)

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/4960