### PR TITLE
Blockbase: Force DOMXPath to use utf-8 encoding

### DIFF
--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -62,7 +62,7 @@ function append_social_links_block( $parent_content, $social_links_block ) {
 	$domXPath = new DomXPath( $dom );
 	// Since the nav block uses HTML5 element names, we need to suppress the warnings it sends when we loadHTML with HTML5 elements.
 	libxml_use_internal_errors( true );
-	$dom->loadHTML( $parent_content );
+	$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $parent_content );
 	$wp_block_navigation__container = $dom->getElementsByTagName('ul')->item( 0 )->parentNode;
 	$social_links_node = $dom->createDocumentFragment();
 	$social_links_node->appendXML( $social_links_block );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
The social navigation code was processing the HTML of the nav block as ISO-8859-1 instead of UTF-8. This force it to use UTF-8, which means that emojis appear as expected:

<img width="538" alt="Screenshot 2021-12-14 at 13 47 10" src="https://user-images.githubusercontent.com/275961/146010502-8a0c0418-6749-4ac2-86c8-f885b0329daf.png">


#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5162