### PR TITLE
#4934: Canard: Fix highlight padding

### DIFF
--- a/canard/style.css
+++ b/canard/style.css
@@ -423,15 +423,12 @@ acronym {
 	border-bottom: 1px dotted #222;
 	cursor: help;
 }
-mark,
+mark:not(.has-inline-color),
 ins {
 	background: #d11415;
 	color: #fff;
 	padding: 0 0.2em;
 	text-decoration: none;
-}
-mark.has-inline-color {
-	padding: unset;
 }
 big {
 	font-size: 125%;

--- a/canard/style.css
+++ b/canard/style.css
@@ -430,6 +430,9 @@ ins {
 	padding: 0 0.2em;
 	text-decoration: none;
 }
+mark.has-inline-color {
+	padding: unset;
+}
 big {
 	font-size: 125%;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Added CSS fix to removing padding when inline color is set using highlight feature in Gutenberg.

##### Before

<img width="1530" alt="Screenshot on 2022-05-11 at 12-34-09" src="https://user-images.githubusercontent.com/45246438/167924179-4a66e1dc-d979-4cab-be92-c4352ecd71fb.png">


##### After

<img width="1602" alt="Screenshot on 2022-05-11 at 14-33-15" src="https://user-images.githubusercontent.com/45246438/167924090-a2b6fe30-e8ee-4bd7-83a3-1a0630957d4d.png">



#### Related issue(s):

https://github.com/Automattic/themes/issues/4934