### PR TITLE
Adjustments to link and button styles

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -25,6 +25,42 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 
 /*
+ * Opinionated Style for Anchors.
+ * Anchors get a thin underline offset more than default.
+ * Headings get slightly different dimensions.
+ * Any anchors IN the content are underlined by default, then none on hover.
+ * Any anchors OUT of the content behave the opposite.
+ * Buttons have no underlines.
+ */
+a {
+	cursor: pointer;
+	text-underline-offset: 0.3em;
+	text-decoration-thickness: 0.05em;
+	text-decoration-line: none;
+}
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+	text-underline-offset: 0.15em;
+	text-decoration-thickness: 0.02em;
+}
+a:hover,
+a:focus {
+	text-decoration-line: underline;
+}
+.block-editor-block-list__layout a,
+.wp-block-post-content a {
+	text-decoration-line: underline;
+}
+.block-editor-block-list__layout a:hover,
+.block-editor-block-list__layout a:focus,
+.wp-block-post-content a:focus,
+.wp-block-post-content a:hover {
+	text-decoration: none;
+}
+ .wp-block-post-content .wp-block-button a {
+	text-decoration: none;
+}
+
+/*
  * Button hover styles.
  * Necessary until the following issue is resolved in Gutenberg:
  * https://github.com/WordPress/gutenberg/issues/27075
@@ -33,7 +69,16 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
-	background-color: var(--wp--preset--color--primary);
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
+	border: 2px solid var(--wp--preset--color--foreground);
+    	padding: 0.667em 1.333em;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link:hover {
+	background-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
+	border: 2px solid var(--wp--preset--color--foreground);
 }
 
 /*

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -203,9 +203,11 @@
                 },
                 "typography": {
                     "fontFamily": "var(--wp--preset--font-family--body-font)",
-                    "fontSize": "var(--wp--preset--font-size--medium)",
-                    "fontWeight": "normal",
-                    "lineHeight": 2
+                    "fontSize": "var(--wp--preset--font-size--small)",
+                    "letterSpacing": "0.1em",
+                    "textTransform": "uppercase",
+                    "fontWeight": "600",
+                    "lineHeight": 1.7 
                 }
             },
             "core/heading": {
@@ -279,7 +281,7 @@
             },
             "link": {
                 "color": {
-                    "text": "var(--wp--preset--color--primary)"
+                    "text": "var(--wp--preset--color--foreground)"
                 }
             }
         },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change adjusts the button Global styles to achieve the design.  This had to be done manually in the theme.json file as the attributes to be edited weren't available in an interface.

Custom CSS was added to style the links per-design.

Header Hover state:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/146530/160163879-6ee95f66-c8e2-4d91-89f8-e059af2a15d6.png">

Smaller items (outside of content) hover state:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/146530/160163958-ac7d3993-ab62-4b3d-a5fe-a81644a21822.png">

Link in content:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/146530/160164024-a33216d5-76cb-403f-9779-bccc857aa9a4.png">

Buttons default state:

<img width="861" alt="image" src="https://user-images.githubusercontent.com/146530/160164159-355b485d-4550-4e95-ac18-ee511fc87c9e.png">

Fill button hover:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/146530/160164229-ff2b1f0f-6214-40ec-a437-77eb97f6e2c1.png">

Outline button hover:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/146530/160164266-2ced74c2-6dcc-4bf0-8345-0ee990deffdb.png">

#### Related issue(s):

May address #5746 

Note: I haven't seen 'click' or 'focus' states defined in our Block Themes before though I see those defined in the design.  

* Is this something we should be doing?
* Are those states vital to the theme?

