### PR TITLE
Stewart: Tidy up navigation

### DIFF
--- a/stewart/parts/sidebar.html
+++ b/stewart/parts/sidebar.html
@@ -9,11 +9,7 @@
 <hr class="wp-block-separator is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:spacer {"height":1} -->
-<div style="height:1px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} -->
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}},"overlayBackgroundColor":"background","overlayTextColor":"foreground"} -->
 <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 <!-- /wp:navigation -->
 

--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -14,7 +14,7 @@
 		{
 			"name": "sidebar",
 			"title": "Sidebar",
-			"area": "sidebar"
+			"area": "uncategorized"
 		},
 		{
 			"name": "footer",


### PR DESCRIPTION
This PR takes are of a few things: 

- It makes sure the navigation's overlay color matches the page background. Previously it was white. 
- It removes an unnecessary `1px` spacer block in the sidebar template. 
- It removes the sidebar template from the "sidebar" area to "uncategorized". Sidebar isn't a valid area at this point, and this was throwing an error message in the Site Editor.  

Aside from the overlay color change, things should basically look the same. Testing might look weird because of these two upstream bugs: 

- https://github.com/WordPress/gutenberg/issues/37695
- https://github.com/WordPress/gutenberg/issues/37694
