### PR TITLE
Added 'block-patterns' to tags

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: 
 Text Domain: pendant
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*


### PR DESCRIPTION
Closes: #5689

This change adds 'block-patterns' to the tags.

The list then matches Archeo's tags.  I'm not sure what else is needed?  We good here?