### PR TITLE
Button 2: add jquery to deps array

### DIFF
--- a/button-2/functions.php
+++ b/button-2/functions.php
@@ -191,7 +191,7 @@ function button_2_scripts() {
 
 	wp_enqueue_style( 'button-2-blocks', get_template_directory_uri() . '/blocks.css' );
 
-	wp_enqueue_script( 'button-2-scripts', get_template_directory_uri() . '/assets/js/main.js', array(), '20170303', true );
+	wp_enqueue_script( 'button-2-scripts', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '20211207', true );
 
 	wp_enqueue_script( 'button-2-navigation', get_template_directory_uri() . '/assets/js/navigation.js', array(), '20151215', true );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
There is an error that is appearing in some mobile browsers. The error that is showing is: `Uncaught ReferenceError: jQuery is not defined`, it seems that some mobile browsers are not loading this which is causing issues. As a solution, I have added `jquery` to the dependency array for the `main.js` file that is throwing the error.

#### Related issue(s):
Fixes #3201 

#### Screenshot:
**before**
<img width="811" alt="Markup 2021-12-07 at 11 51 16" src="https://user-images.githubusercontent.com/33258733/145082214-fea2e362-aa02-4a77-87f5-e235663983e3.png">

**after**
<img width="812" alt="Markup 2021-12-07 at 11 57 27" src="https://user-images.githubusercontent.com/33258733/145081748-3d1f098a-0448-49f5-836f-df65c799056c.png">

