### PR TITLE
Added a command to push an individual theme to sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"deploy:version-bump": "node ./theme-utils.mjs version-bump-themes",
 		"deploy:push:all": "node ./theme-utils.mjs push-to-sandbox",
 		"deploy:push:changes": "node ./theme-utils.mjs push-changes-to-sandbox",
+		"deploy:push:theme": "node ./theme-utils.mjs push-theme-to-sandbox",
 		"deploy:push:premium": "node ./theme-utils.mjs push-premium-to-sandbox",
 		"deploy": "node ./theme-utils.mjs push-button-deploy",
 		"deploy:core:sync": "node ./theme-utils.mjs deploy-sync-core-theme",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -21,6 +21,7 @@ const coreThemes = ['twentyten', 'twentyeleven', 'twentytwelve', 'twentythirteen
 		case "clean-all-sandbox": return cleanAllSandbox();
 		case "push-to-sandbox": return pushToSandbox();
 		case "push-changes-to-sandbox": return pushChangesToSandbox();
+		case "push-theme-to-sandbox": return pushThemeToSandbox(args?.[1]);
 		case "push-premium-to-sandbox": return pushPremiumToSandbox();
 		case "version-bump-themes": return versionBumpThemes();
 		case "land-diff": return landChanges(args?.[1]);


### PR DESCRIPTION
run the command:

```
npm run deploy:push:theme THEMEDIRECTORY
```

It works the same as `npm run deploy:push:changes` but doesn't calculate which themes have changed, it just pushes the theme defined.
