### PR TITLE
Pendant: Made site title click-able link

### DIFF
--- a/pendant/patterns/header.php
+++ b/pendant/patterns/header.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"3vw","top":"3vw"}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
 <div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:3vw;padding-bottom:3vw"><!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"foreground","overlayTextColor":"background"} /-->
 
-<!-- wp:site-title {"textAlign":"center","isLink":false,"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} /-->
+<!-- wp:site-title {"textAlign":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} /-->
 
 <!-- wp:social-links {"iconColor":"background","iconColorValue":"#ffffff","className":"is-style-logos-only"} -->
 <ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"https://instagram.com","service":"instagram"} /--></ul>


### PR DESCRIPTION
Makes the Pendant site title a click-able link.

The design seems to stay correct (in that the underline is only shown on hover).