### PR TITLE
Archeo: Fix nav block blockGaps values

### DIFF
--- a/archeo/inc/patterns/footer.php
+++ b/archeo/inc/patterns/footer.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:group {"layout":{"inherit":"true"}} -->
 	<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top: var(--wp--custom--spacing--medium); padding-bottom: var(--wp--custom--spacing--medium);">
-		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayMenu":"never","className":"site-footer","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"var(--wp--custom--spacing--small)"}},"fontSize":"small"} /-->
+		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayMenu":"never","className":"site-footer","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"2.5rem"}},"fontSize":"small"} /-->
 	
 		<!-- wp:paragraph {"align":"left","fontSize":"small","style":{"spacing":{"margin":{"top":0}}}} -->
 		<p class="has-small-font-size" style="margin-top: 0;">' .

--- a/archeo/parts/header.html
+++ b/archeo/parts/header.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--outer)","top":"var(--wp--custom--spacing--outer)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--outer);padding-bottom:var(--wp--custom--spacing--outer)"><!-- wp:site-title /-->
 
-<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"var(--wp--custom--spacing--small)"}},"fontSize":"small"} -->
+<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":"2.5rem"}},"fontSize":"small"} -->
 <!-- wp:page-list /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR changes the blockGap values in the header and footer templates from `var(--wp--custom--spacing--small)` to`2.5rem`.

We've only recently changed to the variable in this PR https://github.com/Automattic/themes/pull/5640, however, I can't see this working locally anymore and I don't think this is working on dotcom. The `rem` value seems to work consistently both locally and on dotcom. Here's what it looks like:

Footer nav at 400px:
![image](https://user-images.githubusercontent.com/1645628/158586468-eed4b730-79a0-4486-b5b1-da9549fb03f2.png)

Footer nav at 1200px:
![image](https://user-images.githubusercontent.com/1645628/158586539-c631b359-2e5f-4ec9-8f29-b989aaddd213.png)

Header nav at 1200px:
![image](https://user-images.githubusercontent.com/1645628/158586592-167dac67-627e-47a0-a997-e1c5b9806cae.png)

#### Related issues:
Probably related to https://github.com/Automattic/themes/issues/5632