### PR TITLE
Skatepark: Add space below the Featured Image on the single post page

### DIFF
--- a/skatepark/block-templates/single.html
+++ b/skatepark/block-templates/single.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"align":"full"} -->
 <div class="wp-block-group alignfull">
-<!-- wp:post-featured-image {"align":"full"} /--></div>
+<!-- wp:post-featured-image {"align":"full", "style":{"spacing":{"margin":{"bottom":"calc(2*var(--wp--style--block-gap) + 3*var(--wp--custom--gap--horizontal))"}}}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->


### PR DESCRIPTION
The logic behind the `calc()` code is trying to mimic the way the space gets calculated when a Featured Image isn't set.

Before:
<img width="812" alt="space" src="https://user-images.githubusercontent.com/905781/142454064-221f7b24-2c12-4191-8ecf-4ef320135ee4.png">

After:
<img width="815" alt="star" src="https://user-images.githubusercontent.com/905781/142454048-614d5065-c07e-4b28-888d-c82264a905c8.png">

Closes #4976 



