### PR TITLE
Add utilities to sync core themes to wpcom

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,13 @@
 		"deploy:push:changes": "node ./theme-utils.mjs push-changes-to-sandbox",
 		"deploy:push:premium": "node ./theme-utils.mjs push-premium-to-sandbox",
 		"deploy": "node ./theme-utils.mjs push-button-deploy",
+		"deploy:core:sync": "node ./theme-utils.mjs deploy-sync-core-theme",
 		"deploy:preview": "node ./theme-utils.mjs deploy-preview",
 		"deploy:theme": "node ./theme-utils.mjs deploy-theme",
 		"deploy:zip": "node ./theme-utils.mjs build-com-zip",
+		"core:pull": "node ./theme-utils.mjs pull-core-themes",
+		"core:push": "node ./theme-utils.mjs push-core-themes",
+		"core:sync": "node ./theme-utils.mjs sync-core-theme",
 		"build:variations": "node ./variations/build-variations.mjs",
 		"prepare": "husky install"
 	},


### PR DESCRIPTION
This adds a utility (and a push-button-process) to sync changes from the wporg repository to wpcom.

First is the command to sync those changes: `npm run core:sync THEMESLUG [REVISION]` 
(Until the theme has a stored .pub-svn-revision file (created by the utility) the REVISION must be given on the command line.  Based on comments in the repository 52047 seems to be the best revision to start with.)

This command creates a DIFF from the revision given to HEAD and applies it to the GIT repository on your sandbox.  Any conflicts that cannot be resolved are stored in .rej files.

Additionally a "push button" command has been created to assist with the entire process of cleaning, syncing, branching, committing, building, landing deploying and building zip files.  Use `npm run deploy:core:sync THEMESLUG [REVISION]` to use a wizard to guide you through that process (much like `npm run deploy` does for the free themes).

That process would look like this:
```
npm run deploy:core:sync twentytwenty 52047
... 
patch applied
fix any conflicts, remove any .rej files  
ensure theme works as expected
hit y to continue
...
Phabricator diff is created
review the diff
hit y to continue
...
changes are landed
theme is deployed
zip is built
```

Sample diff: D75201-code

The conflict resolution process has to happen on the sandbox and leveraging the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) plugin for VSCode is very helpful with that!

Additionally two other commands have been added to help debug and evaluate the changes made locally.  `npm run core:pull` and `npm run core:push` will rsync the core themes from your sandbox.