### PR TITLE
Blockbase: fixed spacing for header wide

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -164,9 +164,6 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
     text-align: center;
   }
 }
-.wp-site-blocks .site-header .wp-block-navigation__responsive-container-content {
-  gap: var(--wp--style--block-gap, 2em);
-}
 
 @media (max-width: 599px) {
   .wp-site-blocks .site-header-linear .site-words-stack-small {

--- a/blockbase/block-template-parts/header-wide.html
+++ b/blockbase/block-template-parts/header-wide.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+		<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.5em"}}} /-->
 
 	</div>
 	<!-- /wp:group -->

--- a/blockbase/sass/base/_header.scss
+++ b/blockbase/sass/base/_header.scss
@@ -13,12 +13,7 @@
 			text-align: center;
 		}
 	}
-
-	// User for Social Navigation ?
-	// TODO: Ref to issue
-	.wp-block-navigation__responsive-container-content {
-		gap: var( --wp--style--block-gap, 2em );
-	}
+	
 }
 
 // Needed until Gutenberg offers responsive design options


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Header wide is used exclusively by Skatepark by default. The spacing between the items was too tight, this was caused by the gap value on Skatepark being too small compared to other themes.

I removed an extra CSS rule on Blockbase that adds gap to the navigation, this is no longer necessary after the latest changes to the block. I tested on other themes and neither where affected by this change.

Before:

<img width="1220" alt="Screenshot 2022-02-08 at 10 38 31" src="https://user-images.githubusercontent.com/3593343/152959711-6ad98cc2-6f3f-482a-9485-a66dc651f025.png">


After:
<img width="1227" alt="Screenshot 2022-02-08 at 10 32 55" src="https://user-images.githubusercontent.com/3593343/152959548-c93f0686-2877-4dca-9b32-4d6034372eba.png">


#### Related issue(s):

https://github.com/Automattic/themes/issues/5471