### PR TITLE
Remove customizer restoration as it is no longer being removed by Gutenberg.

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -150,14 +150,6 @@ function blockbase_fonts_url() {
 }
 
 /**
- * Restores the Customizer since we still rely on it.
- */
-// function blockbase_restore_customizer() {
-// 	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
-// }
-// add_action( 'init', 'blockbase_restore_customizer' );
-
-/**
  * Customize Global Styles
  */
 if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -152,10 +152,10 @@ function blockbase_fonts_url() {
 /**
  * Restores the Customizer since we still rely on it.
  */
-function blockbase_restore_customizer() {
-	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
-}
-add_action( 'init', 'blockbase_restore_customizer' );
+// function blockbase_restore_customizer() {
+// 	remove_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
+// }
+// add_action( 'init', 'blockbase_restore_customizer' );
 
 /**
  * Customize Global Styles


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This change **removes** the **remove_action** to 'gutenberg_remove_legacy_pages'.  

Because this call was being REMOVED by Blockbase there were two links to the Editor being shown when running WordPress 5.9.

This was evaluated using WP 5.8.2 (and Gutenberg 12.3) and found that removing this remove_action didn't have negative side effects: The customizer is still available.  It seems that Gutenberg is no longer hiding that tool when a Block-based theme is detected.

#### Related issue(s):

Fixes #5131 