### PR TITLE
Blockbase: remove hardcoded flex justify content CSS rule for header component

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -138,7 +138,6 @@ pre {
 }
 
 .wp-site-blocks .site-header {
-	justify-content: start;
 	overflow: inherit;
 	padding-top: var(--wp--custom--gap--vertical);
 }

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -1,5 +1,4 @@
 .wp-site-blocks .site-header {
-	justify-content: start;
 	overflow: inherit;
 	padding-top: var(--wp--custom--gap--vertical);
 


### PR DESCRIPTION



<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Blockbase: remove hardcoded flex justify content CSS rule for header component

#### Related issue(s):
https://github.com/Automattic/themes/issues/5078