### PR TITLE
Slim/block canvas

### DIFF
--- a/block-canvas/parts/post-meta.html
+++ b/block-canvas/parts/post-meta.html
@@ -1,8 +1,8 @@
 <!-- wp:group {"layout":{"type":"flex"}} -->
 <div class="wp-block-group">
-	<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--x-small)"}}} /-->
-	<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--x-small)"}}} /-->
-	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--x-small)"}}} /-->
-	<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--x-small)"}}} /-->
+	<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
+	<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
+	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
+	<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
 </div>
 <!-- /wp:group -->

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -46,7 +46,7 @@ GNU General Public License for more details.
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
-	background-color: var(--wp--preset--color--primary);
+	background-color: var(--wp--preset--color--secondary);
 }
 
 /*

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -66,41 +66,7 @@
                 }
             ]
         },
-        "custom": {
-            "button": {
-                "border": {
-                    "color": "var(--wp--preset--color--primary)",
-                    "radius": "4px",
-                    "style": "solid",
-                    "width": "2px"
-                },
-                "color": {
-                    "background": "var(--wp--preset--color--primary)",
-                    "text": "var(--wp--preset--color--background)"
-                },
-                "hover": {
-                    "border": {
-                        "color": "var(--wp--preset--color--secondary)"
-                    },
-                    "color": {
-                        "background": "var(--wp--preset--color--secondary)",
-                        "text": "var(--wp--preset--color--background)"
-                    }
-                },
-                "spacing": {
-                    "padding": {
-                        "bottom": "0.667em",
-                        "left": "1.333em",
-                        "right": "1.333em",
-                        "top": "0.667em"
-                    }
-                },
-                "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
-                    "fontWeight": "normal",
-                    "lineHeight": 2
-                }
-            },
+        "custom": { 
             "fontSizes": {
                 "normal": "18px",
                 "x-small": "14px"
@@ -177,17 +143,17 @@
         "blocks": {
             "core/button": {
                 "border": {
-                    "radius": "var(--wp--custom--button--border--radius)"
+                    "radius": "4px"
                 },
                 "color": {
-                    "background": "var(--wp--custom--button--color--background)",
-                    "text": "var(--wp--custom--button--color--text)"
+                    "background": "var(--wp--preset--color--primary)",
+                    "text": "var(--wp--preset--color--background)"
                 },
                 "typography": {
                     "fontFamily": "var(--wp--preset--font-family--body-font)",
-                    "fontSize": "var(--wp--custom--button--typography--font-size)",
-                    "fontWeight": "var(--wp--custom--button--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--button--typography--line-height)"
+                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontWeight": "normal",
+                    "lineHeight": "2"
                 }
             },
             "core/code": {
@@ -284,7 +250,7 @@
             },
             "core/search": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--button--typography--font-size)",
+                    "fontSize": "var(--wp--custom--font-sizes--normal)",
                     "lineHeight": "1.6"
                 }
             },

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -68,7 +68,6 @@
         },
         "custom": { 
             "fontSizes": {
-                "normal": "18px",
                 "x-small": "14px"
             },
             "gap": {
@@ -151,7 +150,7 @@
                 },
                 "typography": {
                     "fontFamily": "var(--wp--preset--font-family--body-font)",
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontSize": "var(--wp--preset--font-size-medium)",
                     "fontWeight": "normal",
                     "lineHeight": "2"
                 }
@@ -191,7 +190,7 @@
             },
             "core/navigation": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--normal)"
+                    "fontSize": "var(--wp--preset--font-size-medium)"
                 }
             },
             "core/post-date": {
@@ -244,13 +243,13 @@
                     }
                 },
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontSize": "var(--wp--preset--font-size-medium)",
                     "fontStyle": "normal"
                 }
             },
             "core/search": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontSize": "var(--wp--preset--font-size-medium)",
                     "lineHeight": "1.6"
                 }
             },
@@ -271,7 +270,7 @@
             },
             "core/site-title": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontSize": "var(--wp--preset--font-size-medium)",
                     "fontWeight": "700",
                     "textDecoration": "none"
                 }
@@ -347,7 +346,7 @@
                 },
                 "typography": {
                     "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--custom--font-sizes--normal)",
+                    "fontSize": "var(--wp--preset--font-size-medium)",
                     "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
                     "lineHeight": "var(--wp--custom--heading--typography--line-height)"
                 }
@@ -377,7 +376,7 @@
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--body-font)",
-            "fontSize": "var(--wp--custom--font-sizes--normal)",
+            "fontSize": "var(--wp--preset--font-size-medium)",
             "lineHeight": "1.6"
         }
     },

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -68,7 +68,6 @@
         },
         "custom": { 
             "gap": {
-                "baseline": "15px",
                 "horizontal": "min(30px, 5vw)",
                 "vertical": "min(30px, 5vw)"
             },
@@ -369,7 +368,7 @@
             }
         },
         "spacing": {
-            "blockGap": "calc(2 * var(--wp--custom--gap--baseline))"
+            "blockGap": "30px"
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--body-font)",

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -70,12 +70,6 @@
             "gap": {
                 "horizontal": "min(30px, 5vw)",
                 "vertical": "min(30px, 5vw)"
-            },
-            "heading": {
-                "typography": {
-                    "fontWeight": 400,
-                    "lineHeight": 1.125
-                }
             }
         },
         "layout": {
@@ -175,6 +169,13 @@
                     "margin": {
                         "bottom": "var(--wp--custom--gap--vertical)"
                     }
+                }
+            },
+            "core/heading": {
+                "typography": {
+                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
+                    "fontWeight": "400",
+                    "lineHeight": "1.125"
                 }
             },
             "core/list": {
@@ -278,87 +279,33 @@
         },
         "elements": {
             "h1": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "48px",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "48px"
                 }
             },
             "h2": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--preset--font-size--x-large)",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "var(--wp--preset--font-size--x-large)"
                 }
             },
             "h3": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--preset--font-size--large)",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "var(--wp--preset--font-size--large)"
                 }
             },
             "h4": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--preset--font-size--medium)",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "var(--wp--preset--font-size--medium)"
                 }
             },
             "h5": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--preset--font-size-medium)",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "18px"
                 }
             },
             "h6": {
-                "spacing": {
-                    "margin": {
-                        "bottom": "var(--wp--custom--gap--vertical)",
-                        "top": "var(--wp--custom--gap--vertical)"
-                    }
-                },
                 "typography": {
-                    "fontFamily": "var(--wp--preset--font-family--heading-font)",
-                    "fontSize": "var(--wp--preset--font-size--small)",
-                    "fontWeight": "var(--wp--custom--heading--typography--font-weight)",
-                    "lineHeight": "var(--wp--custom--heading--typography--line-height)"
+                    "fontSize": "var(--wp--preset--font-size--small)"
                 }
             },
             "link": {

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -67,9 +67,6 @@
             ]
         },
         "custom": { 
-            "fontSizes": {
-                "x-small": "14px"
-            },
             "gap": {
                 "baseline": "15px",
                 "horizontal": "min(30px, 5vw)",
@@ -265,7 +262,7 @@
             },
             "core/site-tagline": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--x-small)"
+                    "fontSize": "14px"
                 }
             },
             "core/site-title": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This aims to slim down the theme.json (and a little css that these changes affect) to make it as small and simple as possible with the thought of "when used as a starting point for many other themes".

To do so it:
* removes custom values that were used in only one place.
* moved some settings to block settings in one place instead of custom values used multiple places.

These were mostly things I modified by hand in Pendant and would have preferred started this way.
