### PR TITLE
Sketch: Add page password protection for portfolio page

### DIFF
--- a/sketch/portfolio-page.php
+++ b/sketch/portfolio-page.php
@@ -11,36 +11,48 @@ get_header(); ?>
 		<main id="main" class="site-main" role="main">
 
 		<?php if ( sketch_has_featured_posts( 1 ) ) : ?>
-		    <div class="featured-content">
-		        <?php get_template_part( 'content-featured' ); ?>
-		    </div>
+			<div class="featured-content">
+				<?php get_template_part( 'content-featured' ); ?>
+			</div>
 		<?php endif; ?>
 
-		<?php if ( ! get_theme_mod( 'sketch_hide_portfolio_page_content' ) ) : ?>
-			<?php while ( have_posts() ) : the_post(); ?>
+		<?php if ( post_password_required() ) : ?>
 
-				<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
+			<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
+			<?php the_content(); ?>
 
-				<div class="page-content">
-					<?php
-						the_content();
-						wp_link_pages( array(
-							'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'sketch' ) . '</span>',
-							'after'       => '</div>',
-							'link_before' => '<span>',
-							'link_after'  => '</span>',
-						) );
+		<?php else : ?>
+
+			<?php if ( ! get_theme_mod( 'sketch_hide_portfolio_page_content' ) ) : ?>
+				<?php
+				while ( have_posts() ) :
+					the_post();
 					?>
-					<?php edit_post_link( __( 'Edit', 'sketch' ), '<div class="entry-meta"><span class="edit-link">', '</span></div>' ); ?>
 
-				</div><!-- .page-content -->
+					<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
 
-			<?php endwhile; // end of the loop. ?>
-		<?php endif; ?>
+					<div class="page-content">
+						<?php
+							the_content();
+							wp_link_pages(
+								array(
+									'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'sketch' ) . '</span>',
+									'after'       => '</div>',
+									'link_before' => '<span>',
+									'link_after'  => '</span>',
+								)
+							);
+						?>
+						<?php edit_post_link( __( 'Edit', 'sketch' ), '<div class="entry-meta"><span class="edit-link">', '</span></div>' ); ?>
+
+					</div><!-- .page-content -->
+
+				<?php endwhile; // end of the loop. ?>
+			<?php endif; ?>
 
 			<?php
-				if ( get_query_var( 'paged' ) ) :
-					$paged = get_query_var( 'paged' );
+			if ( get_query_var( 'paged' ) ) :
+				$paged = get_query_var( 'paged' );
 				elseif ( get_query_var( 'page' ) ) :
 					$paged = get_query_var( 'page' );
 				else :
@@ -55,27 +67,28 @@ get_header(); ?>
 					'posts_per_page' => $posts_per_page,
 				);
 
-				$project_query = new WP_Query ( $args );
+				$project_query = new WP_Query( $args );
 
-				if ( $project_query -> have_posts() ) :
-			?>
+				if ( $project_query->have_posts() ) :
+					?>
 
 			<div class="projects clear">
 
-			<?php
-				while ( $project_query -> have_posts() ) : $project_query -> the_post();
+					<?php
+					while ( $project_query->have_posts() ) :
+						$project_query->the_post();
 
-					get_template_part( 'content', 'portfolio' );
+						get_template_part( 'content', 'portfolio' );
 
 				endwhile;
-			?>
+					?>
 
 			</div><!-- .projects -->
 
-			<?php
-				sketch_paging_nav( $project_query->max_num_pages );
-				wp_reset_postdata();
-			?>
+					<?php
+					sketch_paging_nav( $project_query->max_num_pages );
+					wp_reset_postdata();
+					?>
 
 			<?php else : ?>
 
@@ -98,6 +111,7 @@ get_header(); ?>
 				</section><!-- .no-results -->
 
 			<?php endif; ?>
+		<?php endif; // end post_password_required() ?>
 
 		</main><!-- #main -->
 	</div><!-- #primary -->

--- a/sketch/portfolio-page.php
+++ b/sketch/portfolio-page.php
@@ -19,7 +19,10 @@ get_header(); ?>
 		<?php if ( post_password_required() ) : ?>
 
 			<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
-			<?php the_content(); ?>
+
+			<div class="page-content">
+				<?php the_content(); ?>
+			</div><!-- .page-content -->
 
 		<?php else : ?>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Sketch theme has an issue related to the password-protected page: portfolio items are displayed even if the page is protected. It behaves that way because portfolio items are not wrapped with a password check.

This PR fixes the issue: it wraps the code responsible for displaying the portfolio with the condition that checks for password protection.

#### Testing steps:

1. Log in to WP Admin
2. Install the Jetpack plugin and ensure that the portfolio feature is enabled
3. Ensure that the Sketch theme from this PR is installed and enabled
4. Go to Portfolio -> All Projects and add one or more projects
5. Go to Pages -> All Pages and add a new page:
- add any content
- ensure that “Template" is “Portfolio Page Template”
- set “Visibility” to “Password protected”
6. Save changes and open the page on the frontend

The expected behavior is that portfolio items and page content are not displayed, and the password form is displayed instead. Then, when the user enters the password, they should see page content and portfolio items.

![Screen Shot 2022-05-18 at 09 08 50](https://user-images.githubusercontent.com/727413/168978717-5e17cef8-5a04-4b2d-8867-e36d46088f4f.png)

#### Related issue(s):

The following issue tracks this bug, occurring for a few other themes.

https://github.com/Automattic/wp-calypso/issues/60135