### PR TITLE
Archeo: Fix invalid header

### DIFF
--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -1,12 +1,9 @@
 <!-- wp:group {"layout":{"inherit":"true"}} -->
-<div class="wp-block-group">
-    <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--outer)","top":"var(--wp--custom--spacing--outer)"}}}} -->
-    <div class="wp-block-group alignfull" style="padding-bottom:var(--wp--custom--spacing--outer);padding-top:var(--wp--custom--spacing--outer)">
-        <!-- wp:site-title /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--outer)","top":"var(--wp--custom--spacing--outer)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--spacing--outer);padding-bottom:var(--wp--custom--spacing--outer)"><!-- wp:site-title /-->
 
-    <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayBackgroundColor":"foreground","overlayTextColor":"background","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
-        <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-    <!-- /wp:navigation -->
-
-</div>
+<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
+<!-- wp:page-list /-->
+<!-- /wp:navigation --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The Archeo header has an invalid content warning in the site editor, which this fixes.

Before:
<img width="1440" alt="Screenshot 2022-03-02 at 11 34 29" src="https://user-images.githubusercontent.com/275961/156354306-37edd8c2-2ab4-424c-9a5d-8b9c3ae3080e.png">


After:
<img width="1440" alt="Screenshot 2022-03-02 at 11 33 56" src="https://user-images.githubusercontent.com/275961/156354227-b5bcbb8d-4d7f-4334-96d2-05b39c3c7d96.png">

#### Related issue(s):
