### PR TITLE
Tweak/pendant patterns

### DIFF
--- a/pendant/patterns/latest-articles.php
+++ b/pendant/patterns/latest-articles.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Latest Articles
+ * slug: pendant/latest-articles
+ * categories: pendant
+ */
+?>
+
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"2em"}}}} -->
+<div class="wp-block-group" style="padding-top:2em"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:heading {"level":4,"fontSize":"large"} -->
+<h4 class="has-large-font-size"><?php echo  esc_html__( 'Latest Articles', 'pendant' ); ?></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php echo  esc_html__( 'Read All', 'pendant' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:query {"style":{"spacing":{"margin":{"top":"0"}}},"query":{"perPage":"4","pages":1,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
+<div class="wp-block-query" style="margin-top:0"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"1.5em"}}}} -->
+<div class="wp-block-group alignwide" style="padding-bottom:1.5em"><!-- wp:post-template -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","bottom":"2em"}}}} -->
+<div class="wp-block-group" style="padding-top:2em;padding-bottom:2em"><!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"16em"} /-->
+
+<!-- wp:post-title {"level":3,"isLink":true} /-->
+
+<!-- wp:post-excerpt /-->
+
+<!-- wp:read-more {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"fontSize":"medium"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:group --></div>
+<!-- /wp:query -->

--- a/pendant/patterns/latest-interviews.php
+++ b/pendant/patterns/latest-interviews.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Title: Posts and Topics
+ * slug: pendant/latest-interviews
+ */
+?>
+
+<!-- wp:heading {"level":4,"fontSize":"large"} -->
+<h4 class="has-large-font-size"><?php echo esc_html__( 'Latest Interviews', 'pendant' ); ?></h4>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"20px"}}} -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-making-1.jpeg'; ?>" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4} -->
+<h4><?php echo esc_html__( 'Q&amp;A with Lana DeVito, Jewelry designer', 'pendant' ); ?></h4>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-making-2.jpeg'; ?>" alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4} -->
+<h4><?php echo esc_html__( 'Q&amp;A with Andrew Holsen, handmaker', 'pendant' ); ?></h4>
+<!-- /wp:heading --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->

--- a/pendant/patterns/post-topics.php
+++ b/pendant/patterns/post-topics.php
@@ -5,44 +5,7 @@
  */
 ?>
 
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"60px","padding":{"top":"80px","bottom":"80px"}}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:80px;padding-bottom:80px"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"level":4,"fontSize":"large"} -->
-<h4 class="has-large-font-size"><?php echo esc_html__( 'Latest Interviews', 'pendant' ); ?></h4>
-<!-- /wp:heading -->
-
-<!-- wp:columns {"style":{"spacing":{"blockGap":"20px"}}} -->
-<div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-making-1.jpeg'; ?>" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:heading {"level":4} -->
-<h4><?php echo esc_html__( 'Q&amp;A with Lana DeVito, Jewelry designer', 'pendant' ); ?></h4>
-<!-- /wp:heading --></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-making-2.jpeg'; ?>" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:heading {"level":4} -->
-<h4><?php echo esc_html__( 'Q&amp;A with Andrew Holsen, handmaker', 'pendant' ); ?></h4>
-<!-- /wp:heading --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"25%","layout":{"inherit":false}} -->
-<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"large"} -->
+<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"large"} -->
 <h2 class="has-large-font-size" style="margin-bottom:20px"><?php echo esc_html__( 'Popular Topics', 'pendant' ); ?></h2>
 <!-- /wp:heading -->
-
-<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","lineHeight":"2","letterSpacing":"0.1em"}},"fontSize":"x-small"} -->
-<p class="has-x-small-font-size" style="line-height:2;text-transform:uppercase;letter-spacing:0.1em"><?php echo wp_kses_post( 'rings<br>engagement/wedding rings<br>earrings<br>bracelets<br>necklaces<br>pendants<br>antique &amp; vintage jewelry<br>watches<br>24k GOLD<br>jewelry books<br>museum collections<br>interviews', 'pendant' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group -->
+<!-- wp:categories /-->

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -198,3 +198,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .wp-block-navigation:where(:not([class*=has-text-decoration])) a {
 	text-decoration-thickness: 1px;
 }
+
+.wp-block-categories {
+	list-style-type: none;
+}

--- a/pendant/templates/home.html
+++ b/pendant/templates/home.html
@@ -2,25 +2,28 @@
 
 <!-- wp:pattern {"slug":"pendant/home-hero"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":"4","pages":1,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"tagName":"main","displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
-<main class="wp-block-query"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"1em","bottom":"1.5em"}}}} -->
-<div class="wp-block-group alignwide" style="padding-top:1em;padding-bottom:1.5em"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","bottom":"2em"}}}} -->
-<div class="wp-block-group" style="padding-top:2em;padding-bottom:2em"><!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"16em"} /-->
+<!-- wp:pattern {"slug":"pendant/latest-articles"} /-->
 
-<!-- wp:post-title {"level":3,"isLink":true} /-->
-
-<!-- wp:post-excerpt /-->
-
-<!-- wp:read-more {"style":{"typography":{"fontStyle":"normal","fontWeight":"500"}},"fontSize":"medium"} /--></div>
-<!-- /wp:group -->
-<!-- /wp:post-template --></div>
-<!-- /wp:group --></main>
-<!-- /wp:query -->
-	
 <!-- wp:pattern {"slug":"pendant/image-series"} /-->
 
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"60px","padding":{"top":"80px","bottom":"80px"}}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:80px;padding-bottom:80px">
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:pattern {"slug":"pendant/latest-interviews"} /-->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%","layout":{"inherit":false}} -->
+<div class="wp-block-column" style="flex-basis:25%">
 <!-- wp:pattern {"slug":"pendant/posts-topics"} /-->
+</div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"pendant/image-gallery"} /-->
 

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -221,6 +221,20 @@
 					"lineHeight": 1.7
 				}
 			},
+			"core/categories": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--body-font)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"letterSpacing": "0.1em",
+					"textTransform": "uppercase",
+					"lineHeight": 2.3 
+				},
+				"spacing": {
+					"padding": {
+						"left": "0"
+					}
+				}
+			},
 			"core/heading": {
 				"typography": {
 					"lineHeight": 1.5


### PR DESCRIPTION
This changes a few patterns on the 'Home' page to better fit the design and leverage dynamic content.

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/146530/163228602-eee116cd-4959-4954-ac4a-1b485334a94f.png">

The 'Latest Interviews' and 'Popular Topics' have been broken into two separate patterns.

Popular Topics uses the `categories` block instead of a paragraph with 'examples'.

The `categories` block has been styled to achieve the design.  (This required some CSS since the list-style-type can't be changed via theme.json.  The changes to theme.json (typography changes) had to be done manually in theme.json since there are no block configurations available for the `categories` block in the FSE.

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/146530/163229121-5cb14038-0f88-478b-a6d6-4ab2e5d022bb.png">

The "Latest Articles" was made into a pattern (mostly so that the words 'Latest Articles' and 'Read All' could be localized).