### PR TITLE
Blockbase: Remove the fallback for the navigation block

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -175,6 +175,14 @@ add_action(
 );
 
 /**
+ * Disable the fallback for the core/navigation block.
+ */
+function blockbase_core_navigation_render_fallback() {
+	return null;
+}
+add_filter( 'block_core_navigation_render_fallback', 'blockbase_core_navigation_render_fallback' );
+
+/**
  * Block Styles.
  */
 require get_template_directory() . '/inc/block-styles.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
By default the navigation block outputs a list of pages when it doesn't have any other content. This is causing some confusion in https://github.com/Automattic/themes/issues/5337 and makes it impossible for universal themes to have an empty navigation block.

This PR removes that fallback so that if no menu is specified at a location then nothing displays. We might want to only do this for Arbutus.

To test:
- switch to arbutus
- set your primary menu location to not have any menu
- check that the block doesn't output anything
- set your primary menu location to a defined menu
- check that the block outputs the menu defined at the primary menu location