### PR TITLE
Adjust the sync logic to be simpler

### DIFF
--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -20,3 +20,5 @@ deploy-dotorg.sh
 **/*.zip
 variations
 variations/**
+inc/headstart
+languages

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -588,6 +588,7 @@ async function pushChangesToSandbox() {
 	console.log("Pushing Changes to Sandbox.");
 	let hash = await getLastDeployedHash();
 	let changedThemes = await getChangedThemes(hash);
+	changedThemes = changedThemes.filter(item=>directoriesToIgnore.includes(item));
 	console.log(`Syncing ${changedThemes.length} themes`);
 
 	for ( let theme of changedThemes ) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -588,7 +588,7 @@ async function pushChangesToSandbox() {
 	console.log("Pushing Changes to Sandbox.");
 	let hash = await getLastDeployedHash();
 	let changedThemes = await getChangedThemes(hash);
-	changedThemes = changedThemes.filter(item=>directoriesToIgnore.includes(item));
+	changedThemes = changedThemes.filter( item=> ! directoriesToIgnore.includes( item ) );
 	console.log(`Syncing ${changedThemes.length} themes`);
 
 	for ( let theme of changedThemes ) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -586,68 +586,16 @@ function pushPremiumToSandbox() {
 async function pushChangesToSandbox() {
 
 	console.log("Pushing Changes to Sandbox.");
-
 	let hash = await getLastDeployedHash();
+	let changedThemes = await getChangedThemes(hash);
+	console.log(`Syncing ${changedThemes.length} themes`);
 
-	let deletedFiles = await getDeletedFilesSince(hash);
-	let changedFiles = await getComittedChangesSinceHash(hash);
-
-	//remove deleted files from changed files
-	changedFiles = changedFiles.filter( item => {
-		return false === deletedFiles.includes(item);
-	});
-
-
-	if(deletedFiles.length > 0) {
-		console.log('deleting from sandbox: ', deletedFiles);
-		await executeOnSandbox(`
-			cd ${sandboxPublicThemesFolder};
-			rm -f ${deletedFiles.join(' ')}
-		`, true);
-	}
-
-	if(changedFiles.length > 0) {
-		console.log('pushing changed files to sandbox:', changedFiles);
+	for ( let theme of changedThemes ) {
+		console.log( `Syncing ${theme}` );
 		await executeCommand(`
-			rsync -avR --no-p --no-times --exclude-from='.sandbox-ignore' ${changedFiles.join(' ')} wpcom-sandbox:${sandboxPublicThemesFolder}/
+			rsync -avR --no-p --no-times --delete -m --exclude-from='.sandbox-ignore' ./${theme}/ wpcom-sandbox:${sandboxPublicThemesFolder}/
 		`, true);
 	}
-}
-
-/*
- Provide a collection of all files that have changed since the given hash.
- Used by pushChangesToSandbox
-*/
-async function getComittedChangesSinceHash(hash) {
-	const directoriesToIgnoreString = directoriesToIgnore.map( directory => ':^' + directory ).join(' ');
-	let comittedChanges = await executeCommand(`git diff ${hash} HEAD --name-only -- . ${directoriesToIgnoreString}`);
-	comittedChanges = comittedChanges.replace(/\r?\n|\r/g, " ").split(" ");
-
-	let uncomittedChanges = await executeCommand(`git diff HEAD --name-only -- . ${directoriesToIgnoreString}`);
-	uncomittedChanges = uncomittedChanges.replace(/\r?\n|\r/g, " ").split(" ");
-
-	return comittedChanges.concat(uncomittedChanges);
-}
-
-/*
- Provide a collection of all files that have been deleted since the given hash.
- Used by pushChangesToSandbox
-*/
-async function getDeletedFilesSince(hash){
-
-	let deletedSinceHash = await executeCommand(`
-		git log --format=format:"" --name-only -M100% --diff-filter=D ${hash}..HEAD
-	`);
-	deletedSinceHash = deletedSinceHash.replace(/\r?\n|\r/g, " ").trim().split(" ");
-
-	let deletedAndUncomitted = await executeCommand(`
-		git diff HEAD --name-only --diff-filter=D
-	`);
-	deletedAndUncomitted = deletedAndUncomitted.replace(/\r?\n|\r/g, " ").trim().split(" ");
-
-	return deletedSinceHash.concat(deletedAndUncomitted).filter( item => {
-		return item != '';
-	});
 }
 
 /*


### PR DESCRIPTION
It was clear when trying to deploy the change to move templates to another folder that the "syncing" process of our deploy script wasn't working as intended.  "Moved" files weren't being tracked as "deleted".

This change relies 100% on rsync to bring the two locations into alignment.  (Thanks to @jffng for questioning why were weren't doing that already... )

First it determines which themes have changed (using existing logic) and rsyncs that theme's folder, INCLUDING removing deleted (or moved) files and empty folders from the destination (sandbox).

This can be tested in isolation by running `npm run deploy:push:changes` and also runs during the deploy action with `run deploy:svn`
