### PR TITLE
Blockbase Fonts: Only unset properties that are set

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -437,6 +437,13 @@ class GlobalStylesFontsCustomizer {
 		}
 	}
 
+	function unset_property_if_it_exists( $property ) {
+		if ( isset( $property ) ) {
+			unset( $property );
+		}
+
+	}
+
 	function handle_customize_save_after( $wp_customize ) {
 		$body_value    = $wp_customize->get_setting( $this->section_key . 'body' )->value();
 		$heading_value = $wp_customize->get_setting( $this->section_key . 'heading' )->value();
@@ -493,19 +500,19 @@ class GlobalStylesFontsCustomizer {
 
 		//If the typeface choices === the default then we remove it instead
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
-			unset( $user_theme_json_post_content->settings->typography->fontFamilies );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->settings->typography->fontFamilies );
 
 			// These lines need to stay for backwards compatibility.
-			unset( $user_theme_json_post_content->styles->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h1->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h2->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h3->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h4->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h5->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->elements->h6->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamily );
-			unset( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h1->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h2->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h3->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h4->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h5->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h6->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography->fontFamily );
 		}
 
 		// Update the theme.json with the new settings.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This is another approach to https://github.com/Automattic/themes/pull/5148.

The problem with this "unset" code is that if there are no properties set in the object, calling unset actually creates properties at that level, for example if we have an object of the form:

```
{ "version":"2" }
```

and we call `unset( $object->styles->typography->fontFamily)` on that object, the object is mutated to look like this:


```
{ "version":"2","styles":{} }
```

This will force the user version of theme.json to be empty and thus break all the styling on the frontend of the site.

The fix proposed here checks whether the properties exist in the object before unsetting them, which avoids the problem.

#### Related issue(s):
Fixes https://github.com/Automattic/wp-calypso/issues/58724