### PR TITLE
Tweaks to achieve desktop responsive navigation design

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -188,3 +188,13 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	font-size: var(--wp--preset--font-size--x-small);
 	letter-spacing: 0.1em;
 }
+
+/* Desktop responsive navigation layout */
+.wp-block-navigation.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content {
+    margin: 0 auto;
+    max-width: 820px;
+}
+
+.wp-block-navigation:where(:not([class*=has-text-decoration])) a {
+	text-decoration-thickness: 1px;
+}

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -228,7 +228,8 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "clamp(1.5rem, 5vw, 4.25rem)",
+					"lineHeight": "1.5"
 				}
 			},
 			"core/query-pagination": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Uses dynamic font sizing for navigation primary items.  

Restricts width of navigation to content width.

Before:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/146530/162797293-60ca3c7c-5e67-4815-94bb-f72436a6d604.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/162797254-c5bc5a0b-40e5-44a0-9c06-41de0858fad8.png">


After:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/146530/162797157-7fcd4306-a50e-491e-9fea-b9c942cdf559.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/162797212-e8e19ac9-889d-4ea2-ac5b-49bb1aff6275.png">


#### Related issue(s):
Fixes #5818