### PR TITLE
Revert "Change the way we fetch users CPT to use the Gutenberg function directly

### DIFF
--- a/blockbase/inc/customizer/wp-customize-utils.php
+++ b/blockbase/inc/customizer/wp-customize-utils.php
@@ -14,15 +14,17 @@ function set_settings_array( $target, $array, $value ) {
 	$key     = array_shift( $array );
 	$current =& $target;
 	while ( 0 < sizeof( $array ) ) {
-		$current = (array) $current; // Old data might be an object, so convert it.
-		if ( ! array_key_exists( $current, $key ) ) {
-			$current[ $key ] = array();
+		if ( ! property_exists( $current, $key ) ) {
+			$current->{ $key } = (object) array();
 		}
-		$current =& $current[ $key ];
+		$current =& $current->{ $key };
+
+		// Cast to an object in the case where it's been set as an array.
+		$current = (object) $current;
 
 		$key     = array_shift( $array );
 	}
-	$current[ $key ] = $value;
+	$current->{ $key } = $value;
 	return $target;
 }
 


### PR DESCRIPTION
This reverts commit 75ba42af5b5fce3736867af55d32c63e5f93e711.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change introduced a whole heap of bugs. We should reconsider the implementation here to take advantage of this new API: https://github.com/WordPress/gutenberg/pull/35801/files

To test:
- Try changing fonts in the customizer
- Try changing colors in the customizer

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/59886
https://github.com/Automattic/wp-calypso/issues/60019
