### PR TITLE
Archeo: Try using button as an element

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -98,6 +98,10 @@ a:active,
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 }
 
+.wp-block-search__button {
+	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+}
+
 /*
  * Comment Form Fields
  */

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -99,6 +99,7 @@ a:active,
 
 /*
  * Outline block button needs a padding tweak so it's the same size of normal buttons
+ * https://github.com/WordPress/gutenberg/issues/27476
  */
 .is-style-outline > :where(.wp-block-button__link), 
 :where(.wp-block-button__link).is-style-outline {

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -83,21 +83,6 @@ a:active,
 }
 
 /*
- * File Block button styles.
- * Necessary until the following issues are resolved in Gutenberg:
- * https://github.com/WordPress/gutenberg/issues/27760
- */
-
-.wp-block-file .wp-block-file__button {
-	background-color: var(--wp--preset--color--foreground);
-	border-radius: 0;
-	border: none;
-	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--font-size--normal);
-	padding: calc(0.667em + 2px) calc(1.333em + 2px);
-}
-
-/*
  * Outline block button needs a padding tweak so it's the same size of normal buttons
  * https://github.com/WordPress/gutenberg/issues/27476
  */

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -98,10 +98,6 @@ a:active,
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 }
 
-.wp-block-search__button {
-	padding: calc(0.667em + 2px) calc(1.333em + 2px);
-}
-
 /*
  * Comment Form Fields
  */

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -77,7 +77,6 @@ a:active,
  * https://github.com/WordPress/gutenberg/issues/27075
  */
 
-.wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
 	background-color: var(--wp--preset--color--primary);
@@ -90,7 +89,6 @@ a:active,
  * https://github.com/WordPress/gutenberg/issues/27760
  */
 
-.wp-block-search__button,
 .wp-block-file .wp-block-file__button {
 	background-color: var(--wp--preset--color--foreground);
 	border-radius: 0;

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -83,9 +83,8 @@ a:active,
 }
 
 /*
- * Search and File Block button styles.
+ * File Block button styles.
  * Necessary until the following issues are resolved in Gutenberg:
- * https://github.com/WordPress/gutenberg/issues/36444
  * https://github.com/WordPress/gutenberg/issues/27760
  */
 
@@ -94,9 +93,19 @@ a:active,
 	border-radius: 0;
 	border: none;
 	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--normal);
+	font-size: var(--wp--preset--font-size--normal);
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 }
+
+/*
+ * Outline block button needs a padding tweak so it's the same size of normal buttons
+ */
+.is-style-outline > :where(.wp-block-button__link), 
+:where(.wp-block-button__link).is-style-outline {
+	padding-top: 0.667em;
+	padding-bottom: 0.667em;
+}
+
 
 /*
  * Comment Form Fields

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -155,6 +155,11 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/button": {
+				"typography": {
+					"textTransform": "uppercase"
+				}
+			},
 			"core/heading": {
 				"typography": {
 					"fontWeight": "100",
@@ -273,8 +278,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--chivo)",
-					"fontSize": "var(--wp--preset--typography--font-size--normal)",
-					"textTransform": "uppercase"
+					"fontSize": "var(--wp--preset--typography--font-size--normal)"
 				}
 			}
 		},

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -155,20 +155,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"radius": "0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--foreground)",
-					"text": "var(--wp--preset--color--background)"
-				},
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--chivo)",
-					"fontSize": "var(--wp--preset--typography--font-size--normal)",
-					"textTransform": "uppercase"
-				}
-			},
 			"core/heading": {
 				"typography": {
 					"fontWeight": "100",
@@ -275,6 +261,20 @@
 			"h6": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"button": {
+				"border": {
+					"radius": "0"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--foreground)",
+					"text": "var(--wp--preset--color--background)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--chivo)",
+					"fontSize": "var(--wp--preset--typography--font-size--normal)",
+					"textTransform": "uppercase"
 				}
 			}
 		},

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -279,6 +279,14 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--chivo)",
 					"fontSize": "var(--wp--preset--font-size--normal)"
+				},
+				"spacing": {
+					"padding": {
+						"top": "calc(0.667em + 2px)",
+						"bottom": "calc(0.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
 				}
 			}
 		},

--- a/archeo/theme.json
+++ b/archeo/theme.json
@@ -278,7 +278,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--chivo)",
-					"fontSize": "var(--wp--preset--typography--font-size--normal)"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			}
 		},


### PR DESCRIPTION
This is useful for testing https://github.com/WordPress/gutenberg/pull/40260/files

Things to note:
- The CSS for the search block button has been removed
- The styles for buttons have been moved from `styles > blocks > core/button` to `styles > elements > button`.
