### PR TITLE
Penscratch 2: add style resets for social links

### DIFF
--- a/penscratch-2/style.css
+++ b/penscratch-2/style.css
@@ -1390,6 +1390,12 @@ object {
 	color: #666;
 }
 
+/* Social links */
+.wp-block-social-links li.wp-social-link {
+	padding-top: 0;
+	border-top: none;
+}
+
 /* Calendar widget */
 #wp-calendar td,
 #wp-calendar th,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Problem:
Non text widgets are given padding-top and border-top in the penscratch-2 theme.
These style are also effecting social links.

#### Changes proposed in this Pull Request:

* add style resets to override styles for social links

<img width="339" alt="image" src="https://user-images.githubusercontent.com/1935113/155696674-49c956bb-a28f-4eb2-a26a-b9c731640319.png">


#### Related issue(s):

Fixes: #4519 
