### PR TITLE
Lodestar: Add page password protection for portfolio page

### DIFF
--- a/lodestar/components/features/portfolio/content-portfolio-template.php
+++ b/lodestar/components/features/portfolio/content-portfolio-template.php
@@ -7,8 +7,10 @@
 ?>
 
 <?php
-	if ( have_posts() ) :
-		while ( have_posts() ) : the_post(); ?>
+if ( have_posts() ) :
+	while ( have_posts() ) :
+		the_post();
+		?>
 
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 				<header class="entry-header">
@@ -20,11 +22,14 @@
 				</div>
 			</article><!-- #post-<?php the_ID(); ?> -->
 
-		<?php endwhile;
+		<?php
+		endwhile;
 	endif;
 ?>
 
-<?php
+<?php if ( ! post_password_required() ) : ?>
+
+	<?php
 	if ( get_query_var( 'paged' ) ) {
 		$paged = get_query_var( 'paged' );
 	} elseif ( get_query_var( 'page' ) ) {
@@ -33,34 +38,39 @@
 		$paged = 1;
 	}
 
-	/**
-	 * Query projects with a fixed posts-per-page. The category sorting in the template works
-	 * best if all projects are loaded. A limit of 120 makes sure not too many projects are
-	 * loaded at once, and the page speed is helped by lazy loading images.
-	 */
-	$args = array(
-		'post_type'      => 'jetpack-portfolio',
-		'posts_per_page' => '120',
-		'paged'          => $paged,
-	);
-	$project_query = new WP_Query ( $args );
-?>
+		/**
+		 * Query projects with a fixed posts-per-page. The category sorting in the template works
+		 * best if all projects are loaded. A limit of 120 makes sure not too many projects are
+		 * loaded at once, and the page speed is helped by lazy loading images.
+		 */
+		$args          = array(
+			'post_type'      => 'jetpack-portfolio',
+			'posts_per_page' => '120',
+			'paged'          => $paged,
+		);
+		$project_query = new WP_Query( $args );
+		?>
 
 
-<div class="portfolio-projects" id="portfolio-projects">
+	<div class="portfolio-projects" id="portfolio-projects">
 
-	<?php if ( post_type_exists( 'jetpack-portfolio' ) && $project_query -> have_posts() ) : ?>
+		<?php if ( post_type_exists( 'jetpack-portfolio' ) && $project_query->have_posts() ) : ?>
 
-		<?php lodestar_project_terms(); ?>
+			<?php lodestar_project_terms(); ?>
 
-		<div class="portfolio-wrapper" id="main">
+			<div class="portfolio-wrapper" id="main">
 
-			<?php while ( $project_query -> have_posts() ) : $project_query -> the_post(); ?>
+				<?php
+				while ( $project_query->have_posts() ) :
+					$project_query->the_post();
+					?>
 
-				<?php get_template_part( 'components/features/portfolio/content', 'portfolio' ); ?>
+					<?php get_template_part( 'components/features/portfolio/content', 'portfolio' ); ?>
 
-			<?php endwhile; ?>
-		</div><!-- .portfolio-wrapper -->
+				<?php endwhile; ?>
+			</div><!-- .portfolio-wrapper -->
 
-	<?php endif; ?>
-</div><!-- .portfolio-projects -->
+		<?php endif; ?>
+	</div><!-- .portfolio-projects -->
+
+<?php endif; // end post_password_required() ?>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Lodestar theme has an issue related to the password-protected page: portfolio items are displayed even if the page is protected. It behaves that way because portfolio items are not wrapped with a password check.

This PR fixes the issue: it wraps the code responsible for displaying the portfolio with the condition that checks for password protection.

#### Testing steps:

1. Log in to WP Admin
2. Install the Jetpack plugin and ensure that the portfolio feature is enabled
3. Ensure that the Lodestar theme from this PR is installed and enabled
4. Go to Portfolio -> All Projects and add one or more projects
5. Go to Pages -> All Pages and add a new page:

- add any content
- ensure that “Template" is “Portfolio Template.”
- set “Visibility” to “Password protected.”
6. Save changes and open the page on the frontend

The expected behavior is that portfolio items and page content are not displayed, and the password form is displayed instead. Then, when the user enters the password, they should see page content and portfolio items.

![Screen Shot 2022-05-18 at 08 42 13](https://user-images.githubusercontent.com/727413/168974412-130d6966-f25b-48c1-8d0d-4e813e1dc4f5.png)

#### Related issue(s):

The following issue tracks this bug, occurring for a few other themes.

https://github.com/Automattic/wp-calypso/issues/60135