### PR TITLE
Fix issue with duplicate title tags in blockbase

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -17,9 +17,6 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		// Add support for post thumbnails.
 		add_theme_support( 'post-thumbnails' );
 
-		// Declare that there are no <title> tags and allow WordPress to provide them
-		add_theme_support( 'title-tag' );
-
 		// Experimental support for adding blocks inside nav menus
 		add_theme_support( 'block-nav-menus' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

All Blockbase (free & premium) child themes have two <title> tags rendering on the page.

The extra title tag comes from `wp-includes/block-template.php`. There's a `wp-head` action that gets triggered for themes with `title-tag` support and outputs a `<title>` tag.

See https://github.com/Automattic/themes/issues/5702 for the full
discussion but the gist is that `title-tag` support is redundant for block
themes.

#### Testing

1. Create a test wpcom site and pick any blockbase child theme (like Calvin, for example)
2. Go to the homepage of the site and view the page source in the browser.
3. You should see two <title> tags.

Now apply this branch.

1. Go to your test site and change to another blockbase child theme.
2. Go to the homepage of the site and view the page source in the browser.
3. You should see only one <title> tag.


#### Related issue(s):
Closes #5702