### PR TITLE
Blockbase: Remove blank template

### DIFF
--- a/russell/block-templates/blank.html
+++ b/russell/block-templates/blank.html
@@ -1,1 +1,0 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->


### PR DESCRIPTION
Blockbase children inherit the blank template from Blockbase, so they don't need to implement their own. To test check that you still see a blank template option in Russell.