### PR TITLE
Remote: reassigned block patterns to default categories

### DIFF
--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -14,6 +14,36 @@
  */
 function remote_register_block_patterns() {
 
+	$block_pattern_categories = array(
+		'featured' => array( 'label' => __( 'Featured', 'remote' ) ),
+		'columns'  => array( 'label' => __( 'Columns', 'remote' ) ),
+		'text'     => array( 'label' => __( 'Text', 'remote' ) ),
+		'query'    => array( 'label' => __( 'Query', 'remote' ) ),
+	);
+
+	/**
+	 * Filters the theme block pattern categories.
+	 *
+	 * @since remote 1.0
+	 *
+	 * @param array[] $block_pattern_categories {
+	 *     An associative array of block pattern categories, keyed by category name.
+	 *
+	 *     @type array[] $properties {
+	 *         An array of block category properties.
+	 *
+	 *         @type string $label A human-readable label for the pattern category.
+	 *     }
+	 * }
+	 */
+	$block_pattern_categories = apply_filters( 'remote_block_pattern_categories', $block_pattern_categories );
+
+	foreach ( $block_pattern_categories as $name => $properties ) {
+		if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( $name ) ) {
+			register_block_pattern_category( $name, $properties );
+		}
+	}
+
 	$block_patterns = array(
 		'hero-text',
 		'hidden-404-content',

--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -14,6 +14,7 @@
  */
 function remote_register_block_patterns() {
 
+	//Needed until https://github.com/WordPress/gutenberg/issues/39500 is fixed.
 	$block_pattern_categories = array(
 		'featured' => array( 'label' => __( 'Featured', 'remote' ) ),
 		'columns'  => array( 'label' => __( 'Columns', 'remote' ) ),

--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -13,32 +13,6 @@
  * @return void
  */
 function remote_register_block_patterns() {
-	$block_pattern_categories = array(
-		'pages' => array( 'label' => __( 'Pages', 'remote' ) ),
-	);
-
-	/**
-	 * Filters the theme block pattern categories.
-	 *
-	 * @since remote 1.0
-	 *
-	 * @param array[] $block_pattern_categories {
-	 *     An associative array of block pattern categories, keyed by category name.
-	 *
-	 *     @type array[] $properties {
-	 *         An array of block category properties.
-	 *
-	 *         @type string $label A human-readable label for the pattern category.
-	 *     }
-	 * }
-	 */
-	$block_pattern_categories = apply_filters( 'remote_block_pattern_categories', $block_pattern_categories );
-
-	foreach ( $block_pattern_categories as $name => $properties ) {
-		if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( $name ) ) {
-			register_block_pattern_category( $name, $properties );
-		}
-	}
 
 	$block_patterns = array(
 		'hero-text',

--- a/remote/inc/patterns/categories.php
+++ b/remote/inc/patterns/categories.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Categories', 'remote' ),
-	'categories' => array( 'text' ),
+	'categories' => array( 'text', 'featured' ),
 	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
 		<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Categories', 'remote' ) . '</p>
 		<!-- /wp:paragraph -->

--- a/remote/inc/patterns/hero-text.php
+++ b/remote/inc/patterns/hero-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Hero text', 'remote' ),
-	'categories' => array( 'text' ),
+	'categories' => array( 'text', 'featured' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
     <div class="wp-block-group alignwide"><!-- wp:spacer {"height":"32px"} -->
     <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/remote/inc/patterns/hero-text.php
+++ b/remote/inc/patterns/hero-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Hero text', 'remote' ),
-	'categories' => array( 'pages' ),
+	'categories' => array( 'text' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
     <div class="wp-block-group alignwide"><!-- wp:spacer {"height":"32px"} -->
     <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/remote/inc/patterns/hidden-search-form.php
+++ b/remote/inc/patterns/hidden-search-form.php
@@ -3,10 +3,9 @@
  * Search form
  */
 return array(
-	'title'      => __( 'Search form', 'remote' ),
-	'categories' => array( 'pages' ),
-	'inserter'   => false,
-	'content'    => '<!-- wp:group {"layout":{"inherit":true}} -->
+	'title'    => __( 'Search form', 'remote' ),
+	'inserter' => false,
+	'content'  => '<!-- wp:group {"layout":{"inherit":true}} -->
     <div class="wp-block-group"><!-- wp:spacer {"height":"32px"} -->
     <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->

--- a/remote/inc/patterns/image-with-text.php
+++ b/remote/inc/patterns/image-with-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Image with text', 'remote' ),
-	'categories' => array( 'text', 'columns' ),
+	'categories' => array( 'text', 'columns', 'featured' ),
 	'content'    => '<!-- wp:image {"align":"wide","sizeSlug":"large","linkDestination":"none"} -->
 	<figure class="wp-block-image alignwide size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/laptop.jpg" alt="' . esc_attr__( 'Picture of a laptop', 'remote' ) . '"/></figure>
 	<!-- /wp:image -->

--- a/remote/inc/patterns/posts-grid.php
+++ b/remote/inc/patterns/posts-grid.php
@@ -7,7 +7,7 @@
 
 return array(
 	'title'      => __( 'Posts grid', 'remote' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'query', 'featured' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 	<div class="wp-block-group alignfull"><!-- wp:query {"queryId":0,"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null},"tagName":"main","displayLayout":{"type":"flex","columns":2},"align":"wide"} -->

--- a/remote/inc/patterns/posts-list.php
+++ b/remote/inc/patterns/posts-list.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Posts list', 'remote' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'query', 'featured' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
     <div class="wp-block-group alignfull"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null},"tagName":"main","align":"wide"} -->
     <main class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/remote/inc/patterns/posts-list.php
+++ b/remote/inc/patterns/posts-list.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Posts list', 'remote' ),
-	'categories' => array( 'pages' ),
+	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
     <div class="wp-block-group alignfull"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null},"tagName":"main","align":"wide"} -->
     <main class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/remote/inc/patterns/tags.php
+++ b/remote/inc/patterns/tags.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Tags', 'remote' ),
-	'categories' => array( 'text' ),
+	'categories' => array( 'text', 'featured' ),
 	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
 		<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Tags', 'remote' ) . '</p>
 		<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Instead of using the pages category (blame copy paste when setting up the theme for that) I've assigned all patters to default categories for now. @kjellr @beafialho feel free to correct any that you think it's not the right one.