### PR TITLE
Blockbase: update font sizes to rem instead of px for a11y

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -173,8 +173,9 @@
 				}
 			],
 			"fontSizes": {
-				"x-small": "14px",
-				"normal": "18px"
+				"x-small": "0.875rem",
+				"normal": "1.125rem",
+				"huge": "3rem"
 			},
 			"form": {
 				"padding": "calc( 0.5 * var(--wp--custom--gap--horizontal) )",
@@ -375,22 +376,22 @@
 			"fontSizes": [
 				{
 					"name": "Small",
-					"size": "16px",
+					"size": "1rem",
 					"slug": "small"
 				},
 				{
 					"name": "Medium",
-					"size": "24px",
+					"size": "1.5rem",
 					"slug": "medium"
 				},
 				{
 					"name": "Large",
-					"size": "28px",
+					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
 					"name": "Extra Large",
-					"size": "32px",
+					"size": "2rem",
 					"slug": "x-large"
 				}
 			]
@@ -545,7 +546,7 @@
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)",
-					"fontSize": "48px"
+					"fontSize": "var(--wp--custom--font-sizes--huge)"
 				},
 				"spacing": {
 					"margin": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* update font sizes from px to rem to support a11y
* introduce `normal` and `huge` preset sizes to support a11y for inserted patterns ( some patterns using variables such as `--wp-preset-font-size-normal` which are in px )

#### Screenshots:

Browser font setting: Medium (default)

<img width="930" alt="image" src="https://user-images.githubusercontent.com/1935113/160107626-7ad12a8f-f4c2-4dbf-b2b8-113946455cdc.png">

Browser font setting: Very Large

<img width="923" alt="image" src="https://user-images.githubusercontent.com/1935113/160107757-a3275aee-4d04-44be-acd3-29c3c706773c.png">


#### Related issue(s):

Fixes: #5659 