### PR TITLE
Blockbase: move social-navigation.php requirement inside of `class_exists` check

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -156,9 +156,8 @@ if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
 	require get_template_directory() . '/inc/customizer/wp-customize-colors.php';
 	require get_template_directory() . '/inc/customizer/wp-customize-color-palettes.php';
 	require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
+	require get_template_directory() . '/inc/social-navigation.php';
 }
-
-require get_template_directory() . '/inc/social-navigation.php';
 
 // Force menus to reload
 add_action(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR moves the `require get_template_directory() . '/inc/social-navigation.php';` inside of the same `if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' )` as the other files that use this class, to make sure it exists before the code tries to load it. 

#### Related issue(s):

Closes #5653