### PR TITLE
Archeo: Add navigation styles

### DIFF
--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -1,7 +1,7 @@
 <!-- wp:group {"layout":{"inherit":"true"}} -->
 <div class="wp-block-group">
-    <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
-    <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--medium)">
+    <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--outer)"}}}} -->
+    <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--outer)">
         <!-- wp:site-title /-->
 
         <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->

--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -2,21 +2,9 @@
 <div class="wp-block-group">
     <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
     <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--medium)">
+        <!-- wp:site-title /-->
 
-        <!-- wp:group {"layout":{"type":"flex"}} -->
-        <div class="wp-block-group">
-            <!-- wp:site-logo {"width":64} /-->
-
-            <!-- wp:group -->
-            <div class="wp-block-group">
-                <!-- wp:site-title /-->
-                <!-- wp:site-tagline /-->
-            </div>
-            <!-- /wp:group -->
-        </div>
-        <!-- /wp:group -->
-
-        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
+        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
             <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
         <!-- /wp:navigation -->
 

--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -2,11 +2,11 @@
 <div class="wp-block-group">
     <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
     <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--medium)">
-    
+
         <!-- wp:group {"layout":{"type":"flex"}} -->
         <div class="wp-block-group">
             <!-- wp:site-logo {"width":64} /-->
-    
+
             <!-- wp:group -->
             <div class="wp-block-group">
                 <!-- wp:site-title /-->
@@ -15,13 +15,13 @@
             <!-- /wp:group -->
         </div>
         <!-- /wp:group -->
-    
-        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayBackgroundColor":"background","overlayTextColor":"foreground","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
+
+        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
             <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
         <!-- /wp:navigation -->
-        
+
     </div>
     <!-- /wp:group -->
-    
+
 </div>
 <!-- /wp:group -->

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -162,3 +162,12 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	padding-right: var(--wp--custom--spacing--outer);
 	padding-left: var(--wp--custom--spacing--outer);
 }
+
+/*
+ * We need this until https://github.com/WordPress/gutenberg/issues/37035 is fixed.
+ */
+.wp-block-navigation__responsive-container.is-menu-open ul {
+	font-size: var(--wp--preset--font-size--large) !important;
+	font-weight: 300;
+	gap: var(--wp--style--block-gap);
+}

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -148,3 +148,17 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	margin-right: auto !important;
 	width: inherit;
 }
+
+/*
+ * Responsive menu container padding.
+ * This ensures the responsive container inherits the same
+ * spacing defined above. This behavior may be built into
+ * the Block Editor in the future.
+ */
+
+.wp-block-navigation__responsive-container.is-menu-open {
+	padding-top: var(--wp--custom--spacing--outer);
+	padding-bottom: var(--wp--custom--spacing--large);
+	padding-right: var(--wp--custom--spacing--outer);
+	padding-left: var(--wp--custom--spacing--outer);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This updates the navigation block for Archeo:

<img width="1440" alt="Screenshot 2022-02-04 at 12 25 41" src="https://user-images.githubusercontent.com/275961/152529122-34545a0d-3a5f-4626-96d1-cf498fca4ea5.png">
<img width="576" alt="Screenshot 2022-02-04 at 12 25 52" src="https://user-images.githubusercontent.com/275961/152529114-8576193b-0f55-4940-89c9-0356424f4a23.png">

@kjellr @beafialho I didn't see any mockups for this, so I just had a go at something myself. It would be nice if the text could left align but that's a limitation of the nav block at the moment. cc @getdave.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5431