### PR TITLE
Blockbase: Update customizer PHP library to work with latest version of Gutenberg

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -185,7 +185,7 @@ class GlobalStylesColorCustomizer {
 		if ( ! $this->check_if_colors_are_default() ) {
 			$user_theme_json_post_content = set_settings_array(
 				$user_theme_json_post_content,
-				array( 'settings', 'color', 'palette' ),
+				array( 'settings', 'color', 'palette', 'custom' ),
 				$this->user_color_palette
 			);
 
@@ -214,7 +214,7 @@ class GlobalStylesColorCustomizer {
 				$custom_duotone_filter_variable = "var(--wp--preset--duotone--custom-filter)";
 				$user_theme_json_post_content = set_settings_array(
 					$user_theme_json_post_content,
-					array( 'settings', 'color', 'duotone' ),
+					array( 'settings', 'color', 'duotone', 'custom' ),
 					array_merge( $custom_duotone_filter, $this->theme_duotone_settings )
 				);
 
@@ -225,7 +225,7 @@ class GlobalStylesColorCustomizer {
 						if( $block['filter'] ) {
 							$user_theme_json_post_content = set_settings_array(
 								$user_theme_json_post_content,
-								array( 'styles', 'blocks', $key, 'filter', 'duotone' ),
+								array( 'styles', 'blocks', $key, 'filter', 'duotone', 'custom' ),
 								$custom_duotone_filter_variable
 							);
 						}
@@ -238,6 +238,7 @@ class GlobalStylesColorCustomizer {
 		$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );
 		wp_update_post( $user_theme_json_post );
 		delete_transient( 'global_styles' );
+		delete_transient( 'global_styles_' . get_stylesheet() );
 		delete_transient( 'gutenberg_global_styles' );
 		delete_transient( 'gutenberg_global_styles_' . get_stylesheet() );
 	}

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -162,9 +162,9 @@ class GlobalStylesColorCustomizer {
 		$this->update_user_color_palette( $wp_customize );
 
 		// Get the user's theme.json from the CPT.
-		if ( method_exists( WP_Theme_JSON_Resolver_Gutenberg, 'get_user_global_styles_post_id' ) ) { // This is the new name.
+		if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_global_styles_post_id' ) ) { // This is the new name.
 			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-		} else if ( method_exists( WP_Theme_JSON_Resolver_Gutenberg, 'get_user_custom_post_type_id' ) ) { // This is the old name.
+		} else if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_custom_post_type_id' ) ) { // This is the old name.
 			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 		}
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -505,9 +505,9 @@ class GlobalStylesFontsCustomizer {
 		$heading_font_family_variable = 'var(--wp--preset--font-family--' . $heading_setting['slug'] . ')';
 
 		// Get the user's theme.json from the CPT.
-		if ( method_exists( WP_Theme_JSON_Resolver_Gutenberg, 'get_user_global_styles_post_id' ) ) { // This is the new name.
+		if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_global_styles_post_id' ) ) { // This is the new name.
 			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-		} else if ( method_exists( WP_Theme_JSON_Resolver_Gutenberg, 'get_user_custom_post_type_id' ) ) { // This is the old name.
+		} else if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_custom_post_type_id' ) ) { // This is the old name.
 			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 		}
 
@@ -521,7 +521,7 @@ class GlobalStylesFontsCustomizer {
 		// Set the typography settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
-			array( 'settings', 'typography', 'fontFamilies' ),
+			array( 'settings', 'typography', 'fontFamilies', 'custom' ),
 			$font_families
 		);
 
@@ -546,6 +546,7 @@ class GlobalStylesFontsCustomizer {
 		$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );
 		wp_update_post( $user_theme_json_post );
 		delete_transient( 'global_styles' );
+		delete_transient( 'global_styles_' . get_stylesheet() );
 		delete_transient( 'gutenberg_global_styles' );
 		delete_transient( 'gutenberg_global_styles_' . get_stylesheet() );
 	}


### PR DESCRIPTION
Gutenberg now expects customizations to be explicitly stored under `custom` in the Global Styles. This updates the PHP files to store the customizations under `custom`. To test, try changing fonts and colors in the Customizer.