### PR TITLE
Rebalance: Add page password protection for portfolio page

### DIFF
--- a/rebalance/portfolio-page.php
+++ b/rebalance/portfolio-page.php
@@ -15,74 +15,93 @@ get_header(); ?>
 	<div id="primary" class="content-area">
 
 		<?php
-			/*
-			 * Include the Featured Project loop.
-			 * - if featured posts exist, collect their IDs and exclude them from the main loop
-			 */
-			if ( rebalance_has_featured_projects( 1 ) ) {
-				$featured_ids = rebalance_get_featured_project_ids();
-				get_template_part( 'template-parts/section', 'featured' );
-			} else {
-				$featured_ids = null;
-			} ?>
+		if ( post_password_required() ) :
+				the_content();
 
-		<main id="main" class="site-main" role="main">
+			else :
 
-			<?php // Set Up New Query
+				/*
+				 * Include the Featured Project loop.
+				 * - if featured posts exist, collect their IDs and exclude them from the main loop
+				 */
+				if ( rebalance_has_featured_projects( 1 ) ) {
+					$featured_ids = rebalance_get_featured_project_ids();
+					get_template_part( 'template-parts/section', 'featured' );
+				} else {
+					$featured_ids = null;
+				}
+				?>
+
+				<main id="main" class="site-main" role="main">
+
+				<?php
+				// Set Up New Query
 				if ( get_query_var( 'paged' ) ) :
 					$paged = get_query_var( 'paged' );
-				elseif ( get_query_var( 'page' ) ) :
-					$paged = get_query_var( 'page' );
-				else :
-					$paged = 1;
-				endif;
+					elseif ( get_query_var( 'page' ) ) :
+						$paged = get_query_var( 'page' );
+					else :
+						$paged = 1;
+					endif;
 
-				$posts_per_page = get_option( 'jetpack_portfolio_posts_per_page', '10' );
+					$posts_per_page = get_option( 'jetpack_portfolio_posts_per_page', '10' );
 
-				$temp = null;
-				$project_query = $temp;
-				$project_query = new WP_Query();
-				$project_query->query( array(
-					'post_type'    => 'jetpack-portfolio',
-					'paged'        => $paged,
-					'posts_per_page' => $posts_per_page,
-					'post__not_in' => $featured_ids
-				) ); ?>
+					$temp          = null;
+					$project_query = $temp;
+					$project_query = new WP_Query();
+					$project_query->query(
+						array(
+							'post_type'      => 'jetpack-portfolio',
+							'paged'          => $paged,
+							'posts_per_page' => $posts_per_page,
+							'post__not_in'   => $featured_ids,
+						)
+					);
+				?>
 
-			<?php if ( $project_query->have_posts() ) : ?>
+				<?php if ( $project_query->have_posts() ) : ?>
 
-				<div id="infinite-wrap">
+					<div id="infinite-wrap">
 
-					<?php /* Start the Loop */ ?>
-					<?php while ( $project_query->have_posts() ) : $project_query->the_post(); ?>
-
+						<?php /* Start the Loop */ ?>
 						<?php
-							/*
-							 * Include the Card template for the project content.
-							 */
-							get_template_part( 'template-parts/content', 'card' );
-						?>
+						while ( $project_query->have_posts() ) :
+							$project_query->the_post();
+							?>
 
-					<?php endwhile; ?>
+							<?php
+								/*
+								 * Include the Card template for the project content.
+								 */
+								get_template_part( 'template-parts/content', 'card' );
+							?>
 
-				</div>
+						<?php endwhile; ?>
 
-				<?php rebalance_paging_nav( $project_query->max_num_pages ); ?>
+					</div>
 
-			<?php else : ?>
+					<?php rebalance_paging_nav( $project_query->max_num_pages ); ?>
 
-				<?php get_template_part( 'template-parts/content', 'none' ); ?>
+				<?php else : ?>
 
-			<?php endif; ?>
+					<?php get_template_part( 'template-parts/content', 'none' ); ?>
 
-			<?php // Empty queries
-				$project_query = $temp;
-				$temp = null; ?>
+				<?php endif; ?>
 
-			<?php // Reset posts so our normal loop isn't affected
-				wp_reset_postdata(); ?>
+				<?php
+				// Empty queries
+					$project_query = $temp;
+					$temp          = null;
+				?>
 
-		</main><!-- #main -->
+				<?php
+				// Reset posts so our normal loop isn't affected
+					wp_reset_postdata();
+				?>
+
+			</main><!-- #main -->
+
+		<?php endif; // end post_password_required() ?>
 
 	</div><!-- #primary -->
 

--- a/rebalance/portfolio-page.php
+++ b/rebalance/portfolio-page.php
@@ -15,6 +15,7 @@ get_header(); ?>
 	<div id="primary" class="content-area">
 
 		<?php
+		// if password is required for this page, let's use the_content() to display the password form.
 		if ( post_password_required() ) :
 				the_content();
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Rebalance theme has two issues related to the password-protected page:
* it doesn't show the password form if the page is protected with a password. It happens because the Portfolio Page template doesn't display the page content using the `the_content()` function, which internally displays the password form.
* portfolio items are displayed even if the page is protected. It behaves that way because portfolio items are not wrapped with a password check. 

This PR fixes both issues: it wraps the code responsible for displaying the portfolio with the condition that checks for password protection. Then it displays `the_content()` if a password is required. I used a similar implementation to one from the Blask theme.

#### Testing steps

1. Log in to WP Admin
2. Install the Jetpack plugin and ensure that the portfolio feature is enabled
3. Ensure that Rebalance theme from this PR is installed and enabled
4. Go to Portfolio -> All Projects and add one or more projects
5. Go to Pages -> All Pages and add a new page:
* add any content
* ensure that “Template" is “Portfolio Page.”
* set “Visibility” to “Password protected,” choose a password
6. Save changes and open the page on the frontend

The expected behavior is that portfolio items and page content are not displayed, and the password form is displayed instead. Then, when the user enters the password, they should see portfolio items. They shouldn't see the page content.

#### Related issue(s):

The following issue tracks this bug, occurring for a few other themes.

https://github.com/Automattic/wp-calypso/issues/60135
