### PR TITLE
Fix Woo number input in Blockbase

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -216,6 +216,17 @@ body.admin-bar .wp-site-blocks {
   margin-top: 0 !important;
 }
 
+/* 
+Remove the normalized box-sizing: border-box when used with Woo's quantity field,
+because Woo limits the field's width to 50px, 
+which leaves no space for the context between 50px and 20px padding and the spinner arrows (that come from type=number)
+
+See: https://github.com/Automattic/wp-calypso/issues/58958#issuecomment-1015263777
+*/
+.quantity .qty {
+  box-sizing: content-box;
+}
+
 /**
  * Elements
  * - Styles for basic HTML elemants

--- a/blockbase/sass/base/_utility.scss
+++ b/blockbase/sass/base/_utility.scss
@@ -24,3 +24,14 @@
 		margin-top: 0 !important;
 	}
 }
+
+/* 
+Remove the normalized box-sizing: border-box when used with Woo's quantity field,
+because Woo limits the field's width to 50px, 
+which leaves no space for the context between 50px and 20px padding and the spinner arrows (that come from type=number)
+
+See: https://github.com/Automattic/wp-calypso/issues/58958#issuecomment-1015263777
+*/
+.quantity .qty { 
+	box-sizing: content-box;
+}


### PR DESCRIPTION
Hi!

It appears that Woo limits the `type=number` input field's width to[ 3.631em (50px)](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/legacy/css/woocommerce.scss#L117). This works until some padding is set. 

Blockbase sets a total [`padding of 20px`](https://github.com/Automattic/themes/blob/blockbase/fix-woo-number-input/blockbase/assets/ponyfill.css#L283), and sets [`box-sizing: border-box`](https://github.com/Automattic/themes/blob/blockbase/fix-woo-number-input/blockbase/sass/base/_normalize.scss#L8), add the spin buttons and you're left with 0px for the content.

#### Changes proposed in this Pull Request:
This PR allows the padding to widen the element by changing the box-sizing value to `content-box`.

#### Related issue(s):
Automattic/themes#5761