### PR TITLE
Shoreditch: Prevent blocks inside the layout grid block going full width

### DIFF
--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -30,7 +30,7 @@ Description: Used to style Gutenberg Blocks.
 	margin-right: 0;
 }
 
-.can-align-wide .alignfull,
+.can-align-wide :not(.wp-block-jetpack-layout-grid-column) > .alignfull,
 .page-template-full-width-page .alignfull,
 .page-template-panel-page .alignfull {
 	margin-left: calc(50% - 50vw);
@@ -66,7 +66,7 @@ Description: Used to style Gutenberg Blocks.
 }
 
 @media (min-width: 900px) {
-	.can-align-wide .alignfull {
+	.can-align-wide :not(.wp-block-jetpack-layout-grid-column) > .alignfull {
 		margin-left: calc(50% - 50vw + 150px + 0.5em );
 		margin-right: calc(50% - 50vw - 150px - 0.5em );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
The code to achieve full width has some strange side effects when used inside the jetpack layout grid block in Shoreditch. Since this is alignment code is an idiosyncrasy of the theme I think it's best to just add exceptions for this case.

To test
- Switch to Shoreditch
- Add the about us pattern with a yellow photo
- Check that the text isn't hidden by the photo

#### Related issue(s):
Fixes #5384