### PR TITLE
Archeo: Update next/prev links in the post footer

### DIFF
--- a/archeo/templates/single.html
+++ b/archeo/templates/single.html
@@ -51,25 +51,19 @@
 		<div class="wp-block-columns alignwide is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->
 		<hr class="wp-block-separator is-style-wide"/>
-		<!-- /wp:separator --></div>
+		<!-- /wp:separator -->
+		<!-- wp:post-navigation-link {"type":"previous","label":"Previous Post"} /-->
+		</div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->
 		<hr class="wp-block-separator is-style-wide"/>
-		<!-- /wp:separator --></div>
+		<!-- /wp:separator -->
+		<!-- wp:post-navigation-link {"textAlign":"right","label":"Next Post"} /-->
+		</div>
 		<!-- /wp:column --></div>
 		<!-- /wp:columns -->
-
-		<!-- wp:group {"align":"wide","layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
-		<div class="wp-block-group alignwide"><!-- wp:post-navigation-link {"type":"previous","label":"Previous Post","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
-
-		<!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator is-style-wide"/>
-		<!-- /wp:separator -->
-
-		<!-- wp:post-navigation-link {"label":"Next Post","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /--></div>
-		<!-- /wp:group -->
 
 		<!-- wp:spacer {"height":"48px"} -->
 		<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -117,6 +117,13 @@
 					"lineHeight": "1.1"
 				}
 			},
+			"core/post-navigation-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "300",
+					"textTransform": "uppercase"
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -120,7 +120,7 @@
 			"core/post-navigation-link": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": "300",
+					"fontWeight": "100",
 					"textTransform": "uppercase"
 				}
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Updates the post footer:

Before:
<img width="1437" alt="Screenshot 2022-02-10 at 14 27 39" src="https://user-images.githubusercontent.com/275961/153427924-5d56ad92-d109-45b4-822d-1b2eba9fc217.png">

After:
<img width="1440" alt="Screenshot 2022-02-10 at 14 27 16" src="https://user-images.githubusercontent.com/275961/153427926-eea8b4d7-e143-4f3b-a1b1-e9a01960a42a.png">
