### PR TITLE
Multiple themes: Set inherit to true in archive posts

### DIFF
--- a/mayland-blocks/block-templates/archive.html
+++ b/mayland-blocks/block-templates/archive.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-group">
 
-<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 <div class="wp-block-query">
 <!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"120px"}}}} /-->
 <!-- wp:post-template -->

--- a/skatepark/patterns/blog-posts.php
+++ b/skatepark/patterns/blog-posts.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
+<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template -->
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"30px"}}},"layout":{"inherit":false}} -->
 <div class="wp-block-group" style="padding-top:30px">


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Set `Inherit query from template` to true in Skatepark and MaylandBlocks Archive pages
* Exclude sticky posts from archive pages in MaylandBlocks

#### Related issue(s):

Fixes: #5890 
