### PR TITLE
Livre: Update alignment rules

### DIFF
--- a/livre/style.css
+++ b/livre/style.css
@@ -105,7 +105,9 @@ a:active {
 body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group {
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align="full"] > .wp-block-group,
+.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);
 }


### PR DESCRIPTION
This PR updates the alignment rules to include Cover blocks as well. This syncs it back up with the alignment code in Twenty Twenty-Two. Cover block styles for these rules were left out of Twenty Twenty-Two by mistake, and added in https://github.com/WordPress/twentytwentytwo/pull/310.