### PR TITLE
WIP Skatepark: theme variations

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -153,8 +153,14 @@ function blockbase_fonts_url() {
  * Customize Global Styles
  */
 if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
-	require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
-	require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
+
+	$customize_colors = apply_filters( 'blockbase_customize_colors', true );
+
+	if ( $customize_colors ) {
+		require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
+		require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
+	}
+
 	require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 }
 

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -16,3 +16,11 @@ function add_featured_image_class( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'add_featured_image_class' );
+
+/**
+ * Disable color panel on the customizer coming from Blockbase.
+ */
+function disable_blockbase_customizer_colors( ) {
+	return false;
+}
+add_filter( 'blockbase_customize_colors', 'disable_blockbase_customizer_colors', 10, 3 );

--- a/skatepark/styles/blue-cream.json
+++ b/skatepark/styles/blue-cream.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
+	"settings": {
+		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#252B39", "#F9EED4" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#F9EED4",
+					"name": "Primary"
+				},
+				{
+					"slug": "background",
+					"color": "#252B39",
+					"name": "Background"
+				}
+			]
+		}
+	}
+}

--- a/skatepark/styles/blue.json
+++ b/skatepark/styles/blue.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
+	"settings": {
+		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#000000", "#C9E4ED" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#000000",
+					"name": "Primary"
+				},
+				{
+					"slug": "background",
+					"color": "#C9E4ED",
+					"name": "Background"
+				}
+			]
+		}
+	}
+}

--- a/skatepark/styles/green-pink.json
+++ b/skatepark/styles/green-pink.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
+	"settings": {
+		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#153232", "#F7B9A9" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#F7B9A9",
+					"name": "Primary"
+				},
+				{
+					"slug": "background",
+					"color": "#153232",
+					"name": "Background"
+				}
+			]
+		}
+	}
+}

--- a/skatepark/styles/red.json
+++ b/skatepark/styles/red.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
+	"settings": {
+		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#000000", "#F3B2A9" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#000000",
+					"name": "Primary"
+				},
+				{
+					"slug": "background",
+					"color": "#F3B2A9",
+					"name": "Background"
+				}
+			]
+		}
+	}
+}

--- a/skatepark/styles/white.json
+++ b/skatepark/styles/white.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://json.schemastore.org/theme-v1.json",
+	"version": 1,
+	"settings": {
+		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#000000", "#FFFFFF" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
+			"palette": [
+				{
+					"slug": "primary",
+					"color": "#000000",
+					"name": "Primary"
+				},
+				{
+					"slug": "background",
+					"color": "#FFFFFF",
+					"name": "Background"
+				}
+			]
+		}
+	}
+}

--- a/skatepark/theme.json
+++ b/skatepark/theme.json
@@ -91,48 +91,6 @@
 				"secondary": "var(--wp--preset--color--primary)",
 				"tertiary": "var(--wp--preset--color--background)"
 			},
-			"colorPalettes": [
-				{
-					"label": "White",
-					"slug": "white",
-					"colors": {
-						"primary": "#000000",
- 						"background": "#FFFFFF"
-					}
-				},
-				{
-					"label": "Red",
-					"slug": "red",
-					"colors": {
-						"primary": "#000000",
-						"background": "#F3B2A9"
-					}
-				},
-				{
-					"label": "Blue",
-					"slug": "blue",
-					"colors": {
-						"primary": "#000000",
-						"background": "#C9E4ED"
-					}
-				},
-				{
-					"label": "Blue/Cream",
-					"slug": "blue-cream",
-					"colors": {
-						"primary": "#F9EED4",
-						"background": "#252B39"
-					}
-				},
-				{
-					"label": "Green/Pink",
-					"slug": "green-pink",
-					"colors": {
-						"primary": "#F7B9A9",
-						"background": "#153232"
-					}
-				}
-			],
 			"form": {
 				"border": {
 					"color": "var(--wp--custom--color--primary)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I've opened this PR to consider the possibility of leveraging https://github.com/WordPress/gutenberg/pull/35619 instead of the customizer (since Skatepark has not been yet launched) for the color customizations + duotone. In this PR:

- I added a filter so that the child themes can disable color customization. This could be something we can extend to other Blockbase functions to ake some child themes "less universal" while still benefiting from the parent's CSS, patterns and templates.
- I added variations for all the colors, those seem to be working mostly fine, but the duotone filter is not showing on the editor. This is a known issue reported in https://github.com/WordPress/gutenberg/issues/35331
- I added a variation that disables duotone for the blocks and that works as intended but since style variations don't have labels, it's not recognizable as to what the variation does (the icon is the same as the default theme). Variations will have labels in the future, but they don't have one now.

#### Related issue(s):
