### PR TITLE
Adding table styles to tables added inside a widget area

### DIFF
--- a/textbook/style.css
+++ b/textbook/style.css
@@ -662,15 +662,18 @@ table td {
   text-align: left;
 }
 
-.entry-content table {
+.entry-content table,
+.widget-area table {
   border-collapse: collapse;
 }
 
-.entry-content table tbody tr:nth-child(odd) {
+.entry-content table tbody tr:nth-child(odd),
+.widget-area table tbody tr:nth-child(odd) {
   background: #FFF;
 }
 
-.entry-content table tbody {
+.entry-content table tbody
+.widget-area table tbody {
   background: #FFF;
   border: 1px solid #ce4639;
   -webkit-border-bottom-left-radius: 0.5em;
@@ -682,16 +685,20 @@ table td {
   overflow: hidden;
 }
 
-.entry-content table tbody tr:nth-child(even) {
+.entry-content table tbody tr:nth-child(even),
+.widget-area table tbody tr:nth-child(even) {
   background: #f0eeec;
 }
 
 .entry-content table th,
-.entry-content table td {
+.entry-content table td,
+.widget-area table th,
+.widget-area table td {
   border: 1px solid #ce4639;
 }
 
-.entry-content table thead tr {
+.entry-content table thead tr,
+.widget-area table thead tr {
   font-size: 12.8px;
   font-size: 0.8rem;
   font-weight: 700;

--- a/textbook/style.css
+++ b/textbook/style.css
@@ -668,7 +668,8 @@ table td {
 }
 
 .entry-content table tbody tr:nth-child(odd),
-.widget-area table tbody tr:nth-child(odd) {
+.widget-area table tbody tr:nth-child(odd),
+.widget-area table {
   background: #FFF;
 }
 

--- a/textbook/style.css
+++ b/textbook/style.css
@@ -710,6 +710,10 @@ table td {
   color: #FFF;
 }
 
+.wp-block-table.is-style-stripes table {
+  background-clip: padding-box;
+}
+
 /*--------------------------------------------------------------
 # Navigation
 --------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Currently the theme's styling for tables are only applied to tables appearing in post/page content, with the `.entry-content` class applied. As a result, a table added to the widget area is unstyled.

This pull request modifies the `style.css` file so the styles available for tables get applied to tables with the `.widget-area` class as well as `.entry-content`

**Before:**

![Textbook before](https://user-images.githubusercontent.com/11873759/144580511-3a6c0ee4-4a7a-4635-9091-2b6bb63c6d39.png)

**After:**

![Textbook after](https://user-images.githubusercontent.com/11873759/144580555-63e5bf03-6318-4b20-a8df-97c4c359bdb8.png)

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5124