### PR TITLE
Blockbase: Load Block Patterns for children automatically

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -183,3 +183,8 @@ require get_template_directory() . '/inc/block-styles.php';
  * Block Patterns.
  */
 require get_template_directory() . '/inc/block-patterns.php';
+
+// Add the child theme patterns if they exist.
+if ( file_exists( get_stylesheet_directory() . '/inc/block-patterns.php' ) ) {
+	require_once get_stylesheet_directory() . '/inc/block-patterns.php';
+}

--- a/geologist-blue/functions.php
+++ b/geologist-blue/functions.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/geologist-cream/functions.php
+++ b/geologist-cream/functions.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/geologist-slate/functions.php
+++ b/geologist-slate/functions.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/geologist-yellow/functions.php
+++ b/geologist-yellow/functions.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/geologist/functions.php
+++ b/geologist/functions.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/quadrat-black/functions.php
+++ b/quadrat-black/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/quadrat-black/style.css
+++ b/quadrat-black/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: Quadrat Black 
+Theme Name: Quadrat Black
 Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
 Author: Automattic
 Author URI: https://automattic.com/

--- a/quadrat-green/functions.php
+++ b/quadrat-green/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/quadrat-red/functions.php
+++ b/quadrat-red/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/quadrat-white/functions.php
+++ b/quadrat-white/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/quadrat-yellow/functions.php
+++ b/quadrat-yellow/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/quadrat/functions.php
+++ b/quadrat/functions.php
@@ -14,11 +14,6 @@ if ( ! function_exists( 'quadrat_support' ) ) :
 endif;
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/seedlet-blocks/functions.php
+++ b/seedlet-blocks/functions.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';
-
-/**
  * Block Styles.
  */
 require get_stylesheet_directory() . '/inc/block-styles.php';

--- a/variations/geologist/geologist-blue/style.css
+++ b/variations/geologist/geologist-blue/style.css
@@ -7,7 +7,7 @@ Description: Geologist-blue is a streamlined theme for modern bloggers. It consi
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.0.18
+Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/geologist/geologist-cream/style.css
+++ b/variations/geologist/geologist-cream/style.css
@@ -7,7 +7,7 @@ Description: Geologist-cream is a streamlined theme for modern bloggers. It cons
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.0.18
+Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/geologist/geologist-slate/style.css
+++ b/variations/geologist/geologist-slate/style.css
@@ -7,7 +7,7 @@ Description: Geologist-slate is a streamlined theme for modern bloggers. It cons
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.0.18
+Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/geologist/geologist-yellow/style.css
+++ b/variations/geologist/geologist-yellow/style.css
@@ -7,7 +7,7 @@ Description: Geologist-yellow is a streamlined theme for modern bloggers. It con
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.0.18
+Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/quadrat/quadrat-black/style.css
+++ b/variations/quadrat/quadrat-black/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: Quadrat Black 
+Theme Name: Quadrat Black
 Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
 Author: Automattic
 Author URI: https://automattic.com/
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.31
+Version: 1.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/quadrat/quadrat-green/style.css
+++ b/variations/quadrat/quadrat-green/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.31
+Version: 1.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/quadrat/quadrat-red/style.css
+++ b/variations/quadrat/quadrat-red/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.31
+Version: 1.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/quadrat/quadrat-white/style.css
+++ b/variations/quadrat/quadrat-white/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.31
+Version: 1.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/quadrat/quadrat-yellow/style.css
+++ b/variations/quadrat/quadrat-yellow/style.css
@@ -7,7 +7,7 @@ Description: Quadrat is a simple, versatile WordPress theme, designed for blogs 
 Requires at least: 5.7
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.1.31
+Version: 1.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/variations/videomaker/videomaker-white/style.css
+++ b/variations/videomaker/videomaker-white/style.css
@@ -7,7 +7,7 @@ Description: Videomaker is a free, minimalistic WordPress theme ideal for film d
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 1.0.3
+Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase

--- a/videomaker-white/functions.php
+++ b/videomaker-white/functions.php
@@ -14,8 +14,3 @@ function videomaker_editor_styles() {
 	);
 }
 add_action( 'after_setup_theme', 'videomaker_editor_styles' );
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';

--- a/videomaker/functions.php
+++ b/videomaker/functions.php
@@ -14,8 +14,3 @@ function videomaker_editor_styles() {
 	);
 }
 add_action( 'after_setup_theme', 'videomaker_editor_styles' );
-
-/**
- * Block Patterns.
- */
-require get_stylesheet_directory() . '/inc/block-patterns.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Rather than having custom code to load block patterns, we should just load them if they are there. This adds code to Blockbase to check for patterns in the child and load them.

To test check that you can still see the patterns in these themes:

Videomaker (and variants)
Quadrat (and variants)
Geologist (and variants)
Skatepark
Seedlet Blocks
Zoologist