### PR TITLE
Fixed import to include __DIR__ instead of assuming relative path

### DIFF
--- a/blockbase/inc/customizer/wp-customize-color-palettes.php
+++ b/blockbase/inc/customizer/wp-customize-color-palettes.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'wp-customize-color-palette-control.php';
+require_once ( __DIR__ . '/wp-customize-color-palette-control.php' );
 
 class GlobalStylesColorPalettes {
 	private $palettes = array();

--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once 'wp-customize-global-styles-setting.php';
-require_once 'wp-customize-utils.php';
+require_once ( __DIR__ . '/wp-customize-global-styles-setting.php' );
+require_once ( __DIR__ . '/wp-customize-utils.php' );
 
 class GlobalStylesColorCustomizer {
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once 'wp-customize-global-styles-setting.php';
-require_once 'wp-customize-utils.php';
+require_once ( __DIR__ . '/wp-customize-global-styles-setting.php' );
+require_once ( __DIR__ . '/wp-customize-utils.php' );
 
 class GlobalStylesFontsCustomizer {
 


### PR DESCRIPTION
Deploying the latest build didn't mast muster due to this error:

```
remote: ***********************************
remote: Syntax Error in: blockbase/inc/customizer/wp-customize-colors.php:
remote: Relative path includes are not allowed. Please fix this relative include before committing the file:
remote:
remote: require_once 'wp-customize-global-styles-setting.php';
remote:
remote: You can use the __DIR__ or ABSPATH constants for this. For example:
remote:
remote: require( __DIR__ . '/myfile.php' );
remote: or
remote: require( ABSPATH . 'wp-content/mu-plugins/myfile.php' );
remote: ***********************************
```

This change uses the __DIR__ option.
