### PR TITLE
Fixed submenu style of focused submenu to match hover styling

### DIFF
--- a/alves/sass/_extra-child-theme.scss
+++ b/alves/sass/_extra-child-theme.scss
@@ -266,11 +266,8 @@ body:not(.fse-enabled) {
 			}
 
 			& > div > ul > li:hover,
-			& > div > ul > li.focus,
+			& > div > ul > li:focus-within,
 			& > div > ul > li.current-menu-item {
-
-				& > a {
-				}
 
 				& > ul {
 					box-shadow: none;
@@ -284,17 +281,6 @@ body:not(.fse-enabled) {
 						display: block;
 						margin-left: #{map-deep-get($config-global, "spacing", "unit")};
 						width: #{map-deep-get($config-global, "spacing", "unit")};
-					}
-				}
-
-				& li {
-
-					& > a {
-					}
-
-					&:hover > a,
-					&.focus > a,
-					&.current-menu-item > a {
 					}
 				}
 			}

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -4292,13 +4292,30 @@ body:not(.fse-enabled) #masthead {
 		font-size: 0.625rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #3E7D98;
+		border-right: 8px solid transparent;
+		border-left: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-right: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #3E7D98;
 		border-right: 8px solid transparent;

--- a/alves/style.css
+++ b/alves/style.css
@@ -4321,13 +4321,30 @@ body:not(.fse-enabled) #masthead {
 		font-size: 0.625rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #3E7D98;
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-left: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #3E7D98;
 		border-left: 8px solid transparent;

--- a/balasana/sass/_extra-child-theme.scss
+++ b/balasana/sass/_extra-child-theme.scss
@@ -176,7 +176,7 @@ dt {
 		}
 
 		& > div > ul > li:hover,
-		& > div > ul > li.focus,
+		& > div > ul > li:focus-within,
 		& > div > ul > li.current-menu-item {
 
 			& > ul {

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -4247,7 +4247,15 @@ dt {
 		vertical-align: middle;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		border: 1px solid #D0D0D0;
+		border-radius: 4px;
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		border: 1px solid #D0D0D0;
 		border-radius: 4px;

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -4276,7 +4276,15 @@ dt {
 		vertical-align: middle;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		border: 1px solid #D0D0D0;
+		border-radius: 4px;
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		border: 1px solid #D0D0D0;
 		border-radius: 4px;

--- a/barnsbury/sass/_extra-child-theme.scss
+++ b/barnsbury/sass/_extra-child-theme.scss
@@ -124,7 +124,7 @@ a {
 		}
 
 		& > div > ul > li:hover,
-		& > div > ul > li.focus,
+		& > div > ul > li:focus-within,
 		& > div > ul > li.current-menu-item {
 
 			& > a {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -4179,18 +4179,40 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		font-size: 0.5rem;
 	}
 	.main-navigation > div > ul > li:hover > a,
-	.main-navigation > div > ul > li.focus > a,
+	.main-navigation > div > ul > li[focus-within] > a,
+	.main-navigation > div > ul > li.current-menu-item > a {
+		color: #20603C;
+	}
+	.main-navigation > div > ul > li:hover > a,
+	.main-navigation > div > ul > li:focus-within > a,
 	.main-navigation > div > ul > li.current-menu-item > a {
 		color: #20603C;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover > ul:before,
-	.main-navigation > div > ul > li.focus > ul:before,
+	.main-navigation > div > ul > li[focus-within] > ul:before,
+	.main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #20603C;
+		border-right: 8px solid transparent;
+		border-left: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-right: 16px;
+		width: 16px;
+	}
+	.main-navigation > div > ul > li:hover > ul:before,
+	.main-navigation > div > ul > li:focus-within > ul:before,
 	.main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #20603C;
 		border-right: 8px solid transparent;
@@ -4201,7 +4223,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		width: 16px;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #20603C;
+		color: #FFFDF6;
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #20603C;
 		color: #FFFDF6;
@@ -4209,9 +4237,20 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	.main-navigation > div > ul > li:hover li:hover > a,
 	.main-navigation > div > ul > li:hover li.focus > a,
 	.main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.main-navigation > div > ul > li.focus li:hover > a,
-	.main-navigation > div > ul > li.focus li.focus > a,
-	.main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.main-navigation > div > ul > li[focus-within] li:hover > a,
+	.main-navigation > div > ul > li[focus-within] li.focus > a,
+	.main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #133a24;
+	}
+	.main-navigation > div > ul > li:hover li:hover > a,
+	.main-navigation > div > ul > li:hover li.focus > a,
+	.main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.main-navigation > div > ul > li:focus-within li:hover > a,
+	.main-navigation > div > ul > li:focus-within li.focus > a,
+	.main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -4208,18 +4208,40 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		font-size: 0.5rem;
 	}
 	.main-navigation > div > ul > li:hover > a,
-	.main-navigation > div > ul > li.focus > a,
+	.main-navigation > div > ul > li[focus-within] > a,
+	.main-navigation > div > ul > li.current-menu-item > a {
+		color: #20603C;
+	}
+	.main-navigation > div > ul > li:hover > a,
+	.main-navigation > div > ul > li:focus-within > a,
 	.main-navigation > div > ul > li.current-menu-item > a {
 		color: #20603C;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover > ul:before,
-	.main-navigation > div > ul > li.focus > ul:before,
+	.main-navigation > div > ul > li[focus-within] > ul:before,
+	.main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #20603C;
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-left: 16px;
+		width: 16px;
+	}
+	.main-navigation > div > ul > li:hover > ul:before,
+	.main-navigation > div > ul > li:focus-within > ul:before,
 	.main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #20603C;
 		border-left: 8px solid transparent;
@@ -4230,7 +4252,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		width: 16px;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #20603C;
+		color: #FFFDF6;
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #20603C;
 		color: #FFFDF6;
@@ -4238,9 +4266,20 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	.main-navigation > div > ul > li:hover li:hover > a,
 	.main-navigation > div > ul > li:hover li.focus > a,
 	.main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.main-navigation > div > ul > li.focus li:hover > a,
-	.main-navigation > div > ul > li.focus li.focus > a,
-	.main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.main-navigation > div > ul > li[focus-within] li:hover > a,
+	.main-navigation > div > ul > li[focus-within] li.focus > a,
+	.main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #133a24;
+	}
+	.main-navigation > div > ul > li:hover li:hover > a,
+	.main-navigation > div > ul > li:hover li.focus > a,
+	.main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.main-navigation > div > ul > li:focus-within li:hover > a,
+	.main-navigation > div > ul > li:focus-within li.focus > a,
+	.main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/brompton/sass/_extra-child-theme.scss
+++ b/brompton/sass/_extra-child-theme.scss
@@ -171,7 +171,7 @@
 		}
 
 		& > div > ul > li:hover,
-		& > div > ul > li.focus,
+		& > div > ul > li:focus-within,
 		& > div > ul > li.current-menu-item {
 
 			& > ul {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -4235,13 +4235,25 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		background: #252E36;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #252E36;
+		border-top: 1px solid rgba(255, 255, 255, 0.5);
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #252E36;
 		border-top: 1px solid rgba(255, 255, 255, 0.5);

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -4264,13 +4264,25 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 		background: #252E36;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #252E36;
+		border-top: 1px solid rgba(255, 255, 255, 0.5);
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #252E36;
 		border-top: 1px solid rgba(255, 255, 255, 0.5);

--- a/dalston/sass/_extra-child-theme.scss
+++ b/dalston/sass/_extra-child-theme.scss
@@ -112,7 +112,7 @@ a {
 			}
 
 			& > div > ul > li:hover,
-			& > div > ul > li.focus,
+			& > div > ul > li:focus-within,
 			& > div > ul > li.current-menu-item {
 
 				& > ul {

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -4176,13 +4176,30 @@ a {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #0073AA;
+		border-right: 8px solid transparent;
+		border-left: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-right: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #0073AA;
 		border-right: 8px solid transparent;
@@ -4193,7 +4210,13 @@ a {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: #0073AA;
+		color: #FFFFFF;
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: #0073AA;
 		color: #FFFFFF;
@@ -4201,9 +4224,20 @@ a {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #005177;
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -4205,13 +4205,30 @@ a {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #0073AA;
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-left: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #0073AA;
 		border-left: 8px solid transparent;
@@ -4222,7 +4239,13 @@ a {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: #0073AA;
+		color: #FFFFFF;
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: #0073AA;
 		color: #FFFFFF;
@@ -4230,9 +4253,20 @@ a {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #005177;
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/hever/package-lock.json
+++ b/hever/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hever",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hever/sass/_extra-child-theme.scss
+++ b/hever/sass/_extra-child-theme.scss
@@ -131,7 +131,7 @@ body:not(.fse-enabled) {
 			}
 
 			& > div > ul > li:hover,
-			& > div > ul > li.focus,
+			& > div > ul > li:focus-within,
 			& > div > ul > li.current-menu-item {
 
 				& > a {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.12
+Version: 1.5.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4237,18 +4237,40 @@ body:not(.fse-enabled) #colophon {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item > a {
+		color: var(--wp--preset--color--primary);
+	}
+	.site-header .main-navigation > div > ul > li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item > a {
 		color: var(--wp--preset--color--primary);
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid var(--wp--preset--color--primary);
+		border-right: 8px solid transparent;
+		border-left: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-right: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid var(--wp--preset--color--primary);
 		border-right: 8px solid transparent;
@@ -4259,7 +4281,13 @@ body:not(.fse-enabled) #colophon {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: var(--wp--preset--color--primary);
+		color: var(--wp--preset--color--background);
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: var(--wp--preset--color--primary);
 		color: var(--wp--preset--color--background);
@@ -4267,9 +4295,20 @@ body:not(.fse-enabled) #colophon {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: var(--wp--preset--color--primary-hover);
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/hever/style.css
+++ b/hever/style.css
@@ -4266,18 +4266,40 @@ body:not(.fse-enabled) #colophon {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item > a {
+		color: var(--wp--preset--color--primary);
+	}
+	.site-header .main-navigation > div > ul > li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item > a {
 		color: var(--wp--preset--color--primary);
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid var(--wp--preset--color--primary);
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-left: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid var(--wp--preset--color--primary);
 		border-left: 8px solid transparent;
@@ -4288,7 +4310,13 @@ body:not(.fse-enabled) #colophon {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: var(--wp--preset--color--primary);
+		color: var(--wp--preset--color--background);
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: var(--wp--preset--color--primary);
 		color: var(--wp--preset--color--background);
@@ -4296,9 +4324,20 @@ body:not(.fse-enabled) #colophon {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: var(--wp--preset--color--primary-hover);
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/morden/sass/_extra-child-theme.scss
+++ b/morden/sass/_extra-child-theme.scss
@@ -155,7 +155,7 @@ body {
 			}
 
 			& > div > ul > li:hover,
-			& > div > ul > li.focus,
+			& > div > ul > li:focus-within,
 			& > div > ul > li.current-menu-item {
 
 				& > a {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -4257,12 +4257,25 @@ p:not(.site-title) a:hover {
 		font-size: 0.5rem;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > a {
+		color: rgba(var(--wp--preset--color--background), 0.8);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > a {
 		color: rgba(var(--wp--preset--color--background), 0.8);
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover > ul,
-	.site-header-wrap .main-navigation > div > ul > li.focus > ul,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > ul {
+		background: var(--wp--preset--color--foreground);
+		border: 1px solid var(--wp--preset--color--foreground-high-contrast);
+		border-radius: 5px;
+		overflow: hidden;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover > ul,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within > ul,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > ul {
 		background: var(--wp--preset--color--foreground);
 		border: 1px solid var(--wp--preset--color--foreground-high-contrast);
@@ -4270,17 +4283,34 @@ p:not(.site-title) a:hover {
 		overflow: hidden;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li,
-	.site-header-wrap .main-navigation > div > ul > li.focus li,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li {
+		border-top: 1px solid var(--wp--preset--color--foreground-high-contrast);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li {
 		border-top: 1px solid var(--wp--preset--color--foreground-high-contrast);
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li:first-child,
-	.site-header-wrap .main-navigation > div > ul > li.focus li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:first-child {
+		border-top: 0;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li:first-child,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:first-child {
 		border-top: 0;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li > a {
+		background: var(--wp--preset--color--foreground);
+		color: var(--wp--preset--color--background);
+		padding: 8px 24px;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li > a {
 		background: var(--wp--preset--color--foreground);
 		color: var(--wp--preset--color--background);
@@ -4289,9 +4319,20 @@ p:not(.site-title) a:hover {
 	.site-header-wrap .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header-wrap .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header-wrap .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: var(--wp--preset--color--primary);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/morden/style.css
+++ b/morden/style.css
@@ -4286,12 +4286,25 @@ p:not(.site-title) a:hover {
 		font-size: 0.5rem;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > a {
+		color: rgba(var(--wp--preset--color--background), 0.8);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > a {
 		color: rgba(var(--wp--preset--color--background), 0.8);
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover > ul,
-	.site-header-wrap .main-navigation > div > ul > li.focus > ul,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > ul {
+		background: var(--wp--preset--color--foreground);
+		border: 1px solid var(--wp--preset--color--foreground-high-contrast);
+		border-radius: 5px;
+		overflow: hidden;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover > ul,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within > ul,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item > ul {
 		background: var(--wp--preset--color--foreground);
 		border: 1px solid var(--wp--preset--color--foreground-high-contrast);
@@ -4299,17 +4312,34 @@ p:not(.site-title) a:hover {
 		overflow: hidden;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li,
-	.site-header-wrap .main-navigation > div > ul > li.focus li,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li {
+		border-top: 1px solid var(--wp--preset--color--foreground-high-contrast);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li {
 		border-top: 1px solid var(--wp--preset--color--foreground-high-contrast);
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li:first-child,
-	.site-header-wrap .main-navigation > div > ul > li.focus li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:first-child {
+		border-top: 0;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li:first-child,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li:first-child,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:first-child {
 		border-top: 0;
 	}
 	.site-header-wrap .main-navigation > div > ul > li:hover li > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li > a {
+		background: var(--wp--preset--color--foreground);
+		color: var(--wp--preset--color--background);
+		padding: 8px 24px;
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li > a {
 		background: var(--wp--preset--color--foreground);
 		color: var(--wp--preset--color--background);
@@ -4318,9 +4348,20 @@ p:not(.site-title) a:hover {
 	.site-header-wrap .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header-wrap .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header-wrap .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header-wrap .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: var(--wp--preset--color--primary);
+	}
+	.site-header-wrap .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header-wrap .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header-wrap .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/redhill/sass/_extra-child-theme.scss
+++ b/redhill/sass/_extra-child-theme.scss
@@ -144,7 +144,7 @@ a {
 		}
 
 		& > div > ul > li:hover,
-		& > div > ul > li.focus,
+		& > div > ul > li:focus-within,
 		& > div > ul > li.current-menu-item {
 
 			& > a {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -4222,20 +4222,40 @@ p:not(.site-title) a:hover {
 		padding-left: 16px;
 	}
 	.main-navigation > div > ul > li:hover > a,
-	.main-navigation > div > ul > li.focus > a,
+	.main-navigation > div > ul > li[focus-within] > a,
+	.main-navigation > div > ul > li.current-menu-item > a {
+		background: #CA2017;
+		border-radius: 4px;
+		color: #FFFFFF;
+	}
+	.main-navigation > div > ul > li:hover > a,
+	.main-navigation > div > ul > li:focus-within > a,
 	.main-navigation > div > ul > li.current-menu-item > a {
 		background: #CA2017;
 		border-radius: 4px;
 		color: #FFFFFF;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		border-radius: 4px;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		border-radius: 4px;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #222222;
+		color: #FFFFFF;
+		font-weight: normal;
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #222222;
 		color: #FFFFFF;
@@ -4244,9 +4264,20 @@ p:not(.site-title) a:hover {
 	.main-navigation > div > ul > li:hover li:hover > a,
 	.main-navigation > div > ul > li:hover li.focus > a,
 	.main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.main-navigation > div > ul > li.focus li:hover > a,
-	.main-navigation > div > ul > li.focus li.focus > a,
-	.main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.main-navigation > div > ul > li[focus-within] li:hover > a,
+	.main-navigation > div > ul > li[focus-within] li.focus > a,
+	.main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #CA2017;
+	}
+	.main-navigation > div > ul > li:hover li:hover > a,
+	.main-navigation > div > ul > li:hover li.focus > a,
+	.main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.main-navigation > div > ul > li:focus-within li:hover > a,
+	.main-navigation > div > ul > li:focus-within li.focus > a,
+	.main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -4251,20 +4251,40 @@ p:not(.site-title) a:hover {
 		padding-right: 16px;
 	}
 	.main-navigation > div > ul > li:hover > a,
-	.main-navigation > div > ul > li.focus > a,
+	.main-navigation > div > ul > li[focus-within] > a,
+	.main-navigation > div > ul > li.current-menu-item > a {
+		background: #CA2017;
+		border-radius: 4px;
+		color: #FFFFFF;
+	}
+	.main-navigation > div > ul > li:hover > a,
+	.main-navigation > div > ul > li:focus-within > a,
 	.main-navigation > div > ul > li.current-menu-item > a {
 		background: #CA2017;
 		border-radius: 4px;
 		color: #FFFFFF;
 	}
 	.main-navigation > div > ul > li:hover > ul,
-	.main-navigation > div > ul > li.focus > ul,
+	.main-navigation > div > ul > li[focus-within] > ul,
+	.main-navigation > div > ul > li.current-menu-item > ul {
+		border-radius: 4px;
+		overflow: hidden;
+	}
+	.main-navigation > div > ul > li:hover > ul,
+	.main-navigation > div > ul > li:focus-within > ul,
 	.main-navigation > div > ul > li.current-menu-item > ul {
 		border-radius: 4px;
 		overflow: hidden;
 	}
 	.main-navigation > div > ul > li:hover li > a,
-	.main-navigation > div > ul > li.focus li > a,
+	.main-navigation > div > ul > li[focus-within] li > a,
+	.main-navigation > div > ul > li.current-menu-item li > a {
+		background: #222222;
+		color: #FFFFFF;
+		font-weight: normal;
+	}
+	.main-navigation > div > ul > li:hover li > a,
+	.main-navigation > div > ul > li:focus-within li > a,
 	.main-navigation > div > ul > li.current-menu-item li > a {
 		background: #222222;
 		color: #FFFFFF;
@@ -4273,9 +4293,20 @@ p:not(.site-title) a:hover {
 	.main-navigation > div > ul > li:hover li:hover > a,
 	.main-navigation > div > ul > li:hover li.focus > a,
 	.main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.main-navigation > div > ul > li.focus li:hover > a,
-	.main-navigation > div > ul > li.focus li.focus > a,
-	.main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.main-navigation > div > ul > li[focus-within] li:hover > a,
+	.main-navigation > div > ul > li[focus-within] li.focus > a,
+	.main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #CA2017;
+	}
+	.main-navigation > div > ul > li:hover li:hover > a,
+	.main-navigation > div > ul > li:hover li.focus > a,
+	.main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.main-navigation > div > ul > li:focus-within li:hover > a,
+	.main-navigation > div > ul > li:focus-within li.focus > a,
+	.main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/rivington/sass/_extra-child-theme.scss
+++ b/rivington/sass/_extra-child-theme.scss
@@ -110,7 +110,7 @@ a {
 			}
 
 			& > div > ul > li:hover,
-			& > div > ul > li.focus,
+			& > div > ul > li:focus-within,
 			& > div > ul > li.current-menu-item {
 
 				& > a {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -4176,18 +4176,40 @@ p:not(.site-title) a:hover {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item > a {
+		color: #CAAB57;
+	}
+	.site-header .main-navigation > div > ul > li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item > a {
 		color: #CAAB57;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #CAAB57;
+		border-right: 8px solid transparent;
+		border-left: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-right: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #CAAB57;
 		border-right: 8px solid transparent;
@@ -4198,7 +4220,13 @@ p:not(.site-title) a:hover {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: #CAAB57;
+		color: #060f29;
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: #CAAB57;
 		color: #060f29;
@@ -4206,9 +4234,20 @@ p:not(.site-title) a:hover {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #b59439;
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4205,18 +4205,40 @@ p:not(.site-title) a:hover {
 		font-size: 0.5rem;
 	}
 	.site-header .main-navigation > div > ul > li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item > a {
+		color: #CAAB57;
+	}
+	.site-header .main-navigation > div > ul > li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item > a {
 		color: #CAAB57;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul,
-	.site-header .main-navigation > div > ul > li.focus > ul,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
+		box-shadow: none;
+		overflow: hidden;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul,
+	.site-header .main-navigation > div > ul > li:focus-within > ul,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul {
 		box-shadow: none;
 		overflow: hidden;
 	}
 	.site-header .main-navigation > div > ul > li:hover > ul:before,
-	.site-header .main-navigation > div > ul > li.focus > ul:before,
+	.site-header .main-navigation > div > ul > li[focus-within] > ul:before,
+	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
+		border-bottom: 8px solid #CAAB57;
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		content: "";
+		display: block;
+		margin-left: 16px;
+		width: 16px;
+	}
+	.site-header .main-navigation > div > ul > li:hover > ul:before,
+	.site-header .main-navigation > div > ul > li:focus-within > ul:before,
 	.site-header .main-navigation > div > ul > li.current-menu-item > ul:before {
 		border-bottom: 8px solid #CAAB57;
 		border-left: 8px solid transparent;
@@ -4227,7 +4249,13 @@ p:not(.site-title) a:hover {
 		width: 16px;
 	}
 	.site-header .main-navigation > div > ul > li:hover li > a,
-	.site-header .main-navigation > div > ul > li.focus li > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
+		background: #CAAB57;
+		color: #060f29;
+	}
+	.site-header .main-navigation > div > ul > li:hover li > a,
+	.site-header .main-navigation > div > ul > li:focus-within li > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li > a {
 		background: #CAAB57;
 		color: #060f29;
@@ -4235,9 +4263,20 @@ p:not(.site-title) a:hover {
 	.site-header .main-navigation > div > ul > li:hover li:hover > a,
 	.site-header .main-navigation > div > ul > li:hover li.focus > a,
 	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
-	.site-header .main-navigation > div > ul > li.focus li:hover > a,
-	.site-header .main-navigation > div > ul > li.focus li.focus > a,
-	.site-header .main-navigation > div > ul > li.focus li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li:hover > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.focus > a,
+	.site-header .main-navigation > div > ul > li[focus-within] li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
+	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {
+		background: #b59439;
+	}
+	.site-header .main-navigation > div > ul > li:hover li:hover > a,
+	.site-header .main-navigation > div > ul > li:hover li.focus > a,
+	.site-header .main-navigation > div > ul > li:hover li.current-menu-item > a,
+	.site-header .main-navigation > div > ul > li:focus-within li:hover > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.focus > a,
+	.site-header .main-navigation > div > ul > li:focus-within li.current-menu-item > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li:hover > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.focus > a,
 	.site-header .main-navigation > div > ul > li.current-menu-item li.current-menu-item > a {


### PR DESCRIPTION
Fixes: #1843

Varia supplies a "hover or focus" style for navigation submenus.

Some child themes modify this style, however they incorrectly selected the "focus" styles, thus when the submenu was "selected" (clicked and the menu stays open, for a11y reasons) the styles rolled back to varia's defaults.

This change just changes the selector to use `:focus-within` instead of (an absent) `.focus` class to address the problem.  The result is that the style now matches the "hover" state.

The following themes are affected:

Alves
Before:
<img src="https://user-images.githubusercontent.com/146530/146559691-50810ae5-edb7-4124-97ca-325dee6d0e58.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146558910-960e281b-346e-4535-bbc2-084595eeaf5a.png" width=250>

Balasana
Before:
<img src="https://user-images.githubusercontent.com/146530/146559753-1aa07173-ce2d-4a3b-bb5c-db6092d2ea74.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146558995-cc67055b-e165-41b2-9225-861a4f99e936.png" width=250>

Barnsbury
Before:
<img src="https://user-images.githubusercontent.com/146530/146559856-bd2d07bb-1003-4951-977c-c35ea76f9ef5.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559047-0145127f-d036-4de2-80ed-2c3b219c7a8c.png" width=250>

Brompton
Before:
<img src="https://user-images.githubusercontent.com/146530/146559915-7d2dfd95-7cfb-4893-8bb3-451b1c7b35cd.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559113-55e85803-8bcf-4654-8707-3b55744985c7.png" width=250>

Dalston
Before:
<img src="https://user-images.githubusercontent.com/146530/146560016-3e8bcc97-618b-4be8-98b3-cfe4d6891063.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559183-a524c717-83e0-432a-8949-5813a400c148.png" width=250>

Hever
Before:
<img src="https://user-images.githubusercontent.com/146530/146560074-fd4cb6f9-5917-4fcb-aace-a6692a4f393d.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559252-d2cadb39-0e5d-435a-8af0-a56d71634a8e.png" width=250>

Morden
Before:
<img src="https://user-images.githubusercontent.com/146530/146560139-9b680fbb-e90b-483f-8c64-0f047a22dab9.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559307-199e6205-b9da-4a54-b995-2d5e2bb321bf.png" width=250>

Redhill
Before:
<img src="https://user-images.githubusercontent.com/146530/146560207-c85056e8-2222-4dbd-9f57-bdcbec910f0d.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559369-e95d40b1-73f6-4982-bcb2-30300c9afd29.png" width=250>

Rivington
Before:
<img src="https://user-images.githubusercontent.com/146530/146559643-aad4aa9f-a23b-44d9-802d-15efea4bbc86.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/146530/146559425-fe9c66df-9910-4be2-8aff-98ed0165f1cb.png" width=250>

The rest of the Varia child themes either use the Varia default styling or properly style the focused state already.
