### PR TITLE
Archeo: Update comment form styles

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -92,8 +92,9 @@ a:active,
 
 .wp-block-post-comments input:not([type='submit']),
 .wp-block-post-comments textarea {
-	background-color: var(--wp--preset--color--background);
-	border-color: var(--wp--preset--color--foreground);
+	background-color: var(--wp--preset--color--foreground);
+	border-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--background);
 }
 
 /*

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -107,6 +107,7 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--chivo)",
 					"fontSize": "var(--wp--preset--typography--font-size--normal)",
 					"textTransform": "uppercase"
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Updates the comment form CSS. I tried to keep the CSS light rather than matching the comps exactly:
<img width="1440" alt="Screenshot 2022-02-10 at 14 13 30" src="https://user-images.githubusercontent.com/275961/153425746-bd04523d-7e8a-40f7-832f-572a6d99db25.png">
<img width="1440" alt="Screenshot 2022-02-10 at 14 12 34" src="https://user-images.githubusercontent.com/275961/153425753-8b475057-46e0-4491-837d-e5f99c916ad8.png">


#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/5430
