### PR TITLE
[Livre] Add header-footer-only template.

### DIFF
--- a/livre/templates/header-footer-only.html
+++ b/livre/templates/header-footer-only.html
@@ -1,0 +1,7 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:post-content {"layout":{"inherit":true}} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/livre/theme.json
+++ b/livre/theme.json
@@ -8,6 +8,14 @@
 				"page",
 				"post"
 			]
+		},
+		{
+			"name": "header-footer-only",
+			"title": "Header and Footer Only",
+			"postTypes": [
+				"page",
+				"post"
+			]
 		}
 	],
 	"settings": {


### PR DESCRIPTION
This PR adds a custom template to Livre that contains just a header and footer.

<img width="281" alt="Screen Shot 2022-01-07 at 9 33 42 AM" src="https://user-images.githubusercontent.com/1202812/148558961-d13947b2-b4c9-4ecb-8a9d-c5ee1ebfa35e.png">

_(Note that the footer won't actually show up yet since it relies on a block pattern that doesn't exist — I'm working on fixing that in a separate PR)._ 