### PR TITLE
Blockbase: add a footer only template

### DIFF
--- a/blockbase/block-templates/footer-only.html
+++ b/blockbase/block-templates/footer-only.html
@@ -1,0 +1,3 @@
+<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true},"className":"site-footer-container"} /--> 

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -27,7 +27,15 @@
 				"page",
 				"post"
 			]
-		}
+		},
+        {
+            "name": "footer-only",
+            "title": "Footer Only",
+            "postTypes": [
+                "page",
+                "post"
+            ]
+        }
 	],
 	"settings": {
 		"border": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a footer only custom template to Blockbase, so that child themes like Paxton 2 don't need to [define it themselves](https://github.com/Automattic/themes/pull/5054).

After talking (p1637901915219800-slack-C029FM1EH) to @alaczek I think it could be a good idea to include this template directly in Blockbase, since multiple themes will make use of it.

An alternative to this is to alter the dotcom footer credits script to include the footer credits automatically on every page that doesn't have it but this has two problems: 

- The markup for the footer may not be correct for every theme, some may decide to change some things like padding, background color, etc and this brings inconsistency with the rest of the pages that do include a footer
- It makes the "blank" template not blank anymore. I'd love @kjellr input on this but as I see it the blank template is there to allow for full customization of a page and being forced to have a footer kind of defeats that purpose.

We could of course not include this in Blockbase and let the child themes define the footer every time. Keen to hear your thoughts!