### PR TITLE
Archeo: Simplify heading declarations

### DIFF
--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -43,12 +43,6 @@
 					"lineHeight": 1.5
 				}
 			},
-			"heading": {
-				"typography": {
-					"fontWeight": "400",
-					"lineHeight": 1.1
-				}
-			},
 			"spacing": {
 				"small": "clamp(20px, 4vw, 90px)",
 				"medium": "clamp(30px, 8vw, 100px)",
@@ -112,6 +106,12 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/heading": {
+				"typography": {
+					"fontWeight": "300",
+					"lineHeight": "1.1"
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",
@@ -127,44 +127,32 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "min(max(64px, 5vw), 100px)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "min(max(64px, 5vw), 100px)"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "var(--wp--preset--font-size--huge)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			}
 		},

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -108,7 +108,7 @@
 			},
 			"core/heading": {
 				"typography": {
-					"fontWeight": "300",
+					"fontWeight": "400",
 					"lineHeight": "1.1"
 				}
 			},


### PR DESCRIPTION
This moves a lot of the declarations for heading blocks to the core/heading section of global styles, since this also controls h1-h6 elements. This helps keep the code simpler. You should notice no difference in the frontend.