### PR TITLE
#5737: Apostrophe 2: Fix VideoPress display if alignwide or alignfull

### DIFF
--- a/apostrophe-2/css/blocks.css
+++ b/apostrophe-2/css/blocks.css
@@ -93,7 +93,6 @@ body {
 
 .apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignfull iframe {
 	width: 100% !important;
-	height: 100% !important;
 }
 
 .apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignfull:before {
@@ -101,15 +100,6 @@ body {
 	display: block;
 }
 
-.apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignfull iframe {
-	position:  absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	width: 100% !important;
-	height: 100% !important;
-}
 
 /* Wide Width */
 
@@ -123,20 +113,6 @@ body {
 		position: relative;
 	}
 
-	.apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignwide:before {
-		content: "";
-		display: block;
-	}
-
-	.apostrophe-2-no-sidebar .wp-block-embed.is-type-video.alignwide iframe {
-		position:  absolute;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
-		width: 100%;
-		height: 100%;
-	}
 }
 
 /* Nested Blocks */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


##### Before

<img width="1121" alt="Screenshot on 2022-05-13 at 11-39-57" src="https://user-images.githubusercontent.com/45246438/168322657-9dd83348-c9d3-446e-807b-8d4a6cadfae0.png">


##### After

<img width="1273" alt="Screenshot on 2022-05-13 at 11-54-52" src="https://user-images.githubusercontent.com/45246438/168322780-1a8fdb9d-4e70-4a4d-a5c7-638ae3ddb9fd.png">

#### Related issue(s):

https://github.com/Automattic/themes/issues/5737