### PR TITLE
Fix the 'grid-of-posts' pattern so that it can be dropped in and used

### DIFF
--- a/pendant/patterns/grid-of-posts.php
+++ b/pendant/patterns/grid-of-posts.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<!-- wp:query {"queryId":1,"query":{"perPage":4,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":true},"tagName":"main","displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
+<!-- wp:query {"query":{"perPage":4,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"tagName":"main","displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
 <main class="wp-block-query"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"1em","bottom":"1.5em"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top:1em;padding-bottom: 1.5em"><!-- wp:post-template -->
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","bottom":"2em"}}}} -->


### PR DESCRIPTION
The pattern originally had 'inherit:true' which I thought was necessary for it to be used in a page like "search".  

However, it turns out that the 'inherity: true' caused the pattern to not work as expected when dropped into a page.

Also, it turns out that 'inherit: true' also isn't necessary to be used in the 'search' page template either.  

This just makes it 'false' so that the pattern can be dropped in a user-created page.