### PR TITLE
Blockbase: add style overrides for navigation block links

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -221,24 +221,27 @@ body.admin-bar .wp-site-blocks {
  * Elements
  * - Styles for basic HTML elemants
  */
-a {
+a,
+.wp-block-navigation a {
   cursor: pointer;
   text-underline-offset: 0.15em;
   text-decoration: none;
 }
-a:hover, a:focus {
+a:hover, a:focus,
+.wp-block-navigation a:hover,
+.wp-block-navigation a:focus {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
 
-.block-editor-block-list__layout a,
-.wp-block-post-content a {
+main.block-editor-block-list__layout a,
+.wp-block-post a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.block-editor-block-list__layout a:hover, .block-editor-block-list__layout a:focus,
-.wp-block-post-content a:hover,
-.wp-block-post-content a:focus {
+main.block-editor-block-list__layout a:hover, main.block-editor-block-list__layout a:focus,
+.wp-block-post a:hover,
+.wp-block-post a:focus {
   text-decoration: none;
 }
 
@@ -514,7 +517,7 @@ input[type=checkbox] + label {
   flex-wrap: nowrap;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item {
-  row-gap: 0rem;
+  row-gap: 0;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item > a:hover {
   -webkit-text-decoration-line: underline;
@@ -593,7 +596,7 @@ input[type=checkbox] + label {
   flex-direction: column;
 }
 
-p.has-drop-cap:not(:focus):first-letter {
+p.has-drop-cap:not(:focus)::first-letter {
   font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
   font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
   margin: var(--wp--custom--paragraph--dropcap--margin);

--- a/blockbase/package-lock.json
+++ b/blockbase/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blockbase",
-  "version": "2.0.24",
+  "version": "2.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/blockbase/sass/elements/_links.scss
+++ b/blockbase/sass/elements/_links.scss
@@ -1,5 +1,6 @@
 // Default link styles
-a {
+a,
+.wp-block-navigation a {
 	cursor: pointer;
 	text-underline-offset: 0.15em;
 	text-decoration: none;
@@ -11,8 +12,8 @@ a {
 }
 
 //Links that appear in the main content area
-.block-editor-block-list__layout a, // Needed for the post area
-.wp-block-post-content a {
+main.block-editor-block-list__layout a, // Needed for the post area
+.wp-block-post a {
 	text-decoration-line: underline;
 
 	&:hover,
@@ -23,6 +24,7 @@ a {
 
 // Select the focus states of all non-wpadmin and screen reader links
 a:not(.ab-item):not(.screen-reader-shortcut) {
+
 	&:active,
 	&:focus {
 		outline: 1px dotted currentColor;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Gutenberg ads `text-decoration: none` to links in navigation block and CSS specificity in theme overrides is less specific.
* included parent class in style overrides.

#### Results

* Similar to other page links, navigation block links doesn't show underline in normal state.
* underline appear on hover state.

![blockbase-nav-links](https://user-images.githubusercontent.com/1935113/159881491-dccdc1f4-fe7c-49d6-94df-6d3620c7fa1a.gif)

#### Related issue(s):

Fixes: #5670 
