### PR TITLE
[Livro] Minor theme review fixes

### DIFF
--- a/livro/functions.php
+++ b/livro/functions.php
@@ -4,8 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package WordPress
- * @subpackage Livro
+ * @package Livro
  * @since Livro 1.0
  */
 

--- a/livro/readme.txt
+++ b/livro/readme.txt
@@ -1,7 +1,7 @@
 === Livro ===
 Contributors: automattic
 Requires at least: 5.8
-Tested up to: 5.9
+Tested up to: 5.8.3
 Requires PHP: 5.6
 Stable tag: 1.0
 License: GPLv2 or later

--- a/livro/style.css
+++ b/livro/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Livro is a simple theme designed to evoke the calm feeling you get when you settle in with a classic book. 
 Requires at least: 5.8
-Tested up to: 5.9
+Tested up to: 5.8.3
 Requires PHP: 5.6
 Version: 1.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Fixes [the minor issues](https://themes.trac.wordpress.org/ticket/110931#comment:4) raised during Theme Review.

- Changes "Tested up to" to 5.8.3, since 5.9 isn't released yet. 
- Removes mention of the `@WordPress` package. 