### PR TITLE
removed header template part from skatepark's json

### DIFF
--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -1,12 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/theme-v1.json",
 	"version": 1,
-	"templateParts": [
-		{
-			"name": "header-ollie",
-			"area": "header"
-		}
-	],
 	"settings": {
 		"color": {
 			"duotone": [


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the header-ollie definition on the child theme's json, since it was moved upstream to the parent and we forgot to delete it from theme.json
