### PR TITLE
Refactored dotorg deploy script to use svn cp

### DIFF
--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -19,9 +19,7 @@ declare -a THEMES_TO_DEPLOY=(
 	"blockbase" 
 	"zoologist"
 	"geologist"
-	"mayland-blocks"
 	"quadrat"
-	"skatepark"
 	"seedlet-blocks",
 	"livro",
 	"videomaker"

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -19,6 +19,7 @@ declare -a THEMES_TO_DEPLOY=(
 	"blockbase" 
 	"zoologist"
 	"geologist"
+	"mayland-blocks"
 	"quadrat"
 	"seedlet-blocks",
 	"livro",


### PR DESCRIPTION
Prompted by [this suggestion](https://wordpress.slack.com/archives/C02RP4Y3K/p1637539288210900?thread_ts=1637073824.200700&cid=C02RP4Y3K) this change:

* Copies the "last" version (last being determined by the "last one in the array", is this appropriate with semver directories?) of the theme to the NEW version folder
* rsyncs the source theme assets to the new version folder (including deleting files missing from the source theme)
* SVN ADD and SVN DELETE the appropriate assets
* commit the changes

Additionally a "preview" option has been added which does not commit these changes but allows them to be made to determine that the changes are correct.
```
./deploy-dotorg.sh preview
```

This change also adds Livro and Videomaker to the list of themes to deploy to dotorg.