### PR TITLE
Illustratr: Add page password protection for portfolio page

### DIFF
--- a/illustratr/page-templates/portfolio-page.php
+++ b/illustratr/page-templates/portfolio-page.php
@@ -11,7 +11,10 @@ get_header(); ?>
 		<main id="main" class="site-main" role="main">
 
 		<?php if ( ! get_theme_mod( 'illustratr_hide_portfolio_page_content' ) ) : ?>
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<?php if ( '' != get_the_post_thumbnail() ) : ?>
 					<div class="entry-thumbnail">
@@ -24,12 +27,14 @@ get_header(); ?>
 				<div class="page-content">
 					<?php
 						the_content();
-						wp_link_pages( array(
-							'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'illustratr' ) . '</span>',
-							'after'       => '</div>',
-							'link_before' => '<span>',
-							'link_after'  => '</span>',
-						) );
+						wp_link_pages(
+							array(
+								'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'illustratr' ) . '</span>',
+								'after'       => '</div>',
+								'link_before' => '<span>',
+								'link_after'  => '</span>',
+							)
+						);
 					?>
 				</div><!-- .page-content -->
 
@@ -39,8 +44,8 @@ get_header(); ?>
 		<?php endif; ?>
 
 			<?php
-				if ( get_query_var( 'paged' ) ) :
-					$paged = get_query_var( 'paged' );
+			if ( get_query_var( 'paged' ) ) :
+				$paged = get_query_var( 'paged' );
 				elseif ( get_query_var( 'page' ) ) :
 					$paged = get_query_var( 'page' );
 				else :
@@ -48,19 +53,22 @@ get_header(); ?>
 				endif;
 
 				$posts_per_page = get_option( 'jetpack_portfolio_posts_per_page', '10' );
-				$args = array(
+				$args           = array(
 					'post_type'      => 'jetpack-portfolio',
 					'posts_per_page' => $posts_per_page,
 					'paged'          => $paged,
 				);
-				$project_query = new WP_Query ( $args );
-				if ( post_type_exists( 'jetpack-portfolio' ) && $project_query -> have_posts() ) :
-			?>
+				$project_query  = new WP_Query( $args );
+				if ( post_type_exists( 'jetpack-portfolio' ) && $project_query->have_posts() ) :
+					?>
 
 				<div class="portfolio-wrapper">
 
 					<?php /* Start the Loop */ ?>
-					<?php while ( $project_query -> have_posts() ) : $project_query -> the_post(); ?>
+					<?php
+					while ( $project_query->have_posts() ) :
+						$project_query->the_post();
+						?>
 
 						<?php get_template_part( 'content', 'portfolio' ); ?>
 
@@ -68,10 +76,10 @@ get_header(); ?>
 
 				</div><!-- .portfolio-wrapper -->
 
-				<?php
+					<?php
 					illustratr_paging_nav( $project_query->max_num_pages );
 					wp_reset_postdata();
-				?>
+					?>
 
 			<?php else : ?>
 

--- a/illustratr/page-templates/portfolio-page.php
+++ b/illustratr/page-templates/portfolio-page.php
@@ -10,42 +10,49 @@ get_header(); ?>
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 
-		<?php if ( ! get_theme_mod( 'illustratr_hide_portfolio_page_content' ) ) : ?>
-			<?php
-			while ( have_posts() ) :
-				the_post();
-				?>
+			<?php if ( post_password_required() ) : ?>
+				<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
+				<div class="page-content">
+					<?php the_content(); ?>
+				</div><!-- .page-content -->
+			<?php else : ?>
 
-				<?php if ( '' != get_the_post_thumbnail() ) : ?>
-					<div class="entry-thumbnail">
-						<?php the_post_thumbnail( 'illustratr-featured-image' ); ?>
-					</div><!-- .entry-thumbnail -->
+				<?php if ( ! get_theme_mod( 'illustratr_hide_portfolio_page_content' ) ) : ?>
+					<?php
+					while ( have_posts() ) :
+						the_post();
+						?>
+
+						<?php if ( '' != get_the_post_thumbnail() ) : ?>
+						<div class="entry-thumbnail">
+							<?php the_post_thumbnail( 'illustratr-featured-image' ); ?>
+						</div><!-- .entry-thumbnail -->
+					<?php endif; ?>
+
+						<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
+
+					<div class="page-content">
+						<?php
+							the_content();
+							wp_link_pages(
+								array(
+									'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'illustratr' ) . '</span>',
+									'after'       => '</div>',
+									'link_before' => '<span>',
+									'link_after'  => '</span>',
+								)
+							);
+						?>
+					</div><!-- .page-content -->
+
+						<?php edit_post_link( __( 'Edit', 'illustratr' ), '<div class="entry-meta"><span class="edit-link">', '</span></div>' ); ?>
+
+					<?php endwhile; // end of the loop. ?>
 				<?php endif; ?>
 
-				<?php the_title( '<header class="page-header"><h1 class="page-title">', '</h1></header>' ); ?>
-
-				<div class="page-content">
-					<?php
-						the_content();
-						wp_link_pages(
-							array(
-								'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'illustratr' ) . '</span>',
-								'after'       => '</div>',
-								'link_before' => '<span>',
-								'link_after'  => '</span>',
-							)
-						);
-					?>
-				</div><!-- .page-content -->
-
-				<?php edit_post_link( __( 'Edit', 'illustratr' ), '<div class="entry-meta"><span class="edit-link">', '</span></div>' ); ?>
-
-			<?php endwhile; // end of the loop. ?>
-		<?php endif; ?>
-
-			<?php
-			if ( get_query_var( 'paged' ) ) :
-				$paged = get_query_var( 'paged' );
+				<?php
+				if ( get_query_var( 'paged' ) ) :
+					$paged = get_query_var( 'paged' );
 				elseif ( get_query_var( 'page' ) ) :
 					$paged = get_query_var( 'page' );
 				else :
@@ -62,47 +69,49 @@ get_header(); ?>
 				if ( post_type_exists( 'jetpack-portfolio' ) && $project_query->have_posts() ) :
 					?>
 
-				<div class="portfolio-wrapper">
+					<div class="portfolio-wrapper">
 
 					<?php /* Start the Loop */ ?>
-					<?php
-					while ( $project_query->have_posts() ) :
-						$project_query->the_post();
-						?>
+						<?php
+						while ( $project_query->have_posts() ) :
+							$project_query->the_post();
+							?>
 
-						<?php get_template_part( 'content', 'portfolio' ); ?>
+							<?php get_template_part( 'content', 'portfolio' ); ?>
 
-					<?php endwhile; ?>
+						<?php endwhile; ?>
 
-				</div><!-- .portfolio-wrapper -->
+					</div><!-- .portfolio-wrapper -->
 
 					<?php
 					illustratr_paging_nav( $project_query->max_num_pages );
 					wp_reset_postdata();
 					?>
 
-			<?php else : ?>
+				<?php else : ?>
 
-				<section class="no-results not-found">
-					<header class="page-header">
-						<h1 class="page-title"><?php _e( 'Nothing Found', 'illustratr' ); ?></h1>
-					</header><!-- .page-header -->
+					<section class="no-results not-found">
+						<header class="page-header">
+							<h1 class="page-title"><?php _e( 'Nothing Found', 'illustratr' ); ?></h1>
+						</header><!-- .page-header -->
 
-					<div class="page-content">
-						<?php if ( current_user_can( 'publish_posts' ) ) : ?>
+						<div class="page-content">
+							<?php if ( current_user_can( 'publish_posts' ) ) : ?>
 
-							<p><?php printf( __( 'Ready to publish your first project? <a href="%1$s">Get started here</a>.', 'illustratr' ), esc_url( admin_url( 'post-new.php?post_type=jetpack-portfolio' ) ) ); ?></p>
+								<p><?php printf( __( 'Ready to publish your first project? <a href="%1$s">Get started here</a>.', 'illustratr' ), esc_url( admin_url( 'post-new.php?post_type=jetpack-portfolio' ) ) ); ?></p>
 
-						<?php else : ?>
+							<?php else : ?>
 
-							<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'illustratr' ); ?></p>
-							<?php get_search_form(); ?>
+								<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'illustratr' ); ?></p>
+								<?php get_search_form(); ?>
 
-						<?php endif; ?>
-					</div><!-- .page-content -->
-				</section><!-- .no-results -->
+							<?php endif; ?>
+						</div><!-- .page-content -->
+					</section><!-- .no-results -->
 
-			<?php endif; ?>
+				<?php endif; ?>
+
+			<?php endif; // end post_password_required() ?>
 
 		</main><!-- #main -->
 	</div><!-- #primary -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Illustratr theme has an issue related to the password-protected page: portfolio items are displayed even if the page is protected. It behaves that way because portfolio items are not wrapped with a password check.

This PR fixes the issue: it wraps the code responsible for displaying the portfolio with the condition that checks for password protection.

#### Testing steps:

1. Log in to WP Admin
2. Install the Jetpack plugin and ensure that the portfolio feature is enabled
3. Ensure that the Illustratr theme from this PR is installed and enabled
4. Go to Portfolio -> All Projects and add one or more projects
5. Go to Pages -> All Pages and add a new page:
* add any content
* ensure that “Template" is “Portfolio Page Template”
* set “Visibility” to “Password protected”
6. Save changes and open the page on the frontend

The expected behavior is that portfolio items and page content are not displayed, and the password form is displayed instead. Then, when the user enters the password, they should see page content and portfolio items.

![Screen Shot 2022-05-18 at 13 45 45](https://user-images.githubusercontent.com/727413/169031517-4def2625-cf28-41c1-b9a4-a89b22cd06ce.png)

#### Related issue(s):

The following issue tracks this bug, occurring for a few other themes.

https://github.com/Automattic/wp-calypso/issues/60135
