### PR TITLE
Archeo: update block pattern categories function ref

### DIFF
--- a/archeo/functions.php
+++ b/archeo/functions.php
@@ -99,4 +99,4 @@ function archeo_register_block_pattern_categories() {
 	}
 
 }
-add_action( 'init', 'archeo_register_block_patterns', 9 );
+add_action( 'init', 'archeo_register_block_pattern_categories', 9 );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This fixes a typo on one of the references to the `archeo_register_block_pattern_categories` function.

I spotted this whilst deploying to wpcom earlier but didn't spot it before I'd already merged everything. I fixed it on wpcom during the deployment (in D78023-code), so this is to replicate the fix in GH.