### PR TITLE
[Livro] Update alignment rules

### DIFF
--- a/livro/style.css
+++ b/livro/style.css
@@ -105,6 +105,7 @@ a:active {
 body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
+.wp-block-group.has-background,
 .wp-block-cover.alignfull,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group,
 .is-root-container .wp-block[data-align="full"] > .wp-block-cover {
@@ -113,6 +114,14 @@ body > .is-root-container,
 }
 
 .wp-site-blocks .alignfull,
+.wp-site-blocks > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-cover,
+.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
+body > .is-root-container > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-cover,
+body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;


### PR DESCRIPTION
This PR updates Livro's alignment rules to better handle Group blocks that have a background color as well as Cover blocks. 

When these blocks are added to the top level of the site, or directly within a Template Part at that level, they'll now go edge-to-edge by default. This feels natural, and allows folks to easily get full-width headers and footer backgrounds without any workarounds. 

The PR is a straight-up copy of [a recent update to Twenty Twenty-Two](https://href.li/?https://github.com/WordPress/twentytwentytwo/pull/336/), so you can read about the change there too if you'd like. All of these alignment styles are just copied/pasted from there. The same testing instructions apply here. 

Before|After
---|---
<img width="1173" alt="Screen Shot 2022-01-13 at 2 45 24 PM" src="https://user-images.githubusercontent.com/1202812/149398761-3f2bc367-23bb-401b-8f0f-9b14a0d56157.png">|<img width="1174" alt="Screen Shot 2022-01-13 at 2 44 53 PM" src="https://user-images.githubusercontent.com/1202812/149398763-a2527f65-0444-4bf0-8f23-c48c12ee44c8.png">

