### PR TITLE
Fixed the header spacer element in header-center template

### DIFF
--- a/blockbase/block-template-parts/header-centered.html
+++ b/blockbase/block-template-parts/header-centered.html
@@ -16,7 +16,7 @@
 <!-- /wp:spacer -->
 <!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"}} /-->
 
-<!-- wp:template-part {"slug":"header-spacer","theme":"themes/seedlet-blocks"} /-->
+<!-- wp:template-part {"slug":"header-spacer"} /-->
 
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The spacer template part block shouldn't specify a theme.  Doing so breaks things.  I think this was caused by a copy/paste from the Block Editor.

