### PR TITLE
Vertically Centered navigation.  Cleaned up style comments.

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -225,14 +225,24 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	margin: 0 auto;
 	max-width: 820px;
 	height: 100%;
-	padding-top: 0;
+	padding-top: 2rem;
+	padding-bottom: 2rem;
 }
+
 .wp-block-navigation .wp-block-navigation__responsive-dialog,
 .wp-block-navigation .wp-block-navigation__responsive-close {
 	height: 100%;
 }
 .wp-block-navigation.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__container {
 	justify-content: center;
+}
+.wp-block-navigation .wp-block-navigation__responsive-container-close {
+	left: 0;
+}
+.wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open {
+	padding-left: var(--wp--custom--gap--horizontal);
+	padding-right: var(--wp--custom--gap--horizontal);
+	padding-top: 3vw;
 }
 
 /** Categories list block: remove list decoration **/

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -206,6 +206,11 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	padding-left: 0;
 }
 
+/** Navigation text-decoration correction **/
+.wp-block-navigation:where(:not([class*=has-text-decoration])) a {
+	text-decoration-thickness: 1px;
+}
+
 /** Navigation sub-menu items **/
 .wp-block-navigation .wp-block-navigation__responsive-container-content .has-child .wp-block-navigation__submenu-container {
 	text-transform: uppercase;
@@ -215,22 +220,28 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	letter-spacing: 0.1em;
 }
 
-/* Desktop responsive navigation layout */
+/** Desktop responsive navigation layout **/
 .wp-block-navigation.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content {
-    margin: 0 auto;
-    max-width: 820px;
+	margin: 0 auto;
+	max-width: 820px;
+	height: 100%;
+	padding-top: 0;
+}
+.wp-block-navigation .wp-block-navigation__responsive-dialog,
+.wp-block-navigation .wp-block-navigation__responsive-close {
+	height: 100%;
+}
+.wp-block-navigation.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__container {
+	justify-content: center;
 }
 
-.wp-block-navigation:where(:not([class*=has-text-decoration])) a {
-	text-decoration-thickness: 1px;
-}
-
+/** Categories list block: remove list decoration **/
 .wp-block-categories {
 	list-style-type: none;
 }
 
-
- .pendant-post-navigation .wp-block-post-navigation-link .post-navigation-link__label {
+/** Post Navigation Styles **/
+.pendant-post-navigation .wp-block-post-navigation-link .post-navigation-link__label {
 	font-family: var(--wp--preset--font-family--body-font);
 	font-size: var(--wp--preset--font-size--x-small);
 	font-weight: 600;
@@ -238,7 +249,6 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	text-transform: uppercase;
 	line-height: 3;
 }
-
 @media (max-width: 599px) {
 	.pendant-post-navigation .post-navigation-link__title {
 		display: none;


### PR DESCRIPTION
This change centers vertically the responsive navigation.

Fixes: #5865
Before:
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/146530/165372628-5611aa17-2ed4-498c-badc-bca64aaeb51c.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/165372576-a268b3ae-626c-43f8-a648-deb39830191c.png">

After:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/146530/165371948-02d52d6c-8ef8-47d1-a38f-2c23ae596d8e.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/165371909-72210df1-2cbb-47d8-915b-cff261ddc9fc.png">

I was afraid that navigation elements that exceed the height would start "scrolled offscreen" but things appear to be working as desired:

After:
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/146530/165372161-924dcea1-9f67-4ad8-97b2-2a9a19c0d9f5.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/146530/165372195-51438c82-a6b7-42b2-873e-d718a83b59f7.png">
