### PR TITLE
Pendant: add 404 template

### DIFF
--- a/pendant/patterns/404.php
+++ b/pendant/patterns/404.php
@@ -23,7 +23,8 @@
 </p>
 <!-- /wp:paragraph -->
 
-<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo  esc_html__( 'Search', 'pendant' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php echo  esc_html__( 'Search', 'pendant' ); ?>","style":{"border":{"radius":"0px"}},"className":"custom-404-wp-search"} /-->
+<!-- wp:search {"showLabel":false,"placeholder":"<?php echo  esc_html__( 'Search…', 'pendant' ); ?>","width":500,"widthUnit":"px","buttonText":"<?php echo  esc_html__( 'Search', 'pendant' ); ?>","buttonPosition":"button-inside"} /-->
+
 </div>
 <!-- /wp:group -->
 

--- a/pendant/patterns/404.php
+++ b/pendant/patterns/404.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:heading {"textAlign":"left","level":2,"align":"wide","style":{"typography":{"fontSize":"clamp(2rem, 12vw, 8rem)"}}} -->
-<h2 class="alignwide has-text-align-left" id="oops-that-page-can-t-be-found" style="font-size:clamp(2rem, 12vw, 8rem)"><?php echo esc_html__( 'There\'s nothing here.', 'pendant' ); ?></h2>
+<!-- wp:heading {"textAlign":"left","level":1,"align":"wide"} -->
+<h1 class="alignwide has-text-align-left" id="oops-that-page-can-t-be-found"><?php echo esc_html__( 'There\'s nothing here.', 'pendant' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"0.8em"} -->

--- a/pendant/patterns/404.php
+++ b/pendant/patterns/404.php
@@ -7,10 +7,23 @@
 
 ?>
 
-<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"medium"} -->
-<h1 class="has-text-align-center has-medium-font-size" id="oops-that-page-can-t-be-found"><?php echo esc_html__( 'Oops! That page can&rsquo;t be found.', 'pendant' ); ?></h1>
+<!-- wp:heading {"textAlign":"left","level":2,"align":"wide","style":{"typography":{"fontSize":"clamp(2rem, 12vw, 8rem)"}}} -->
+<h2 class="alignwide has-text-align-left" id="oops-that-page-can-t-be-found" style="font-size:clamp(2rem, 12vw, 8rem)"><?php echo esc_html__( 'There\'s nothing here.', 'pendant' ); ?></h2>
 <!-- /wp:heading -->
 
+<!-- wp:spacer {"height":"0.8em"} -->
+<div style="height:0.8em" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"align":"wide"} -->
+<div class="wp-block-group alignwide">
 <!-- wp:paragraph -->
-<p><?php echo  esc_html__( 'It looks like nothing was found at this location. Maybe try a search?', 'pendant' ); ?></p>
+<p class="has-text-align-left has-medium-font-size">
+<?php echo  esc_html__( 'This page could not be found. Try searching posts using the search field.', 'pendant' ); ?>
+</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo  esc_html__( 'Search', 'pendant' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php echo  esc_html__( 'Search', 'pendant' ); ?>","style":{"border":{"radius":"0px"}},"className":"custom-404-wp-search"} /-->
+</div>
+<!-- /wp:group -->
+

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -157,3 +157,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	margin-right: auto !important;
 	width: inherit;
 }
+
+.custom-404-wp-search {
+	max-width: 500px;
+}

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -72,7 +72,7 @@ a:focus {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 	border: 2px solid var(--wp--preset--color--foreground);
-    	padding: 0.667em 1.333em;
+    	padding: 0.667em 1.333em !important;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
@@ -87,15 +87,25 @@ a:focus {
  * https://github.com/WordPress/gutenberg/issues/36444
  * https://github.com/WordPress/gutenberg/issues/27760
  */
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	padding: 0;
+	border-color: var(--wp--preset--color--foreground);
+}
 
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+	padding-left: 1em;
+}
 .wp-block-search__button,
 .wp-block-file .wp-block-file__button {
 	background-color: var(--wp--preset--color--foreground);
-	border-radius: 0;
-	border: none;
 	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--normal);
-	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+	font-size: var(--wp--preset--typography--font-size--medium);
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	font-weight: 600;
+	line-height: 1.7;
+	border:none;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px) !important;
 }
 
 /*

--- a/pendant/templates/404.html
+++ b/pendant/templates/404.html
@@ -1,12 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-group">
-
-	<!-- wp:pattern {"slug":"pendant/404"} /-->
-	<!-- wp:search {"label":""} /-->
-
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"72px","bottom":"128px"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-top:72px;padding-bottom:128px">
+<!-- wp:pattern {"slug":"pendant/404"} /-->
 </main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->
+

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -250,7 +250,7 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontWeight": 400,
-					"fontSize": "clamp(3.75rem, 8vw, 6.25rem)"
+					"fontSize": "clamp(4rem, 10vw, 8rem)"
 				}
 			},
 			"h2": {

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -182,7 +182,7 @@
 		},
 		"layout": {
 			"contentSize": "820px",
-			"wideSize": "1000px"
+			"wideSize": "1240px"
 		},
 		"border": {
 			"color": true,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Without a letter spacing, the letters `t` and `h` are getting merged.

![image](https://user-images.githubusercontent.com/1935113/160590643-4fa89c28-a504-45aa-995e-a001c591688b.png)

With at letter spacing of `1px` content with `130px` font size doesn't fit inside 1240px container.

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/1935113/160590948-4fa8250d-5c7b-461b-8ef9-f79cce495363.png">

**Other issues:**

* Search box has padding between border and search button. seems like overrides aren't working. need suggestions here.
* Used H1 and H4 for the text. Are these semantics right?

#### Related issue(s):

May address: #5674 
