### PR TITLE
Fix/deploy versioning

### DIFF
--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -22,3 +22,4 @@ variations
 variations/**
 inc/headstart
 languages
+*.map

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -109,11 +109,24 @@ async function pushButtonDeploy(repoType) {
 
 		let thingsWentBump = await versionBumpThemes();
 
+		if( thingsWentBump ){
+			prompt = await inquirer.prompt([{
+				type: 'confirm',
+				message: 'Are you good with the version bump changes? Make any manual adjustments now if necessary.',
+				name: "continue",
+				default: false
+			}]);
+
+			if(!prompt.continue){
+				console.log(`Aborted Automated Deploy Process at version bump changes.` );
+				return;
+			}
+		}
+
 		let changedThemes = await getChangedThemes(hash);
 
 		await pushChangesToSandbox();
 
-		await updateLastDeployedHash();
 
 		//push changes (from version bump)
 		if( thingsWentBump ){
@@ -134,6 +147,8 @@ async function pushButtonDeploy(repoType) {
 				git push
 			`, true);
 		}
+
+		await updateLastDeployedHash();
 
 		if (repoType === 'git' ) {
 			diffUrl = await createGitPhabricatorDiff(hash);


### PR DESCRIPTION
Due to a bug in the deploy process version bumping was lagging behind where it should have been; "has it been version bumped" was looking at the incorrect hash and determining that a theme HAD been version bumped, while it actually hadn't and should have been.

This change changes the order of "committing the change" (thus creating the hash) and updating the hash in the sandbox as well as adds a step to allow the user to verify (and change if necessary) the themes being automatically version bumped.

Additionally *.map files are now ignored when pushing to the sandbox.
