### PR TITLE
Adding static keyword to avoid error in PHP 8

### DIFF
--- a/blockbase/inc/customizer/wp-customize-color-palettes.php
+++ b/blockbase/inc/customizer/wp-customize-color-palettes.php
@@ -38,7 +38,7 @@ class GlobalStylesColorPalettes {
 				$custom_palette_setting = array();
 				foreach ( $custom_palette['colors'] as $color_slug => $color ) {
 					//the alternative palettes need to have the same color mapping as the default one
-					if(isset($default_palette_setting[$color_slug])){
+					if ( isset( $default_palette_setting[ $color_slug ] ) ) {
 						$custom_palette_setting[ $color_slug ] = $color;
 					}
 				}
@@ -86,8 +86,8 @@ class GlobalStylesColorPalettes {
 		);
 	}
 
-	function sanitize_color_palette( $palette ) {
-		return sanitize_title($palette);
+	static function sanitize_color_palette( $palette ) {
+		return sanitize_title( $palette );
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Adding `static` keyword to class method to avoid error in PHP 8.

Declaring class properties or methods as static makes them accessible without needing an instantiation of the class.

#### Related issue(s):
https://github.com/Automattic/themes/issues/5001