### PR TITLE
Update all navigation blocks to new markup

### DIFF
--- a/arbutus/block-template-parts/header.html
+++ b/arbutus/block-template-parts/header.html
@@ -5,5 +5,5 @@
 
 <!-- wp:site-tagline {"fontSize":"small","fontFamily":"open-sans"} /-->
 
-<!-- wp:navigation {"__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /--></div>
 <!-- /wp:group -->

--- a/arbutus/block-template-parts/header.html
+++ b/arbutus/block-template-parts/header.html
@@ -5,5 +5,5 @@
 
 <!-- wp:site-tagline {"fontSize":"small","fontFamily":"open-sans"} /-->
 
-<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive"} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /--></div>
 <!-- /wp:group -->

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -151,6 +151,7 @@ pre {
 
 .wp-site-blocks .site-header .wp-block-navigation {
 	flex-grow: 1;
+	margin-top: 0;
 }
 
 @media (max-width: 599px) {

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header.html
+++ b/blockbase/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -5,6 +5,7 @@
 
 	.wp-block-navigation {
 		flex-grow: 1;
+		margin-top: 0;
 	}
 	// The blockGap is used HORIZONTALLY when the viewport is LARGE (in which case the value defined in theme.json is appropriate)
 	// It needs to be a different value then when the viewport is SMALL and the gap is used VERTICALLY

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/geologist/block-template-parts/header.html
+++ b/geologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/geologist/inc/patterns/header-with-rounded-site-logo.php
+++ b/geologist/inc/patterns/header-with-rounded-site-logo.php
@@ -13,7 +13,7 @@ return array(
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo {"className":"is-style-rounded"} /-->
 	<!-- wp:site-title /-->
-	<!-- wp:navigation {"itemsJustification":"right","__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->',
 );

--- a/geologist/inc/patterns/header-with-rounded-site-logo.php
+++ b/geologist/inc/patterns/header-with-rounded-site-logo.php
@@ -13,7 +13,7 @@ return array(
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo {"className":"is-style-rounded"} /-->
 	<!-- wp:site-title /-->
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary"} /-->
+	<!-- wp:navigation {"itemsJustification":"right","__unstableLocation":"primary"} /-->
 </header>
 <!-- /wp:group -->',
 );

--- a/kerr/block-template-parts/header.html
+++ b/kerr/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/kerr/block-template-parts/header.html
+++ b/kerr/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/footer.html
+++ b/mayland-blocks/block-template-parts/footer.html
@@ -9,7 +9,7 @@
 
 <!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center">
-    <!-- wp:navigation {"textColor":"foreground-light","overlayMenu":"never","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"fontSize":"small"} -->
+    <!-- wp:navigation {"textColor":"foreground-light","overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"fontSize":"small"} -->
         <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
         <!-- wp:navigation-link {"label":"Services","url":"#"} /-->
         <!-- wp:navigation-link {"label":"Portfolio","url":"#"} /-->

--- a/mayland-blocks/block-template-parts/footer.html
+++ b/mayland-blocks/block-template-parts/footer.html
@@ -8,15 +8,14 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"orientation":"horizontal","textColor":"foreground-light","itemsJustification":"right","fontSize":"small"} -->
-<!-- wp:navigation-link {"label":"Home","url":"#"} /-->
-
-<!-- wp:navigation-link {"label":"Services","url":"#"} /-->
-
-<!-- wp:navigation-link {"label":"Portfolio","url":"#"} /-->
-
-<!-- wp:navigation-link {"label":"Contact","url":"#"} /-->
-<!-- /wp:navigation --></div>
+<div class="wp-block-column is-vertically-aligned-center">
+    <!-- wp:navigation {"textColor":"foreground-light","overlayMenu":"never","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"fontSize":"small"} -->
+        <!-- wp:navigation-link {"label":"Home","url":"#"} /-->
+        <!-- wp:navigation-link {"label":"Services","url":"#"} /-->
+        <!-- wp:navigation-link {"label":"Portfolio","url":"#"} /-->
+        <!-- wp:navigation-link {"label":"Contact","url":"#"} /-->
+    <!-- /wp:navigation -->
+</div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -9,6 +9,6 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/mayland-blocks/block-template-parts/header.html
+++ b/mayland-blocks/block-template-parts/header.html
@@ -9,6 +9,6 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/payton/block-template-parts/header.html
+++ b/payton/block-template-parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"10px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-top:10px">
-	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"fontSize":"small","fontFamily":"overpass"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"},"fontSize":"small","fontFamily":"overpass"} /-->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}}} -->
 	<div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh">

--- a/payton/block-template-parts/header.html
+++ b/payton/block-template-parts/header.html
@@ -1,7 +1,6 @@
 <!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"10px"}}},"className":"site-header"} -->
 <header class="wp-block-group site-header" style="padding-top:10px">
-	<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","style":{"typography":{"fontFamily":"var:preset|font-family|overpass"}},"fontSize":"small"} -->
-	<!-- /wp:navigation -->
+	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"fontSize":"small","fontFamily":"overpass"} /-->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"6vh","bottom":"6vh"}}}} -->
 	<div class="wp-block-group" style="padding-top:6vh;padding-bottom:6vh">

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/quadrat/block-template-parts/header.html
+++ b/quadrat/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/russell/block-template-parts/header.html
+++ b/russell/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/russell/block-template-parts/header.html
+++ b/russell/block-template-parts/header.html
@@ -9,6 +9,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </div>
 <!-- /wp:group -->

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} /-->
+<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"}} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/seedlet-blocks/block-template-parts/header.html
+++ b/seedlet-blocks/block-template-parts/header.html
@@ -8,7 +8,7 @@
 
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"small"} /-->
 
-<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"center","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} /-->
 
 <!-- wp:spacer {"height":60} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}}} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/block-template-parts/header.html
+++ b/skatepark/block-template-parts/header.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"className":"nav-links"} -->
 <div class="wp-block-group nav-links">
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","orientation":"horizontal","itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}},"__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"fontStyle":"normal","fontWeight":"900","textTransform":"uppercase"},"spacing":{"blockGap":"40px"}}} /-->
 </div>
 <!-- /wp:group -->
 </div>

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -31,7 +31,7 @@ return array(
 		<h3 style="font-size:14px;"><strong>' . esc_html__( 'More info', 'skatepark' ) . '</strong></h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
+		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->

--- a/skatepark/inc/patterns/pre-footer.php
+++ b/skatepark/inc/patterns/pre-footer.php
@@ -31,7 +31,7 @@ return array(
 		<h3 style="font-size:14px;"><strong>' . esc_html__( 'More info', 'skatepark' ) . '</strong></h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"primary","style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
+		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->

--- a/videomaker/block-template-parts/footer.html
+++ b/videomaker/block-template-parts/footer.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group alignfull" style="padding-top: 170px; padding-right: var(--wp--custom--gap--horizontal);padding-bottom: var(--wp--custom--gap--horizontal);padding-left: var(--wp--custom--gap--horizontal);">
 	<!-- wp:group -->
 	<div class="wp-block-group">
-		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer","style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
+		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"footer","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:group {"className":"footer-credit"} -->

--- a/videomaker/block-template-parts/footer.html
+++ b/videomaker/block-template-parts/footer.html
@@ -1,8 +1,8 @@
-<!-- wp:group {"align":"wide","layout":{"type":"flex"},"style":{"spacing":{"padding":{"top":"170px","bottom":"var(--wp--custom--gap--horizontal"}}}} -->
-<div class="wp-block-group alignwide" style="padding-top: 170px;padding-bottom: var(--wp--custom--gap--horizontal);">
+<!-- wp:group {"align":"full","layout":{"type":"flex"},"style":{"spacing":{"padding":{"top":"170px","right":"var(--wp--custom--gap--horizontal)","bottom":"var(--wp--custom--gap--horizontal)","left":"var(--wp--custom--gap--horizontal)"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top: 170px; padding-right: var(--wp--custom--gap--horizontal);padding-bottom: var(--wp--custom--gap--horizontal);padding-left: var(--wp--custom--gap--horizontal);">
 	<!-- wp:group -->
 	<div class="wp-block-group">
-	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer","style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
+		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer","style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:group {"className":"footer-credit"} -->

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -7,6 +7,6 @@
 		<!-- wp:site-tagline /-->
 	</div>
 	<!-- /wp:group -->
-	<!-- wp:navigation {"className":"is-style-blockbase-navigation-improved-responsive","itemsJustification":"right","overlayMenu":"always","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/videomaker/block-template-parts/header.html
+++ b/videomaker/block-template-parts/header.html
@@ -7,6 +7,6 @@
 		<!-- wp:site-tagline /-->
 	</div>
 	<!-- /wp:group -->
-	<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","className":"is-style-blockbase-navigation-improved-responsive","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/videomaker/inc/patterns/background-video.php
+++ b/videomaker/inc/patterns/background-video.php
@@ -17,7 +17,7 @@ return array(
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
 	<div class="wp-block-column is-vertically-aligned-center">
-	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
 	</div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->

--- a/videomaker/inc/patterns/background-video.php
+++ b/videomaker/inc/patterns/background-video.php
@@ -17,7 +17,7 @@ return array(
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
 	<div class="wp-block-column is-vertically-aligned-center">
-	<!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
 	</div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->

--- a/videomaker/inc/patterns/footer.php
+++ b/videomaker/inc/patterns/footer.php
@@ -11,7 +11,7 @@ return array(
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column -->
 	<div class="wp-block-column">
-	<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"footer","style":{"typography":{"lineHeight":"1"}}} /-->
+	<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"footer","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"lineHeight":"1"}}} /-->
 	</div>
 	<!-- /wp:column -->
 

--- a/videomaker/inc/patterns/footer.php
+++ b/videomaker/inc/patterns/footer.php
@@ -11,7 +11,7 @@ return array(
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 	<div class="wp-block-columns alignwide"><!-- wp:column -->
 	<div class="wp-block-column">
-	<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"footer","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"lineHeight":"1"}}} /-->
+	<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"footer","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"lineHeight":"1"}}} /-->
 	</div>
 	<!-- /wp:column -->
 

--- a/videomaker/inc/patterns/full-width-homepage.php
+++ b/videomaker/inc/patterns/full-width-homepage.php
@@ -15,7 +15,7 @@ return array(
 	<!-- /wp:column -->
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true,"__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 

--- a/videomaker/inc/patterns/full-width-homepage.php
+++ b/videomaker/inc/patterns/full-width-homepage.php
@@ -15,7 +15,7 @@ return array(
 	<!-- /wp:column -->
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 

--- a/videomaker/inc/patterns/header-description-and-grid-of-projects.php
+++ b/videomaker/inc/patterns/header-description-and-grid-of-projects.php
@@ -19,7 +19,7 @@ return array(
 		<h3 style="font-weight:300">' . esc_html__( 'Jonah is Creative Director of Hano, a production studio that specializes in combining storytelling with visual design.', 'videomaker' ) . '</h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"orientation":"vertical","__unstableLocation":"primary","style":{"typography":{"textTransform":"uppercase"}}} /-->
+		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 		</div>
 		<!-- /wp:column -->

--- a/videomaker/inc/patterns/header-description-and-grid-of-projects.php
+++ b/videomaker/inc/patterns/header-description-and-grid-of-projects.php
@@ -19,7 +19,7 @@ return array(
 		<h3 style="font-weight:300">' . esc_html__( 'Jonah is Creative Director of Hano, a production studio that specializes in combining storytelling with visual design.', 'videomaker' ) . '</h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
+		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 		</div>
 		<!-- /wp:column -->

--- a/zoologist/block-template-parts/header.html
+++ b/zoologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->

--- a/zoologist/block-template-parts/header.html
+++ b/zoologist/block-template-parts/header.html
@@ -3,6 +3,6 @@
 	<!-- wp:site-logo /-->
 	<!-- wp:site-title /-->
 	<!-- wp:site-tagline {"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} /-->
-	<!-- wp:navigation {"itemsJustification":"right","overlayMenu":"mobile","__unstableLocation":"primary","__unstableSocialLinks":"social"} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->
### Do no merge until Gutenberg 11.9.1 is on wpcom

#### Changes proposed in this Pull Request:
This PR updates all navigation blocks to the new markup. This fixes a couple of issues ready for GB 11.9:

- Fixes broken vertical navigation blocks
- Fixes right and center alignments
- Removes a `margin-top` setting that's being inherited by the `wp-block-navigation` container*

&ast; This is only an issue if there's a paragraph block next to the navigation. This isn't needed if the site title and logo are inside a group block, as the navigation then sits next to a div. I saw it happening in quite a few themes so I thought I'd add a CSS fix in Blockbase.

To test, check each navigation block in Blockbase & Co still renders with its original settings, especially alignment and orientation.