### PR TITLE
Changed source of pagination arrows from CSS to block attributes.

### DIFF
--- a/geologist-blue/assets/theme.css
+++ b/geologist-blue/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/geologist-blue/block-templates/archive.html
+++ b/geologist-blue/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-blue/block-templates/index.html
+++ b/geologist-blue/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-cream/assets/theme.css
+++ b/geologist-cream/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/geologist-cream/block-templates/archive.html
+++ b/geologist-cream/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-cream/block-templates/index.html
+++ b/geologist-cream/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-slate/assets/theme.css
+++ b/geologist-slate/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/geologist-slate/block-templates/archive.html
+++ b/geologist-slate/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-slate/block-templates/index.html
+++ b/geologist-slate/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-yellow/assets/theme.css
+++ b/geologist-yellow/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/geologist-yellow/block-templates/archive.html
+++ b/geologist-yellow/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist-yellow/block-templates/index.html
+++ b/geologist-yellow/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/geologist/block-templates/archive.html
+++ b/geologist/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist/block-templates/index.html
+++ b/geologist/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/geologist/sass/blocks/_query-pagination.scss
+++ b/geologist/sass/blocks/_query-pagination.scss
@@ -1,24 +1,6 @@
 .wp-block-query-pagination {
 	border-top: 1px solid var(--wp--custom--color--primary);
 
-	.wp-block-query-pagination-previous {
-		&::before{
-			content:"←";
-			margin-right: 0.5em;
-		}
-	}
-	.wp-block-query-pagination-next {
-		&::after{
-			content:"→";
-			margin-left: 0.5em;
-		}
-	}
-
-	.wp-block-query-pagination-previous::before,
-	.wp-block-query-pagination-next::after {
-		display: inline-block;
-	}
-
 	.page-numbers {
 		padding: 0 0.1em;
 	}

--- a/zoologist/assets/theme.css
+++ b/zoologist/assets/theme.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Breakpoints & Media Queries
  */
@@ -137,18 +136,6 @@ ul ul {
 
 .wp-block-query-pagination {
   border-top: 1px solid var(--wp--custom--color--primary);
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before {
-  content: "←";
-  margin-right: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  content: "→";
-  margin-left: 0.5em;
-}
-.wp-block-query-pagination .wp-block-query-pagination-previous::before,
-.wp-block-query-pagination .wp-block-query-pagination-next::after {
-  display: inline-block;
 }
 .wp-block-query-pagination .page-numbers {
   padding: 0 0.1em;

--- a/zoologist/block-templates/archive.html
+++ b/zoologist/block-templates/archive.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/zoologist/block-templates/index.html
+++ b/zoologist/block-templates/index.html
@@ -15,7 +15,7 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:query-pagination {"align":"wide"} -->
+	<!-- wp:query-pagination {"align":"wide","paginationArrow":"arrow"} -->
 	<!-- wp:query-pagination-previous /-->
 	<!-- wp:query-pagination-numbers /-->
 	<!-- wp:query-pagination-next /-->

--- a/zoologist/sass/blocks/_query-pagination.scss
+++ b/zoologist/sass/blocks/_query-pagination.scss
@@ -1,24 +1,6 @@
 .wp-block-query-pagination {
 	border-top: 1px solid var(--wp--custom--color--primary);
 
-	.wp-block-query-pagination-previous {
-		&::before{
-			content:"←";
-			margin-right: 0.5em;
-		}
-	}
-	.wp-block-query-pagination-next {
-		&::after{
-			content:"→";
-			margin-left: 0.5em;
-		}
-	}
-
-	.wp-block-query-pagination-previous::before,
-	.wp-block-query-pagination-next::after {
-		display: inline-block;
-	}
-
 	.page-numbers {
 		padding: 0 0.1em;
 	}


### PR DESCRIPTION
This change removes the :content attributes that supplied the arrows for the previous/next elements and instead assigns those via block attributes.

This fixes that issue in Zoologist, Geologist and all of Geologist's variations.

The design remains unchanged except for fixing the noted error.

Editor:
![image](https://user-images.githubusercontent.com/146530/154097973-d99bd596-434a-45e5-80e7-166dc8770cc3.png)

View:
![image](https://user-images.githubusercontent.com/146530/154097906-59a616f3-78e1-443d-bdba-c1db7180412d.png)


Fixes #5520 