### PR TITLE
Blockbase: Add appearanceTools setting to theme.json

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -30,12 +30,7 @@
 		}
 	],
 	"settings": {
-		"border": {
-			"customColor": true,
-			"customRadius": true,
-			"customStyle": true,
-			"customWidth": true
-		},
+		"appearanceTools": true,
 		"color": {
 			"palette": [
 				{
@@ -327,8 +322,6 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
-			"blockGap": true,
-			"customPadding": true,
 			"units": [
 				"%",
 				"px",
@@ -339,8 +332,6 @@
 			]
 		},
 		"typography": {
-			"customFontSize": true,
-			"customLineHeight": true,
 			"fontFamilies": [
 				{
 					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Do not merge until GB 12.1 is live on wpcom

#### Changes proposed in this Pull Request:
This PR adds the new `appearanceTools` setting to theme.json, which allows us to remove several other properties in favor of this single property.

These changes are based on this Gutenberg PR: https://github.com/WordPress/gutenberg/pull/36646.

#### Related issue(s):
Closes #5029