### PR TITLE
Removes instances of x-small font size

### DIFF
--- a/pendant/patterns/hero.php
+++ b/pendant/patterns/hero.php
@@ -15,8 +15,8 @@
 <div class="wp-block-column is-vertically-aligned-bottom" style="padding-left:var(--wp--custom--gap--horizontal);flex-basis:calc(1240px / 2)"><!-- wp:group {"style":{"spacing":{"padding":{"top":"100px","bottom":"100px","right":"calc(var(--wp--custom--gap--horizontal)/2)"}}},"layout":{"inherit":true}} -->
 <div class="wp-block-group" style="padding-top:100px;padding-right:calc(var(--wp--custom--gap--horizontal)/2);padding-bottom:100px">
 
-<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.1em","fontStyle":"normal","fontWeight":"500"}},"fontSize":"x-small"} -->
-<p class="has-x-small-font-size" style="font-style:normal;font-weight:500;text-transform:uppercase;letter-spacing:0.1em"><?php echo esc_html__( 'Featured', 'pendant' ); ?></p>
+<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.1em","fontStyle":"normal","fontWeight":"500"}},"fontSize":"0.9rem"} -->
+<p style="font-style:normal;font-weight:500;text-transform:uppercase;letter-spacing:0.1em;font-size:0.9rem"><?php echo esc_html__( 'Featured', 'pendant' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":1,"style":{"typography":{"lineHeight":"1"}}} -->

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -198,7 +198,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .wp-block-quote cite {
 	font-family: var(--wp--preset--font-family--body-font);
 	font-style: italic;
-	font-size: var(--wp--preset--font-size--x-small);
+	font-size: 0.9rem;
 }
 
 /* The plain quote block has a left-padding that doesn't work well with our design */
@@ -211,7 +211,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	text-transform: uppercase;
 	font-weight: 500;
 	line-height: 2.6;
-	font-size: var(--wp--preset--font-size--x-small);
+	font-size: 0.9rem;
 	letter-spacing: 0.1em;
 }
 
@@ -232,7 +232,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 
  .pendant-post-navigation .wp-block-post-navigation-link .post-navigation-link__label {
 	font-family: var(--wp--preset--font-family--body-font);
-	font-size: var(--wp--preset--font-size--x-small);
+	font-size: 0.9rem;
 	font-weight: 600;
 	letter-spacing: 0.1em;
 	text-transform: uppercase;

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -159,11 +159,6 @@
 			],
 			"fontSizes": [
 				{
-					"name": "Extra Small",
-					"size": "0.9rem",
-					"slug": "x-small"
-				},
-				{
 					"name": "Small",
 					"size": "1rem",
 					"slug": "small"
@@ -209,7 +204,7 @@
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
-					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontSize": "0.9rem",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase",
 					"fontWeight": "600",
@@ -219,7 +214,7 @@
 			"core/categories": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
-					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontSize": "0.9rem",
 					"fontWeight": "500",
 					"letterSpacing": "0.1em",
 					"textTransform": "uppercase",
@@ -261,20 +256,20 @@
 				"typography": {
 					"fontWeight": "500",
 					"textTransform": "uppercase",
-					"fontSize": "var(--wp--preset--font-size--x-small)"
+					"fontSize": "0.9rem"
 				}
 			},
 			"core/query-pagination-numbers": {
 				"typography": {
 					"fontWeight": "500",
-					"fontSize": "var(--wp--preset--font-size--x-small)"
+					"fontSize": "0.9rem"
 				}
 			},
 			"core/query-pagination-previous": {
 				"typography": {
 					"fontWeight": "500",
 					"textTransform": "uppercase",
-					"fontSize": "var(--wp--preset--font-size--x-small)"
+					"fontSize": "0.9rem"
 				}
 			},
 			"core/quote": {
@@ -313,7 +308,7 @@
 					"fontStyle": "normal",
 					"fontWeight": "500",
 					"letterSpacing": "0.1em",
-					"fontSize": "var:preset|font-size|x-small",
+					"fontSize": "0.9rem",
 					"textTransform": "uppercase"
 				}
 			}


### PR DESCRIPTION
This change replaces all instances of the preset font size `x-small` with the value.

This is because `x-small` is a non-standard font size that may not be provided by other themes.  Thus any resource that needs to be set to that size is instead hard-coded to the value the preset was set to (`0.9rem`).