### PR TITLE
Added site logo size restriction CSS

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #4d6974;
 }

--- a/alves/style.css
+++ b/alves/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #4d6974;
 }

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #505050;
 }

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #505050;
 }

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #844d4d;
 }

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #844d4d;
 }

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2771,6 +2771,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #FFFFFF;
 }

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2790,6 +2790,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #FFFFFF;
 }

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2767,6 +2767,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #767676;
 }

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2786,6 +2786,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #767676;
 }

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2769,6 +2769,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #000000;
 }

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2788,6 +2788,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #000000;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #6E6E6E;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #6E6E6E;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2797,6 +2797,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/hever/style.css
+++ b/hever/style.css
@@ -2816,6 +2816,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #767676;
 }

--- a/leven/style.css
+++ b/leven/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #767676;
 }

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2769,6 +2769,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #666666;
 }

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2788,6 +2788,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #666666;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #686868;
 }

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #686868;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2797,6 +2797,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--background);
 }

--- a/morden/style.css
+++ b/morden/style.css
@@ -2816,6 +2816,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--background);
 }

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2771,6 +2771,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #666666;
 }

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2790,6 +2790,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #666666;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2770,6 +2770,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #f2f2f2;
 }

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2789,6 +2789,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #f2f2f2;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2793,6 +2793,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--background);
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2812,6 +2812,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--background);
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2798,6 +2798,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2817,6 +2817,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -2797,6 +2797,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/stow/style.css
+++ b/stow/style.css
@@ -2816,6 +2816,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2796,6 +2796,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2815,6 +2815,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: var(--wp--preset--color--foreground-low-contrast);
 }

--- a/varia/sass/components/header/_site-branding.scss
+++ b/varia/sass/components/header/_site-branding.scss
@@ -1,7 +1,11 @@
 // Site logo
 
 .site-logo {
-
+	a {
+		display: inline-block;
+		width: 64px;
+		height: auto;
+	}
 }
 
 // Site branding

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2803,6 +2803,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #444444;
 }

--- a/varia/style.css
+++ b/varia/style.css
@@ -2822,6 +2822,12 @@ table.is-style-stripes tbody tr:nth-child(odd),
  * Components
  * - Similar to Blocks but exist outside of the "current" editor context
  */
+.site-logo a {
+	display: inline-block;
+	width: 64px;
+	height: auto;
+}
+
 .site-branding {
 	color: #444444;
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Adds CSS to the site logo in the header to restrict the width to 64px (allowing the height to scale to retain dimensions).

Confirmed that site header blocks used in the content are sized according to the user adjustments.

Rebuilt all Varia themes to include that change.

#### Related issue(s):

Fixes #2066 

Before:
<img src="https://user-images.githubusercontent.com/146530/146032562-af27830d-7385-4904-9dfd-3c32a0a1c53e.png" width=400>

<img src="https://user-images.githubusercontent.com/146530/146032801-da820545-28d6-48e0-bed2-ef146411fb79.png" width=400>

After:

<img src="https://user-images.githubusercontent.com/146530/146032460-73e3f3cf-1726-4fa0-8af4-f4ae01f83bf5.png" width=400>

<img src="https://user-images.githubusercontent.com/146530/146032878-3f9691c3-0d83-4158-abe0-4de05e90f9c9.png" width=400>
