### PR TITLE
#3299: Intergalactic 2: Image captions are left aligned in published …

### DIFF
--- a/intergalactic-2/style.css
+++ b/intergalactic-2/style.css
@@ -1964,6 +1964,9 @@ object {
 	padding-bottom: .75em;
 	text-align: center;
 }
+.wp-block-image figcaption {
+	text-align: center;
+}
 
 /*--------------------------------------------------------------
 12.2 Galleries


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Add CSS to center captions on frontend of the site. They now match what shows in the editor.

##### Before

<img width="1641" alt="Screenshot on 2022-04-27 at 14-14-24" src="https://user-images.githubusercontent.com/45246438/165596506-45d48139-e5b6-4c22-aff5-f7f1c89831df.png">

##### After


<img width="1641" alt="Screenshot on 2022-04-27 at 14-19-55" src="https://user-images.githubusercontent.com/45246438/165596559-2dfe43af-0fff-45f7-8519-a7c99a2fce37.png">

#### Related issue(s):

https://github.com/Automattic/themes/issues/3299