### PR TITLE
Fix/variation versioning

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -387,7 +387,7 @@ async function versionBumpThemes() {
 	return changesWereMade;
 }
 
-function getThemeMetadata(styleCss, attribute) {
+export function getThemeMetadata(styleCss, attribute) {
 	if ( !styleCss || !attribute ) {
 		return null;
 	}
@@ -829,7 +829,7 @@ EOF`, logResponse);
 /*
  Execute a command locally.
 */
-async function executeCommand(command, logResponse) {
+export async function executeCommand(command, logResponse) {
 	return new Promise((resolove, reject) => {
 
 		let child;

--- a/variations/build-variations.mjs
+++ b/variations/build-variations.mjs
@@ -6,9 +6,9 @@ import { fileURLToPath } from 'url';
 import { executeCommand, getThemeMetadata } from '../theme-utils.mjs';
 
 const localpath = dirname( fileURLToPath( import.meta.url ) );
+const args = process.argv.slice(2);
 
 async function start() {
-	let args = process.argv.slice(2);
 	let source = args?.[0];
 	let variation = args?.[1];
 	if ( source && variation ) {
@@ -75,6 +75,10 @@ async function buildVariation(source, variation) {
 		// replace the with current version
 		if ( currentVersion != null ) {
 			await executeCommand(`perl -pi -e 's/Version: (.*)$/"Version: '${currentVersion}'"/ge' ${destDir}/style.css`);
+		}
+
+		if ( args[0] == 'git-add-changes') {
+			await executeCommand(`git add ${destDir}`, true);
 		}
 	
 		console.log('Finished sucessfully.\n\n');

--- a/variations/build-variations.mjs
+++ b/variations/build-variations.mjs
@@ -7,7 +7,7 @@ import { executeCommand, getThemeMetadata } from '../theme-utils.mjs';
 
 const localpath = dirname( fileURLToPath( import.meta.url ) );
 
-(async function start() {
+async function start() {
 	let args = process.argv.slice(2);
 	let source = args?.[0];
 	let variation = args?.[1];
@@ -15,7 +15,9 @@ const localpath = dirname( fileURLToPath( import.meta.url ) );
 		return await buildVariation(source, variation);
 	}
 	return await buildAllVariations();
-})();
+}
+
+start();
 
 async function buildAllVariations(){
 	for (let source of getDirectories( localpath )){
@@ -34,7 +36,7 @@ async function buildVariation(source, variation) {
 
 	try {
 		// First grab the existing version if the variation exists already
-		let variationExists = true; //TODO
+		let variationExists = fs.existsSync(`${destDir}/style.css`);
 		let currentVersion = null;
 
 		if( variationExists ) {
@@ -51,7 +53,6 @@ async function buildVariation(source, variation) {
 		// remove unneeded resources
 		await fs.remove( destDir + '/sass');
 		await fs.remove( destDir + '/node_modules' );
-		await fs.remove( destDir + '/template-mods.json');
 		await fs.remove( destDir + '/package.json');
 		await fs.remove( destDir + '/package-lock.json');
 
@@ -61,16 +62,6 @@ async function buildVariation(source, variation) {
 		// copy the readme
 		await fs.copy( localpath + '/variation-readme.md', destDir + '/variation-readme.md' );
 
-		// make template modifications
-		const hasMods = fs.existsSync( `${srcVariationDir}/template-mods.json`);
-		if(hasMods) {
-			const srcModsFile = await fs.readFile( `${srcVariationDir}/template-mods.json`, 'utf8' );
-			const modsJson = JSON.parse( srcModsFile );
-			modsJson.forEach(mod => {
-				modifyTemplates(mod.from, mod.to, destDir + '/block-templates');
-			});
-		}
-	
 		// merge the theme.json files
 		const srcJsonFile = await fs.readFile( srcDir + '/theme.json', 'utf8' );
 		const srcVariationJsonFile = await fs.readFile( srcVariationDir + '/theme.json', 'utf8' )

--- a/variations/variation-readme.md
+++ b/variations/variation-readme.md
@@ -24,20 +24,3 @@ For a variation in that folder `/variations/geologist/geologist-banana`
 * Lastly the theme.json files in `/geologist` and `/variations/geologist/geologist-banana` will be merged.
 
 Any resource in the /variations folder will replace the resources in the source theme (with the exception of theme.json);
-
-### Template Mods
-
-A variation can have a `template-mods.json` file that lists strings in the templates to replace.  The use-case this mechanism was build
-for was so that the variation theme could have a different header by defining that in one place.  There are plenty of gaps in this
-implementation but should cover the basic use-cases we need.
-
-The format for this file is:
-
-```
-[
-	{
-		"from": "STRING TO REPLACE",
-		"to": "STRING TO BE USED AS REPLACEMENT"
-	}
-]
-```


### PR DESCRIPTION
This change does a few things:

First the 'template-mods' feature of the variations script has been removed.  It isn't used and its presence is confusing considering there's no examples.  The need was filled by using patterns instead of template parts so this has been removed.

Modifies the build variation script to use the version in the DESTINATION directory (if there is one) when the variation is built.  This addresses #5401.  To test run the script `npm run build:variations` and note that the versions in the variation style.css files is unchanged.

Additionally the variation script can now STAGE changes in git when ran.  Run it with `node ./variations/build-variations.mjs git-add-changes`

Lastly the deploy script (`theme-utils.mjs`) now leverages the build-variations.mjs script (with `git-add-changes` option) during the deployment process.  This now happens just before version-bumping themes (so that any variation themes that were changed are included in the version bump).