### PR TITLE
Archeo: remove bottom margin from columns

### DIFF
--- a/archeo/inc/patterns/image-with-headline-description.php
+++ b/archeo/inc/patterns/image-with-headline-description.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'featured', 'images' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"5vw","bottom":"0","left":"5vw"}}}} -->
 	<div class="wp-block-group alignfull" style="padding-top:0;padding-right:5vw;padding-bottom:0;padding-left:5vw"><!-- wp:media-text {"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/chahk.gif","mediaType":"image","mediaWidth":64,"verticalAlignment":"top"} -->
-	<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-top" style="grid-template-columns:64% auto"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/chahk.gif" alt="' . esc_attr__( 'Chahk: rain deity', 'archeo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"textAlign":"right","style":{"typography":{"fontSize":"clamp(64px, 6vw, 100px)","lineHeight":"1","textTransform":"uppercase"},"spacing":{"margin":{"bottom":"48px"}}}} -->
-	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:48px;text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
+	<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-top" style="grid-template-columns:64% auto"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/chahk.gif" alt="' . esc_attr__( 'Chahk: rain deity', 'archeo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"textAlign":"right","style":{"typography":{"fontSize":"clamp(64px, 6vw, 100px)","lineHeight":"1","textTransform":"uppercase"},"spacing":{"margin":{"bottom":"clamp(5px, 2vw, 20px)"}}}} -->
+	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:clamp(10px, 2vw, 20px);text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:columns -->

--- a/archeo/inc/patterns/image-with-headline-description.php
+++ b/archeo/inc/patterns/image-with-headline-description.php
@@ -8,7 +8,7 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"5vw","bottom":"0","left":"5vw"}}}} -->
 	<div class="wp-block-group alignfull" style="padding-top:0;padding-right:5vw;padding-bottom:0;padding-left:5vw"><!-- wp:media-text {"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/chahk.gif","mediaType":"image","mediaWidth":64,"verticalAlignment":"top"} -->
 	<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-top" style="grid-template-columns:64% auto"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/chahk.gif" alt="' . esc_attr__( 'Chahk: rain deity', 'archeo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:heading {"textAlign":"right","style":{"typography":{"fontSize":"clamp(64px, 6vw, 100px)","lineHeight":"1","textTransform":"uppercase"},"spacing":{"margin":{"bottom":"clamp(5px, 2vw, 20px)"}}}} -->
-	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:clamp(10px, 2vw, 20px);text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
+	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:clamp(5px, 2vw, 20px);text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:columns -->

--- a/archeo/inc/patterns/image-with-headline-description.php
+++ b/archeo/inc/patterns/image-with-headline-description.php
@@ -11,8 +11,8 @@ return array(
 	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:48px;text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:columns -->
-	<div class="wp-block-columns"><!-- wp:column {"width":"15%"} -->
+	<!-- wp:columns {"style":{"spacing":{"margin":{"bottom":"0px"}}}} -->
+	<div class="wp-block-columns" style="margin-bottom:0px"><!-- wp:column {"width":"15%"} -->
 	<div class="wp-block-column" style="flex-basis:15%"></div>
 	<!-- /wp:column -->
 

--- a/archeo/inc/patterns/image-with-headline-description.php
+++ b/archeo/inc/patterns/image-with-headline-description.php
@@ -11,8 +11,8 @@ return array(
 	<h2 class="has-text-align-right" id="chahk-raindeity" style="font-size:clamp(64px, 6vw, 100px);line-height:1;margin-bottom:48px;text-transform:uppercase">' . wp_kses_post( __( 'Chahk:<br>Rain<br>deity', 'archeo' ) ) . '</h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:columns {"style":{"spacing":{"margin":{"bottom":"0px"}}}} -->
-	<div class="wp-block-columns" style="margin-bottom:0px"><!-- wp:column {"width":"15%"} -->
+	<!-- wp:columns -->
+	<div class="wp-block-columns"><!-- wp:column {"width":"15%"} -->
 	<div class="wp-block-column" style="flex-basis:15%"></div>
 	<!-- /wp:column -->
 

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -40,7 +40,7 @@
 		"custom": {
 			"spacing": {
 				"small": "clamp(20px, 4vw, 40px)",
-				"medium": "clamp(30px, 8vw, 100px)",
+				"medium": "clamp(48px, 8vw, 100px)",
 				"large": "clamp(100px, 12vw, 460px)",
 				"outer": "min(4vw, 90px)"
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the bottom margin from the columns in the 'Image with headline and description' pattern. This allows the space at mobile between this pattern and the list of posts to be `48px`, as suggested in https://github.com/Automattic/themes/issues/5631.

Before|After
----|----
![image](https://user-images.githubusercontent.com/1645628/157499099-b9162231-72f4-4949-83bf-8c05a1869e9a.png) | ![image](https://user-images.githubusercontent.com/1645628/157499022-b429566e-8878-416d-aebc-0dd57543bf4a.png)

#### Related issue(s):
https://github.com/Automattic/themes/issues/5631