### PR TITLE
Added a dependency check for Gutenberg 

### DIFF
--- a/livro/functions.php
+++ b/livro/functions.php
@@ -61,3 +61,5 @@ add_action( 'wp_enqueue_scripts', 'livro_styles' );
 
 // Add block patterns
 require get_template_directory() . '/inc/block-patterns.php';
+
+require get_template_directory() . '/inc/gutenberg-dependency-check.php';

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -9,7 +9,11 @@ function show_admin_messages() {
 		return;
 	}
 	$version = $match[0];
-	if( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+	if( defined( 'IS_GUTENBERG_PLUGIN' ) && defined( 'GUTENBERG_VERSION' ) ) {
+		if ( version_compare( GUTENBERG_VERSION, trim( $version ) ) >= 0 ) {
+			return;
+		}
+	}
 		$plugins = get_plugins();
 		foreach ( $plugins as $plugin ) {
 			if ( 'Gutenberg' === $plugin['Name'] ) {

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -9,7 +9,7 @@ function show_admin_messages() {
 		return;
 	}
 	$version = $match[0];
-	if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+	if( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
 		$plugins = get_plugins();
 		foreach ( $plugins as $plugin ) {
 			if ( 'Gutenberg' === $plugin['Name'] ) {

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -1,0 +1,27 @@
+<?php
+
+add_action('admin_notices', 'showAdminMessages');
+
+function showAdminMessages() {
+	$metadata = file_get_contents( get_stylesheet_directory() . '/style.css' );
+	preg_match( '/(?<=Requires Gutenberg:).+/', $metadata, $match );
+	if( 0 === sizeof($match) ) {
+		return;
+	}
+	$version = $match[0];
+	if( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+		$plugins = get_plugins();
+		foreach( $plugins as $plugin ) {
+			if( $plugin['Name'] === 'Gutenberg' ) {
+				if( version_compare(trim($plugin['Version']), trim($version) ) >= 0 ) {
+					return;
+				}
+				break;
+			}
+		}
+	}
+
+	echo '<div id="message" class="error"><p><strong>';
+	printf( __( 'The installed theme requires <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg</a> version %s or higher.', 'livro' ), $version );
+	echo '</strong></p></div>';
+}

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -1,8 +1,8 @@
 <?php
 
-add_action( 'admin_notices', 'showAdminMessages' );
+add_action( 'admin_notices', 'show_admin_messages' );
 
-function showAdminMessages() {
+function show_admin_messages() {
 	$metadata = file_get_contents( get_stylesheet_directory() . '/style.css' );
 	preg_match( '/(?<=Requires Gutenberg:).+/', $metadata, $match );
 	if ( 0 === sizeof( $match ) ) {

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -28,16 +28,9 @@ function show_admin_messages() {
 		return;
 	}
 
-	if ( ! function_exists('get_plugins') ) {
-		// We can't check the version of Gutenberg that is installed, but have confirmed that it is installed and activated.
-		// We'll just hope for the best!
-		return;
-	}
-
 	// We have confirmed that Gutenberg is installed and activated, however we cannot use the GUTENBERG_VERSION constant
 	// (probably because we are in development mode)
-	// We have confirmed that get_plugins() is something we can call, so we'll use the metadata reported there to determine
-	// the version of Gutenberg
+	// we'll use the metadata from get_plugins() to determine the version of Gutenberg
 	$plugins = get_plugins();
 	foreach ( $plugins as $plugin ) {
 		if ( 'Gutenberg' === $plugin['Name'] ) {
@@ -47,4 +40,6 @@ function show_admin_messages() {
 			return;
 		}
 	}
+
+	// We weren't able to confirm the version, however we do know that it's installed and activated so we'll just hope for the best!
 }

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -15,14 +15,14 @@ function show_admin_messages() {
 		return; // Gutenberg is not required
 	}
 	$version = trim( $match[0] );
-	if( ! defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+	if ( ! defined( 'IS_GUTENBERG_PLUGIN' ) ) {
 		print_admin_message( $version ); // Gutenberg is not activated
 		return;
 	}
 
 	// Determine Gutenberg version from defined constant
 	if ( defined( 'GUTENBERG_VERSION' ) ) {
-		if( version_compare( GUTENBERG_VERSION, $version ) < 0 ) {
+		if ( version_compare( GUTENBERG_VERSION, $version ) < 0 ) {
 			print_admin_message( $version );
 		}
 		return;

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -2,30 +2,49 @@
 
 add_action( 'admin_notices', 'show_admin_messages' );
 
+function print_admin_message( $version ) {
+	echo '<div id="message" class="error"><p><strong>';
+	printf( __( 'The installed theme requires <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg</a> version %s or higher.', 'livro' ), $version );
+	echo '</strong></p></div>';
+}
+
 function show_admin_messages() {
 	$metadata = file_get_contents( get_stylesheet_directory() . '/style.css' );
 	preg_match( '/(?<=Requires Gutenberg:).+/', $metadata, $match );
 	if ( 0 === sizeof( $match ) ) {
+		return; // Gutenberg is not required
+	}
+	$version = trim( $match[0] );
+	if( ! defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+		print_admin_message( $version ); // Gutenberg is not activated
 		return;
 	}
-	$version = $match[0];
-	if( defined( 'IS_GUTENBERG_PLUGIN' ) && defined( 'GUTENBERG_VERSION' ) ) {
-		if ( version_compare( GUTENBERG_VERSION, trim( $version ) ) >= 0 ) {
+
+	// Determine Gutenberg version from defined constant
+	if ( defined( 'GUTENBERG_VERSION' ) ) {
+		if( version_compare( GUTENBERG_VERSION, $version ) < 0 ) {
+			print_admin_message( $version );
+		}
+		return;
+	}
+
+	if ( ! function_exists('get_plugins') ) {
+		// We can't check the version of Gutenberg that is installed, but have confirmed that it is installed and activated.
+		// We'll just hope for the best!
+		return;
+	}
+
+	// We have confirmed that Gutenberg is installed and activated, however we cannot use the GUTENBERG_VERSION constant
+	// (probably because we are in development mode)
+	// We have confirmed that get_plugins() is something we can call, so we'll use the metadata reported there to determine
+	// the version of Gutenberg
+	$plugins = get_plugins();
+	foreach ( $plugins as $plugin ) {
+		if ( 'Gutenberg' === $plugin['Name'] ) {
+			if ( version_compare( trim( $plugin['Version'] ), $version ) < 0 ) {
+				print_admin_message( $version );
+			}
 			return;
 		}
 	}
-		$plugins = get_plugins();
-		foreach ( $plugins as $plugin ) {
-			if ( 'Gutenberg' === $plugin['Name'] ) {
-				if ( version_compare( trim( $plugin['Version'] ), trim( $version ) ) >= 0 ) {
-					return;
-				}
-				break;
-			}
-		}
-	}
-
-	echo '<div id="message" class="error"><p><strong>';
-	printf( __( 'The installed theme requires <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg</a> version %s or higher.', 'livro' ), $version );
-	echo '</strong></p></div>';
 }

--- a/livro/inc/gutenberg-dependency-check.php
+++ b/livro/inc/gutenberg-dependency-check.php
@@ -1,19 +1,19 @@
 <?php
 
-add_action('admin_notices', 'showAdminMessages');
+add_action( 'admin_notices', 'showAdminMessages' );
 
 function showAdminMessages() {
 	$metadata = file_get_contents( get_stylesheet_directory() . '/style.css' );
 	preg_match( '/(?<=Requires Gutenberg:).+/', $metadata, $match );
-	if( 0 === sizeof($match) ) {
+	if ( 0 === sizeof( $match ) ) {
 		return;
 	}
 	$version = $match[0];
-	if( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+	if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 		$plugins = get_plugins();
-		foreach( $plugins as $plugin ) {
-			if( $plugin['Name'] === 'Gutenberg' ) {
-				if( version_compare(trim($plugin['Version']), trim($version) ) >= 0 ) {
+		foreach ( $plugins as $plugin ) {
+			if ( 'Gutenberg' === $plugin['Name'] ) {
+				if ( version_compare( trim( $plugin['Version'] ), trim( $version ) ) >= 0 ) {
 					return;
 				}
 				break;

--- a/livro/style.css
+++ b/livro/style.css
@@ -7,6 +7,7 @@ Description: Livro is a simple theme designed to evoke the calm feeling you get 
 Requires at least: 5.8
 Tested up to: 5.8.3
 Requires PHP: 5.6
+Requires Gutenberg: 12.8
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Added a dependency check for Gutenberg based on metadata stored in st…yle.css

#### Changes proposed in this Pull Request:

Adds a (reuse-able) `/inc/gutenberg-dependency-check.php` which checks style.css for a `Requires Gutenberg:` entry and compares that against the version of Gutenberg installed.

If unactivated or a version is installed that is lower than expressed in the theme metadata an error is shown in the WP admin.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/146530/159337900-a47af6fa-990e-40a5-af5d-ab039ddbc5be.png">

Tested with 12.8.1 installed.  Livro requires 12.8 (where webfonts was introduced).  

#### Related issue(s):

A tinker after discussing #5705