### PR TITLE
Updated pendant image-series pattern to be centered always

### DIFF
--- a/pendant/patterns/image-series.php
+++ b/pendant/patterns/image-series.php
@@ -5,27 +5,59 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"20px","padding":{"top":"50px","bottom":"50px"}}},"backgroundColor":"tertiary","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-tertiary-background-color has-background" style="padding-top:50px;padding-bottom:50px"><!-- wp:heading {"textAlign":"center","level":4} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px","padding":{"top":"60px","bottom":"60px"}}},"backgroundColor":"tertiary","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-tertiary-background-color has-background" style="padding-top:60px;padding-bottom:60px"><!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center"><?php echo esc_html__( 'Our Picks', 'pendant' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
-<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center">
+	
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-1.png'; ?>" alt=""/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-2.png'; ?>" alt=""/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-3.png'; ?>" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+
+
+
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px","padding":{"top":"60px","bottom":"60px"}}},"backgroundColor":"tertiary","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-tertiary-background-color has-background" style="padding-top:60px;padding-bottom:60px"><!-- wp:heading {"textAlign":"center","level":4} -->
+<h4 class="has-text-align-center">Our Picks</h4>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="http://localhost:4759/wp-content/themes/themes/pendant/assets/images/jewelery-1.png" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="http://localhost:4759/wp-content/themes/themes/pendant/assets/images/jewelery-2.png" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"40px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="http://localhost:4759/wp-content/themes/themes/pendant/assets/images/jewelery-3.png" alt=""/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/pendant/patterns/image-series.php
+++ b/pendant/patterns/image-series.php
@@ -5,24 +5,28 @@
  */
 ?>
 
-<!-- wp:group {"backgroundColor":"tertiary","layout":{"inherit":true}} -->
-<div class="wp-block-group has-tertiary-background-color has-background"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"},"blockGap":"100px"}},"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-group alignwide" style="padding-top:60px;padding-bottom:60px"><!-- wp:heading {"textAlign":"center","level":4} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"20px","padding":{"top":"50px","bottom":"50px"}}},"backgroundColor":"tertiary","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-tertiary-background-color has-background" style="padding-top:50px;padding-bottom:50px"><!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center"><?php echo esc_html__( 'Our Picks', 'pendant' ); ?></h4>
 <!-- /wp:heading -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"100px"}},"layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-1.png'; ?>" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-2.png'; ?>" alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-3.png'; ?>" alt=""/></figure>
+<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-1.png'; ?>" alt=""/></figure>
 <!-- /wp:image --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-2.png'; ?>" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:image {"align":"center","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-full"><img src="<?php echo esc_url( get_template_directory_uri() ) . '/assets/images/jewelery-3.png'; ?>" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes: #5863

This changes the design of the 'Image Series' pattern so that the label is centered always.  The mobile and desktop designs could not both be accomplished.

The layout was accomplished with columns and the images centered in them.
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/146530/164745682-d9113499-52ca-440a-9a46-84c28a9df359.png">

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/146530/164745543-9da0b8d9-8bcf-41fa-aec3-08cf785c629b.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/146530/164745591-13ac600f-6177-41a4-ab58-99dffe3fcf44.png">

Leveraging a 'row' block with the images with 'justify: centered' applied was also considered but that had a much smaller footprint on larger screens.

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/146530/164745501-fb3ec142-bec4-4b2f-8065-bf6262795916.png">
