### PR TITLE
#4730: Canard: Fix Blog Post block thumbnail background

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -2136,9 +2136,7 @@ body:not(.group-blog) .sticky .entry-summary + .entry-meta > span:nth-of-type(3)
 
 /* Post Thumbnail */
 .post-thumbnail {
-	background: #000;
 	display: block;
-	height: 100%;
 	position: relative;
 	width: 100%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adjust background color and height in blog post block.

##### Before

<img width="1659" alt="Screenshot on 2022-05-09 at 13-03-02" src="https://user-images.githubusercontent.com/45246438/167462917-d73d86b8-0c95-462e-aade-6667e4881013.png">

##### After

<img width="2131" alt="Screenshot on 2022-05-09 at 13-13-02" src="https://user-images.githubusercontent.com/45246438/167463013-29d8bd77-cc20-4bdc-9827-942cd3a02892.png">


#### Related issue(s):

https://github.com/Automattic/themes/issues/4730