### PR TITLE
Archeo: Move footer part markup into pattern

### DIFF
--- a/archeo/inc/block-patterns.php
+++ b/archeo/inc/block-patterns.php
@@ -41,6 +41,7 @@ function archeo_register_block_patterns() {
 	}
 
 	$block_patterns = array(
+		'footer',
 		'headline-over-dark-image',
 		'hidden-404',
 		'image-with-headline-on-dark-background',

--- a/archeo/inc/patterns/footer.php
+++ b/archeo/inc/patterns/footer.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Default footer block pattern
+ */
+return array(
+	'title'      => __( 'Default footer', 'archeo' ),
+	'categories' => array( 'footer' ),
+	'blockTypes' => array( 'core/template-part/footer' ),
+	'content'    => '<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
+	<div class="wp-block-group" style="padding-top: var(--wp--custom--spacing--medium); padding-bottom: var(--wp--custom--spacing--medium);">
+		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"},"overlayMenu":"never","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} /-->
+	
+		<!-- wp:paragraph {"align":"center","fontSize":"small","style":{"spacing":{"margin":{"top":0}}}} -->
+		<p class="has-text-align-center has-small-font-size" style="margin-top: 0;">' .
+		sprintf(
+			/* Translators: WordPress link. */
+			esc_html__( 'Proudly powered by %s', 'archeo' ),
+			'<a href="' . esc_url( __( 'https://wordpress.org', 'archeo' ) ) . '" rel="nofollow">WordPress</a>'
+		) . '</p>
+		<!-- /wp:paragraph --></div>
+		<!-- /wp:group -->',
+);

--- a/archeo/parts/footer.html
+++ b/archeo/parts/footer.html
@@ -1,9 +1,1 @@
-<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
-<div class="wp-block-group" style="padding-top: 100px; padding-bottom: 100px;">
-	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"},"overlayMenu":"never","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} /-->
-
-	<!-- wp:paragraph {"align":"center","fontSize":"small","style":{"spacing":{"margin":{"top":0}}}} -->
-	<p class="has-text-align-center has-small-font-size" style="margin-top: 0;">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-	<!-- /wp:paragraph -->
-</div>
-<!-- /wp:group -->
+<!-- wp:pattern {"slug":"archeo/footer"} /-->

--- a/archeo/templates/archive.html
+++ b/archeo/templates/archive.html
@@ -17,4 +17,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer","className":"site-footer-container"} /-->
+<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/index.html
+++ b/archeo/templates/index.html
@@ -16,4 +16,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer","className":"site-footer-container"} /-->
+<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/search.html
+++ b/archeo/templates/search.html
@@ -21,4 +21,4 @@
 </main>
 <!-- /wp:query -->
 
-<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer","className":"site-footer-container"} /-->
+<!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This moves the Archeo default footer part markup into a pattern. 

I was seeing the 'invalid content' block error in the editor with the old one. Moving it into a pattern seems to fix this and allows the 'proudly powered by' text to be translatable.

This also removes the `site-footer-container` class, as I don't believe this is needed as there are no custom styles.

To test, make sure you don't see the 'attempt block recovery' error in the editor for the footer.