### PR TITLE
Tools: automatically handle changelog updates

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -46,18 +46,16 @@ function showHelp(){
  Optionally pass in boolean bulletPoints to add bullet points to each commit log
 */
 async function getCommitLogs(hash, bulletPoints) {
-	let logs;
-
 	if (!hash) {
 		hash = await getLastDeployedHash();
 	}
+
+	let logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
 
 	if (bulletPoints) {
 		// Add a '*' to the start of each log (used in changelogs)
 		logs = await executeCommand(`git log --reverse --pretty=format:"* %s" ${hash}..HEAD`);
 	}
-
-	logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
 
 	// Remove any double quotes from commit messages
 	logs = logs.replace(/"/g, '');

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -518,10 +518,10 @@ async function updateThemeChangelog(theme, addChanges) {
  	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
  	let version = getThemeMetadata(styleCss, 'Version');
 
-	// Get list of updates
+	// Get list of updates with bullet points
  	let logs = await getCommitLogs('', true);
 
-	// Find theme readme.txt
+	// Get theme readme.txt
 	let readmeFile = `${theme}/readme.txt`;
 
 	// Build changelog entry
@@ -529,6 +529,11 @@ async function updateThemeChangelog(theme, addChanges) {
 
 = ${version} =
 ${logs}`;
+
+	if (!readmeFile) {
+		console.log(`Unable to find a readme.txt for ${theme}. Aborted Automated Deploy Process at changelog step.`);
+		return;
+	}
 
 	// Update readme.txt
 	fs.readFile(readmeFile, 'utf8', function(err, data) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -475,7 +475,7 @@ async function versionBumpThemes() {
 		}
 
 		await versionBumpTheme(theme, true);
-		await updateThemeChangelog(theme);
+		await updateThemeChangelog(theme, true);
 		changesWereMade = true;
 	}
 
@@ -509,7 +509,7 @@ export function getThemeMetadata(styleCss, attribute) {
  Update theme changelog using current commit logs.
  Used by versionBumpThemes to update each theme changelog.
 */
-async function updateThemeChangelog(theme) {
+async function updateThemeChangelog(theme, addChanges) {
 	console.log(`Updating ${theme} changelog`);
 
 	// Get theme version
@@ -519,6 +519,9 @@ async function updateThemeChangelog(theme) {
 	// Get list of updates
  	let logs = await getCommitLogs('', true);
 
+	// Find theme readme.txt
+	let readmeFile = `${theme}/readme.txt`;
+
 	// Build changelog entry
 	let newChangelogEntry = `== Changelog ==
 
@@ -526,15 +529,20 @@ async function updateThemeChangelog(theme) {
 ${logs}`;
 
 	// Update readme.txt
-	fs.readFile(`${theme}/readme.txt`, 'utf8', function(err, data) {
+	fs.readFile(readmeFile, 'utf8', function(err, data) {
 		let changelogSection = '== Changelog ==';
 		let regex = new RegExp('^.*' + changelogSection + '.*$', 'gm');
 		let formattedChangelog = data.replace(regex, newChangelogEntry);
 
-		fs.writeFile(`${theme}/readme.txt`, formattedChangelog, 'utf8', function(err) {
+		fs.writeFile(readmeFile, formattedChangelog, 'utf8', function(err) {
 			if (err) return console.log(err);
 		});
 	});
+
+	// Stage readme.txt
+	if (addChanges) {
+		await executeCommand(`git add ${readmeFile}`);
+	}
 }
 
 /*

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -46,16 +46,18 @@ function showHelp(){
  Optionally pass in boolean bulletPoints to add bullet points to each commit log
 */
 async function getCommitLogs(hash, bulletPoints) {
+	let logs;
+
 	if (!hash) {
 		hash = await getLastDeployedHash();
 	}
 
-	let logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
-
 	if (bulletPoints) {
-		// Add * to the start of each log (used in changelogs)
+		// Add a '*' to the start of each log (used in changelogs)
 		logs = await executeCommand(`git log --reverse --pretty=format:"* %s" ${hash}..HEAD`);
 	}
+
+	logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
 
 	// Remove any double quotes from commit messages
 	logs = logs.replace(/"/g, '');

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -43,14 +43,23 @@ function showHelp(){
 /*
  Create list of changes from git logs
  Optionally pass in a deployed hash or default to calling getLastDeployedHash()
+ Optionally pass in boolean bulletPoints to add bullet points to each commit log
 */
-async function getCommitLogs(hash) {
+async function getCommitLogs(hash, bulletPoints) {
 	if (!hash) {
 		hash = await getLastDeployedHash();
 	}
+
 	let logs = await executeCommand(`git log --reverse --pretty=format:%s ${hash}..HEAD`);
+
+	if (bulletPoints) {
+		// Add * to the start of each log (used in changelogs)
+		logs = await executeCommand(`git log --reverse --pretty=format:"* %s" ${hash}..HEAD`);
+	}
+
 	// Remove any double quotes from commit messages
 	logs = logs.replace(/"/g, '');
+
 	return logs;
 }
 
@@ -508,7 +517,7 @@ async function updateThemeChangelog(theme) {
  	let version = getThemeMetadata(styleCss, 'Version');
 
 	// Get list of updates
- 	let logs = await getCommitLogs();
+ 	let logs = await getCommitLogs('', true);
 
 	// Build changelog entry
 	let newChangelogEntry = `== Changelog ==


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds a function called `updateThemeChangelog` to the deploy script, which is called during `versionBumpThemes`. It accepts a theme slug as an argument, and then runs through the following process for the corresponding theme:

- Gets the current theme version from `style.css`. This is run after a version bump has already happened, so this should always be the latest version.
- Gets the list of updates from the commit logs, and adds a bullet point (*) to each line
- Builds a new changelog entry based on the commit logs and the latest version number
- Updates the theme's `readme.txt` with the new changelog entry
- The user is given an option to manually update any of these changes at the same time as verifying the version bump changes

The idea is that all commit logs will be added to each updated theme's changelog, and the user will need to delete the appropriate logs during the manual step. Ideally, only a small number of themes should be updated per deployment, as this reduces the overhead when running the deploy script.

I've also added a new function called `getCommitLogs` to reduce the number of times we seemed to be repeating this functionality.

Thanks to @pbking for the prompt! This is an alternative to #5861.

#### Related issue(s):
https://github.com/Automattic/themes/pull/5861
https://github.com/Automattic/themes/pull/5092