### PR TITLE
[Livro] Try adding support for the aside post format.

### DIFF
--- a/livro/functions.php
+++ b/livro/functions.php
@@ -23,6 +23,9 @@ if ( ! function_exists( 'livro_support' ) ) :
 		// Add support for block styles.
 		add_theme_support( 'wp-block-styles' );
 
+		// Support the "Aside" post format.
+		add_theme_support( 'post-formats', array( 'aside' ) );
+
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
 

--- a/livro/style.css
+++ b/livro/style.css
@@ -205,3 +205,15 @@ input:not([type="submit"]):not([type="button"]):focus {
 	font-weight: 300;
 	margin: 0.25em 0.125em 0 0;
 }
+
+/*
+ * Aside post format.
+ */
+
+.single-format-aside h1.wp-block-post-title,
+.single-format-aside h1.wp-block-post-title + .wp-block-post-date,
+.home .post_format-post-format-aside .wp-block-post-title,
+.archive .post_format-post-format-aside .wp-block-post-title,
+.blog .post_format-post-format-aside .wp-block-post-title {
+	display: none;
+}


### PR DESCRIPTION
Just trying out a quick way to add "Aside" support to Livro with CSS.

Context in `p1648032338713309-slack-C029FM1EH`.

This does not work in the Site Editor because it lacks the necessary class assignments.

---

<img width="281" alt="Screen Shot 2022-03-23 at 10 37 51 AM" src="https://user-images.githubusercontent.com/1202812/159724974-a911176f-5325-4dc1-8d10-5f72562689ef.png">

Archives: 

Before|After
---|---
<img width="1090" alt="Screen Shot 2022-03-23 at 10 37 26 AM" src="https://user-images.githubusercontent.com/1202812/159725062-71c8a30f-e135-4154-992e-52fe9413495c.png">|<img width="1090" alt="Screen Shot 2022-03-23 at 10 35 48 AM" src="https://user-images.githubusercontent.com/1202812/159725064-f2a0439c-bd9e-4b0b-b496-c152e5ddabd3.png">

Single Post: 

Before|After
---|---
<img width="1089" alt="Screen Shot 2022-03-23 at 10 37 14 AM" src="https://user-images.githubusercontent.com/1202812/159725019-7bafffc9-b574-4760-8f30-f4b1574f2c20.png">|<img width="1091" alt="Screen Shot 2022-03-23 at 10 36 01 AM" src="https://user-images.githubusercontent.com/1202812/159725022-82a2c545-c342-4f90-b967-e97f8dd10ce4.png">

