### PR TITLE
Blockbase: fix variables for 2 colored themes

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -1023,7 +1023,7 @@ p.wp-block-site-tagline {
 
 .wp-block-table.is-style-stripes figcaption,
 .wp-block-table figcaption {
-	color: var(--wp--preset--color--primary);
+	color: var(--wp--custom--color--primary);
 	font-size: var(--wp--custom--table--figcaption--typography--font-size);
 	text-align: center;
 }
@@ -1036,7 +1036,7 @@ p.wp-block-site-tagline {
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
-	background-color: var(--wp--preset--color--tertiary);
+	background-color: var(--wp--custom--color--tertiary);
 }
 
 .wp-block-video figcaption {

--- a/blockbase/sass/blocks/_table.scss
+++ b/blockbase/sass/blocks/_table.scss
@@ -1,7 +1,7 @@
 .wp-block-table.is-style-stripes,
 .wp-block-table {
 	figcaption { // See https://github.com/WordPress/gutenberg/issues/34650
-		color: var(--wp--preset--color--primary);
+		color: var(--wp--custom--color--primary);
 		font-size: var(--wp--custom--table--figcaption--typography--font-size);
 		text-align: center;
 	}
@@ -18,7 +18,7 @@
 .wp-block-table.is-style-stripes {
 	tbody {
 		tr:nth-child(odd) {
-			background-color: var(--wp--preset--color--tertiary);
+			background-color: var(--wp--custom--color--tertiary);
 		}
 	}
 }

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -268,14 +268,14 @@
 			"navigation": {
 				"submenu": {
 					"border": {
-						"color": "var(--wp--preset--color--primary)",
+						"color": "var(--wp--custom--color--primary)",
 						"radius": "var(--wp--custom--form--border--radius)",
 						"style": "var(--wp--custom--form--border--style)",
 						"width": "var(--wp--custom--form--border--width)"
 					},
 					"color": {
 						"background": "var(--wp--custom--color--background)",
-						"text": "var(--wp--preset--color--foreground)"
+						"text": "var(--wp--custom--color--foreground)"
 					}
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR changes the variables used for the colors in the navigation block. We were using the preset values instead of the custom ones: those may not always be 5, so for themes like Skatepark `--wp--preset--color--primary` was empty while `--wp--preset--color--primary` actually had an alternative defined.

<img width="464" alt="Screenshot 2021-12-21 at 17 30 30" src="https://user-images.githubusercontent.com/3593343/146965027-1c09c045-16e9-4600-bb08-3e29958e3ded.png">

#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/5232