### PR TITLE
Pendant: Fix link color

### DIFF
--- a/pendant/patterns/hero.php
+++ b/pendant/patterns/hero.php
@@ -5,8 +5,8 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-bottom:0px"><!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"padding":{"top":"0px","bottom":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-bottom:0px"><!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-columns alignfull"><!-- wp:column -->
 <div class="wp-block-column"></div>
 <!-- /wp:column -->


### PR DESCRIPTION
Apply the 'foreground' color to links in the group in the 'hero' pattern to match the 'text' color (which is set to `background`).

To achieve this (with the FSE) you must "turn on" link color editing. 
<img width="308" alt="image" src="https://user-images.githubusercontent.com/146530/164041979-d9610f83-4bbd-4cc0-9b9b-568e459a2180.png">
<img width="583" alt="image" src="https://user-images.githubusercontent.com/146530/164042062-f7847a86-10b6-4d53-a111-c0147fb56dee.png">

Fixes #5885

Before:
<img width="565" alt="image" src="https://user-images.githubusercontent.com/146530/164042310-d727e3a1-f14c-4a57-b288-49f77f540689.png">

After:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/146530/164042371-e925da1b-20d0-4aa8-936c-f29e2e972e91.png">

