### PR TITLE
AltoFocus: set correct value for `featured-content[show-all]` option.

### DIFF
--- a/altofocus/inc/customizer.php
+++ b/altofocus/inc/customizer.php
@@ -124,6 +124,6 @@ add_action( 'featured_content_default_settings', 'altofocus_featured_content_def
  */
 function altofocus_change_featured_content_default_settings() {
 	set_theme_mod( 'featured-content[show-all]', 1 );
-	update_option( 'featured-content[show-all]', 1 );
+	update_option( 'featured-content[show-all]', '1' );
 }
 add_action( 'after_setup_theme', 'altofocus_change_featured_content_default_settings' );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The expected type of the `featured-content[show-all]` option is a string, not an integer.

#### Related issue(s):
