### PR TITLE
Exclude /sass from any premium themes pushed to premium repo

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -574,7 +574,7 @@ function pushPremiumToSandbox() {
 		'videomaker-white'
 	]
 	executeCommand(`
-		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxRootFolder}/wp-content/themes/premium/
+		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude='sass/' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxRootFolder}/wp-content/themes/premium/
 	`, true);
 }
 


### PR DESCRIPTION
This change excludes any SASS files pushed to the /premium repo.

This is because the projects may contain relative imports to projects outside of that premium theme (in the case of videomaker referencing blockbase .sass resources).
