### PR TITLE
Blockbase: Account for additional content via css grid configuration

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -659,25 +659,25 @@ p.has-drop-cap:not(:focus)::first-letter {
   margin-top: 0;
   margin-bottom: var(--wp--custom--gap--vertical);
 }
-.wp-block-post-comments form .comment-notes {
+.wp-block-post-comments form > .comment-notes {
   grid-area: notes;
 }
-.wp-block-post-comments form .comment-form-author {
+.wp-block-post-comments form > .comment-form-author {
   grid-area: author;
 }
-.wp-block-post-comments form .comment-form-email {
+.wp-block-post-comments form > .comment-form-email {
   grid-area: email;
 }
-.wp-block-post-comments form .comment-form-url {
+.wp-block-post-comments form > .comment-form-url {
   grid-area: url;
 }
-.wp-block-post-comments form .comment-form-comment {
+.wp-block-post-comments form > .comment-form-comment {
   grid-area: comment;
 }
-.wp-block-post-comments form .comment-form-cookies-consent {
+.wp-block-post-comments form > .comment-form-cookies-consent {
   grid-area: cookies-consent;
 }
-.wp-block-post-comments form .form-submit {
+.wp-block-post-comments form > .form-submit {
   grid-area: form-submit;
 }
 .wp-block-post-comments form .comment-form-cookies-consent input[type=checkbox] {

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -636,7 +636,7 @@ p.has-drop-cap:not(:focus)::first-letter {
   display: grid;
   column-gap: 1em;
   grid-template-rows: auto;
-  grid-template-areas: "notes notes" "author author" "email url" "comment comment" "cookies-consent cookies-consent" "form-submit form-submit";
+  grid-template-areas: "misc misc" "notes notes" "author author" "email url" "comment comment" "cookies-consent cookies-consent" "form-submit form-submit";
 }
 .wp-block-post-comments form input:not([type=submit]):not([type=checkbox]),
 .wp-block-post-comments form textarea {
@@ -659,25 +659,28 @@ p.has-drop-cap:not(:focus)::first-letter {
   margin-top: 0;
   margin-bottom: var(--wp--custom--gap--vertical);
 }
-.wp-block-post-comments form > .comment-notes {
+.wp-block-post-comments form > * {
+  grid-area: misc;
+}
+.wp-block-post-comments form .comment-notes {
   grid-area: notes;
 }
-.wp-block-post-comments form > .comment-form-author {
+.wp-block-post-comments form .comment-form-author {
   grid-area: author;
 }
-.wp-block-post-comments form > .comment-form-email {
+.wp-block-post-comments form .comment-form-email {
   grid-area: email;
 }
-.wp-block-post-comments form > .comment-form-url {
+.wp-block-post-comments form .comment-form-url {
   grid-area: url;
 }
-.wp-block-post-comments form > .comment-form-comment {
+.wp-block-post-comments form .comment-form-comment {
   grid-area: comment;
 }
-.wp-block-post-comments form > .comment-form-cookies-consent {
+.wp-block-post-comments form .comment-form-cookies-consent {
   grid-area: cookies-consent;
 }
-.wp-block-post-comments form > .form-submit {
+.wp-block-post-comments form .form-submit {
   grid-area: form-submit;
 }
 .wp-block-post-comments form .comment-form-cookies-consent input[type=checkbox] {

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -53,31 +53,31 @@
 			margin-bottom: var(--wp--custom--gap--vertical);
 		}
 
-		.comment-notes {
+		& > .comment-notes {
 			grid-area: notes;
 		}
 
-		.comment-form-author {
+		& > .comment-form-author {
 			grid-area: author;
 		}
 
-		.comment-form-email {
+		& > .comment-form-email {
 			grid-area: email;
 		}
 
-		.comment-form-url {
+		& > .comment-form-url {
 			grid-area: url;
 		}
 
-		.comment-form-comment {
+		& > .comment-form-comment {
 			grid-area: comment;
 		}
 
-		.comment-form-cookies-consent {
+		& > .comment-form-cookies-consent {
 			grid-area: cookies-consent;
 		}
 
-		.form-submit {
+		& > .form-submit {
 			grid-area: form-submit;
 		}
 

--- a/blockbase/sass/blocks/_post-comments.scss
+++ b/blockbase/sass/blocks/_post-comments.scss
@@ -21,6 +21,7 @@
 		column-gap: 1em;
 		grid-template-rows: auto;
 		grid-template-areas:
+			"misc misc"
 			"notes notes"
 			"author author"
 			"email url"
@@ -52,32 +53,35 @@
 			margin-top: 0;
 			margin-bottom: var(--wp--custom--gap--vertical);
 		}
+		& > * {
+			grid-area: misc;
+		}
 
-		& > .comment-notes {
+		.comment-notes {
 			grid-area: notes;
 		}
 
-		& > .comment-form-author {
+		.comment-form-author {
 			grid-area: author;
 		}
 
-		& > .comment-form-email {
+		.comment-form-email {
 			grid-area: email;
 		}
 
-		& > .comment-form-url {
+		.comment-form-url {
 			grid-area: url;
 		}
 
-		& > .comment-form-comment {
+		.comment-form-comment {
 			grid-area: comment;
 		}
 
-		& > .comment-form-cookies-consent {
+		.comment-form-cookies-consent {
 			grid-area: cookies-consent;
 		}
 
-		& > .form-submit {
+		.form-submit {
 			grid-area: form-submit;
 		}
 


### PR DESCRIPTION
ensure that any immediate children that are unaccounted for in the grid area definitions span both columns.

This is necessary because wp simple and wp atomic implement the comment section override differently.

Fixes: #5622

Checked in wpcom (simple) wpcom (automic) wporg (authenticated) wporg (unauthenticated)

Atomic:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/146530/161782867-88496f2a-b44d-4f39-a378-a2c19417b104.png">

Simple:
<img width="749" alt="image" src="https://user-images.githubusercontent.com/146530/161783085-8a2b6df2-7f8a-45ce-8c6b-2a2c3a2397d5.png">

wporg (authenticated)
<img width="746" alt="image" src="https://user-images.githubusercontent.com/146530/161783562-d651223b-1b1a-4ea6-abb5-ee441113dd5a.png">

wporg (unauthenticated)
<img width="809" alt="image" src="https://user-images.githubusercontent.com/146530/161783618-84a365f1-dd83-48b7-9656-2feab2259ce1.png">
