### PR TITLE
Archeo: Tidy up responsive font sizes

### DIFF
--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -90,7 +90,7 @@
 				},
 				{
 					"name": "Huge",
-					"size": "clamp(42px, 7vw, 72px)",
+					"size": "clamp(42px, 7vw, 64px)",
 					"slug": "huge"
 				}
 			]
@@ -132,7 +132,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "clamp(48px, 8vw, 100px)"
+					"fontSize": "clamp(48px, 8vw, 72px)"
 				}
 			},
 			"h2": {

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -80,17 +80,17 @@
 				},
 				{
 					"name": "Medium",
-					"size": "min(max(24px, 5vw), 32px)",
+					"size": "clamp(24px, 5vw, 32px)",
 					"slug": "medium"
 				},
 				{
 					"name": "Large",
-					"size": "min(max(36px, 5vw), 48px)",
+					"size": "clamp(36px, 6vw, 48px)",
 					"slug": "large"
 				},
 				{
 					"name": "Huge",
-					"size": "min(max(48px, 5vw), 72px)",
+					"size": "clamp(42px, 7vw, 72px)",
 					"slug": "huge"
 				}
 			]
@@ -132,7 +132,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontSize": "min(max(64px, 5vw), 100px)"
+					"fontSize": "clamp(48px, 8vw, 100px)"
 				}
 			},
 			"h2": {


### PR DESCRIPTION
This PR adds a more fluid mobile > desktop font scale, and switches to using `clamp()` which is a little more straightforward than the mix of `min()` and `max()` we were using before. 

## Mobile

Before|After
---|---
<img width="374" alt="Screen Shot 2022-02-10 at 11 00 14 AM" src="https://user-images.githubusercontent.com/1202812/153447456-55a4afe1-c6a3-4b0b-9b78-542b5819763c.png">|<img width="371" alt="Screen Shot 2022-02-10 at 11 02 00 AM" src="https://user-images.githubusercontent.com/1202812/153447458-18dfe274-4525-4d3c-9ec7-c074d3ebd815.png">

## Desktop

Before|After
---|---
<img width="655" alt="Screen Shot 2022-02-10 at 10 59 49 AM" src="https://user-images.githubusercontent.com/1202812/153447518-c4328309-7c63-46f8-babb-827727110f08.png">|<img width="674" alt="Screen Shot 2022-02-10 at 11 01 48 AM" src="https://user-images.githubusercontent.com/1202812/153447521-dbd08fed-4195-45a4-b10d-8237d5ee4cf0.png">

