### PR TITLE
Stewart: removing no needed definitions in theme.json

### DIFF
--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -285,8 +285,6 @@
 			},
 			"core/separator": {
 				"border": {
-					"color": "currentColor",
-					"style": "solid",
 					"width": "0 0 1px 0"
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Stewart: removing no needed definitions about separator block in theme.json 

#### Related issue(s):
https://github.com/Automattic/themes/issues/5728