### PR TITLE
#5524: Shoreditch: Fix editor text highlight colors

### DIFF
--- a/shoreditch/css/editor-blocks.css
+++ b/shoreditch/css/editor-blocks.css
@@ -12,6 +12,7 @@ Description: Used to style Gutenberg Blocks in the editor.
 4.0 Blocks - Formatting
 5.0 Blocks - Layout Elements
 6.0 Blocks - Widgets
+7.0 Blocks - Colors
 
 --------------------------------------------------------------*/
 
@@ -612,4 +613,88 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-latest-comments__comment-date {
 	font-size: 80%;
+}
+
+/*--------------------------------------------------------------
+7.0 Blocks - Colors
+--------------------------------------------------------------*/
+
+.has-blue-color,
+.has-blue-color:hover,
+.has-blue-color:focus,
+.has-blue-color:active,
+.has-blue-color:visited {
+	color: #3e69dc;
+}
+
+.has-blue-background-color,
+.has-blue-background-color:hover,
+.has-blue-background-color:focus,
+.has-blue-background-color:active,
+.has-blue-background-color:visited {
+	background-color: #3e69dc;
+}
+
+.has-dark-gray-color,
+.has-dark-gray-color:hover,
+.has-dark-gray-color:focus,
+.has-dark-gray-color:active,
+.has-dark-gray-color:visited {
+	color: #2c313f;
+}
+
+.has-dark-gray-background-color,
+.has-dark-gray-background-color:hover,
+.has-dark-gray-background-color:focus,
+.has-dark-gray-background-color:active,
+.has-dark-gray-background-color:visited {
+	background-color: #2c313f;
+}
+
+.has-medium-gray-color,
+.has-medium-gray-color:hover,
+.has-medium-gray-color:focus,
+.has-medium-gray-color:active,
+.has-medium-gray-color:visited {
+	color: #73757D;
+}
+
+.has-medium-gray-background-color,
+.has-medium-gray-background-color:hover,
+.has-medium-gray-background-color:focus,
+.has-medium-gray-background-color:active,
+.has-medium-gray-background-color:visited {
+	background-color: #73757D;
+}
+
+.has-light-gray-color,
+.has-light-gray-color:hover,
+.has-light-gray-color:focus,
+.has-light-gray-color:active,
+.has-light-gray-color:visited {
+	color: #f3f3f3;
+}
+
+.has-light-gray-background-color,
+.has-light-gray-background-color:hover,
+.has-light-gray-background-color:focus,
+.has-light-gray-background-color:active,
+.has-light-gray-background-color:visited {
+	background-color: #f3f3f3;
+}
+
+.has-white-color,
+.has-white-color:hover,
+.has-white-color:focus,
+.has-white-color:active,
+.has-white-color:visited {
+	color: #fff;
+}
+
+.has-white-background-color,
+.has-white-background-color:hover,
+.has-white-background-color:focus,
+.has-white-background-color:active,
+.has-white-background-color:visited {
+	background-color: #fff;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Added colors to `editor-styles.css` to fix color highlight issue.

#### Before

**Editor**

<img width="424" alt="Screenshot on 2022-05-12 at 13-19-29" src="https://user-images.githubusercontent.com/45246438/168134450-b7b074a1-56e2-434c-b44e-0deb20dbb788.png">

<img width="334" alt="Screenshot on 2022-05-12 at 13-21-19" src="https://user-images.githubusercontent.com/45246438/168134544-0bba22cc-0cdb-4fbf-b1c7-6eef3571dd6e.png">


**Frontend**

<img width="362" alt="Screenshot on 2022-05-12 at 13-20-22" src="https://user-images.githubusercontent.com/45246438/168134638-7e14a47d-7b3c-42b4-a52f-3602a1264417.png">

#### After

<img width="336" alt="Screenshot on 2022-05-12 at 13-23-27" src="https://user-images.githubusercontent.com/45246438/168134379-043a4759-c1da-4618-b459-08270b17ffb9.png">


### Related issue(s):

https://github.com/Automattic/themes/issues/5524