### PR TITLE
Pendant: Fix mobile post navigation

### DIFF
--- a/pendant/patterns/post-navigation.php
+++ b/pendant/patterns/post-navigation.php
@@ -6,9 +6,9 @@
  */
 ?>
 
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-navigation-link {"textAlign":"right","type":"previous","showTitle":true,"label":"<?php echo esc_html__( 'Previous Post', 'pendant' ); ?><br>"} /--></div>
+<!-- wp:columns {"isStackedOnMobile":false,"className":"pendant-post-navigation"} -->
+<div class="wp-block-columns is-not-stacked-on-mobile pendant-post-navigation"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-navigation-link {"textAlign":"right","type":"previous","showTitle":true,"label":"<?php echo esc_html__( 'Previous Post', 'pendant' ); ?><br>","linkLabel":true} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"33.33%"} -->
@@ -16,6 +16,6 @@
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-navigation-link {"showTitle":true,"label":"<?php echo esc_html__( 'Next Post', 'pendant' ); ?><br>"} /--></div>
+<div class="wp-block-column"><!-- wp:post-navigation-link {"showTitle":true,"label":"<?php echo esc_html__( 'Next Post', 'pendant' ); ?><br>","linkLabel":true} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -229,11 +229,27 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	list-style-type: none;
 }
 
-.wp-block-post-navigation-link .post-navigation-link__label {
+
+ .pendant-post-navigation .wp-block-post-navigation-link .post-navigation-link__label {
 	font-family: var(--wp--preset--font-family--body-font);
 	font-size: var(--wp--preset--font-size--x-small);
-	font-weight: 500;
+	font-weight: 600;
 	letter-spacing: 0.1em;
 	text-transform: uppercase;
 	line-height: 3;
+}
+
+@media (max-width: 599px) {
+	.pendant-post-navigation .post-navigation-link__title {
+		display: none;
+	}
+	.pendant-post-navigation .wp-block-column:nth-of-type(2) {
+		display: none;
+	}	
+	.pendant-post-navigation .post-navigation-link-previous {
+		text-align: left;
+	}
+	.pendant-post-navigation .post-navigation-link-next {
+		text-align: right;
+	}
 }


### PR DESCRIPTION
Adjusted post navigation blocks and added theme-specific css to achieve design target

Closes #5883 

This introduces a custom class `pendant-post-navigation` used in the post navigation pattern used in the `single.html` template.

The class is used to hide elements when in mobile and change the alignment of the remaining elements (labels).

This change also makes the 'label' anchor targets (in both desktop and mobile).

Lastly the weight of the labels was changed from 500 to 600 so that Jost Medium typeface is used.

Before:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/146530/164031067-7570b974-e0c7-4b7d-b224-6c2be7cbafda.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/146530/164031011-9acf6f5b-9f22-454d-9286-6836d2b98eaa.png">

After:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/146530/164030863-9758d2cc-5ac3-447c-b52e-03a6636e691b.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/146530/164030924-a2c859e3-a02f-4186-b96b-529e7a175774.png">
