### PR TITLE
Canard: fix button styles outside of entry-content

### DIFF
--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -236,6 +236,13 @@ p.has-drop-cap:not(:focus)::first-letter {
 	color: #fff;
 }
 
+.wp-block-button .wp-block-button__link:active,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:hover {
+	color: #d11415;
+	background: #fff;
+}
+
 .is-style-outline .wp-block-button__link {
 	background: transparent;
 	border-color: currentColor;
@@ -245,18 +252,14 @@ p.has-drop-cap:not(:focus)::first-letter {
 	color: #d11415;
 }
 
-.wp-block-button .wp-block-button__link:active,
-.wp-block-button .wp-block-button__link:focus,
-.wp-block-button .wp-block-button__link:hover,
 .is-style-outline .wp-block-button__link:not(.has-background):active,
 .is-style-outline .wp-block-button__link:not(.has-background):hover,
 .is-style-outline .wp-block-button__link:not(.has-background):focus,
 .is-style-outline .wp-block-button__link:not(.has-text-color):active,
 .is-style-outline .wp-block-button__link:not(.has-text-color):hover,
 .is-style-outline .wp-block-button__link:not(.has-text-color):focus {
-	color: #d11415 !important;
-	background: #fff !important;
-	border-color: #d11415;
+	border-color: currentColor;
+	color: currentColor;
 }
 
 /* Seperator */

--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -245,11 +245,17 @@ p.has-drop-cap:not(:focus)::first-letter {
 	color: #d11415;
 }
 
-.entry-content .wp-block-button .wp-block-button__link:active,
-.entry-content .wp-block-button .wp-block-button__link:focus,
-.entry-content .wp-block-button .wp-block-button__link:hover {
-	color: #d11415;
-	background: #fff;
+.wp-block-button .wp-block-button__link:active,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:hover,
+.is-style-outline .wp-block-button__link:not(.has-background):active,
+.is-style-outline .wp-block-button__link:not(.has-background):hover,
+.is-style-outline .wp-block-button__link:not(.has-background):focus,
+.is-style-outline .wp-block-button__link:not(.has-text-color):active,
+.is-style-outline .wp-block-button__link:not(.has-text-color):hover,
+.is-style-outline .wp-block-button__link:not(.has-text-color):focus {
+	color: #d11415 !important;
+	background: #fff !important;
 	border-color: #d11415;
 }
 

--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -241,6 +241,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-button .wp-block-button__link:hover {
 	color: #d11415;
 	background: #fff;
+	border-color: #d11415;
 }
 
 .is-style-outline .wp-block-button__link {

--- a/canard/inc/wpcom-colors.php
+++ b/canard/inc/wpcom-colors.php
@@ -341,7 +341,10 @@ add_color_rule( 'fg1', '#222222', array(
 	array(
 		'.toggled .menu-toggle,
 		.sidebar-toggle.toggled,
-		.toggled .search-toggle', 'border-color'
+		.toggled .search-toggle,
+		.wp-block-button .wp-block-button__link:active,
+		.wp-block-button .wp-block-button__link:focus,
+		.wp-block-button .wp-block-button__link:hover', 'border-color'
 	),
 	array(
 		'.main-navigation.toggled > div:before,
@@ -383,7 +386,13 @@ add_color_rule( 'fg1', '#222222', array(
 		'.rtl .secondary-navigation li + li', 'border-right-color', 'fg1', 2
 	),
 	array(
-		'.site-info .sep', 'color', 'fg1', 2
+		'.site-info .sep,
+		.wp-block-button .wp-block-button__link:active,
+		.wp-block-button .wp-block-button__link:focus,
+		.wp-block-button .wp-block-button__link:hover,
+		.is-style-outline>.wp-block-button__link:not(.has-text-color):active,
+		.is-style-outline>.wp-block-button__link:not(.has-text-color):focus,
+		.is-style-outline>.wp-block-button__link:not(.has-text-color):hover', 'color', 'fg1', 2
 	),
 
 	// #555555
@@ -456,7 +465,8 @@ add_color_rule( 'link', '#d11415', array(
 		#infinite-handle span button:focus,
 		#infinite-handle span button:hover,
 		.widget_akismet_widget .a-stats a,
-		.milestone-widget .milestone-header', 'background-color', 'bg', 2
+		.milestone-widget .milestone-header,
+		.wp-block-button .wp-block-button__link', 'background-color', 'bg', 2
 	),
 	array(
 		'button,
@@ -472,7 +482,8 @@ add_color_rule( 'link', '#d11415', array(
 		#infinite-handle span button:active,
 		#infinite-handle span button:focus,
 		#infinite-handle span button:hover,
-		.widget_akismet_widget .a-stats a', 'border-color', 'bg', 2
+		.widget_akismet_widget .a-stats a,
+		.wp-block-button .wp-block-button__link', 'border-color', 'bg', 2
 	),
 	array(
 		'pre', 'border-left-color', 'bg', 2
@@ -542,7 +553,8 @@ add_color_rule( 'link', '#d11415', array(
 		.widget_akismet_widget .a-stats a:hover .count,
 		.widget_authors > ul > li > a:active,
 		.widget_authors > ul > li > a:focus,
-		.widget_authors > ul > li > a:hover', 'color', 'bg', 2
+		.widget_authors > ul > li > a:hover,
+		.is-style-outline>.wp-block-button__link:not(.has-text-color)', 'color', 'bg', 2
 	),
 
 ), __( 'Accent' ) );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This applies the default button styles to all button blocks on Canard, instead of only targeting those in `entry-content`. This means that any buttons added outside of `entry-content`, such as in a widget area, will be styled the same as any other button blocks.

I'm not sure why these styles were specific to `entry-content`, so I don't know if this might break something else.

I've also added `!important` to the `background-color` and `color` properties of the default styles on the button link for the active, focus, and hover states. This means we should always have decent color contrast in these states when custom colors have been added via the editor.

To test, add a button to a widget area. Make sure this button is styled the same as a button in a page or post, and that custom styles can still be applied correctly.

#### Related issue(s):
Fixes part of #4580.