### PR TITLE
Blockbase: avoid margin-top on the first paragraph child of a group

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -514,7 +514,7 @@ input[type=checkbox] + label {
   flex-wrap: nowrap;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item {
-  row-gap: 0rem;
+  row-gap: 0;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item > a:hover {
   -webkit-text-decoration-line: underline;
@@ -593,7 +593,7 @@ input[type=checkbox] + label {
   flex-direction: column;
 }
 
-p.has-drop-cap:not(:focus):first-letter {
+p.has-drop-cap:not(:focus)::first-letter {
   font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
   font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
   margin: var(--wp--custom--paragraph--dropcap--margin);
@@ -740,7 +740,7 @@ p.has-drop-cap:not(:focus):first-letter {
 .wp-block-post-content p.wp-block.wp-block-paragraph,
 .wp-block-post-content *[class^=wp-container] > * + p,
 .wp-block-post-content *[class^=wp-container] > p + *,
-.wp-block-post-content p {
+.wp-block-post-content p:not(.wp-block-group > p) {
   margin-top: 1em;
 }
 

--- a/blockbase/sass/blocks/_post-content.scss
+++ b/blockbase/sass/blocks/_post-content.scss
@@ -3,7 +3,7 @@
 	p.wp-block.wp-block-paragraph, // This selector has been made extra specific to override the block gap being set in the editor.
 	*[class^="wp-container"] > * + p,
 	*[class^="wp-container"] > p + *,
-	p {
+	p:not(.wp-block-group > p) {
 		margin-top: 1em;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Blockbase: add an exception in a too general CSS selector to avoid the unwanted margin described on the issue.

#### Code used:
```
<!-- wp:group {"style":{"spacing":{"padding":{"top":"25px","right":"25px","bottom":"25px","left":"25px"}}},"borderColor":"luminous-vivid-orange"} -->
<div class="wp-block-group has-border-color has-luminous-vivid-orange-border-color" style="padding-top:25px;padding-right:25px;padding-bottom:25px;padding-left:25px"><!-- wp:paragraph -->
<p>Hello, I'm a paragraph inside a group block.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Hello, I'm a paragraph inside a group block.</p>
<!-- /wp:paragraph -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Hello, I'm a paragraph inside a group, inside a group.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

#### Screenshots of Blockbase with this fix:

![image](https://user-images.githubusercontent.com/1310626/157268490-3cbb5ea6-6ac4-4940-809a-f595a76a48f2.png)
![image](https://user-images.githubusercontent.com/1310626/157268809-c4ab3cc4-4a56-4515-97a0-21a612828d5d.png)

#### Screenshots of Blockbase without this fix:

![image](https://user-images.githubusercontent.com/1310626/157269103-0ba1c720-4f69-42d5-b378-21bffa9d8f90.png)

#### Related issue(s):
https://github.com/Automattic/themes/issues/5617