### PR TITLE
Livre: Refine link styles

### DIFF
--- a/livre/style.css
+++ b/livre/style.css
@@ -37,11 +37,12 @@ body {
 a {
 	text-decoration-thickness: 1px;
 	text-underline-offset: 0.25ch;
+	text-decoration-style: dotted;
 }
 
 a:hover,
 a:focus {
-	text-decoration-style: dashed;
+	text-decoration-style: solid;
 }
 
 a:active {


### PR DESCRIPTION
As discussed with @beafialho, this PR adjusts the text link treatment for Livre to be a bit more subtle. Links will now have a dotted line by default, and change to a solid line on hover. 

## Screenshots

Default|Hover/Focus
---|---
<img width="154" alt="Screen Shot 2022-01-06 at 9 31 25 AM" src="https://user-images.githubusercontent.com/1202812/148398665-a21b21dc-d8aa-4108-9644-dddc08100bc5.png">|<img width="164" alt="Screen Shot 2022-01-06 at 9 31 32 AM" src="https://user-images.githubusercontent.com/1202812/148398667-df641073-34c4-41e6-b8a8-1751ed5a6ffd.png">

