### PR TITLE
Update wp-customize-fonts.php

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -491,23 +491,6 @@ class GlobalStylesFontsCustomizer {
 			$font_families
 		);
 
-		//If the typeface choices === the default then we remove it instead
-		if ( $body_value === $body_default && $heading_value === $heading_default ) {
-			unset( $user_theme_json_post_content->settings->typography->fontFamilies );
-
-			// These lines need to stay for backwards compatibility.
-			unset( $user_theme_json_post_content->styles->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h1->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h2->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h3->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h4->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h5->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h6->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography->fontFamily );
-		}
-
 		// Update the theme.json with the new settings.
 		$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );
 		wp_update_post( $user_theme_json_post );


### PR DESCRIPTION
Attempts to fix an issue when adding custom css, and the theme fonts do not load on the frontend.

- Load new site.
- Activate Blockbase or one of its children.
- Navigate to the customizer.
- Add Custom CSS.
- Test that all theme styles from theme.json load on the frontend still, as well as the custom css.
- Change the fonts using the criteria in #4490 and make sure the changes persist on the frontend.

See #4490 and #4510 for testing context.

**Note: we need to figure out how to fix existing sites as this only fixes the problem for fresh sites. The problem is that existing sites already have a database entry for a post type wp_global_styles which is incorrect.**

Co-authored-by: @danieldudzic

#### Related issue(s):
#4490
#4510 