### PR TITLE
Videomaker: Remove the redundant template

### DIFF
--- a/videomaker-white/block-templates/blank.html
+++ b/videomaker-white/block-templates/blank.html
@@ -1,1 +1,0 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/videomaker/block-templates/blank.html
+++ b/videomaker/block-templates/blank.html
@@ -1,1 +1,0 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes a redundant template from Videomaker. The template already exists in blockbase, so it's not needed in Videomaker. To test, check that "blank" is still an option here:
<img width="312" alt="Screenshot 2022-01-11 at 16 33 00" src="https://user-images.githubusercontent.com/275961/148982941-0d4ac620-6b53-419b-8419-c2753f3fd81a.png">

