### PR TITLE
Blockbase: fixing separator block dots option

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -921,6 +921,13 @@ div.wp-block-query-pagination .wp-block-query-pagination-numbers .current {
 .wp-block-separator:not(.is-style-wide) {
   width: var(--wp--custom--separator--width);
 }
+.wp-block-separator.is-style-dots {
+  /*
+  	We can solve this using including the Gutenberg block styles with: add_theme_support( 'wp-block-styles' )
+  	but we decided not to add those styles to blockbase because of potential broad impact of those styles.
+  */
+  width: 100%;
+}
 
 p.wp-block-site-tagline {
   margin: 0;

--- a/blockbase/sass/blocks/_separator.scss
+++ b/blockbase/sass/blocks/_separator.scss
@@ -1,6 +1,15 @@
 .wp-block-separator {
 	opacity: var(--wp--custom--separator--opacity); // Mirror controls that Gutenberg theme.css offers: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/separator/theme.scss - See: https://github.com/WordPress/gutenberg/issues/34637
-	&:not(.is-style-wide){
+	&:not(.is-style-wide) {
 		width: var(--wp--custom--separator--width); // See https://github.com/WordPress/gutenberg/issues/34638
+	}
+
+	&.is-style-dots {
+
+		/*
+			We can solve this using including the Gutenberg block styles with: add_theme_support( 'wp-block-styles' )
+			but we decided not to add those styles to blockbase because of potential broad impact of those styles.
+		*/
+		width: 100%;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Blockbase: fixing separator block dots option

We can solve this using including the Gutenberg block styles with `add_theme_support( 'wp-block-styles' )` but we decided not to add those styles to blockbase because of the potentially broad impact of those styles.

See this closed PR for more info: https://github.com/Automattic/themes/pull/5834

Before:
![image](https://user-images.githubusercontent.com/1310626/165999705-16d57cf7-7cf2-400f-b5dc-c49436280fa4.png)


After:
![image](https://user-images.githubusercontent.com/1310626/165999718-99db1241-26cb-46ad-b6fd-a4ac5609cd3a.png)



#### Related issue(s):
https://github.com/Automattic/themes/issues/5582