### PR TITLE
#3080: Canard: Fix byline in blog post block

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -1959,6 +1959,7 @@ a:visited {
 	display: none;
 }
 .group-blog .byline,
+.wpnbha .byline,
 .wpnbpc .byline {
 	display: inline;
 }

--- a/canard/style.css
+++ b/canard/style.css
@@ -1958,8 +1958,8 @@ a:visited {
 .updated:not(.published) {
 	display: none;
 }
-.wpnbpc .byline,
-.group-blog .byline {
+.group-blog .byline,
+.wpnbpc .byline {
 	display: inline;
 }
 .byline img {

--- a/canard/style.css
+++ b/canard/style.css
@@ -1958,6 +1958,7 @@ a:visited {
 .updated:not(.published) {
 	display: none;
 }
+.wpnbpc .byline,
 .group-blog .byline {
 	display: inline;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix `.byline` display in blog post carousel block by adding exception to `display: none` for `.byline` for the blog carousel block. Displaying `.byline` by default doesn't work as it messes up the post listing and shows the author where it wasn't before.

##### Before

<img width="1661" alt="Screenshot on 2022-05-07 at 12-29-58" src="https://user-images.githubusercontent.com/45246438/167264068-d9ec9977-4ede-4199-b7c4-a92da177fad1.png">


##### After

<img width="1718" alt="Screenshot on 2022-05-07 at 12-45-56" src="https://user-images.githubusercontent.com/45246438/167264098-7099e6e7-054b-4538-96de-4de130d5a80f.png">


#### Related issue(s):

https://github.com/Automattic/themes/issues/3080
