### PR TITLE
Blockbase: removing fixed grid styles from the query-pagination

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -737,42 +737,16 @@ p.has-drop-cap:not(:focus):first-letter {
 	color: var(--wp--custom--color--background);
 }
 
-div.wp-block-query-pagination {
+.wp-block-query-pagination {
 	padding-top: 1.5em;
-	justify-content: space-between;
-	display: grid;
-	grid-template-areas: "prev numbers next";
-	grid-template-columns: 1fr 2fr 1fr;
 }
 
-@media (max-width: 599px) {
-	div.wp-block-query-pagination {
-		grid-template-areas: "prev next";
-		grid-template-columns: 1fr 1fr;
-	}
-}
-
-div.wp-block-query-pagination .wp-block-query-pagination-previous {
-	justify-self: start;
-	grid-area: prev;
-}
-
-div.wp-block-query-pagination .wp-block-query-pagination-next {
-	justify-self: flex-end;
-	grid-area: next;
-}
-
-div.wp-block-query-pagination .wp-block-query-pagination-numbers {
-	grid-area: numbers;
-	justify-self: center;
-}
-
-div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
+.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 	text-decoration: underline;
 }
 
 @media (max-width: 599px) {
-	div.wp-block-query-pagination .wp-block-query-pagination-numbers {
+	.wp-block-query-pagination .wp-block-query-pagination-numbers {
 		display: none;
 	}
 }

--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -18,7 +18,7 @@
 <!-- /wp:post-template -->
 <!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
-	<!-- wp:query-pagination -->
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
 		<!-- wp:query-pagination-previous /-->
 
 		<!-- wp:query-pagination-numbers /-->

--- a/blockbase/sass/blocks/_query-pagination.scss
+++ b/blockbase/sass/blocks/_query-pagination.scss
@@ -1,28 +1,7 @@
-div.wp-block-query-pagination { // This CSS needs to be stronger than Gutenberg's until https://github.com/WordPress/gutenberg/issues/34997 is merged.
+.wp-block-query-pagination {
 	padding-top: 1.5em;
-	justify-content: space-between;
-	display: grid;
-	grid-template-areas: "prev numbers next";
-	grid-template-columns: 1fr 2fr 1fr;
-
-	@include break-small-only(){
-		grid-template-areas: "prev next";
-		grid-template-columns: 1fr 1fr;
-	}
-
-	.wp-block-query-pagination-previous {
-		justify-self: start;
-		grid-area: prev;
-	}
-
-	.wp-block-query-pagination-next {
-		justify-self: flex-end;
-		grid-area: next;
-	}
 
 	.wp-block-query-pagination-numbers{
-		grid-area: numbers;
-		justify-self: center;
 		.current {
 			text-decoration: underline;
 		}


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Blockbase: removing fixed grid styles to be able to use all the flex justification options on the query-pagination component now https://github.com/WordPress/gutenberg/pull/36681 is merged.

#### Related issue(s):
https://github.com/Automattic/themes/issues/4800