### PR TITLE
Archeo: fix image block widths

### DIFF
--- a/archeo/inc/patterns/image-with-description.php
+++ b/archeo/inc/patterns/image-with-description.php
@@ -24,7 +24,7 @@ return array(
 	<!-- /wp:paragraph -->
 
 	<!-- wp:image {"id":840,"sizeSlug":"full","linkDestination":"none"} -->
-	<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ancien-temple.jpg" alt="' . __( 'Photo of ancient temple, at Chichen-Itza', 'archeo' ) . '"/></figure>
+	<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ancien-temple.jpg" alt="' . __( 'Photo of ancient temple, at Chichen-Itza', 'archeo' ) . '" class="wp-image-840"/></figure>
 	<!-- /wp:image --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->',

--- a/archeo/inc/patterns/image-with-description.php
+++ b/archeo/inc/patterns/image-with-description.php
@@ -24,7 +24,7 @@ return array(
 	<!-- /wp:paragraph -->
 
 	<!-- wp:image {"id":840,"sizeSlug":"full","linkDestination":"none"} -->
-	<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ancien-temple.jpg" alt="' . __( 'Photo of ancient temple, at Chichen-Itza', 'archeo' ) . '" class="wp-image-840"/></figure>
+	<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ancien-temple.jpg" alt="' . __( 'Photo of ancient temple, at Chichen-Itza', 'archeo' ) . '"/></figure>
 	<!-- /wp:image --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->',

--- a/archeo/inc/patterns/image-with-description.php
+++ b/archeo/inc/patterns/image-with-description.php
@@ -23,7 +23,7 @@ return array(
 	<p class="has-small-font-size" style="font-style:italic;font-weight:400">' . __( 'From "American Cities and Ruins: Mitla, Palenqué, Izamal, Chichen-Itza, Uxmal, Atlas" housed at the New York Public Library.', 'archeo' ) . '</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:image {"id":840,"sizeSlug":"full","linkDestination":"none"} -->
+	<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
 	<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ancien-temple.jpg" alt="' . __( 'Photo of ancient temple, at Chichen-Itza', 'archeo' ) . '"/></figure>
 	<!-- /wp:image --></div>
 	<!-- /wp:column --></div>

--- a/archeo/inc/patterns/layered-images-with-headline.php
+++ b/archeo/inc/patterns/layered-images-with-headline.php
@@ -22,8 +22,8 @@ return array(
 	<div style="height:8vw" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:image {"align":"right","sizeSlug":"full","linkDestination":"none"} -->
-	<div class="wp-block-image"><figure class="alignright size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/palais-du-cirque.jpg" alt="' . esc_attr__( 'Photo of Palace of the Circus', 'archeo' ) . '"/></figure></div>
+	<!-- wp:image {"align":"right","id":775,"sizeSlug":"full","linkDestination":"none"} -->
+	<div class="wp-block-image"><figure class="alignright size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/palais-du-cirque.jpg" alt="' . esc_attr__( 'Photo of Palace of the Circus', 'archeo' ) . '" class="wp-image-775"/></figure></div>
 	<!-- /wp:image --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns --></div></div>

--- a/archeo/inc/patterns/layered-images-with-headline.php
+++ b/archeo/inc/patterns/layered-images-with-headline.php
@@ -22,8 +22,8 @@ return array(
 	<div style="height:8vw" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:image {"align":"right","id":775,"sizeSlug":"full","linkDestination":"none"} -->
-	<div class="wp-block-image"><figure class="alignright size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/palais-du-cirque.jpg" alt="' . esc_attr__( 'Photo of Palace of the Circus', 'archeo' ) . '" class="wp-image-775"/></figure></div>
+	<!-- wp:image {"align":"right","sizeSlug":"full","linkDestination":"none"} -->
+	<div class="wp-block-image"><figure class="alignright size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/palais-du-cirque.jpg" alt="' . esc_attr__( 'Photo of Palace of the Circus', 'archeo' ) . '"/></figure></div>
 	<!-- /wp:image --></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns --></div></div>

--- a/archeo/inc/patterns/layout-with-two-images-and-text.php
+++ b/archeo/inc/patterns/layout-with-two-images-and-text.php
@@ -16,8 +16,8 @@ return array(
 	<p class="has-medium-font-size" style="font-style:normal;font-weight:100;line-height:1.2">' . wp_kses_post( __( 'The Pyramid of the <br>Magician at Uxmal', 'archeo' ) ) . '</p>
 	<!-- /wp:paragraph -->
 	
-	<!-- wp:image {"align":"left","sizeSlug":"full","linkDestination":"none"} -->
-	<div class="wp-block-image"><figure class="alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure></div>
+	<!-- wp:image {"align":"left","id":869,"sizeSlug":"full","linkDestination":"none"} -->
+	<figure class="wp-block-image alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '" class="wp-image-869"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure>
 	<!-- /wp:image --></div>
 	<!-- /wp:column -->
 	

--- a/archeo/inc/patterns/layout-with-two-images-and-text.php
+++ b/archeo/inc/patterns/layout-with-two-images-and-text.php
@@ -16,8 +16,8 @@ return array(
 	<p class="has-medium-font-size" style="font-style:normal;font-weight:100;line-height:1.2">' . wp_kses_post( __( 'The Pyramid of the <br>Magician at Uxmal', 'archeo' ) ) . '</p>
 	<!-- /wp:paragraph -->
 	
-	<!-- wp:image {"align":"left","id":869,"sizeSlug":"full","linkDestination":"none"} -->
-	<figure class="wp-block-image alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '" class="wp-image-869"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure>
+	<!-- wp:image {"align":"left","sizeSlug":"full","linkDestination":"none"} -->
+	<div class="wp-block-image"><figure class="alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure></div>
 	<!-- /wp:image --></div>
 	<!-- /wp:column -->
 	

--- a/archeo/inc/patterns/layout-with-two-images-and-text.php
+++ b/archeo/inc/patterns/layout-with-two-images-and-text.php
@@ -17,7 +17,7 @@ return array(
 	<!-- /wp:paragraph -->
 	
 	<!-- wp:image {"align":"left","sizeSlug":"full","linkDestination":"none"} -->
-	<div class="wp-block-image"><figure class="alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure></div>
+	<figure class="wp-block-image alignleft size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/pyramid.jpg" alt="' . __( 'Photograph by Désiré Charnay, 1862 to 1863', 'archeo' ) . '"/><figcaption><mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-background-color"><em>' . __( 'Photograph by Désiré Charnay, 1862 – 1863', 'archeo' ) . '</em></mark></figcaption></figure>
 	<!-- /wp:image --></div>
 	<!-- /wp:column -->
 	

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -203,3 +203,12 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .wp-block-group.simple-list-of-posts {
 	align-items: baseline;
 }
+
+/*
+ * Needed until there's a fix in GB.
+ * Related: https://github.com/WordPress/gutenberg/pull/39045
+ */
+ .wp-block-image img {
+	height: auto;
+	max-width: 100%;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds the `wp-image-` class and ID attribute to any image blocks in Archeo's patterns.

Since https://github.com/WordPress/gutenberg/pull/39045 was merged, only images that have the `wp-image-` class are targeted with the responsive styles. Without this class, the images are not resized to 100%:

| Without class | With class |
| ------------- | ---------- |
| <img width="1427" alt="image" src="https://user-images.githubusercontent.com/1645628/157231633-13aca138-1ba7-452e-8396-2c5290e6d824.png">   | <img width="1424" alt="image" src="https://user-images.githubusercontent.com/1645628/157231711-d2c974f2-6f4f-4b99-84f5-a70802106811.png">     |

It looks like images in cover blocks and media + text blocks are not affected.

Do we need to run through all block themes and add these classes?