### PR TITLE
Add default layout to Geologist single posts

### DIFF
--- a/geologist/block-templates/single.html
+++ b/geologist/block-templates/single.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
-	<!-- wp:group -->
+	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-title {"textAlign":"left","level":1,"style":{"spacing":{"margin":{"bottom":"calc(2 * var(--wp--style--block-gap))"}}}} /-->
 		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"calc(2 * var(--wp--style--block-gap))"}}}} /-->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Somehow the post titles are being allowed to stretch full width. Before:
<img width="1440" alt="Screenshot 2021-12-03 at 16 54 12" src="https://user-images.githubusercontent.com/275961/144642201-8ef05b71-1847-4c87-a2bf-dd6a3ea65ec1.png">

After:
<img width="1440" alt="Screenshot 2021-12-03 at 16 53 30" src="https://user-images.githubusercontent.com/275961/144642221-81529446-01ff-45c9-af83-8733c749927d.png">

@kjellr I assume this isn't intentional