### PR TITLE
Blockbase: replace user key with custom

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -121,6 +121,16 @@ function blockbase_fonts_url() {
 				$font_families[] = $font['google'];
 			}
 		}
+
+	// NOTE: This should be removed once Gutenberg 12.1 lands stably in all environments
+	} else if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
+		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
+			if ( ! empty( $font['google'] ) ) {
+				$font_families[] = $font['google'];
+			}
+		}
+	// End Gutenberg < 12.1 compatibility patch
+
 	} else {
 		if ( ! empty( $theme_data['typography']['fontFamilies']['theme'] ) ) {
 			foreach( $theme_data['typography']['fontFamilies']['theme'] as $font ) {

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -115,8 +115,8 @@ function blockbase_fonts_url() {
 	}
 
 	$font_families = [];
-	if ( ! empty( $theme_data['typography']['fontFamilies']['user'] ) ) {
-		foreach( $theme_data['typography']['fontFamilies']['user'] as $font ) {
+	if ( ! empty( $theme_data['typography']['fontFamilies']['custom'] ) ) {
+		foreach( $theme_data['typography']['fontFamilies']['custom'] as $font ) {
 			if ( ! empty( $font['google'] ) ) {
 				$font_families[] = $font['google'];
 			}
@@ -181,4 +181,3 @@ require get_template_directory() . '/inc/block-styles.php';
  * Block Patterns.
  */
 require get_template_directory() . '/inc/block-patterns.php';
-

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -77,6 +77,12 @@ class GlobalStylesColorCustomizer {
 			$user_color_palette = $theme_json['settings']['color']['palette']['custom'];
 		}
 
+		// NOTE: This should be removed once Gutenberg 12.1 lands stably in all environments
+		else if ( isset( $theme_json['settings']['color']['palette']['user'] ) ) {
+			$user_color_palette = $theme_json['settings']['color']['palette']['user'];
+		}
+		// End Gutenberg < 12.1 compatibility patch
+	
 		// Combine theme settings with user settings.
 		foreach ( $combined_color_palette as $key => $palette_item ) {
 			//make theme color value the default

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -73,8 +73,8 @@ class GlobalStylesColorCustomizer {
 
 		$combined_color_palette = $theme_json['settings']['color']['palette']['theme'];
 		$user_color_palette     = null;
-		if ( isset( $theme_json['settings']['color']['palette']['user'] ) ) {
-			$user_color_palette = $theme_json['settings']['color']['palette']['user'];
+		if ( isset( $theme_json['settings']['color']['palette']['custom'] ) ) {
+			$user_color_palette = $theme_json['settings']['color']['palette']['custom'];
 		}
 
 		// Combine theme settings with user settings.

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -330,6 +330,22 @@ class GlobalStylesFontsCustomizer {
 				return $font_family['slug'] === "heading-font";
 			} );
 			$heading_font_selected = array_shift( $heading_font_selected_array );
+
+		// NOTE: This should be removed once Gutenberg 12.1 lands stably in all environments
+		} else if ( array_key_exists( 'user', $merged_json['settings']['typography']['fontFamilies'] ) ) {
+			$merged_font_families = $merged_json['settings']['typography']['fontFamilies']['user'];
+
+			$body_font_selected_array = array_filter( $merged_font_families, function( $font_family ) {
+				return $font_family['slug'] === "body-font";
+			} );
+			$body_font_selected = array_shift( $body_font_selected_array );
+
+			$heading_font_selected_array = array_filter( $merged_font_families, function( $font_family ) {
+				return $font_family['slug'] === "heading-font";
+			} );
+			$heading_font_selected = array_shift( $heading_font_selected_array );
+		// End Gutenberg < 12.1 compatibility patch
+	
 		} else {
 			$body_font_selected = $body_font_default;
 			$heading_font_selected = $heading_font_default;

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -319,8 +319,8 @@ class GlobalStylesFontsCustomizer {
 			return;
 		}
 
-		if ( array_key_exists( 'user', $merged_json['settings']['typography']['fontFamilies'] ) ) {
-			$merged_font_families = $merged_json['settings']['typography']['fontFamilies']['user'];
+		if ( array_key_exists( 'custom', $merged_json['settings']['typography']['fontFamilies'] ) ) {
+			$merged_font_families = $merged_json['settings']['typography']['fontFamilies']['custom'];
 			$body_font_selected_array = array_filter( $merged_font_families, function( $font_family ) {
 				return $font_family['slug'] === "body-font";
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR replaces the `user` origin key with `custom`, from this GB PR: https://github.com/WordPress/gutenberg/pull/36748.

To test, make sure you're using at least GB 12.1, and change the color and fonts of Blockbase in the Customizer. Without this change, these settings will be overwritten/reverted when leaving or refreshing the Customizer. With this change, these settings should save correctly.

I couldn't find any references to the `core` key, which we should change to `default` (from this PR: https://github.com/WordPress/gutenberg/pull/36645), and as the color and font customizations seem to be working with the above, I'm hoping it's only the `user` key we need to change.

#### Related issue(s):
Closes #5077 