### PR TITLE
Update alignment rules

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -114,8 +114,10 @@ body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
+.wp-block-columns.alignfull.has-background,
 .wp-block-cover.alignfull,
 .is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
 .is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -83,7 +83,11 @@ body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
-.is-root-container .wp-block[data-align=full] > .wp-block-group {
+.wp-block-columns.alignfull.has-background,
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align=full] > .wp-block-group,
+.is-root-container .wp-block[data-align=full] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align=full] > .wp-block-cover {
   padding-left: var(--wp--custom--gap--horizontal);
   padding-right: var(--wp--custom--gap--horizontal);
 }

--- a/blockbase/sass/base/_alignment.scss
+++ b/blockbase/sass/base/_alignment.scss
@@ -37,7 +37,11 @@ body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group {
+.wp-block-columns.alignfull.has-background,
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	padding-left: var(--wp--custom--gap--horizontal);
 	padding-right: var(--wp--custom--gap--horizontal);
 }

--- a/livro/style.css
+++ b/livro/style.css
@@ -106,9 +106,11 @@ body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
+.wp-block-columns.alignfull.has-background,
 .wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+.is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);
 }

--- a/remote/style.css
+++ b/remote/style.css
@@ -3,7 +3,7 @@ Theme Name: Remote
 Theme URI: https://github.com/Automattic/themes/tree/trunk/archeo
 Author: Automattic
 Author URI: https://automattic.com
-Description: 
+Description:
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
@@ -35,18 +35,20 @@ body {
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
- .wp-site-blocks,
- body > .is-root-container,
- .edit-post-visual-editor__post-title-wrapper,
- .wp-block-group.alignfull,
- .wp-block-group.has-background,
- .wp-block-cover.alignfull,
- .is-root-container .wp-block[data-align='full'] > .wp-block-group,
- .is-root-container .wp-block[data-align='full'] > .wp-block-cover {
+.wp-site-blocks,
+body > .is-root-container,
+.edit-post-visual-editor__post-title-wrapper,
+.wp-block-group.alignfull,
+.wp-block-group.has-background,
+.wp-block-columns.alignfull.has-background,
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	 padding-left: var(--wp--custom--spacing--outer);
 	 padding-right: var(--wp--custom--spacing--outer);
  }
- 
+
  .wp-site-blocks .alignfull,
  .wp-site-blocks > .wp-block-group.has-background,
  .wp-site-blocks > .wp-block-cover,
@@ -61,7 +63,7 @@ body {
 	 max-width: unset;
 	 width: unset;
  }
- 
+
  /* Blocks inside columns don't have negative margins. */
  .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
  .is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
@@ -72,14 +74,14 @@ body {
 	 margin-right: auto !important;
 	 width: inherit;
  }
- 
+
  /*
   * Responsive menu container padding.
   * This ensures the responsive container inherits the same
   * spacing defined above. This behavior may be built into
   * the Block Editor in the future.
   */
- 
+
  .wp-block-navigation__responsive-container.is-menu-open {
 	 padding-top: var(--wp--custom--spacing--outer);
 	 padding-bottom: var(--wp--custom--spacing--large);

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -135,9 +135,11 @@ body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
+.wp-block-columns.alignfull.has-background,
 .wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+.is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This updates the alignment rules from https://github.com/Automattic/themes/pull/5487 in all block themes.

To test add the "Image with description and right-aligned headline" pattern from Archeo and check that on mobile the edges look correct:

Before | After
---|---
<img width="1904" alt="Screen Shot 2022-02-09 at 12 50 55 PM" src="https://user-images.githubusercontent.com/5375500/153260495-4e016840-2164-4255-8001-0b820a789826.png"> | <img width="1904" alt="Screen Shot 2022-02-09 at 12 50 40 PM" src="https://user-images.githubusercontent.com/5375500/153260524-d199016a-9900-4184-ab9f-4ffee57cb9b1.png">

