### PR TITLE
Styled navigation (open overlay)

### DIFF
--- a/pendant/parts/header.html
+++ b/pendant/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"3vw","top":"3vw"}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:3vw;padding-bottom:3vw"><!-- wp:navigation {"overlayMenu":"always"} /-->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:3vw;padding-bottom:3vw"><!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"foreground","overlayTextColor":"background"} /-->
 
 <!-- wp:site-title {"textAlign":"center","isLink":false,"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} /-->
 

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -171,7 +171,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 /** Navigation sub-menu items **/
 .wp-block-navigation .wp-block-navigation__responsive-container-content .has-child .wp-block-navigation__submenu-container {
 	text-transform: uppercase;
-	font-weight: 400;
+	font-weight: 500;
 	line-height: 2.6;
 	font-size: var(--wp--preset--font-size--x-small);
 	letter-spacing: 0.1em;

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -168,6 +168,11 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	width: inherit;
 }
 
-.custom-404-wp-search {
-	max-width: 500px;
+/** Navigation sub-menu items **/
+.wp-block-navigation .wp-block-navigation__responsive-container-content .has-child .wp-block-navigation__submenu-container {
+	text-transform: uppercase;
+	font-weight: 400;
+	line-height: 2.6;
+	font-size: var(--wp--preset--font-size--x-small);
+	letter-spacing: 0.1em;
 }

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -228,7 +228,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--large)"
 				}
 			},
 			"core/query-pagination": {


### PR DESCRIPTION
This adds styling for navigation overlay menu.

The overlayBackgroundColor and overlayTextColor only seem to be available for non-default menu.  The controls on the FSE UI aren't available for a menu that hasn't been set so were set on template blocks manually.

The rest of the styling is custom CSS to apply a different style to sub-menu items.

This is (at best) inspired from the figma design.  Unavailable to execute from the original design:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/146530/161132676-f2ec38b8-cb2f-4f0b-a12b-b73997581b91.png">

* The site title can't be added.
* The close X defaults to the right side.  (This could be moved to the left side with CSS).
* The search block is unavailable for the overlay menu.
* The top menu items (with sub-menu items) cannot be opened/closed thus there is no ^ type of indicator or underline.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/146530/161133630-f9595e97-0922-49db-a232-712454b3390a.png">

The actual implementation looks like this:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/146530/161133962-4f5a6b44-3e33-458c-aacd-a47e0cb340e0.png">

Fixes #5782