### PR TITLE
[Livre] Enable dropcaps

### DIFF
--- a/livre/style.css
+++ b/livre/style.css
@@ -137,3 +137,13 @@ body > .is-root-container,
 .wp-block-site-title a:hover {
 	text-decoration: underline;
 }
+
+/*
+ * Drop cap refinements.
+ */
+
+.has-drop-cap:not(:focus)::first-letter {
+	font-size: 3.15em;
+	font-weight: 300;
+	margin: 0.25em 0.125em 0 0;
+}

--- a/livre/theme.json
+++ b/livre/theme.json
@@ -68,7 +68,6 @@
 			]
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Newsreader\", serif",


### PR DESCRIPTION
Closes #5216 

This enables drop caps for the Livre theme, and adds a little CSS to fine-tune the appearance (It looks [pretty bad otherwise](https://cloudup.com/cifi9y1mxbj)). 

## Screenshot

<img width="722" alt="Screen Shot 2022-01-04 at 11 16 55 AM" src="https://user-images.githubusercontent.com/1202812/148090036-d10c22c1-d5d9-4a9c-9837-76b4cd2dfe42.png">

