### PR TITLE
Blockbase: fix alignments

### DIFF
--- a/blockbase/block-templates/index.html
+++ b/blockbase/block-templates/index.html
@@ -3,7 +3,7 @@
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">
 <!-- wp:post-template -->
-<!-- wp:group -->
+<!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:post-title {"isLink":true} /-->
 	<!-- wp:post-featured-image {"isLink":true} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Blockbase was missing a declaration of inheriting layout on the home template, which causes some alignment issues:

Before:
<img width="1440" alt="Screenshot 2022-02-23 at 09 52 09" src="https://user-images.githubusercontent.com/275961/155296040-f9e50d05-8d14-422c-bee1-951893472d9c.png">


After:
<img width="1440" alt="Screenshot 2022-02-23 at 09 51 57" src="https://user-images.githubusercontent.com/275961/155296049-a91f6b20-abcf-4be0-82fd-a7212ce031c7.png">



#### Related issue(s):
