### PR TITLE
Heiwa: Add site-footer-container css class to remove the gap between main and footer

### DIFF
--- a/heiwa/templates/header-footer-only.html
+++ b/heiwa/templates/header-footer-only.html
@@ -4,4 +4,4 @@
 <main class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:post-content {"layout":{"inherit":true}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->


### PR DESCRIPTION
A minor edit that intends to remove the gap between the main and the footer. Thanks in advance for the review!

**Before:**
<img width="1440" alt="Screenshot 2022-05-12 at 15 13 20" src="https://user-images.githubusercontent.com/908665/168096589-413e70b8-48e5-44ab-8d5b-149202232624.png">

**After:**
<img width="1438" alt="Screenshot 2022-05-12 at 15 14 18" src="https://user-images.githubusercontent.com/908665/168096656-0ead5e31-ffe8-4b93-861d-7d028e69346a.png">

