### PR TITLE
Change how 'old custom theme colors' are cleaned out to be more specific

### DIFF
--- a/blockbase/inc/customizer/wp-customize-colors.php
+++ b/blockbase/inc/customizer/wp-customize-colors.php
@@ -152,7 +152,18 @@ class GlobalStylesColorCustomizer {
 		$new_settings['color']['palette']['theme'] = $this->user_color_palette;
 		// We used to set the values in 'custom' but moved to 'theme' to mirror GS functionality.
 		// This ensures that new saves don't store the customizations in both places.
-		unset($new_settings['color']['palette']['custom']);
+		if($new_settings['color']['palette']['custom']) {
+			foreach ( $new_settings['color']['palette']['theme'] as $theme_color ) {
+				foreach ( $new_settings['color']['palette']['custom'] as $key => $custom_color ) {
+					if( $theme_color['slug'] === $custom_color['slug'] ) {
+						unset( $new_settings['color']['palette']['custom'][$key] );
+					}
+				}
+			}
+			if ( ! $new_settings['color']['palette']['custom'] ) {
+				unset ( $new_settings['color']['palette']['custom'] );
+			}
+		}
 
 		// Add the updated global styles to the update request
 		$update_request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change only deletes from the 'custom' color space those color objects which have the exact same slugs as those in 'theme'.  This removes any colors that might have been previously stored in this space by this tool, but leaves any other colors a user might have added in the FSE.

To test add a custom color using the FSE:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/146530/160149857-10455aad-6a82-4fb3-a042-067d2407b678.png">

Customize something in the customizer.  (I edited colors)

Return to the FSE (or block editor) and see that the customized color is still available.

#### Related issue(s):

Fixes: #5740