### PR TITLE
Premium: Update blockbase references when we push to the premium repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
 		"sandbox:watch": "chokidar '**/*' -i '*/node_modules' -i '.git' -c './sandbox.sh push --ignore' --initial",
 		"sandbox:clean:git": "node ./theme-utils.mjs clean-sandbox-git",
 		"sandbox:clean:svn": "node ./theme-utils.mjs clean-sandbox-svn",
+		"sandbox:clean-premium:git": "node ./theme-utils.mjs clean-premium-sandbox-git",
+		"sandbox:clean-premium:svn": "node ./theme-utils.mjs clean-premium-sandbox-svn",
 		"sandbox:clean-all:git": "node ./theme-utils.mjs clean-all-sandbox-git",
 		"sandbox:clean-all:svn": "node ./theme-utils.mjs clean-all-sandbox-svn",
 		"local:clean": "git reset --hard HEAD; git clean -fd",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -641,8 +641,7 @@ async function pushPremiumToSandbox() {
 
 	// Push the changes in the premium themes to the sandbox
 	await executeCommand(`
-		rsync -avR --no-p --no-times --delete -m --exclude-from='.sandbox-ignore' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxPremiumThemesFolder}/
-	
+		rsync -avR --no-p --no-times --delete -m --exclude-from='.sandbox-ignore' --exclude='sass' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxPremiumThemesFolder}/
 	`, true);
 
 	// revert the local blockbase-premium changes

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -664,7 +664,7 @@ async function pushChangesToSandbox() {
 	console.log("Pushing Changes to Sandbox.");
 	let hash = await getLastDeployedHash();
 	let changedThemes = await getChangedThemes(hash);
-	changedThemes = changedThemes.filter( item=> ! directoriesToIgnore.includes( item ) );
+	changedThemes = changedThemes.filter( item=> ! premiumThemes.includes( item ) );
 	console.log(`Syncing ${changedThemes.length} themes`);
 
 	for ( let theme of changedThemes ) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -5,9 +5,10 @@ import inquirer from 'inquirer';
 
 const remoteSSH = 'wpcom-sandbox';
 const sandboxPublicThemesFolder = '/home/wpdev/public_html/wp-content/themes/pub';
+const sandboxPremiumThemesFolder = '/home/wpdev/public_html/wp-content/themes/premium';
 const sandboxRootFolder = '/home/wpdev/public_html/';
 const isWin = process.platform === 'win32';
-const directoriesToIgnore = [ 'variations', 'videomaker', 'videomaker-white' ];
+const premiumThemes = [ 'videomaker', 'videomaker-white' ];
 
 (async function start() {
 	let args = process.argv.slice(2);
@@ -17,6 +18,8 @@ const directoriesToIgnore = [ 'variations', 'videomaker', 'videomaker-white' ];
 		case "push-button-deploy-svn": return pushButtonDeploy('svn');
 		case "clean-sandbox-git": return cleanSandboxGit();
 		case "clean-sandbox-svn": return cleanSandboxSvn();
+		case "clean-premium-sandbox-git": return cleanPremiumSandboxGit();
+		case "clean-premium-sandbox-svn": return cleanPremiumSandboxSvn();
 		case "clean-all-sandbox-git": return cleanAllSandboxGit();
 		case "clean-all-sandbox-svn": return cleanAllSandboxSvn();
 		case "push-to-sandbox": return pushToSandbox();
@@ -512,6 +515,25 @@ async function cleanSandboxGit() {
 }
 
 /*
+ Clean the premium theme sandbox.
+ Assumes sandbox is in 'git' mode
+ checkout origin/develop and ensure it's up-to-date.
+ Remove any other changes.
+*/
+async function cleanPremiumSandboxGit() {
+	console.log('Cleaning the Themes Sandbox');
+	await executeOnSandbox(`
+		cd ${sandboxPremiumThemesFolder};
+		git reset --hard HEAD;
+		git clean -fd;
+		git checkout develop;
+		git pull;
+		echo;
+		git status
+	`, true);
+	console.log('All done cleaning.');
+}
+/*
  Clean the entire sandbox.
  Assumes sandbox is in 'git' mode
  checkout origin/develop and ensure it's up-to-date.
@@ -538,7 +560,7 @@ async function cleanAllSandboxGit() {
  Remove any other changes
 */
 async function cleanSandboxSvn() {
-	console.log('Cleaning the theme sandbox');
+	console.log('Cleaning the premium theme sandbox');
 	await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};
   		svn revert -R .;
@@ -548,6 +570,22 @@ async function cleanSandboxSvn() {
 	console.log('All done cleaning.');
 }
 
+/*
+ Clean the premium theme sandbox.
+ Assumes sandbox is in 'svn' mode
+ ensure trunk is up-to-date
+ Remove any other changes
+*/
+async function cleanPremiumSandboxSvn() {
+	console.log('Cleaning the premium theme sandbox');
+	await executeOnSandbox(`
+		cd ${sandboxPremiumThemesFolder};
+  		svn revert -R .;
+  		svn cleanup --remove-unversioned;
+  		svn up;
+	`, true);
+	console.log('All done cleaning.');
+}
 /*
  Clean the entire sandbox.
  Assumes sandbox is in 'svn' mode
@@ -585,25 +623,37 @@ function pushToSandbox() {
    * Triggering the .zip builds
 */
 async function pushPremiumToSandbox() {
-	await executeCommand( `git reset --hard HEAD`, true );
-	const premiumThemes = [
-		'videomaker',
-		'videomaker-white'
+
+	//TODO: It would be nice to determine this list programatically
+	const filesToModify = [
+		'style.css',
+		'block-templates/404.html',
+		'block-template-parts/header.html',
+		'block-template-parts/footer.html'
 	];
 
+	// Change 'blockbase' to 'blockbase-premium' in the files noted
 	for ( let theme of premiumThemes ) {
-		console.log( theme );
-		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/style.css`, true);
-		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-templates/404.html`, true);
-		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-template-parts/header.html`, true);
-		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-template-parts/footer.html`, true);
+		for ( let file of filesToModify ) {
+			await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/${file}`, true);
+		}
 	}
 
-	executeCommand(`
-		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude='sass/' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxRootFolder}/wp-content/themes/premium/
+	// Push the changes in the premium themes to the sandbox
+	await executeCommand(`
+		rsync -avR --no-p --no-times --delete -m --exclude-from='.sandbox-ignore' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxPremiumThemesFolder}/
+	
 	`, true);
 
-	await executeCommand( `git reset --hard HEAD`, true );
+	// revert the local blockbase-premium changes
+	for ( let theme of premiumThemes ) {
+		for ( let file of filesToModify ) {
+			await executeCommand(`
+				git restore --source=HEAD --staged --worktree ./${theme}/${file}
+			`);
+		}
+	}
+
 }
 
 /*

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -560,7 +560,7 @@ async function cleanAllSandboxGit() {
  Remove any other changes
 */
 async function cleanSandboxSvn() {
-	console.log('Cleaning the premium theme sandbox');
+	console.log('Cleaning the theme sandbox');
 	await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};
   		svn revert -R .;

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -584,14 +584,26 @@ function pushToSandbox() {
    * Deploying the theme
    * Triggering the .zip builds
 */
-function pushPremiumToSandbox() {
+async function pushPremiumToSandbox() {
+	await executeCommand( `git reset --hard HEAD`, true );
 	const premiumThemes = [
 		'videomaker',
 		'videomaker-white'
-	]
+	];
+
+	for ( let theme of premiumThemes ) {
+		console.log( theme );
+		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/style.css`, true);
+		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-templates/404.html`, true);
+		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-template-parts/header.html`, true);
+		await executeCommand(`perl -pi -e 's/blockbase/blockbase-premium/' ${theme}/block-template-parts/footer.html`, true);
+	}
+
 	executeCommand(`
 		rsync -av --no-p --no-times --exclude-from='.sandbox-ignore' --exclude='sass/' ./${premiumThemes.join(' ./')} wpcom-sandbox:${sandboxRootFolder}/wp-content/themes/premium/
 	`, true);
+
+	await executeCommand( `git reset --hard HEAD`, true );
 }
 
 /*


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When we push Videomaker and Videomaker White to the premium repo we need to update the `blockbase` slug with `blockbase-premium`. This script takes care of that change and then reverts the slug once the sync is complete.

#### Related issue(s):
https://github.com/Automattic/themes/pull/5196
https://github.com/Automattic/themes/issues/5211