### PR TITLE
[Stewart] Rename template parts

### DIFF
--- a/stewart/parts/header-spacer.html
+++ b/stewart/parts/header-spacer.html
@@ -1,3 +1,0 @@
-<!-- wp:spacer {"height":70} -->
-<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->

--- a/stewart/parts/header-title-nav.html
+++ b/stewart/parts/header-title-nav.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"top":"var(--wp--custom--margin--horizontal, 30px)","bottom":"40px"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--margin--horizontal, 30px);padding-bottom:40px">
+	<!-- wp:site-title /-->
+	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
+</div>
+<!-- /wp:group -->

--- a/stewart/parts/header.html
+++ b/stewart/parts/header.html
@@ -1,6 +1,3 @@
-<!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"top":"var(--wp--custom--margin--horizontal, 30px)","bottom":"40px"}}}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--margin--horizontal, 30px);padding-bottom:40px">
-	<!-- wp:site-title /-->
-	<!-- wp:navigation {"isResponsive":true,"__unstableLocation":"primary"} /-->
-</div>
-<!-- /wp:group -->
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/stewart/templates/archive.html
+++ b/stewart/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/templates/header-footer-only.html
+++ b/stewart/templates/header-footer-only.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header-title-nav","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">

--- a/stewart/templates/index.html
+++ b/stewart/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/templates/page.html
+++ b/stewart/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/templates/search.html
+++ b/stewart/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/templates/sidebar-footer-only.html
+++ b/stewart/templates/sidebar-footer-only.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/templates/single.html
+++ b/stewart/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-spacer","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -7,8 +7,8 @@
 			"area": "header"
 		},
 		{
-			"name": "header-spacer",
-			"title": "Header Spacer",
+			"name": "header-title-nav",
+			"title": "Header with Site Title and Navigation",
 			"area": "header"
 		},
 		{


### PR DESCRIPTION
By default, the header template part in Stewart was called "Header Spacer". I think that's going to be confusing for users, so this PR renames it to just "Header". 

We had a more traditional header template part that already used that name, so I've renamed that one to "Header with Site Title and Navigation". 

Before|After
---|---
<img width="290" alt="Screen Shot 2022-01-13 at 3 46 07 PM" src="https://user-images.githubusercontent.com/1202812/149406587-83c94fdb-4bd3-4e0e-ad6a-0556a53f4afe.png">|<img width="293" alt="Screen Shot 2022-01-13 at 3 45 15 PM" src="https://user-images.githubusercontent.com/1202812/149406611-d9c38af2-f2ef-4606-9ee9-d07e830b4348.png">


