### PR TITLE
Update Create Theme Checklist

### DIFF
--- a/create-a-theme-checklist.js
+++ b/create-a-theme-checklist.js
@@ -18,6 +18,7 @@ function sleep( ms ) {
 
 async function createLabel() {
 	try {
+		await sleep( 1000 );
 		return await octokit.request( 'POST /repos/Automattic/themes/labels', {
 			name: '[Theme] ' + theme,
 			color: 'c1f4a1',
@@ -30,6 +31,7 @@ async function createLabel() {
 
 async function createMilestone() {
 	try {
+		await sleep( 1000 );
 		return await octokit.request(
 			'POST /repos/Automattic/themes/milestones',
 			{
@@ -71,15 +73,19 @@ async function createIssues( milestoneNumber ) {
 	];
 	issues.forEach( async ( issue ) => {
 		try {
-			return await octokit
-				.request( 'POST /repos/Automattic/themes/issues', {
+			await sleep( 1000 );
+			return await octokit.request(
+				'POST /repos/Automattic/themes/issues',
+				{
 					title: theme + ': ' + issue,
 					labels: [ '[Theme] ' + theme ],
 					milestone: milestoneNumber,
-				} )
-				.then( ( issueData ) => {
-					addIssueToProject( issueData );
-				} );
+				}
+			);
+			// If you want to automatically add this to the Theme Dev Board, uncomment this.
+			// .then( ( issueData ) => {
+			// 	addIssueToProject( issueData );
+			// } );
 		} catch ( error ) {
 			console.log( error );
 		}
@@ -88,6 +94,7 @@ async function createIssues( milestoneNumber ) {
 
 async function addIssueToProject( issueData ) {
 	try {
+		await sleep( 1000 );
 		return await octokit.request( 'POST /projects/columns/11021541/cards', {
 			note: null,
 			content_id: issueData.data.id,

--- a/create-a-theme-checklist.js
+++ b/create-a-theme-checklist.js
@@ -1,22 +1,22 @@
-const theme = process.argv[2];
+const theme = process.argv[ 2 ];
 
-if (!theme) {
-	console.error('\x1b[41m', 'You must specify a theme!');
+if ( ! theme ) {
+	console.error( '\x1b[41m', 'You must specify a theme!' );
 	return;
 }
 
-const { Octokit } = require('octokit');
-const octokit = new Octokit({ auth: `PUT YOUR TOKEN HERE` });
+const { Octokit } = require( 'octokit' );
+const octokit = new Octokit( { auth: `PUT YOUR TOKEN HERE` } );
 
 async function createLabel() {
 	try {
-		return await octokit.request('POST /repos/Automattic/themes/labels', {
+		return await octokit.request( 'POST /repos/Automattic/themes/labels', {
 			name: '[Theme] ' + theme,
 			color: 'c1f4a1',
 			description: 'Automatically generated label for ' + theme + '.',
-		});
-	} catch (error) {
-		console.log(error);
+		} );
+	} catch ( error ) {
+		console.log( error );
 	}
 }
 
@@ -30,69 +30,73 @@ async function createMilestone() {
 					'Automatically generated milestone for ' + theme + '.',
 			}
 		);
-	} catch (error) {
-		console.error('\x1b[41m', 'Milestone already created.');
+	} catch ( error ) {
+		console.error( '\x1b[41m', 'Milestone already created.' );
 	}
 }
 
-async function createIssues(milestoneNumber) {
+async function createIssues( milestoneNumber ) {
 	const issues = [
-		'Create base theme',
-		'Create a demo site on dotcom',
-		'theme.json: Typography settings',
-		'theme.json: Color palette',
-		'theme.json: Margin/spacing settings + content layout',
-		'Templates: Page templates - Index',
-		'Templates: Page templates - Search',
-		'Templates: Page templates - 404',
-		'Templates: Page templates - Archive',
-		'Templates: Post templates - Single',
-		'Templates: page.html',
+		'Block Patterns',
+		'Create Base Theme',
+		'Styles: Colors',
+		'Styles: Typography — Fonts & Weights',
+		'Styles: Typography — Sizes & Line Height',
+		'Styles: Links',
+		'Styles: Buttons',
+		'Styles: Layout',
+		'Styles: Comments',
+		'Styles: Navigation',
+		'Styles: Quote',
+		'Styles: Variations',
+		'Templates: Search, Category, Tag',
+		'Templates: 404',
+		'Templates: Single',
+		'Templates: Page',
+		'Templates: Index',
 		'Templates: Header template part',
 		'Templates: Footer template part',
-		'Block patterns',
-		'Comment form styles (dotcom and dotorg)',
-		'theme.json: Core block settings',
-		'Pre-launch: readme.txt',
-		'Pre-launch: screenshot.png',
-		'Pre-launch: style.css tags',
+		'Pre-launch: Screenshot, readme.txt & description',
+		'Pre-launch: Demo Site',
+		'Pre-launch: Showcase Entry',
+		'Pre-launch: Headstart Annotation',
 	];
-	issues.forEach(async (issue) => {
+	issues.forEach( async ( issue ) => {
 		try {
 			return await octokit
-				.request('POST /repos/Automattic/themes/issues', {
+				.request( 'POST /repos/Automattic/themes/issues', {
 					title: theme + ': ' + issue,
-					labels: ['[Theme] ' + theme],
+					labels: [ '[Theme] ' + theme ],
 					milestone: milestoneNumber,
-				})
-				.then((issueData) => {
-					addIssueToProject(issueData);
-				});
-		} catch (error) {
-			console.log(error);
+				} )
+				.then( ( issueData ) => {
+					addIssueToProject( issueData );
+				} );
+		} catch ( error ) {
+			console.log( error );
 		}
-	});
+	} );
 }
 
-async function addIssueToProject(issueData) {
+async function addIssueToProject( issueData ) {
 	try {
-		return await octokit.request('POST /projects/columns/11021541/cards', {
+		return await octokit.request( 'POST /projects/columns/11021541/cards', {
 			note: null,
 			content_id: issueData.data.id,
 			content_url: issueData.data.url,
 			content_type: 'Issue',
 			mediaType: {
-				previews: ['inertia'],
+				previews: [ 'inertia' ],
 			},
-		});
-	} catch (error) {
-		console.log(error);
+		} );
+	} catch ( error ) {
+		console.log( error );
 	}
 }
 
-createLabel().then(() => {
-	createMilestone().then((milestoneData) => {
+createLabel().then( () => {
+	createMilestone().then( ( milestoneData ) => {
 		const milestoneNumber = milestoneData.data.number;
-		createIssues(milestoneNumber);
-	});
-});
+		createIssues( milestoneNumber );
+	} );
+} );

--- a/create-a-theme-checklist.js
+++ b/create-a-theme-checklist.js
@@ -6,7 +6,15 @@ if ( ! theme ) {
 }
 
 const { Octokit } = require( 'octokit' );
-const octokit = new Octokit( { auth: `PUT YOUR TOKEN HERE` } );
+const octokit = new Octokit( {
+	auth: `PUT YOUR ACCESS TOKEN HERE`,
+} );
+
+function sleep( ms ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, ms );
+	} );
+}
 
 async function createLabel() {
 	try {


### PR DESCRIPTION
This PR cleans up the create theme checklist a bit, by refreshing the list of issues that are created and introducing some logic to avoid [secondary rate limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits). According to github's [best practices](https://docs.github.com/en/rest/guides/best-practices-for-integrators): 

> If you're making a large number of POST, PATCH, PUT, or DELETE requests for a single user or client ID, wait at least one second between each request.

I tailored the issues slightly after reviewing the designs for Cult, but I think it can still apply for most new block themes. 