### PR TITLE
Fix Customizer Font Editing causing Site Editor WSOD

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -460,8 +460,8 @@ class GlobalStylesFontsCustomizer {
 	}
 
 	function unset_property_if_it_exists( $object, $property ) {
-		if ( isset( $object->{$property} ) ) {
-			unset( $object->{$property} );
+		if ( isset( $object[ $property ] ) ) {
+			unset( $object[ $property ] );
 		}
 
 	}
@@ -504,21 +504,12 @@ class GlobalStylesFontsCustomizer {
 		$body_font_family_variable    = 'var(--wp--preset--font-family--' . $body_setting['slug'] . ')';
 		$heading_font_family_variable = 'var(--wp--preset--font-family--' . $heading_setting['slug'] . ')';
 
-		// Get the user's theme.json from the CPT.
-		if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_global_styles_post_id' ) ) { // This is the new name.
-			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-		} else if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_custom_post_type_id' ) ) { // This is the old name.
-			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
-		}
+		// Get the user's theme.json.
+		$user_theme_json_post_content = WP_Theme_JSON_Resolver_Gutenberg::get_user_data()->get_raw_data();
 
-		$user_theme_json_post         = get_post( $user_custom_post_type_id );
-		$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
+		$user_theme_json_post_content['isGlobalStylesUserThemeJSON'] = true;
 
-		// Set meta settings.
-		$user_theme_json_post_content->version                     = 1;
-		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
-
-		$this->unset_property_if_it_exists( $user_theme_json_post_content->settings->typography, 'fontFamilies' );
+		$this->unset_property_if_it_exists( $user_theme_json_post_content['settings']['typography'], 'fontFamilies' );
 
 		// Set the typography settings.
 		$user_theme_json_post_content = set_settings_array(
@@ -530,17 +521,25 @@ class GlobalStylesFontsCustomizer {
 		//If the typeface choices === the default then we remove it instead
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
 			// These lines need to stay for backwards compatibility.
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h1->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h2->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h3->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h4->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h5->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h6->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography, 'fontFamily' );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h1']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h2']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h3']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h4']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h5']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['elements']['h6']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['blocks']['core/button']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['blocks']['core/post-title']['typography'], 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content['styles']['blocks']['core/pullquote']['typography'], 'fontFamily' );
 		}
+
+		// Get the user's theme.json from the CPT.
+		if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_global_styles_post_id' ) ) { // This is the new name.
+			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+		} else if ( method_exists( 'WP_Theme_JSON_Resolver_Gutenberg', 'get_user_custom_post_type_id' ) ) { // This is the old name.
+			$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+		}
+		$user_theme_json_post = get_post( $user_custom_post_type_id );
 
 		// Update the theme.json with the new settings.
 		$user_theme_json_post->post_content = json_encode( $user_theme_json_post_content );

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -459,9 +459,9 @@ class GlobalStylesFontsCustomizer {
 		}
 	}
 
-	function unset_property_if_it_exists( $property ) {
-		if ( isset( $property ) ) {
-			unset( $property );
+	function unset_property_if_it_exists( $object, $property ) {
+		if ( isset( $object->{$property} ) ) {
+			unset( $object->{$property} );
 		}
 
 	}
@@ -518,6 +518,8 @@ class GlobalStylesFontsCustomizer {
 		$user_theme_json_post_content->version                     = 1;
 		$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true;
 
+		$this->unset_property_if_it_exists( $user_theme_json_post_content->settings->typography, 'fontFamilies' );
+
 		// Set the typography settings.
 		$user_theme_json_post_content = set_settings_array(
 			$user_theme_json_post_content,
@@ -527,19 +529,17 @@ class GlobalStylesFontsCustomizer {
 
 		//If the typeface choices === the default then we remove it instead
 		if ( $body_value === $body_default && $heading_value === $heading_default ) {
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->settings->typography->fontFamilies );
-
 			// These lines need to stay for backwards compatibility.
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h1->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h2->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h3->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h4->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h5->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h6->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography->fontFamily );
-			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography->fontFamily );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h1->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h2->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h3->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h4->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h5->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->elements->h6->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/button'}->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/post-title'}->typography, 'fontFamily' );
+			$this->unset_property_if_it_exists( $user_theme_json_post_content->styles->blocks->{'core/pullquote'}->typography, 'fontFamily' );
 		}
 
 		// Update the theme.json with the new settings.

--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -14,17 +14,14 @@ function set_settings_array( $target, $array, $value ) {
 	$key     = array_shift( $array );
 	$current =& $target;
 	while ( 0 < sizeof( $array ) ) {
-		if ( ! property_exists( $current, $key ) ) {
-			$current->{ $key } = (object) array();
+		if ( ! array_key_exists( $current, $key ) ) {
+			$current[ $key ] = array();
 		}
-		$current =& $current->{ $key };
-
-		// Cast to an object in the case where it's been set as an array.
-		$current = (object) $current;
+		$current =& $current[ $key ];
 
 		$key     = array_shift( $array );
 	}
-	$current->{ $key } = $value;
+	$current[ $key ] = $value;
 	return $target;
 }
 


### PR DESCRIPTION
Fixes #5261 
See that for details on how to reproduce.



<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Clear fontFamilies data to ensure what is posted is always correct (without tag-along `["0"]` and `["1"]` items.  

Refactored unset_property_if_it_exists() as it wasn't removing the fontFamilies Array as expected

Note... I'm still not sure where the `["0"] and ["1"]` items are coming from...  But this removes them and then everything works...


Once the fix is in place anyone experiencing the WSOD should be able to save font customizations in the customizer again to return their site editor to a working state.

#### Related issue(s):
