### PR TITLE
Archeo: Add core block settings

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -180,36 +180,3 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 }
-
-/*
- * Pullquote styles
- */
- .wp-block-pullquote blockquote {
-	 margin-top: 0;
-	 margin-bottom: 0;
- }
-
-.wp-block-pullquote p {
-	line-height: 1.2;
-	margin-top: 0;
-	margin-bottom: min(2.5rem, 2.5vw);
-}
-
-.wp-block-pullquote cite::before {
-	content: "—";
-	padding-right: 0.5rem;
-}
-
-/* 
- * Citation styles. Needed until https://github.com/WordPress/gutenberg/issues/35735 is fixed.
- */
-.wp-block-pullquote cite, 
-.wp-block-pullquote footer, 
-.wp-block-pullquote__citation {
-	font-size: var(--wp--preset--font-size--normal);
-	text-transform: none;
-}
-
-.wp-block-post-navigation-link > a {
-	text-decoration: none;
-}

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -168,3 +168,32 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	font-weight: 100;
 	gap: var(--wp--style--block-gap);
 }
+
+/*
+ * Pullquote styles
+ */
+ .wp-block-pullquote blockquote {
+	 margin-top: 0;
+	 margin-bottom: 0;
+ }
+
+.wp-block-pullquote p {
+	line-height: 1.2;
+	margin-top: 0;
+	margin-bottom: min(2.5rem, 2.5vw);
+}
+
+.wp-block-pullquote cite::before {
+	content: "—";
+	padding-right: 0.5rem;
+}
+
+/* 
+ * Citation styles. Needed until https://github.com/WordPress/gutenberg/issues/35735 is fixed.
+ */
+.wp-block-pullquote cite, 
+.wp-block-pullquote footer, 
+.wp-block-pullquote__citation {
+	font-size: var(--wp--preset--font-size--normal);
+	text-transform: none;
+}

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -169,6 +169,10 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	gap: var(--wp--style--block-gap);
 }
 
+.wp-block-post-navigation-link > a {
+	text-decoration: none;
+}
+
 /*
  * Needed until https://github.com/WordPress/gutenberg/issues/29167 is addressed.
  */

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -134,6 +134,23 @@
 					}
 				}
 			},
+			"core/pullquote": {
+				"border": {
+					"width": "0"
+				},
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--spacing--medium)",
+						"bottom": "var(--wp--custom--spacing--medium)"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "100",
+					"lineHeight": "1.2",
+					"textTransform": "none"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"background": "var(--wp--preset--color--foreground)"

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -117,6 +117,23 @@
 					"lineHeight": "1.1"
 				}
 			},
+			"core/post-comments": {
+				"elements": {
+					"h3": {
+						"typography": {
+							"textTransform": "uppercase"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "var(--wp--custom--spacing--small)"
+					}
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -134,6 +134,11 @@
 					}
 				}
 			},
+			"core/separator": {
+				"color": {
+					"background": "var(--wp--preset--color--foreground)"
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)",

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -146,8 +146,7 @@
 				},
 				"typography": {
 					"fontWeight": "100",
-					"lineHeight": "1.2",
-					"textTransform": "none"
+					"lineHeight": "1.2"
 				}
 			},
 			"core/quote": {

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -151,6 +151,11 @@
 					"textTransform": "none"
 				}
 			},
+			"core/quote": {
+				"border": {
+					"width": "0"
+				}
+			},
 			"core/separator": {
 				"color": {
 					"background": "var(--wp--preset--color--foreground)"

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -153,7 +153,7 @@
 			},
 			"core/quote": {
 				"border": {
-					"width": "0"
+					"width": "1px"
 				}
 			},
 			"core/separator": {

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -145,7 +145,6 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "100",
 					"lineHeight": "1.2",
 					"textTransform": "none"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds some default block styles for the following blocks:

- Comments
- Separator
- Pullquote
- Quote

I tried to style the pullquote just with theme.json, but there were a few things I could only handle with CSS. I've added the CSS here for now.

Are there any other blocks we should add settings for?

#### Related issue(s):
Closes #5434