### PR TITLE
Fix dotorg deploy for seedlet-blocks and livro

### DIFF
--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -21,8 +21,8 @@ declare -a THEMES_TO_DEPLOY=(
 	"geologist"
 	"mayland-blocks"
 	"quadrat"
-	"seedlet-blocks",
-	"livro",
+	"seedlet-blocks"
+	"livro"
 	"videomaker"
 )
 


### PR DESCRIPTION
Removed commas that were preventing seedlet-blocks and levro from being properly deployed to dotorg

They were causing the path (both file path and SVN path) from being correct resulting in un-deployed themes.

See [this deployment action result](https://github.com/Automattic/themes/runs/4960239459?check_suite_focus=true) for example of a failed run.

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
