### PR TITLE
Blockbase - register standard header and footer in theme json.

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -25,6 +25,14 @@
 		{
 			"name": "header-wide",
 			"area": "header"
+		},
+		{
+			"name": "header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"area": "footer"
 		}
 	],
 	"customTemplates": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Currently, only the extra variations of headers are registered in the theme.json for blockbase.

This means that when loading blockbase for the first time, the header and footer in place do not have any area classification and are set to general. Child themes end up with the same issue, unless they explicitly register these in their theme.json as well (as is the case with quadrat, but not geologist).

#### Testing the changes.

* Load the site editor using the blockbase theme with no customized template parts.
* Open the template dropdown in the top bar, and notice that the variations of the template parts on the page are listed as 'General':

![Screen Shot 2022-02-01 at 8 00 18 AM](https://user-images.githubusercontent.com/28742426/152023505-1eb34478-7ccd-4bd6-b0f5-e84417938c11.png)

* Apply this diff and reload the editor
* Verify that the header and footer classifications are as expected:

![Screen Shot 2022-02-01 at 7 55 23 AM](https://user-images.githubusercontent.com/28742426/152023643-650608c8-1da4-48a5-8215-605c805e63b1.png)

NOTE - if testing on wpcom, an additional fix to the theme json resolver is required to see the expected end result (must patch D74195-code to your sandbox).  However on self hosted there are no additional steps.

#### Related issue(s):