### PR TITLE
Blockbase: Rename Gutenberg functions

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -82,7 +82,7 @@ class GlobalStylesColorCustomizer {
 			$user_color_palette = $theme_json['settings']['color']['palette']['user'];
 		}
 		// End Gutenberg < 12.1 compatibility patch
-	
+
 		// Combine theme settings with user settings.
 		foreach ( $combined_color_palette as $key => $palette_item ) {
 			//make theme color value the default
@@ -162,7 +162,7 @@ class GlobalStylesColorCustomizer {
 		$this->update_user_color_palette( $wp_customize );
 
 		// Get the user's theme.json from the CPT.
-		$user_custom_post_type_id     = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+		$user_custom_post_type_id     = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 		$user_theme_json_post         = get_post( $user_custom_post_type_id );
 		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -505,7 +505,7 @@ class GlobalStylesFontsCustomizer {
 		$heading_font_family_variable = 'var(--wp--preset--font-family--' . $heading_setting['slug'] . ')';
 
 		// Get the user's theme.json from the CPT.
-		$user_custom_post_type_id     = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+		$user_custom_post_type_id     = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 		$user_theme_json_post         = get_post( $user_custom_post_type_id );
 		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This function was renamed in Gutenberg. Since 12.2 is now on dotcom we need to deploy this ASAP.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5240