### PR TITLE
Blockbase: Update heading font size

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -535,7 +535,7 @@
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "32px"
+					"fontSize": "var(--wp--preset--font-size--huge)"
 				},
 				"spacing": {
 					"margin": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The "huge" size in Blockbase is 32px, so we can use the variable for the heading here.

This change will mean that child themes don't need to redeclare the font size for h2 elements, they will just need to change the font size definition.

