### PR TITLE
Update alignment styles

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -126,10 +126,7 @@ body > .is-root-container,
 .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
 body > .is-root-container > .wp-block-cover,
-body
-	> .is-root-container
-	> .wp-block-template-part
-	> .wp-block-group.has-background,
+body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align='full'] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -125,7 +125,6 @@ body > .is-root-container,
 .wp-site-blocks > .wp-block-cover,
 .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-cover,
 body
 	> .is-root-container
@@ -135,6 +134,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align='full'] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	max-width: unset;
 	width: unset;
 }
 

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -93,13 +93,13 @@ body > .is-root-container,
 .wp-site-blocks > .wp-block-cover,
 .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align=full] {
   margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
   margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
+  max-width: unset;
   width: unset;
 }
 

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -47,13 +47,13 @@ body > .is-root-container,
 .wp-site-blocks > .wp-block-cover,
 .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
+	max-width: unset;
 	width: unset;
 }
 

--- a/livro/style.css
+++ b/livro/style.css
@@ -124,8 +124,8 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
-	width: unset;
 	max-width: unset;
+	width: unset;
 }
 
 /* Blocks inside columns don't have negative margins. */

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -3,7 +3,7 @@ Theme Name: Stewart
 Theme URI: https://github.com/Automattic/themes/tree/trunk/stewart
 Author: Automattic
 Author URI: https://automattic.com/
-Description: Stewart is a modern blogging theme with a left sidebar. Its default color scheme is a striking combination of orange and light gray, to give your blog a sophisticated appearance from day one. 
+Description: Stewart is a modern blogging theme with a left sidebar. Its default color scheme is a striking combination of orange and light gray, to give your blog a sophisticated appearance from day one.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.7
@@ -89,7 +89,7 @@ a:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
 	opacity: 0.90;
-} 
+}
 
 /*
  * Search and File Block button styles.
@@ -147,13 +147,13 @@ body > .is-root-container,
 .wp-site-blocks > .wp-block-cover,
 .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	max-width: unset;
 	width: unset;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates our alignment styles to be the same as those in https://github.com/Automattic/themes/pull/5385

To test, make sure the alignments in [this post](https://theamdemo.wordpress.com/2021/08/23/gutenberg-alignment/) work as expected in:
- Livro
- Blockbase (and children)
- Stewart
- Archeo