### PR TITLE
Deploy script: remove double quotes from commit message log

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -659,6 +659,8 @@ async function buildPhabricatorCommitMessageSince(hash){
 
 	let projectVersion = await executeCommand(`node -p "require('./package.json').version"`);
 	let logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
+	// Remove any double quotes from commit messages
+	logs.replace(/"/g, '');
 	return `Deploy Themes ${projectVersion} to wpcom
 
 Summary:
@@ -682,9 +684,6 @@ async function createGitPhabricatorDiff(hash) {
 	console.log('creating Phabricator Diff');
 
 	let commitMessage = await buildPhabricatorCommitMessageSince(hash);
-	
-	// Remove any double quotes from commit message
-	commitMessage = commitMessage.replace(/"/g, '');
 
 	let result = await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};
@@ -715,10 +714,7 @@ async function createSvnPhabricatorDiff(hash) {
 	console.log('creating Phabricator Diff');
 
 	const commitTempFileLocation = '/tmp/theme-deploy-comment.txt';
-	let commitMessage = await buildPhabricatorCommitMessageSince(hash);
-
-	// Remove any double quotes from commit message
-	commitMessage = commitMessage.replace(/"/g, '');
+	const commitMessage = await buildPhabricatorCommitMessageSince(hash);
 
 	console.log(commitMessage);
 

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -682,6 +682,9 @@ async function createGitPhabricatorDiff(hash) {
 	console.log('creating Phabricator Diff');
 
 	let commitMessage = await buildPhabricatorCommitMessageSince(hash);
+	
+	// Remove any double quotes from commit message
+	commitMessage = commitMessage.replace(/"/g, '');
 
 	let result = await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};
@@ -712,7 +715,10 @@ async function createSvnPhabricatorDiff(hash) {
 	console.log('creating Phabricator Diff');
 
 	const commitTempFileLocation = '/tmp/theme-deploy-comment.txt';
-	const commitMessage = await buildPhabricatorCommitMessageSince(hash);
+	let commitMessage = await buildPhabricatorCommitMessageSince(hash);
+
+	// Remove any double quotes from commit message
+	commitMessage = commitMessage.replace(/"/g, '');
 
 	console.log(commitMessage);
 

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -767,6 +767,8 @@ async function tagDeployment(options={}) {
 	}
 	let projectVersion = await executeCommand(`node -p "require('./package.json').version"`);
 	let logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
+	// Remove any double quotes from commit messages
+	logs.replace(/"/g, '');
 	let tag = `v${projectVersion}`;
 	let message = `Deploy Themes ${tag} to wpcom. \n\n${logs} \n\n${workInTheOpenPhabricatorUrl}`;
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes any double quotes from the commit message logs in the deploy script.

This is to fix an error @MaggieCabrera and I saw where a revert commit from GH included double quotes in the commit message, and because they were not escaped they caused the script to error.