### PR TITLE
Pendant: add font display to font definitions

### DIFF
--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -93,6 +93,7 @@
 					"name": "Body (System Font)",
 					"fontFace": [
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Jost",
 							"fontWeight": "300 400",
 							"fontStyle": "normal",
@@ -102,6 +103,7 @@
 							]
 						},
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Jost",
 							"fontWeight": "500 600",
 							"fontStyle": "normal",
@@ -118,6 +120,7 @@
 					"name": "Headings (System Font)",
 					"fontFace": [
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Literata",
 							"fontWeight": "400",
 							"fontStyle": "normal",
@@ -127,6 +130,7 @@
 							]
 						},
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Literata",
 							"fontWeight": "400",
 							"fontStyle": "italic",
@@ -136,6 +140,7 @@
 							]
 						},
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Literata",
 							"fontWeight": "800 900",
 							"fontStyle": "normal",
@@ -145,6 +150,7 @@
 							]
 						},
 						{
+                            "fontDisplay": "block",
 							"fontFamily": "Literata",
 							"fontWeight": "800 900",
 							"fontStyle": "italic",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds font display to Pendant fonts the same way we are doing in https://github.com/Automattic/themes/pull/5609 for the rest of our block themes


