### PR TITLE
Tools: Stale issues action update

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '34 19 * * *'
+  - cron: '0 */2 * * *'
 
 jobs:
   stale:
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        remove-issue-stale-when-updated: true
+        ascending: true
         days-before-stale: 30
         days-before-close: -1
         stale-issue-message: "As a part of this repository’s maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something."


### PR DESCRIPTION
After a few runs of this action, I think there's room for improvement. It looks like there's a [limit of operations per run](https://github.com/actions/stale#operations-per-run) so we've only had a few issues labeled since we created the action.

Instead of increasing the amount of operations I think we can simply run the action every other hour instead and change the order so it starts from the older issues. That should cover most of them faster, then we can go back to once a day for general maintenance once the action is not encountering as many stale issues.

I also added the option to remove the `Stale` label if there's updates to the issue. With the amount of issues we handle, I'd rather have that automated than let the issues labeled as stale even if they are not.