### PR TITLE
Archeo: Remove outer group from header

### DIFF
--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -1,15 +1,10 @@
-<!-- wp:group {"layout":{"inherit":"true"}} -->
-<div class="wp-block-group">
-    <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--outer)"}}}} -->
-    <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--outer)">
-        <!-- wp:site-title /-->
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--outer)"}}}} -->
+<div class="wp-block-group" style="padding-bottom:var(--wp--custom--spacing--medium);padding-top:var(--wp--custom--spacing--outer)">
+    <!-- wp:site-title /-->
 
-        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
-            <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-        <!-- /wp:navigation -->
-
-    </div>
-    <!-- /wp:group -->
+    <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
+        <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+    <!-- /wp:navigation -->
 
 </div>
 <!-- /wp:group -->

--- a/archeo/templates/archive.html
+++ b/archeo/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">

--- a/archeo/templates/index.html
+++ b/archeo/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">

--- a/archeo/templates/search.html
+++ b/archeo/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the outer container group block from Archeo's header. It looks like we don't need it, and the `"layout":{"inherit":"true"}` was causing it to not fill the entire site width.

This also removes the `site-header` class. I don't think this is needed as we don't have any custom styles for this class.

To test, make sure that the header fills the full content width, like in the comps.