### PR TITLE
Blockbase: add theme support for wp-block-styles

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -23,6 +23,9 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		// Experimental support for adding blocks inside nav menus
 		add_theme_support( 'block-nav-menus' );
 
+		// Add support for block styles.
+		add_theme_support( 'wp-block-styles' );
+
 		// Enqueue editor styles.
 		add_editor_style(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds theme support for `wp-block-styles` to Blockbase.

This is mainly to address https://github.com/Automattic/themes/issues/5642, although I'm not sure why we're not already using this in Blockbase, so not sure if this introduces other problems! However, from looking at the [CSS it includes](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#default-block-styles) when enabled, it sounds like something we'd want to support. We also use it in a couple of other block themes.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5642