### PR TITLE
#5893: Rebalance: Fix author display in post carousel block

### DIFF
--- a/rebalance/style.css
+++ b/rebalance/style.css
@@ -1602,7 +1602,6 @@ a:active {
 	margin: 0;
 }
 
-.byline,
 .updated:not(.published) {
 	display: none;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adjusted `style.css` to fix author display issue in [Newspack Blocks](https://github.com/automattic/newspack-blocks) Post Carousel block. Issue is coming from theme, not the Newspack plugin.

##### Before

<img width="2035" alt="Screenshot on 2022-05-05 at 08-36-34" src="https://user-images.githubusercontent.com/45246438/166925587-9e6af6f9-891a-4a9c-98f5-a05e89fa8429.png">

##### After

<img width="2015" alt="Screenshot on 2022-05-05 at 08-35-44" src="https://user-images.githubusercontent.com/45246438/166925576-854f694a-a030-4aef-8f78-a49c489b6434.png">


#### Related issue(s):

https://github.com/Automattic/themes/issues/5893