### PR TITLE
Archeo: add CSS for mobile menu font size

### DIFF
--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--outer)","top":"var(--wp--custom--spacing--outer)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--spacing--outer);padding-bottom:var(--wp--custom--spacing--outer)"><!-- wp:site-title /-->
 
-<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}},"fontSize":"small"} -->
+<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"50px"}}} -->
 <!-- wp:page-list /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:group --></div>

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -224,3 +224,13 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	height: auto;
 	max-width: 100%;
 }
+
+/*
+ * Custom font size at small screens for navigation.
+ * Possible future fix: https://github.com/WordPress/gutenberg/pull/33543
+ */
+@media (max-width: 599px) {
+	.wp-block-navigation__responsive-container-content li {
+		font-size: var(--wp--preset--font-size--large) !important;
+	}
+}

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -224,13 +224,3 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	height: auto;
 	max-width: 100%;
 }
-
-/*
- * Custom font size at small screens for navigation.
- * Possible future fix: https://github.com/WordPress/gutenberg/pull/33543
- */
-@media (max-width: 599px) {
-	.wp-block-navigation__responsive-container-content li {
-		font-size: var(--wp--preset--font-size--large) !important;
-	}
-}

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -118,6 +118,11 @@
 					"lineHeight": "1.1"
 				}
 			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
 			"core/post-comments": {
 				"elements": {
 					"h3": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This increases the font size of the main navigation on small screens, as suggested in https://github.com/Automattic/themes/issues/5631:

Before|After
----|-----
![image](https://user-images.githubusercontent.com/1645628/157496818-cda6dbc5-4f9e-4333-9964-5c355b948d71.png)| ![image](https://user-images.githubusercontent.com/1645628/157496690-da74e451-3f07-46f9-ac0f-9ba92cf3d183.png)

The `blockGap` has already been reduced to `var(--wp--custom--spacing--small)` in https://github.com/Automattic/themes/pull/5640. This is what I've used in the above screenshot. Should this be reduced any further?

#### Related issue(s):
https://github.com/Automattic/themes/issues/5631