### PR TITLE
Pendant: Update category style per design

### DIFF
--- a/pendant/patterns/hero.php
+++ b/pendant/patterns/hero.php
@@ -13,8 +13,10 @@
 
 <!-- wp:column {"verticalAlignment":"bottom","width":"calc(1240px / 2)","style":{"spacing":{"padding":{"left":"var(--wp--custom--gap--horizontal)"}}}} -->
 <div class="wp-block-column is-vertically-aligned-bottom" style="padding-left:var(--wp--custom--gap--horizontal);flex-basis:calc(1240px / 2)"><!-- wp:group {"style":{"spacing":{"padding":{"top":"100px","bottom":"100px","right":"calc(var(--wp--custom--gap--horizontal)/2)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group" style="padding-top:100px;padding-right:calc(var(--wp--custom--gap--horizontal)/2);padding-bottom:100px"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"x-small"} -->
-<p class="has-x-small-font-size" style="text-transform:uppercase"><?php echo esc_html__( 'Featured', 'pendant' ); ?></p>
+<div class="wp-block-group" style="padding-top:100px;padding-right:calc(var(--wp--custom--gap--horizontal)/2);padding-bottom:100px">
+
+<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.1em","fontStyle":"normal","fontWeight":"500"}},"fontSize":"x-small"} -->
+<p class="has-x-small-font-size" style="font-style:normal;font-weight:500;text-transform:uppercase;letter-spacing:0.1em"><?php echo esc_html__( 'Featured', 'pendant' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"}}} -->

--- a/pendant/templates/single.html
+++ b/pendant/templates/single.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"50px","top":"40px"},"blockGap":"40px"}},"className":"has-text-align-center","layout":{"inherit":true}} -->
-<div class="wp-block-group has-text-align-center" style="padding-top:40px;padding-bottom:50px"><!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"typography":{"textTransform":"uppercase"}}} /-->
+<div class="wp-block-group has-text-align-center" style="padding-top:40px;padding-bottom:50px"><!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}}} /-->
 
 <!-- wp:post-featured-image /-->
 

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -224,7 +224,8 @@
 			"core/categories": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontWeight": "500",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase",
 					"lineHeight": 2.3 
@@ -305,8 +306,9 @@
 				"typography": {
 					"fontStyle": "normal",
 					"fontWeight": "500",
-					"letterSpacing": "3px",
-					"fontSize": "var:preset|font-size|small"
+					"letterSpacing": "0.1em",
+					"fontSize": "var:preset|font-size|x-small",
+					"textTransform": "uppercase"
 				}
 			}
 		},


### PR DESCRIPTION
Standardized the category font stylings per #5866

All instances are x-small font size (which has previously been configured to be 0.9rem rather than 15px which actually comes out to 14.4px rendered)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/163393655-be53d0ff-1890-449d-b64e-895b22b558fd.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/163393707-0849f635-b0c3-425f-9d1a-10b12e2fe157.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/163393738-7fd6d9d3-a7f4-48da-a571-2e36079dd93d.png">


Fixes #5866