### PR TITLE
Cult: add color palette.

### DIFF
--- a/cult/theme.json
+++ b/cult/theme.json
@@ -33,7 +33,30 @@
 			"style": true,
 			"width": true
 		},
-		"color": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#000000",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#ffffff",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#761028",
+					"name": "Primary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#FCFAFA",
+					"name": "Tertiary"
+				}
+			]
+		},
 		"custom": {
 			"gap": {
 				"horizontal": "min(30px, 5vw)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adds the theme's color palette:

<img width="803" alt="Screen Shot 2022-04-28 at 9 42 46 AM" src="https://user-images.githubusercontent.com/5375500/165766244-20161c4e-c8a9-4e37-980e-6a4ab827be3f.png">

Verify the colors are correctly applied to the background, text, and links. Ignore hover, focus states for now.

#### Related issue(s):

Closes #5929 