### PR TITLE
[Blockbase] Update alignment rules to better handle full-width items

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -80,12 +80,21 @@ pre {
 body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
+.wp-block-group.has-background,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group {
 	padding-left: var(--wp--custom--gap--horizontal);
 	padding-right: var(--wp--custom--gap--horizontal);
 }
 
 .wp-site-blocks .alignfull,
+.wp-site-blocks > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-cover,
+.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
+body > .is-root-container > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-cover,
+body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -32,29 +32,37 @@
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
- .wp-site-blocks,
- body > .is-root-container,
- .edit-post-visual-editor__post-title-wrapper,
- .wp-block-group.alignfull,
- .is-root-container .wp-block[data-align="full"] > .wp-block-group {
+.wp-site-blocks,
+body > .is-root-container,
+.edit-post-visual-editor__post-title-wrapper,
+.wp-block-group.alignfull,
+.wp-block-group.has-background,
+.is-root-container .wp-block[data-align="full"] > .wp-block-group {
 	padding-left: var(--wp--custom--gap--horizontal);
 	padding-right: var(--wp--custom--gap--horizontal);
- }
+}
 
- .wp-site-blocks .alignfull,
- .is-root-container .wp-block[data-align="full"] {
+.wp-site-blocks .alignfull,
+.wp-site-blocks > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-cover,
+.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
+body > .is-root-container > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-cover,
+body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-template-part > .wp-block-cover,
+.is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	width: unset;
- }
+}
 
- /* Blocks inside columns don't have negative margins. */
- .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
- .is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
- /* We also want to avoid stacking negative margins. */
- .wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
- .is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
+/* Blocks inside columns don't have negative margins. */
+.wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
+.is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
+.wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
+.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
 	margin-left: auto !important;
 	margin-right: auto !important;
 	width: inherit;
- }
+}


### PR DESCRIPTION
This PR updates Blockbase's alignment rules to better handle Group blocks that have a background color as well as Cover blocks. 

When these blocks are added to the top level of the site, or directly within a Template Part at that level, they'll now go edge-to-edge by default. This feels natural, and allows folks to easily get full-width headers and footer backgrounds without any workarounds. 

The PR is a straight-up copy of [a recent update to Twenty Twenty-Two](https://href.li/?https://github.com/WordPress/twentytwentytwo/pull/336/), so you can read about the change there too if you'd like. All of these alignment styles are just copied/pasted from there. The same testing instructions apply here. 

Before|After
---|---
<img width="1152" alt="Screen Shot 2022-01-13 at 3 08 21 PM" src="https://user-images.githubusercontent.com/1202812/149401739-f1e7dc22-98c4-413d-9825-90f21292e469.png">|<img width="1152" alt="Screen Shot 2022-01-13 at 3 03 59 PM" src="https://user-images.githubusercontent.com/1202812/149401756-891d52f5-9f23-4687-8f51-39ad90832169.png">

