### PR TITLE
Archeo: update layout sizing and spacing

### DIFF
--- a/archeo/parts/footer.html
+++ b/archeo/parts/footer.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"100px","top":"100px"}}}} -->
 <div class="wp-block-group" style="padding-top: 100px; padding-bottom: 100px;">
-	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"},"overlayMenu":"never","style":{"typography":{"fontStyle":"normal"}},"fontSize":"small"} /-->
+	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"},"overlayMenu":"never","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} /-->
 
 	<!-- wp:paragraph {"align":"center","fontSize":"small","style":{"spacing":{"margin":{"top":0}}}} -->
 	<p class="has-text-align-center has-small-font-size" style="margin-top: 0;">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>

--- a/archeo/parts/footer.html
+++ b/archeo/parts/footer.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"100px","top":"100px"}}}} -->
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
 <div class="wp-block-group" style="padding-top: 100px; padding-bottom: 100px;">
 	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"},"overlayMenu":"never","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} /-->
 

--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -16,7 +16,7 @@
         </div>
         <!-- /wp:group -->
     
-        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayBackgroundColor":"background","overlayTextColor":"foreground","style":{"typography":{"fontStyle":"normal"}},"fontSize":"small"} -->
+        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayBackgroundColor":"background","overlayTextColor":"foreground","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
             <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
         <!-- /wp:navigation -->
         

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -50,7 +50,7 @@
 				}
 			},
 			"spacing": {
-				"small": "clamp(20px, 4vw, 90px)",
+				"small": "clamp(20px, 4vw, 40px)",
 				"medium": "clamp(30px, 8vw, 100px)",
 				"large": "clamp(100px, 12vw, 460px)",
 				"outer": "min(4vw, 90px)"

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -58,7 +58,7 @@
 		},
 		"layout": {
 			"contentSize": "620px",
-			"wideSize": "835px"
+			"wideSize": "1260px"
 		},
 		"typography": {
 			"fontFamilies": [


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This updates the layout and spacing settings in Archeo's theme.json, using sizes from the mockups.

Here are the main settings I've gone with:

Layout:
```
"layout": {
	"contentSize": "620px",
	"wideSize": "1260px"
},
```

Spacing:
```
"spacing": {
	"small": "clamp(20px, 4vw, 40px)",
	"medium": "clamp(30px, 8vw, 100px)",
	"large": "clamp(100px, 12vw, 460px)",
	"outer": "min(4vw, 90px)"
}
```

I really liked how Livro had the 'small' to 'large' sizes, so I've gone with that format here. I think we've used horizontal/vertical settings before too.

Block gap is currently set to 1.25rem (20px).

#### Related issue(s):
Closes #5421