### PR TITLE
Skatepark: Remove margin of the post content block

### DIFF
--- a/skatepark/assets/theme.css
+++ b/skatepark/assets/theme.css
@@ -196,11 +196,6 @@ body:not(.has-featured-image) h1.wp-block-post-title {
 	padding-bottom: calc(var(--wp--custom--gap--vertical) * 3);
 }
 
-.is-root-container,
-.wp-block-post-content {
-	margin-top: calc(var(--wp--custom--gap--vertical) * 3);
-}
-
 .wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 	text-decoration-thickness: 0.07em;
 	text-underline-offset: 0.46ex;

--- a/skatepark/sass/blocks/_post-content.scss
+++ b/skatepark/sass/blocks/_post-content.scss
@@ -1,4 +1,0 @@
-.is-root-container,
-.wp-block-post-content {
-	margin-top: calc(var(--wp--custom--gap--vertical) * 3);
-}

--- a/skatepark/sass/theme.scss
+++ b/skatepark/sass/theme.scss
@@ -10,7 +10,6 @@
 @import "blocks/post-comments";
 @import "blocks/post-featured-image";
 @import "blocks/post-title";
-@import "blocks/post-content";
 @import "blocks/query";
 @import "blocks/search";
 @import "blocks/separator";


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes a space at the top of the header in the Site Editor.

Before:
<img width="1440" alt="Screenshot 2021-12-20 at 09 02 49" src="https://user-images.githubusercontent.com/275961/146741478-31c1457c-f24f-444c-b83a-a70523b8d069.png">

After:
<img width="1440" alt="Screenshot 2021-12-20 at 09 03 04" src="https://user-images.githubusercontent.com/275961/146741508-f909eef9-b76b-4c83-ab61-222e2aabcf9d.png">

We also need to make sure that the margins between the post title and content or featured image are still correct:
<img width="1440" alt="Screenshot 2021-12-20 at 09 07 39" src="https://user-images.githubusercontent.com/275961/146741743-d99fa2ea-97c1-4d2b-90a2-13d8040e5931.png">
<img width="1440" alt="Screenshot 2021-12-20 at 09 07 32" src="https://user-images.githubusercontent.com/275961/146741751-9e2836a6-dd11-4c85-a354-00cde6858767.png">

#### Related issue(s):
https://github.com/Automattic/themes/pull/5190