### PR TITLE
[Livre] Clean up buttons and comment form

### DIFF
--- a/livre/style.css
+++ b/livre/style.css
@@ -84,6 +84,11 @@ a:active {
 	opacity: 0.90;
 } 
 
+.wp-block-button__link:hover, .wp-block-button__link:focus, 
+.wp-block-button__link:active, .wp-block-button__link:visited {
+	color: initial;
+}
+
 /*
  * Alignment styles.
  * These rules are temporary, and should not be relied on or 
@@ -139,6 +144,33 @@ body > .is-root-container,
 	text-decoration: underline;
 }
 
+/*
+ * Comment form cleanup.
+ */
+
+input {
+	font-family: inherit;
+}
+
+textarea,
+input:not([type="submit"]) {
+	color: var(--wp--preset--color--foreground);
+	background: var(--wp--preset--color--background);
+	border-color: var(--wp--preset--color--foreground);
+}
+
+textarea:focus,
+input:not([type="submit"]):focus {
+	border-color: var(--wp--preset--color--secondary);
+}
+
+.comment-form label {
+	font-size: var(--wp--preset--font-size--small);
+}
+
+.wp-block-post-comments .comment-form-cookies-consent #wp-comment-cookies-consent {
+	margin-top: 0.2em;
+}
 /*
  * Drop cap refinements.
  */

--- a/livre/style.css
+++ b/livre/style.css
@@ -171,7 +171,14 @@ input:not([type="submit"]):focus {
 .wp-block-post-comments .comment-form-cookies-consent #wp-comment-cookies-consent {
 	margin-top: 0.2em;
 }
-/*
+
+.wp-block-post-comments h3#comments {
+	margin-top: var(--wp--style--block-gap);
+}
+
+.wp-block-post-comments .navigation + .comment-respond {
+	margin-top: calc(3 * var(--wp--style--block-gap));
+}/*
  * Drop cap refinements.
  */
 

--- a/livre/style.css
+++ b/livre/style.css
@@ -153,14 +153,14 @@ input {
 }
 
 textarea,
-input:not([type="submit"]) {
+input:not([type="submit"]):not([type="button"]) {
 	color: var(--wp--preset--color--foreground);
 	background: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--foreground);
 }
 
 textarea:focus,
-input:not([type="submit"]):focus {
+input:not([type="submit"]):not([type="button"]):focus {
 	border-color: var(--wp--preset--color--secondary);
 }
 

--- a/livre/theme.json
+++ b/livre/theme.json
@@ -106,11 +106,15 @@
 					"radius": "0"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--foreground)",
+					"background": "var(--wp--preset--color--secondary)",
 					"text": "var(--wp--preset--color--background)"
 				},
+				"spacing": {
+					"padding": "1.25em 1.15em 1.15em 1.15em"
+				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"textTransform": "uppercase"
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
Fixes #5267.

This PR revises the default button style: 

Before|After
---|---
<img width="238" alt="Screen Shot 2022-01-05 at 10 44 57 AM" src="https://user-images.githubusercontent.com/1202812/148246283-547dcfb9-b58d-492a-a82f-0f07c77a42c5.png">|<img width="256" alt="Screen Shot 2022-01-05 at 10 42 42 AM" src="https://user-images.githubusercontent.com/1202812/148246296-7093cdb4-2b11-43b8-b7af-481c938d00d3.png">

@beafialho what do you think of that style for the buttons? I'd kind of prefer to make the default button style an outline style, but I'm not sure if we can do that technically. So this seems like the next best solution. 

---

This PR also provides style + spacing fixes for the post comments block. I think it's appropriate and fine to do these changes in CSS, since it's not possible to modify the styles and spacing of anything within that block at the moment. 

Before|After
---|---
![Screen Shot 2022-01-05 at 10 48 18](https://user-images.githubusercontent.com/1202812/148246869-0e8a194f-d279-4c54-862f-5e84aa531ace.png)|![Screen Shot 2022-01-05 at 10 48 34](https://user-images.githubusercontent.com/1202812/148246871-ea23b7e1-4ed1-441e-a936-17f05e0220a2.png)

