### PR TITLE
Transition Videomaker from /pub to /premium

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"deploy:version-bump": "node ./theme-utils.mjs version-bump-themes",
 		"deploy:push:all": "node ./theme-utils.mjs push-to-sandbox",
 		"deploy:push:changes": "node ./theme-utils.mjs push-changes-to-sandbox",
+		"deploy:push:premium": "node ./theme-utils.mjs push-premium-to-sandbox",
 		"deploy:git": "node ./theme-utils.mjs push-button-deploy-git",
 		"deploy:svn": "node ./theme-utils.mjs push-button-deploy-svn",
 		"deploy:preview": "node ./theme-utils.mjs deploy-preview",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -21,6 +21,7 @@ const directoriesToIgnore = [ 'variations', 'videomaker', 'videomaker-white' ];
 		case "clean-all-sandbox-svn": return cleanAllSandboxSvn();
 		case "push-to-sandbox": return pushToSandbox();
 		case "push-changes-to-sandbox": return pushChangesToSandbox();
+		case "push-premium-to-sandbox": return pushPremiumToSandbox();
 		case "version-bump-themes": return versionBumpThemes();
 		case "land-diff-git": return landChangesGit(args?.[1]);
 		case "land-diff-svn": return landChangesSvn(args?.[1]);
@@ -521,6 +522,26 @@ function pushToSandbox() {
 	executeCommand(`
 		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' ./ wpcom-sandbox:${sandboxPublicThemesFolder}/
 	`);
+}
+
+/*
+  Push exactly what is here (all files) up to the sandbox (with the exclusion of files noted in .sandbox-ignore)
+  This pushes only the folders noted as "premiumThemes" into the premium themes directory.
+
+  This is the only part of the deploy process that is automated; the rest must be done manually including:
+   * Creating a Phabricator Diff
+   * Landing (comitting) the change
+   * Deploying the theme
+   * Triggering the .zip builds
+*/
+function pushPremiumToSandbox() {
+	const premiumThemes = [
+		'videomaker',
+		'videomaker-white'
+	]
+	executeCommand(`
+		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxRootFolder}/wp-content/themes/premium/
+	`, true);
 }
 
 /*


### PR DESCRIPTION
This change adds a command to push "premium themes" to the sandbox.

`npm run deploy:push:premium`

This will rsync the entire contents of the themes defined in the script to the premium location of the sandbox.  No other deployment actions are provided by the script.

This change begins the deployment of Videomaker to premium themes and should be accompanied by:

This change which removes Videomaker from /pub
D71549-code

This change which adds Videomaker and Videomaker-white to /premium
D71550-code