### PR TITLE
Remove unused search block code

### DIFF
--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -253,10 +253,6 @@ ul ul {
 	text-align: unset;
 }
 
-.wp-block-search .wp-block-search__button {
-	border: none;
-}
-
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;

--- a/geologist/sass/blocks/_search.scss
+++ b/geologist/sass/blocks/_search.scss
@@ -1,3 +1,0 @@
-.wp-block-search .wp-block-search__button {
-	border: none;
-}

--- a/geologist/sass/theme.scss
+++ b/geologist/sass/theme.scss
@@ -10,7 +10,6 @@
 @import "blocks/query";
 @import "blocks/query-pagination";
 @import "blocks/quote";
-@import "blocks/search";
 @import "blocks/table";
 @import "blocks/pullquote";
 @import "colors";

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -427,10 +427,6 @@ ul ul {
 	text-align: unset;
 }
 
-.wp-block-search .wp-block-search__button {
-	border: none;
-}
-
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;

--- a/quadrat/sass/blocks/_search.scss
+++ b/quadrat/sass/blocks/_search.scss
@@ -1,5 +1,0 @@
-.wp-block-search {
-	.wp-block-search__button {
-		border: none;
-	}
-}

--- a/quadrat/sass/theme.scss
+++ b/quadrat/sass/theme.scss
@@ -15,7 +15,6 @@
 @import "blocks/query";
 @import "blocks/query-pagination";
 @import "blocks/quote";
-@import "blocks/search";
 @import "blocks/table";
 @import "blocks/pullquote";
 @import "colors";

--- a/zoologist/assets/theme.css
+++ b/zoologist/assets/theme.css
@@ -254,10 +254,6 @@ ul ul {
 	text-align: unset;
 }
 
-.wp-block-search .wp-block-search__button {
-	border: none;
-}
-
 .wp-block-table.is-style-stripes th,
 .wp-block-table th {
 	font-weight: 400;

--- a/zoologist/sass/blocks/_search.scss
+++ b/zoologist/sass/blocks/_search.scss
@@ -1,3 +1,0 @@
-.wp-block-search .wp-block-search__button {
-	border: none;
-}

--- a/zoologist/sass/theme.scss
+++ b/zoologist/sass/theme.scss
@@ -10,7 +10,6 @@
 @import "blocks/query";
 @import "blocks/query-pagination";
 @import "blocks/quote";
-@import "blocks/search";
 @import "blocks/table";
 @import "blocks/pullquote";
 @import "colors";


### PR DESCRIPTION
This code is no longer needed as we zero the border in blockbase:
<img width="717" alt="Screenshot 2021-11-29 at 14 36 19" src="https://user-images.githubusercontent.com/275961/143887778-4178f269-4a43-43cd-b60c-3f86eadd9cfb.png">


