### PR TITLE
Blockbase: Fix social icons

### DIFF
--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -59,6 +59,7 @@ function get_social_menu_as_social_links_block( $block ) {
 	if ( $menu ) {
 		foreach ( $menu as $menu_item ) {
 			$service_name          = preg_replace( '/(-[0-9]+)/', '', $menu_item->post_name );
+			$service_name          = preg_replace( '/(-profile/', '', $service_name );
 			$social_links_content .= '<!-- wp:social-link {"url":"' . $menu_item->url . '","service":"' . $service_name . '"} /-->';
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
On wordpress.com sometimes social links have custom post types of the form `twitter-profile` rather than just `twitter`. We need to strip the `-profile` so that the social icons know what service slug to use.

To test:
Sandbox https://danielwalsh.net/ and check that the twitter icon shows.

#### Related issue(s):
Fixes #5546