### PR TITLE
Manual version bump for some themes

### DIFF
--- a/blank-canvas-blocks/style.css
+++ b/blank-canvas-blocks/style.css
@@ -7,7 +7,7 @@ Description: Blank Canvas is a minimalist theme, designed for single-page websit
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 0.0.2
+Version: 0.0.3
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/quadrat-black/package-lock.json
+++ b/quadrat-black/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.30",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/quadrat-black/package.json
+++ b/quadrat-black/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/quadrat-black/style.css
+++ b/quadrat-black/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.32
+Version: 1.1.33
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/quadrat-green/package-lock.json
+++ b/quadrat-green/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.30",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/quadrat-green/package.json
+++ b/quadrat-green/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/quadrat-green/style.css
+++ b/quadrat-green/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.32
+Version: 1.1.33
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/quadrat-red/package-lock.json
+++ b/quadrat-red/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.30",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/quadrat-red/package.json
+++ b/quadrat-red/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/quadrat-red/style.css
+++ b/quadrat-red/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.32
+Version: 1.1.33
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/quadrat-white/package-lock.json
+++ b/quadrat-white/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.30",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/quadrat-white/package.json
+++ b/quadrat-white/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/quadrat-white/style.css
+++ b/quadrat-white/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.32
+Version: 1.1.33
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/quadrat-yellow/package-lock.json
+++ b/quadrat-yellow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.30",
+  "version": "1.1.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/quadrat-yellow/package.json
+++ b/quadrat-yellow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "",
   "main": "index.php",
   "dependencies": {},

--- a/quadrat-yellow/style.css
+++ b/quadrat-yellow/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.32
+Version: 1.1.33
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/seedlet/package-lock.json
+++ b/seedlet/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.15-wpcom",
+  "version": "1.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/seedlet/package.json
+++ b/seedlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seedlet",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Seedlet",
   "bugs": {
     "url": "https://github.com/Automattic/seedlet/issues"

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.16-wpcom
+Version: 1.1.19-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.16-wpcom
+Version: 1.1.19-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/spearhead/package-lock.json
+++ b/spearhead/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spearhead",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spearhead/package.json
+++ b/spearhead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spearhead",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "a podcast theme",
   "keywords": [
     "gutenberg",

--- a/spearhead/style-rtl.css
+++ b/spearhead/style-rtl.css
@@ -7,7 +7,7 @@ Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.3.3
+Version: 1.3.5
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -7,7 +7,7 @@ Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.3.3
+Version: 1.3.5
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
A couple of the themes in the last deploy didn't get a version bump, so I've bumped them manually for now.

Themes affected:
- Blank Canvas Blocks
- Quadrat red, white, yellow, green, black
- Seedlet
- Spearhead
