### PR TITLE
Tools: add action to check for readme.txt changes

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,41 @@
+# This workflow checks if a readme.txt file has been updated whenever any theme files have been updated. 
+# This is to prevent updating theme files without also updating the corresponding changelog in the readme.txt.
+# It ignores any changes made to root files (e.g. theme-utils.mjs) and any files in excluded sub-directories.
+
+name: "Changelog Check"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Ensure a readme.txt file has been updated if a theme has been changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify any readme files
+        uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            theme_change:
+              - '**/*/**'
+            theme_readme:
+              - '**/readme.txt'
+            root_files:
+              - '*'
+              - '!**/*/**'
+            excluded_subdirectories:
+              - 'variations/**'
+              - '.github/**'
+              - '.husky/**'
+              - '.phab/**'
+      - name: Reminder to update changelog
+        if: ${{ (steps.filter.outputs.excluded_subdirectories == 'false' && steps.filter.outputs.root_files == 'false') && steps.filter.outputs.theme_change == 'true' && steps.filter.outputs.theme_readme == 'false' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+              core.setFailed('Please update the changelog in the readme.txt of any updated themes.')


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds a GH workflow that checks if a readme.txt file has been updated whenever any theme files have been updated. If it detects that a readme.txt hasn't been updated at the same time as a theme change, it will fail and 'grey-out' the PR merge button (we can still merge, but the button won't be green.)

This is a light alternative to something like https://github.com/Automattic/themes/pull/5092, which would require us to change our workflow quite a lot. I thought this action could act as a reminder whilst we work on how we want to automate the changelogs and if we want to use conventional commit messages, etc.

The action works by checking the following conditions:
- If a file has been updated in any sub-directory, in order to catch updates to theme files
- If a file has been updated in the repository root, in order to ignore these changes
- If a file has been updated in any excluded sub-directories, in order to ignore changes to variations/, .github/, .husky/ and .phab/
- And if any readme.txt file has changed (if so, the check will pass)

Possible problems:
- The action doesn't check if a specific readme.txt has been updated, only if any readme.txt has changed. I thought this would be good enough to catch most theme updates, especially as an effective reminder, but maybe this needs more work..

#### Related issue(s):
https://github.com/Automattic/themes/pull/5092