### PR TITLE
Fixed deploy version bump commit problems

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -129,7 +129,7 @@ async function pushButtonDeploy(repoType) {
 			}
 
 			await executeCommand(`
-				git commit -a -m "Version Bump";
+				git commit -m "Version Bump";
 				git push
 			`, true);
 		}


### PR DESCRIPTION
This change fixes a couple of problems with auto-commit-and-pushing of Version Bump changes.

The deploy action no longer breaks if there aren't any version bump changes to push.

The deploy action prompts you before pushing the changes up to github.

Only the changed files are changed in the commit, other files (like scripts, especially this one...) are excluded from that change.