### PR TITLE
Blockbase: Only display font customizer options if not enabled in site editor

### DIFF
--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -209,8 +209,8 @@ class GlobalStylesFontsCustomizer {
 	);
 
 	function __construct() {
-		if ( $this->site_editor_is_implementing_google_fonts() ) {
-			add_action( 'customize_register', array( $this, 'display_section_redirecting_users_to_site_editor' ) );
+		if ( $this->site_editor_is_implementing_google_fonts()  ) {
+			add_action( 'customize_register', array( $this, 'init_deprecation_notice' ) );
 			return;
 		}
 
@@ -236,31 +236,36 @@ class GlobalStylesFontsCustomizer {
 		return $jetpack_has_google_fonts_module && $gutenberg_webfonts_api_supports_enqueueing && Jetpack::is_module_active( 'google-fonts' );
 	}
 
-	function display_section_redirecting_users_to_site_editor( $wp_customize ) {
+	function init_deprecation_notice( $wp_customize ) {
 		$wp_customize->add_section(
 			$this->section_key,
 			array(
 				'capability'  => 'edit_theme_options',
-				'description' => 'Updating fonts for this theme is now even easier! Please use the site editor to select and preview different font families.',
 				'title'       => __( 'Fonts', 'blockbase' ),
+			)
+		);
+
+		$wp_customize->add_control(
+			$this->section_key . '-v1-blockbase-font-deprecation-notice',
+			array(
+				'type'        => 'hidden',
+				'description' => '<div class="notice notice-info">
+				<p>' . __( 'Updating fonts for this theme is now even easier! Use the site editor to select and preview different font families.', 'blockbase' ) . '</p>
+				</div>',
+				'settings'    => array(),
+				'section'     => $this->section_key,
 			)
 		);
 
 		$wp_customize->add_control(
 			$this->section_key . '-site-editor-button',
 			array(
-				'type'        => 'button',
+				'type'        => 'hidden',
+				'description' => sprintf( '<a class="button button-primary" href=%s style="font-style: normal;" >Use Site Editor</a>', esc_url( admin_url( 'site-editor.php' ) ) ),
 				'settings'    => array(),
 				'section'     => $this->section_key,
-				'input_attrs' => array(
-					'value' => __( 'Use Site Editor', 'blockbase' ),
-					'class' => 'button button-link',
-					'data-action' => sprintf("%s", esc_url( admin_url( 'site-editor.php' ) ) ),
-				),
 			)
 		);
-
-		$wp_customize->get_section( $this->section_key );
 	}
 
 

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -444,7 +444,6 @@ class GlobalStylesFontsCustomizer {
 		// Add a reset button
 		$this->font_control_default_body    = $body_font_default['fontSlug'];
 		$this->font_control_default_heading = $heading_font_default['fontSlug'];
-
 		$wp_customize->add_control(
 			$this->section_key . '-reset-button',
 			array(

--- a/blockbase/inc/customizer/wp-customize-fonts.php
+++ b/blockbase/inc/customizer/wp-customize-fonts.php
@@ -445,25 +445,21 @@ class GlobalStylesFontsCustomizer {
 		$this->font_control_default_body    = $body_font_default['fontSlug'];
 		$this->font_control_default_heading = $heading_font_default['fontSlug'];
 
-		if ( $this->site_editor_is_implementing_google_fonts() ) {
-			// TODO: Render HTML notification to user to use google fonts in the site editor instead of the customizer
-		} else {
-			$wp_customize->add_control(
-				$this->section_key . '-reset-button',
-				array(
-					'type'        => 'button',
-					'settings'    => array(),
-					'section'     => $this->section_key,
-					'input_attrs' => array(
-						'value' => __( 'Reset to Default', 'blockbase' ),
-						'class' => 'button button-link',
-					),
-				)
-			);
-	
-			$this->add_setting_and_control( $wp_customize, 'body', __( 'Body font', 'blockbase' ), $body_font_default['fontSlug'], $body_font_selected_font_slug, 'sanitize_title' );
-			$this->add_setting_and_control( $wp_customize, 'heading', __( 'Heading font', 'blockbase' ), $heading_font_default['fontSlug'], $heading_font_selected_font_slug, 'sanitize_title' );
-		}
+		$wp_customize->add_control(
+			$this->section_key . '-reset-button',
+			array(
+				'type'        => 'button',
+				'settings'    => array(),
+				'section'     => $this->section_key,
+				'input_attrs' => array(
+					'value' => __( 'Reset to Default', 'blockbase' ),
+					'class' => 'button button-link',
+				),
+			)
+		);
+
+		$this->add_setting_and_control( $wp_customize, 'body', __( 'Body font', 'blockbase' ), $body_font_default['fontSlug'], $body_font_selected_font_slug, 'sanitize_title' );
+		$this->add_setting_and_control( $wp_customize, 'heading', __( 'Heading font', 'blockbase' ), $heading_font_default['fontSlug'], $heading_font_selected_font_slug, 'sanitize_title' );
 	}
 
 	function get_font_family( $array, $configuration ) {


### PR DESCRIPTION
### Description
More context can be found here paYE8P-1B3-p2#comment-1506.

This PR displays a deprecation notice in the blockbase font customizer if gutenberg and jetpack have the correct versions and configurations to have site editor google fonts enabled.

**NOTE:** For dotcom simple sites

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Screenshots
#### Before
<img width="1439" alt="Screen Shot 2022-05-06 at 1 25 09 PM" src="https://user-images.githubusercontent.com/5414230/167211774-e0e5b651-e684-49c5-82a8-fa4d39d4bed0.png">

#### After
<img width="1197" alt="Screen Shot 2022-05-06 at 3 58 11 PM" src="https://user-images.githubusercontent.com/5414230/167226017-32b9373c-37bc-4bed-b62a-6e48d7294ac9.png">

#### Testing
1. Sandbox a simple site
2. Copy the changes made in `blockbase/inc/customizer/wp-customize-fonts.php` to its mirrored file in the dotcom codebase `wp-content/themes/pub/blockbase/inc/customizer/wp-customize-fonts.php`
3. Activate a Blockbase theme or a theme that uses Blockbase as a parent ( Blockbase, Videomaker, etc. ).
4. Navigate to the Customizer
5. Navigate to the fonts panel
6. Verify that fonts are no longer available for selection for dotcom simple sites.
7. Repeat steps and test on an atomic site

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/63229