### PR TITLE
Remote: revise comments layout

### DIFF
--- a/pendant/templates/single.html
+++ b/pendant/templates/single.html
@@ -13,11 +13,14 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:spacer {"height":"60px"} -->
-<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:post-comments /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:spacer {"height":60} -->
+    <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+    <!-- wp:post-comments /-->
+</div>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR just updates the layout of the single template so the comments follow the default width. Perusing other themes and looking at the current state, I'm not sure we should add any additional CSS to the comments since it still uses the old comments rendering functionality and we don't have much control over what's rendered or how it's styled:

<img width="681" alt="Screen Shot 2022-04-01 at 1 36 45 PM" src="https://user-images.githubusercontent.com/5375500/161314146-287e981a-9a51-4458-884a-235085a103f5.png">

#### Related issue(s):

Closes #5677