### PR TITLE
Adjusted spacing on single per design review

### DIFF
--- a/pendant/templates/single.html
+++ b/pendant/templates/single.html
@@ -1,12 +1,12 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":{"top":"0px","left":"0px"}}}} -->
 <div class="wp-block-group"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4vw","top":"4vw"},"blockGap":{"top":"4vw","left":"4vw"}}},"className":"has-text-align-center","layout":{"inherit":true}} -->
-<div class="wp-block-group has-text-align-center" style="padding-top:4vw;padding-bottom:4vw"><!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"typography":{"textTransform":"uppercase"}}} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"50px","top":"40px"},"blockGap":"40px"}},"className":"has-text-align-center","layout":{"inherit":true}} -->
+<div class="wp-block-group has-text-align-center" style="padding-top:40px;padding-bottom:50px"><!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"typography":{"textTransform":"uppercase"}}} /-->
 
 <!-- wp:post-featured-image /-->
 
-<!-- wp:post-title /-->
+<!-- wp:post-title {"style":{"spacing":{"margin":{"top":"30px"}}}} /-->
 
 <!-- wp:post-date /--></div>
 <!-- /wp:group -->
@@ -14,12 +14,11 @@
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-    <!-- wp:spacer {"height":60} -->
-    <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
-    <!-- /wp:spacer -->
-    <!-- wp:post-comments /-->
-</div>
+<div class="wp-block-group"><!-- wp:spacer {"height":"60px"} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:post-comments /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /--></div>


### PR DESCRIPTION
This changes the spacing on the Pendant 'single' template from VW units to pixels as it suits the design better.

Used different spacing for heading (as opposed to just using block gap value) because of font spacing funkyness.
Before
<img width="920" alt="image" src="https://user-images.githubusercontent.com/146530/161584866-a813ef21-2fd3-4b22-8f3d-d6c549d2cfa1.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/146530/161584841-ffeb0c81-8c4a-44ed-9b12-342837cb9adb.png">
<img width="902" alt="image" src="https://user-images.githubusercontent.com/146530/161584762-f707abcb-1133-4b82-b27e-1f66c02f185d.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/146530/161584681-9ead0a41-405f-4b6f-8354-92b31904d7e4.png">


After
<img width="931" alt="image" src="https://user-images.githubusercontent.com/146530/161584390-1b868da2-bc4e-4ac2-8da5-6d54173e2585.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/146530/161584470-52de0b33-dcaf-4e47-b00d-87dfb8573546.png">
<img width="954" alt="image" src="https://user-images.githubusercontent.com/146530/161584560-7a475dc7-539a-4304-9100-b160e0c97f85.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/146530/161584611-496ec2b7-1147-45c8-acac-830f6cfe4f49.png">
