### PR TITLE
Blockbase: Remove layout inheritance from the footer template

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -30,4 +30,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->

--- a/russell/block-template-parts/footer.html
+++ b/russell/block-template-parts/footer.html
@@ -1,7 +1,0 @@
-<!-- wp:group -->
-<div class="wp-block-group">
-	<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} -->
-	<p class="has-text-align-center" style="font-size:var(--wp--custom--font-sizes--tiny);">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-	<!-- /wp:paragraph -->
-</div>
-<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the layout inheritance from the footer template part block. This allows themes to create full width footers without defining new templates.

I also removed the russell footer since it's identical to the Blockbase one.

