### PR TITLE
Remote: add footer and tags pattern

### DIFF
--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -46,6 +46,7 @@ function remote_register_block_patterns() {
 		'hidden-search-form',
 		'posts-grid',
 		'posts-list',
+		'tags',
 	);
 
 	/**

--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -47,6 +47,7 @@ function remote_register_block_patterns() {
 		'posts-grid',
 		'posts-list',
 		'tags',
+		'categories',
 	);
 
 	/**

--- a/remote/inc/patterns/categories.php
+++ b/remote/inc/patterns/categories.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tags & Categories
+ * Categories Pattern
  */
 return array(
 	'title'      => __( 'Categories', 'remote' ),

--- a/remote/inc/patterns/categories.php
+++ b/remote/inc/patterns/categories.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Tags & Categories
+ */
+return array(
+	'title'      => __( 'Categories', 'remote' ),
+	'categories' => array( 'text' ),
+	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+		<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Categories', 'remote' ) . '</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:tag-cloud {"className":"is-style-outline","taxonomy":"category"} /-->',
+);

--- a/remote/inc/patterns/tags.php
+++ b/remote/inc/patterns/tags.php
@@ -8,5 +8,5 @@ return array(
 	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
 		<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Tags', 'remote' ) . '</p>
 		<!-- /wp:paragraph -->
-		<!-- wp:post-terms {"term":"post_tag"} /-->',
+		<!-- wp:tag-cloud {"className":"is-style-outline"} /-->',
 );

--- a/remote/inc/patterns/tags.php
+++ b/remote/inc/patterns/tags.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Tags & Categories
+ */
+return array(
+	'title'      => __( 'Tags', 'remote' ),
+	'categories' => array( 'text' ),
+	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+		<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Tags', 'remote' ) . '</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:post-terms {"term":"post_tag"} /-->',
+);

--- a/remote/inc/patterns/tags.php
+++ b/remote/inc/patterns/tags.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tags & Categories
+ * Tags Pattern
  */
 return array(
 	'title'      => __( 'Tags', 'remote' ),

--- a/remote/parts/footer.html
+++ b/remote/parts/footer.html
@@ -1,3 +1,26 @@
+<!-- wp:spacer {"height":64} -->
+<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"inherit":"default"}} -->
+<div class="wp-block-group">
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"5%"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:pattern {"slug":"remote/tags"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:pattern {"slug":"remote/categories"} /-->
+</div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:spacer {"height":112} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/remote/parts/footer.html
+++ b/remote/parts/footer.html
@@ -1,42 +1,11 @@
-<!-- wp:spacer {"height":64} -->
-<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":112} -->
+<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"layout":{"inherit":"default"}} -->
-<div class="wp-block-group">
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+<!-- /wp:paragraph -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"5%"}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"fontSize":"small","style":{"typography":{"textTransform":"uppercase"}}} -->
-<h2 class="has-small-font-size" style="text-transform:uppercase">Tags</h2>
-<!-- /wp:heading -->
-
-<!-- wp:tag-cloud {"className":"is-style-outline"} /--></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"fontSize":"small","style":{"typography":{"textTransform":"uppercase"}}} -->
-<h2 class="has-small-font-size" style="text-transform:uppercase">Categories</h2>
-<!-- /wp:heading -->
-
-<!-- wp:tag-cloud {"className":"is-style-outline","taxonomy":"category"} /-->
-</div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-</div>
-<!-- /wp:group -->
-
-<!-- wp:spacer {"height":32} -->
-<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:group -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--tiny)"}}} -->
-<p class="has-text-align-center" style="font-size:var(--wp--custom--font-sizes--tiny)">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
-
-<!-- wp:spacer {"height":32} -->
-<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":58} -->
+<div style="height:58px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/remote/style.css
+++ b/remote/style.css
@@ -196,22 +196,17 @@ a:not(
 	outline-offset: 3px;
 }
 
-/*
- * Needed until https://github.com/WordPress/gutenberg/issues/30472
- */
-.wp-block-post-terms .wp-block-post-terms__separator {
-	display: none;
+.wp-block-tag-cloud.is-style-outline {
+	display: flex;
+	flex-wrap: wrap;
 }
 
 /*
  * Needed until https://github.com/WordPress/gutenberg/issues/34196 or something like it.
  */
-.wp-block-post-terms > a {
-	border: 1px solid var(--wp--preset--color--foreground);
-	border-radius: 6px;
-	display: inline-block;
-	padding: .8rem 1.25rem;
-	margin-right: var(--wp--style--block-gap);
-	margin-bottom: var(--wp--style--block-gap);
-	text-decoration: none;
+.wp-block-tag-cloud.is-style-outline a {
+	border-radius: 10px;
+	padding: .5rem 1.25rem;
+	margin-right: calc( 0.5 * var(--wp--style--block-gap) );
+	margin-bottom: calc( 0.75 * var(--wp--style--block-gap) );
 }

--- a/remote/style.css
+++ b/remote/style.css
@@ -196,17 +196,10 @@ a:not(
 	outline-offset: 3px;
 }
 
-.wp-block-tag-cloud.is-style-outline {
-	display: flex;
-	flex-wrap: wrap;
-}
-
 /*
  * Needed until https://github.com/WordPress/gutenberg/issues/34196 or something like it.
  */
 .wp-block-tag-cloud.is-style-outline a {
 	border-radius: 10px;
 	padding: .5rem 1.25rem;
-	margin-right: calc( 0.5 * var(--wp--style--block-gap) );
-	margin-bottom: calc( 0.75 * var(--wp--style--block-gap) );
 }

--- a/remote/style.css
+++ b/remote/style.css
@@ -195,3 +195,23 @@ a:not(
 	outline: 1.5px dotted var(--wp--preset--color--primary);
 	outline-offset: 3px;
 }
+
+/*
+ * Needed until https://github.com/WordPress/gutenberg/issues/30472
+ */
+.wp-block-post-terms .wp-block-post-terms__separator {
+	display: none;
+}
+
+/*
+ * Needed until https://github.com/WordPress/gutenberg/issues/34196 or something like it.
+ */
+.wp-block-post-terms > a {
+	border: 1px solid var(--wp--preset--color--foreground);
+	border-radius: 6px;
+	display: inline-block;
+	padding: .8rem 1.25rem;
+	margin-right: var(--wp--style--block-gap);
+	margin-bottom: var(--wp--style--block-gap);
+	text-decoration: none;
+}

--- a/remote/theme.json
+++ b/remote/theme.json
@@ -122,6 +122,11 @@
 				"border": {
 					"color": "var(--wp--preset--color--primary)"
 				}
+			},
+			"core/tag-cloud": {
+				"typography": {
+					"textTransform": "uppercase"
+				}
 			}
 		},
 		"color": {

--- a/remote/theme.json
+++ b/remote/theme.json
@@ -122,11 +122,6 @@
 				"border": {
 					"color": "var(--wp--preset--color--primary)"
 				}
-			},
-			"core/tag-cloud": {
-				"typography": {
-					"textTransform": "uppercase"
-				}
 			}
 		},
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR revises the footer template and adds the Tags pattern. 

I did not include the tags in the footer template, since it didn't make sense to have this section on every page. Not sure if folks have an opinion about this.

![Screen Shot 2022-02-16 at 3 28 35 PM](https://user-images.githubusercontent.com/5375500/154374923-ad1312a3-9fac-4501-8ed2-43101c6e5610.png)

To test:
- Go to the site editor and insert / verify the footer appears
- Insert the tags pattern


#### Related issue(s):

https://github.com/Automattic/themes/issues/5498
https://github.com/Automattic/themes/issues/5504 (Tags pattern)