### PR TITLE
Blockbase: add select boxes to form styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -263,7 +263,8 @@ input[type=time],
 input[type=datetime],
 input[type=datetime-local],
 input[type=color],
-textarea {
+textarea,
+select {
   background: var(--wp--custom--form--color--background);
   border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
   border-radius: var(--wp--custom--form--border--radius);
@@ -288,17 +289,18 @@ input[type=time]:focus,
 input[type=datetime]:focus,
 input[type=datetime-local]:focus,
 input[type=color]:focus,
-textarea:focus {
+textarea:focus,
+select:focus {
   border-color: var(--custom--form--color--border);
   color: var(--wp--custom--form--color--text);
-  outline: 1px dotted currentColor;
+  outline: 1px dotted currentcolor;
   outline-offset: 2px;
 }
 
 input[type=checkbox]:focus,
 input[type=submit]:focus,
 button:focus {
-  outline: 1px dotted currentColor;
+  outline: 1px dotted currentcolor;
   outline-offset: 2px;
 }
 input[type=checkbox]::placeholder,
@@ -309,7 +311,6 @@ button::placeholder {
 }
 
 select {
-  font-family: inherit;
   font-size: 100%;
 }
 
@@ -514,7 +515,7 @@ input[type=checkbox] + label {
   flex-wrap: nowrap;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item {
-  row-gap: 0rem;
+  row-gap: 0;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item > a:hover {
   -webkit-text-decoration-line: underline;
@@ -593,7 +594,7 @@ input[type=checkbox] + label {
   flex-direction: column;
 }
 
-p.has-drop-cap:not(:focus):first-letter {
+p.has-drop-cap:not(:focus)::first-letter {
   font-size: var(--wp--custom--paragraph--dropcap--typography--font-size);
   font-weight: var(--wp--custom--paragraph--dropcap--typography--font-weight);
   margin: var(--wp--custom--paragraph--dropcap--margin);

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -14,7 +14,8 @@ input[type="time"],
 input[type="datetime"],
 input[type="datetime-local"],
 input[type="color"],
-textarea {
+textarea,
+select {
 	background: var(--wp--custom--form--color--background);
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--form--border--color);
 	border-radius: var(--wp--custom--form--border--radius);
@@ -26,7 +27,7 @@ textarea {
 	&:focus {
 		border-color: var(--custom--form--color--border);
 		color: var(--wp--custom--form--color--text);
-		outline: 1px dotted currentColor;
+		outline: 1px dotted currentcolor;
 		outline-offset: 2px;
 	}
 }
@@ -34,8 +35,9 @@ textarea {
 input[type="checkbox"],
 input[type="submit"],
 button {
+
 	&:focus {
-		outline: 1px dotted currentColor;
+		outline: 1px dotted currentcolor;
 		outline-offset: 2px;
 	}
 
@@ -46,7 +48,6 @@ button {
 }
 
 select {
-	font-family: inherit;
 	font-size: 100%;
 }
 
@@ -55,7 +56,7 @@ textarea {
 }
 
 // Vertically align checkbox + label relationship
-input[type=checkbox] + label {
+input[type="checkbox"] + label {
 	display: inline;
 	margin-left: 0.5em;
 	line-height: 1em;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds `select` boxes to the existing form input styles for Blockbase, which brings the styling for any select boxes in line with other form elements.

Before|After
------|------
<img width="630" alt="image" src="https://user-images.githubusercontent.com/1645628/160820348-2211b2d5-7af7-4020-a2f5-92d9a7805b48.png">|<img width="638" alt="image" src="https://user-images.githubusercontent.com/1645628/160819728-bdc5ffa4-f21c-46ff-99c0-c4598b535245.png">

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/5651