### PR TITLE
Remote: fix image with text path

### DIFF
--- a/remote/inc/patterns/image-with-text.php
+++ b/remote/inc/patterns/image-with-text.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Image with text', 'remote' ),
 	'categories' => array( 'text', 'columns', 'featured' ),
 	'content'    => '<!-- wp:image {"align":"wide","sizeSlug":"large","linkDestination":"none"} -->
-	<figure class="wp-block-image alignwide size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/laptop.jpg" alt="' . esc_attr__( 'Picture of a laptop', 'remote' ) . '"/></figure>
+	<figure class="wp-block-image alignwide size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/Laptop.jpg" alt="' . esc_attr__( 'Picture of a laptop', 'remote' ) . '"/></figure>
 	<!-- /wp:image -->
 	
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"50px","padding":{"top":"20px"}}}} -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR changes the filename of the image reference, making the first letter uppercase. I didn't realize this would have any impact, but it fixes the issue on dotcom for me.

#### Related issue(s):

Fixes #5778