### PR TITLE
Blockbase: Add padding to footer

### DIFF
--- a/blockbase/block-template-parts/footer.html
+++ b/blockbase/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group -->
-<div class="wp-block-group">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"80px","right":"0px","bottom":"30px","left":"0px"}}}} -->
+<div class="wp-block-group" style="padding-top:80px;padding-right:0px;padding-bottom:30px;padding-left:0px">
 	<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} -->
 	<p class="has-text-align-center" style="font-size:var(--wp--custom--font-sizes--tiny);">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
 	<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds padding to the group block around the footer. I've used fixed values of 80px on the top and 30px on the bottom, which matches the header spacing at large resolutions. I tried to keep it simple by using fixed values, but maybe this is too simple!

#### Related issue(s):
Closes #5084