### PR TITLE
Videomaker: adjusting active states

### DIFF
--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -163,12 +163,12 @@ footer > .wp-block-group .footer-credit {
 
 .wp-block-post-navigation-link {
 	flex-grow: 1;
+	border-top: 1px solid var(--wp--custom--color--primary);
 }
 
 .wp-block-post-navigation-link a {
-	border-top: 1px solid var(--wp--custom--color--primary);
-	display: block;
-	padding-top: 10px;
+	display: inline-block;
+	margin-top: 10px;
 }
 
 .post-navigation-link-next {

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -163,6 +163,9 @@ footer > .wp-block-group .footer-credit {
 
 .wp-block-post-navigation-link {
 	flex-grow: 1;
+}
+
+.wp-block-post-navigation-link:not(:empty) {
 	border-top: 1px solid var(--wp--custom--color--primary);
 }
 

--- a/videomaker/assets/theme.css
+++ b/videomaker/assets/theme.css
@@ -79,7 +79,7 @@
 	background-color: var(--wp--custom--button--color--text);
 }
 
-a:active {
+a:not(.wp-block-query-pagination-next):active {
 	background: var(--wp--custom--color--foreground) !important;
 	color: var(--wp--custom--color--background) !important;
 }

--- a/videomaker/sass/_links.scss
+++ b/videomaker/sass/_links.scss
@@ -1,4 +1,4 @@
-a:active {
+a:not(.wp-block-query-pagination-next):active {
 	background: var(--wp--custom--color--foreground) !important;
 	color: var(--wp--custom--color--background) !important;
 }

--- a/videomaker/sass/blocks/_post-navigation-link.scss
+++ b/videomaker/sass/blocks/_post-navigation-link.scss
@@ -1,6 +1,9 @@
 .wp-block-post-navigation-link {
 	flex-grow: 1;
-	border-top: 1px solid var(--wp--custom--color--primary);
+
+	&:not(:empty){
+		border-top: 1px solid var(--wp--custom--color--primary);
+	}
 
 	a {
 		display: inline-block;

--- a/videomaker/sass/blocks/_post-navigation-link.scss
+++ b/videomaker/sass/blocks/_post-navigation-link.scss
@@ -1,10 +1,10 @@
 .wp-block-post-navigation-link {
 	flex-grow: 1;
+	border-top: 1px solid var(--wp--custom--color--primary);
 
 	a {
-		border-top: 1px solid var(--wp--custom--color--primary);
-		display: block;
-		padding-top: 10px;
+		display: inline-block;
+		margin-top: 10px;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR fixes the active state in a few places for the theme.

The Post navigation blocks before:

<img width="1490" alt="Screenshot 2021-11-24 at 16 43 08" src="https://user-images.githubusercontent.com/3593343/143270993-ee665f34-ad06-4d11-9ab4-228dbff7c0a1.png">

And after:

<img width="1438" alt="Screenshot 2021-11-24 at 16 42 17" src="https://user-images.githubusercontent.com/3593343/143270994-e49fe931-983d-44dd-af65-d543dc5fed6e.png">

The query pagination block was affected too but the markup is different and I couldn't conserve the active state without breaking the look of the block on its normal state so I added an exception for it on the active links rule. It now looks like this (we are inheriting the outline from Blockbase, I didn't want to touch that, is that ok?)


<img width="918" alt="Screenshot 2021-11-24 at 16 47 46" src="https://user-images.githubusercontent.com/3593343/143270990-baf82296-5db5-4888-9604-656c55bdfa27.png">

The tag pills never had any issues for me, couldn't replicate the behavior on Safari or Firefox:

<img width="561" alt="Screenshot 2021-11-24 at 16 49 36" src="https://user-images.githubusercontent.com/3593343/143270986-c33f1d57-0ec5-4909-8385-e11446e4a94f.png">

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/5069