### PR TITLE
Re-export pendant theme.json with a more organized export logic

### DIFF
--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -1,71 +1,64 @@
 {
-	"version": 2,
-	"templateParts": [
-		{
-			"name": "header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"area": "footer"
-		}
-	],
 	"customTemplates": [
 		{
 			"name": "blank",
-			"title": "Blank",
 			"postTypes": [
 				"page",
 				"post"
-			]
+			],
+			"title": "Blank"
 		},
 		{
 			"name": "header-footer-only",
-			"title": "Header and Footer Only",
 			"postTypes": [
 				"page",
 				"post"
-			]
+			],
+			"title": "Header and Footer Only"
 		},
 		{
 			"name": "footer-only",
-			"title": "Footer Only",
 			"postTypes": [
 				"page",
 				"post"
-			]
+			],
+			"title": "Footer Only"
 		}
 	],
 	"settings": {
+		"appearanceTools": true,
 		"color": {
 			"palette": [
 				{
-					"slug": "primary",
 					"color": "#A19982",
-					"name": "Primary"
+					"name": "Primary",
+					"slug": "primary"
 				},
 				{
-					"slug": "foreground",
 					"color": "#000000",
-					"name": "Foreground"
+					"name": "Foreground",
+					"slug": "foreground"
 				},
 				{
-					"slug": "background",
 					"color": "#ffffff",
-					"name": "Background"
+					"name": "Background",
+					"slug": "background"
 				},
 				{
-					"slug": "tertiary",
 					"color": "#f1ede6",
-					"name": "Tertiary"
+					"name": "Tertiary",
+					"slug": "tertiary"
 				}
-			],
-			"link": true
+			]
 		},
 		"custom": {
 			"gap": {
 				"horizontal": "clamp(20px, 6vw, 100px)"
 			}
+		},
+		"layout": {
+			"contentSize": "820px",
+			"wideSize": "1240px"
 		},
 		"spacing": {
 			"units": [
@@ -75,24 +68,18 @@
 				"rem",
 				"vh",
 				"vw"
-			],
-			"blockGap": true,
-			"margin": true,
-			"padding": true
+			]
 		},
 		"typography": {
 			"fontFamilies": [
 				{
-					"fontFamily": "Jost, sans-serif",
-					"slug": "body-font",
-					"name": "Body (System Font)",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Jost",
-							"fontWeight": "300 400",
-							"fontStyle": "normal",
 							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "300 400",
 							"src": [
 								"file:./assets/fonts/Jost-Light.ttf"
 							]
@@ -100,26 +87,26 @@
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Jost",
-							"fontWeight": "500 600",
-							"fontStyle": "normal",
 							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "500 600",
 							"src": [
 								"file:./assets/fonts/Jost-Medium.ttf"
 							]
 						}
-					]
+					],
+					"fontFamily": "Jost, sans-serif",
+					"name": "Body (System Font)",
+					"slug": "body-font"
 				},
 				{
-					"fontFamily": "'Literata', serif",
-					"slug": "heading-font",
-					"name": "Headings (System Font)",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Literata",
-							"fontWeight": "400",
-							"fontStyle": "normal",
 							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "400",
 							"src": [
 								"file:./assets/fonts/Literata_72pt-Light.ttf"
 							]
@@ -127,9 +114,9 @@
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Literata",
-							"fontWeight": "400",
-							"fontStyle": "italic",
 							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "400",
 							"src": [
 								"file:./assets/fonts/Literata_72pt-LightItalic.ttf"
 							]
@@ -137,9 +124,9 @@
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Literata",
-							"fontWeight": "800 900",
-							"fontStyle": "normal",
 							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "800 900",
 							"src": [
 								"file:./assets/fonts/Literata_72pt-Bold.ttf"
 							]
@@ -147,14 +134,17 @@
 						{
 							"fontDisplay": "block",
 							"fontFamily": "Literata",
-							"fontWeight": "800 900",
-							"fontStyle": "italic",
 							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "800 900",
 							"src": [
 								"file:./assets/fonts/Literata_72pt-BoldItalic.ttf"
 							]
 						}
-					]
+					],
+					"fontFamily": "'Literata', serif",
+					"name": "Headings (System Font)",
+					"slug": "heading-font"
 				}
 			],
 			"fontSizes": [
@@ -178,18 +168,7 @@
 					"size": "2rem",
 					"slug": "x-large"
 				}
-			],
-			"lineHeight": true
-		},
-		"layout": {
-			"contentSize": "820px",
-			"wideSize": "1240px"
-		},
-		"border": {
-			"color": true,
-			"radius": true,
-			"style": true,
-			"width": true
+			]
 		}
 	},
 	"styles": {
@@ -205,25 +184,25 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
 					"fontSize": "0.9rem",
-					"letterSpacing": "0.1em",
-					"textTransform": "uppercase",
 					"fontWeight": "600",
-					"lineHeight": 1.7
+					"letterSpacing": "0.1em",
+					"lineHeight": 1.7,
+					"textTransform": "uppercase"
 				}
 			},
 			"core/categories": {
+				"spacing": {
+					"padding": {
+						"left": "0"
+					}
+				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
 					"fontSize": "0.9rem",
 					"fontWeight": "500",
 					"letterSpacing": "0.1em",
-					"textTransform": "uppercase",
-					"lineHeight": 2.3
-				},
-				"spacing": {
-					"padding": {
-						"left": "0"
-					}
+					"lineHeight": 2.3,
+					"textTransform": "uppercase"
 				}
 			},
 			"core/heading": {
@@ -237,10 +216,32 @@
 					"lineHeight": "1.5"
 				}
 			},
+			"core/post-date": {
+				"typography": {
+					"fontSize": "var:preset|font-size|medium"
+				}
+			},
 			"core/post-navigation-link": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"fontSize": "0.9rem",
+					"fontStyle": "normal",
+					"fontWeight": "500",
+					"letterSpacing": "0.1em",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/pullquote": {
+				"border": {
+					"width": "1px"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)"
 				}
 			},
 			"core/query-pagination": {
@@ -254,36 +255,28 @@
 			},
 			"core/query-pagination-next": {
 				"typography": {
+					"fontSize": "0.9rem",
 					"fontWeight": "500",
-					"textTransform": "uppercase",
-					"fontSize": "0.9rem"
+					"textTransform": "uppercase"
 				}
 			},
 			"core/query-pagination-numbers": {
 				"typography": {
-					"fontWeight": "500",
-					"fontSize": "0.9rem"
+					"fontSize": "0.9rem",
+					"fontWeight": "500"
 				}
 			},
 			"core/query-pagination-previous": {
 				"typography": {
+					"fontSize": "0.9rem",
 					"fontWeight": "500",
-					"textTransform": "uppercase",
-					"fontSize": "0.9rem"
+					"textTransform": "uppercase"
 				}
 			},
 			"core/quote": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "clamp(1.25rem, 2.5vw, 2rem)"
-				}
-			},
-			"core/pullquote": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)"
-				},
-				"border": {
-					"width": "1px"
 				}
 			},
 			"core/separator": {
@@ -297,20 +290,6 @@
 					"fontWeight": "900",
 					"textDecoration": "none"
 				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				}
-			},
-			"core/post-terms": {
-				"typography": {
-					"fontStyle": "normal",
-					"fontWeight": "500",
-					"letterSpacing": "0.1em",
-					"fontSize": "0.9rem",
-					"textTransform": "uppercase"
-				}
 			}
 		},
 		"color": {
@@ -321,47 +300,47 @@
 			"h1": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
-					"fontWeight": 400,
-					"fontSize": "clamp(4rem, 10vw, 8rem)"
+					"fontSize": "clamp(4rem, 10vw, 8rem)",
+					"fontWeight": 400
 				}
 			},
 			"h2": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
-					"fontWeight": 400,
-					"fontSize": "clamp(3rem, 6vw, 5rem)"
+					"fontSize": "clamp(3rem, 6vw, 5rem)",
+					"fontWeight": 400
 				}
 			},
 			"h3": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
-					"fontWeight": 400,
-					"fontSize": "clamp(1.75rem, 4vw, 3rem)"
+					"fontSize": "clamp(1.75rem, 4vw, 3rem)",
+					"fontWeight": 400
 				}
 			},
 			"h4": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--heading-font)",
-					"fontWeight": 400,
-					"fontSize": "clamp(1.5rem, 3vw, 2.5rem)"
+					"fontSize": "clamp(1.5rem, 3vw, 2.5rem)",
+					"fontWeight": 400
 				}
 			},
 			"h5": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
+					"fontSize": "clamp(1rem, 2vw, 1.25rem)",
 					"fontWeight": 600,
 					"letterSpacing": "0.1em",
-					"textTransform": "uppercase",
-					"fontSize": "clamp(1rem, 2vw, 1.25rem)"
+					"textTransform": "uppercase"
 				}
 			},
 			"h6": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body-font)",
+					"fontSize": "clamp(0.75, 1.5vw, 1rem)",
 					"fontWeight": 500,
 					"letterSpacing": "0.1em",
-					"textTransform": "uppercase",
-					"fontSize": "clamp(0.75, 1.5vw, 1rem)"
+					"textTransform": "uppercase"
 				}
 			},
 			"link": {
@@ -374,9 +353,20 @@
 			"blockGap": "min(30px, 5vw)"
 		},
 		"typography": {
-			"lineHeight": "1.6",
 			"fontFamily": "var(--wp--preset--font-family--body-font)",
-			"fontSize": "var(--wp--preset--font-size--medium)"
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.6"
 		}
-	}
+	},
+	"templateParts": [
+		{
+			"area": "header",
+			"name": "header"
+		},
+		{
+			"area": "footer",
+			"name": "footer"
+		}
+	],
+	"version": 2
 }


### PR DESCRIPTION
This should have no actual change to the functionality (or actual configuration) of Pendant.  This just re-exports the theme.json using the improved logic found in [this change](https://github.com/Automattic/create-block-theme/pull/55) to the Create Block Theme plugin which mirrors the resources exported directly from core.