### PR TITLE
Karuna: Fix the text in title in Gutenberg editor being transformed t…

### DIFF
--- a/karuna/editor-blocks.css
+++ b/karuna/editor-blocks.css
@@ -69,7 +69,6 @@
 
 .edit-post-visual-editor h1 {
 	font-size: 32px;
-	text-transform: inherit;
 }
 
 .edit-post-visual-editor h2 {
@@ -90,6 +89,10 @@
 
 .edit-post-visual-editor h6 {
 	font-size: 14px;
+}
+
+.edit-post-visual-editor h1.editor-post-title {
+	text-transform: none;
 }
 
 @media screen and (min-width: 768px) {

--- a/karuna/editor-blocks.css
+++ b/karuna/editor-blocks.css
@@ -69,6 +69,7 @@
 
 .edit-post-visual-editor h1 {
 	font-size: 32px;
+	text-transform: inherit;
 }
 
 .edit-post-visual-editor h2 {


### PR DESCRIPTION
…o uppercase

Closes: #4579

Before:
<img width="1250" alt="Edit_Page_‹_This_is_a_site_title_super_long_—_WordPress" src="https://user-images.githubusercontent.com/905781/146576863-437eed0c-1f1e-4f58-98c4-20aabe23b300.png">


After:
<img width="1253" alt="Edit_Page_‹_This_is_a_site_title_super_long_—_WordPress_com_and_karuna_—_wpdev_danieldudzic_dev_dfw_wordpress_com___home_wpcom_public_html_—_-zsh_—_111×32_and_danieldudzic_—_wpdev_danieldudzic_dev_dfw_wordpress_com___home_wpcom_—_ssh_wpdev_" src="https://user-images.githubusercontent.com/905781/146576697-bfd131f0-7462-4e8b-8026-ab09b557fe6d.png">

