### PR TITLE
Pendant: Improvements to Button Styles

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -56,7 +56,7 @@ a:focus {
 .wp-block-post-content a:hover {
 	text-decoration: none;
 }
- .wp-block-post-content .wp-block-button a {
+.wp-block-button a {
 	text-decoration: none;
 }
 

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -65,14 +65,20 @@ a:focus {
  * Necessary until the following issue is resolved in Gutenberg:
  * https://github.com/WordPress/gutenberg/issues/27075
  */
-
+.wp-block-button__link {
+    	padding: calc(1.2em + 2px) calc(2em + 2px);
+}
+.wp-block-button.is-style-outline .wp-block-button__link {
+    	padding: 1.2em 2em;
+}
+	
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 	border: 2px solid var(--wp--preset--color--foreground);
-    	padding: 0.667em 1.333em !important;
+    	padding: 1.2em 2em;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:hover {

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -74,6 +74,7 @@ a:focus {
 	
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
+.wp-block-post-comments input[type=submit]:hover,
 .wp-block-button__link:hover {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -81,6 +81,25 @@ a:focus {
 	border: 2px solid var(--wp--preset--color--foreground);
 }
 
+/* Special Condition for buttons inside of groups where the background color is set to the foreground palette color */
+.wp-block-group.has-foreground-background-color .wp-block-button .wp-block-button__link:not(.has-background-color) {
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
+}
+.wp-block-group.has-foreground-background-color .wp-block-button .wp-block-button__link:not(.has-background-color):hover {
+	background-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
+	border: 2px solid var(--wp--preset--color--background);
+}
+.wp-block-group.has-foreground-background-color .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color) {
+	background-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
+}
+.wp-block-group.has-foreground-background-color .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background-color):hover {
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
+}
+
 /*
  * Search and File Block button styles.
  * Necessary until the following issues are resolved in Gutenberg:

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -214,7 +214,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
-					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontSize": "var(--wp--preset--font-size--x-small)",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase",
 					"fontWeight": "600",


### PR DESCRIPTION
* Style special condition button where it is contained in a group where the background is the foreground color
* insure no underline is presented on the button
* Expand the size of padding on the button
* Force button in comments block to follow the button design rules

Before:
<img width="877" alt="image" src="https://user-images.githubusercontent.com/146530/163433044-1f87cfc2-d3ae-4399-8bc6-c79ba459a0c2.png">

Before (hover):
<img width="865" alt="image" src="https://user-images.githubusercontent.com/146530/163433133-44652b0d-28da-47d7-8f31-2cf13eac8850.png">

Before (comment):
<img width="263" alt="image" src="https://user-images.githubusercontent.com/146530/163433205-f90ff068-56a9-41e5-b4ef-40383b8a6385.png">

Before (comment hover):
<img width="239" alt="image" src="https://user-images.githubusercontent.com/146530/163433277-3ccecd32-f689-466e-a686-f794aae2d1fa.png">


After:
<img width="857" alt="image" src="https://user-images.githubusercontent.com/146530/163432846-d8286cef-18a0-4b97-a86d-3cfd951e0307.png">

After (hover):
<img width="859" alt="image" src="https://user-images.githubusercontent.com/146530/163432978-b248c4ac-3863-489f-929a-ae68097ce8c9.png">

After (comment):
<img width="241" alt="image" src="https://user-images.githubusercontent.com/146530/163433347-7ab81deb-8d1b-47f8-a493-dd33e1e77c34.png">

After (comment hover):
<img width="245" alt="image" src="https://user-images.githubusercontent.com/146530/163433388-bbacd0e4-a6fa-4ae6-ac2e-594f071273ff.png">


Fixes: #5864 
