### PR TITLE
Defaulting videomaker header fonts to Inter

### DIFF
--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -120,10 +120,11 @@
 					"google": "family=Inter:wght@100..900"
 				},
 				{
-					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-					"fontSlug": "system-font",
+					"fontFamily": "\"Inter\", serif",
+					"fontSlug": "inter",
 					"slug": "heading-font",
-					"name": "Headings (System Font)"
+					"name": "Headings (Inter)",
+					"google": "family=Inter:wght@100..900"
 				}
 			],
 			"fontSizes": [


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Does what it says on the tin.

Before:
![image](https://user-images.githubusercontent.com/146530/145624345-2f4bf4b5-ed4f-465e-b34d-db0af3c4c5ca.png)

After:
![image](https://user-images.githubusercontent.com/146530/145624292-51ded5fa-3ff4-49f7-9b69-1f131aad2ca6.png)
