### PR TITLE
Remote: subscribe pattern

### DIFF
--- a/remote/inc/block-patterns.php
+++ b/remote/inc/block-patterns.php
@@ -52,6 +52,7 @@ function remote_register_block_patterns() {
 		'image-with-text',
 		'posts-grid',
 		'posts-list',
+		'subscribe',
 		'tags',
 		'categories',
 	);

--- a/remote/inc/patterns/subscribe.php
+++ b/remote/inc/patterns/subscribe.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Subscription form
+ */
+return array(
+	'title'      => __( 'Subscription form', 'remote' ),
+	'categories' => array( 'text', 'featured' ),
+	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+	<p style="text-transform:uppercase">' . esc_html__( 'Follow this blog', 'remote' ) . '</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>' . esc_html__( 'Sign up to have each new post delivered to your inbox.', 'remote' ) . '</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:jetpack/subscriptions {"buttonWidth":"25%","buttonBackgroundColor":"primary","textColor":"background","fontSize":"20px","customFontSize":"20px","borderRadius":6,"borderColor":"foreground","padding":10,"spacing":10,"className":"is-style-split"} -->
+	<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline is-style-split">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" custom_font_size="20px" custom_border_radius="6" custom_border_weight="1" custom_button_width="25%" custom_padding="10" custom_spacing="10" submit_button_classes="has-20-px-font-size has-foreground-border-color has-text-color has-background-color has-background has-primary-background-color" email_field_classes="has-20-px-font-size has-foreground-border-color" show_only_email_and_button="true" success_message="' . esc_html__( 'Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.', 'remote' ) . '"]</div>
+	<!-- /wp:jetpack/subscriptions -->',
+);

--- a/remote/inc/patterns/subscribe.php
+++ b/remote/inc/patterns/subscribe.php
@@ -5,8 +5,8 @@
 return array(
 	'title'      => __( 'Subscription form', 'remote' ),
 	'categories' => array( 'text', 'featured' ),
-	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
-	<p style="text-transform:uppercase">' . esc_html__( 'Follow this blog', 'remote' ) . '</p>
+	'content'    => '<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+	<p class="has-small-font-size" style="text-transform:uppercase">' . esc_html__( 'Follow this blog', 'remote' ) . '</p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR includes the Jetpack subscribe block pattern. To test this, checkout this branch and run `npm run deploy:push:changes` to see the pattern on your sandbox.

<img width="823" alt="Screenshot 2022-03-21 at 13 59 00" src="https://user-images.githubusercontent.com/3593343/159266214-82cfabcc-247c-4286-b07a-52ec1e7b22fd.png">

The Jetpack block doesn't allow for changing the background color of the input or the input text. This is as close as I could get to the design.

#### Related issue(s):

https://github.com/Automattic/themes/issues/5504