### PR TITLE
Fix/pendant variation navy

### DIFF
--- a/pendant/patterns/post-topics.php
+++ b/pendant/patterns/post-topics.php
@@ -5,7 +5,7 @@
  */
 ?>
 
-<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"large"} -->
-<h2 class="has-large-font-size" style="margin-bottom:20px"><?php echo esc_html__( 'Popular Topics', 'pendant' ); ?></h2>
+<!-- wp:heading {"level":4,"style":{"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"large"} -->
+<h4 class="has-large-font-size" style="margin-bottom:20px"><?php echo esc_html__( 'Popular Topics', 'pendant' ); ?></h4>
 <!-- /wp:heading -->
 <!-- wp:categories /-->

--- a/pendant/styles/dark-navy.json
+++ b/pendant/styles/dark-navy.json
@@ -6,12 +6,12 @@
 			"palette": [
 				{
 					"slug": "primary",
-					"color": "#A6FFD4",
+					"color": "#DEFFEF",
 					"name": "Primary"
 				},
 				{
 					"slug": "foreground",
-					"color": "#DEFFEF",
+					"color": "#A6FFD4",
 					"name": "Foreground"
 				},
 				{
@@ -21,7 +21,7 @@
 				},
 				{
 					"slug": "tertiary",
-					"color": "#DEFFEF",
+					"color": "#0F1E42",
 					"name": "Tertiary"
 				}
 			]

--- a/pendant/styles/dark-navy.json
+++ b/pendant/styles/dark-navy.json
@@ -31,12 +31,12 @@
 				{
 					"fontFamily": "Inter, sans-serif",
 					"slug": "body-font",
-					"name": "Body (System Font)",
+					"name": "Body",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Inter",
-							"fontWeight": "300 400",
+							"fontWeight": "100 500",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
 							"src": [
@@ -46,7 +46,7 @@
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Inter",
-							"fontWeight": "500 600",
+							"fontWeight": "600 900",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
 							"src": [
@@ -56,13 +56,13 @@
 					]
 				},
 				{
-					"fontFamily": "'Inter', serif",
+					"fontFamily": "'InterLight', serif",
 					"slug": "heading-font",
-					"name": "Headings (System Font)",
+					"name": "Headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
-							"fontFamily": "Inter",
+							"fontFamily": "InterLight",
 							"fontStyle": "normal",
 							"fontStretch": "normal",
 							"src": [
@@ -72,6 +72,48 @@
 					]
 				}
 			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--body-font)"
+				}
+			}
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontWeight": 300
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontWeight": 300
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": 300
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--body-font)",
+					"fontWeight": 700
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontWeight": 700
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontWeight": 700
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This addresses the feedback from design regarding the 'Dark Navy' Variation.

Closes: #5882

Depends on [this Gutenberg item](https://github.com/WordPress/gutenberg/pull/40489) to render fonts as expected.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/146530/164521836-a192c145-2b1a-4e7d-ba7b-59e875b7d869.png">

The variable font wasn't slimming down for the smaller weights so the -Light and -Bold options were used instead.

<img width="707" alt="image" src="https://user-images.githubusercontent.com/146530/164523459-382475e0-6c98-4554-a484-3d5dbeb84b8a.png">

<img width="635" alt="image" src="https://user-images.githubusercontent.com/146530/164523667-e404d1b4-b33e-4154-b9ed-05f1262c787b.png">

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/146530/164525077-f8d99d51-8dc0-4bc2-89be-f8c248214de4.png">
