### PR TITLE
POC: remove customizer options from Blockbase children via filters

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -153,9 +153,17 @@ function blockbase_fonts_url() {
  * Customize Global Styles
  */
 if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
-	require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
-	require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
-	require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
+	$customize_colors = apply_filters( 'blockbase_customize_colors', true );
+	$customize_fonts = apply_filters( 'blockbase_customize_fonts', true );
+
+	if ( $customize_colors ) {
+		require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
+		require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
+	}
+
+	if ( $customize_fonts ) {
+		require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
+	}
 }
 
 require get_template_directory() . '/inc/social-navigation.php';

--- a/skatepark/functions.php
+++ b/skatepark/functions.php
@@ -16,3 +16,12 @@ function add_featured_image_class( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'add_featured_image_class' );
+
+/**
+ * Disable customizer options coming from Blockbase.
+ */
+function disable_blockbase_customizer( ) {
+	return false;
+}
+add_filter( 'blockbase_customize_colors', 'disable_blockbase_customizer', 10, 3 );
+add_filter( 'blockbase_customize_fonts', 'disable_blockbase_customizer', 10, 3 );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the customizer options on Skatepark via filters on Blockbase. To test this check that everything is working as intended (fonts are showing correctly, colors can change via the FSE only) and there's no customizer option under the Appearance menu

context: pNEWy-eGS-p2#comment-54234