### PR TITLE
Add the triangle back to the Quadrat footer

### DIFF
--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -400,7 +400,7 @@ textarea:focus {
   outline: 1px dotted currentColor;
 }
 
-.home .site-footer.wp-block-group:before {
+.home .site-footer-container .wp-block-group:before {
   content: "";
   background-color: var(--wp--custom--color--tertiary);
   -webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);

--- a/quadrat/sass/templates/_footer.scss
+++ b/quadrat/sass/templates/_footer.scss
@@ -1,5 +1,5 @@
 .home {
-	.site-footer.wp-block-group {
+	.site-footer-container .wp-block-group {
 		&:before {
 			content: "";
 			background-color: var(--wp--custom--color--tertiary);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This adds the triangle back to the Quadrat footer. Hopefully the variations will be built by the script:

<img width="1308" alt="Screenshot 2022-02-07 at 14 05 56" src="https://user-images.githubusercontent.com/275961/152803077-d8ce045d-5984-4e01-9e59-e1cd0a1e419b.png">

#### Related issue(s):
Raised in https://github.com/Automattic/themes/issues/4155#issuecomment-1030691657