### PR TITLE
[Archeo] Add "Page (No Title)" template

### DIFF
--- a/archeo/templates/page-no-title.html
+++ b/archeo/templates/page-no-title.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)"}}}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"inherit":true}} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -9,6 +9,13 @@
 				"page",
 				"post"
 			]
+		},
+		{
+			"name": "page-no-title",
+			"title": "Page (No Title)",
+			"postTypes": [
+				"page"
+			]
 		}
 	],
 	"settings": {


### PR DESCRIPTION
This PR adds a quick alternate version of our Page template. It's exactly the same, except it's missing the page title. This will come in handy for a couple of the theme demos. 

Page|Page (No Title)
---|---
<img width="1512" alt="Screen Shot 2022-03-22 at 9 41 06 AM" src="https://user-images.githubusercontent.com/1202812/159495022-c14fd1e5-41c3-41f8-b66c-dca1dedfed7d.png">|<img width="1512" alt="Screen Shot 2022-03-22 at 9 40 57 AM" src="https://user-images.githubusercontent.com/1202812/159495021-0d455ef2-e977-40ab-8d94-4f7122317d95.png">

