### PR TITLE
Stewart: fix font sizes on theme.json

### DIFF
--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -296,7 +296,7 @@
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "48px"
+					"fontSize": "var(--wp--preset--font-size--gigantic)"
 				}
 			},
 			"h2": {
@@ -304,7 +304,7 @@
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "32px"
+					"fontSize": "var(--wp--preset--font-size--huge)"
 				}
 			},
 			"h3": {
@@ -312,7 +312,7 @@
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--preset--font-size--extra-large)"
 				}
 			},
 			"h4": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Stewart, font sizes on theme.json:
- Removes hardcoded values
- Fixes hierarchy between h2 and h3

#### Related issue(s):
https://github.com/Automattic/themes/issues/5608