### PR TITLE
Inverts Post Title Links Hover State for post content.

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -248,13 +248,13 @@ a:hover, a:focus {
 
 .block-editor-block-list__layout a,
 .wp-block-post-content a {
-	text-decoration-line: underline;
+	text-decoration: none;
 }
 
 .block-editor-block-list__layout a:hover, .block-editor-block-list__layout a:focus,
 .wp-block-post-content a:hover,
 .wp-block-post-content a:focus {
-	text-decoration: none;
+	text-decoration-line: underline;
 }
 
 a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {

--- a/blockbase/sass/elements/_links.scss
+++ b/blockbase/sass/elements/_links.scss
@@ -13,11 +13,11 @@ a {
 //Links that appear in the main content area
 .block-editor-block-list__layout a, // Needed for the post area
 .wp-block-post-content a {
-	text-decoration-line: underline;
+	text-decoration: none;
 
 	&:hover,
 	&:focus {
-		text-decoration: none;
+		text-decoration-line: underline;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This inverts the styling for links inside the main content area. This changes the behaviour from having links being underlined by default to match the behaviour across the rest of the site. Links show the underline when hovered over.

I'm a little hesitant with this one as it could change behaviour, so I'd like some additional eyes on this. We need to test all the child themes of Blockbase that are currently live:

- [ ] Quadrat
- [ ] Geologist
- [ ] Zoologist
- [ ] Seedlet Blocks
- [ ] Mayland Blocks

| Before  | After |
| ------------- | ------------- |
| <img width="826" alt="Screenshot 2021-11-17 at 12 39 53" src="https://user-images.githubusercontent.com/937325/142192433-7e8a4940-5ac9-452b-8d24-f44e51bc85ba.png">  | <img width="966" alt="Screenshot 2021-11-17 at 12 41 04" src="https://user-images.githubusercontent.com/937325/142192459-bd107c7e-a6cd-4d76-881b-c36a6abb4325.png">  |

| Before  | After |
| ------------- | ------------- |
| <img width="1292" alt="Screenshot 2021-11-17 at 12 40 19" src="https://user-images.githubusercontent.com/937325/142192479-14007dd4-f599-4d87-af9c-8c1409522dfa.png">  | <img width="1209" alt="Screenshot 2021-11-17 at 12 40 51" src="https://user-images.githubusercontent.com/937325/142192486-29dc8ea9-8704-4d1d-a733-a38da15b4301.png">  |

#### Related issue(s):
Fixes #4986