### PR TITLE
Deployment: Removed the check for uncomitted changes.  

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -525,9 +525,8 @@ async function checkProjectForVersionBump(hash){
  Used by versionBumpThemes
 */
 async function checkThemeForChanges(theme, hash){
-	let uncomittedChanges = await executeCommand(`git diff-index --name-only HEAD -- ${theme}`);
 	let comittedChanges = await executeCommand(`git diff --name-only ${hash} HEAD -- ${theme}`);
-	return uncomittedChanges != '' || comittedChanges != '';
+	return comittedChanges != '';
 }
 
 /*


### PR DESCRIPTION
During the build process determining which themes had changed included checking for uncomitted changes.  

Those shouldn't be considered for version bumping or any other deploy action.  

Additionally that was returning false-positives for the variations as illustrated in [this commit](https://github.com/Automattic/themes/commit/7013fc330a0565a33268bf18634c75ef87784b19)  which automatically version bumped all of the variations.