### PR TITLE
Curator: update link and button styles

### DIFF
--- a/curator/style.css
+++ b/curator/style.css
@@ -31,9 +31,14 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
 	padding: 0;
 }
-.wp-block-button__link:hover {
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
 	text-decoration: underline;
 	color: var(--wp--preset--color--primary);
+}
+.wp-block-button:is(.is-style-outline) .wp-block-button__link:hover {
+	background: var(--wp--preset--color--foreground);
+	border-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
 }
 .wp-block-button__link.wp-block-button__link:active {
 	color: var(--wp--preset--color--primary);
@@ -43,7 +48,9 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	border-bottom: .15rem dotted var(--wp--preset--color--primary);
 }
 .wp-block-button:is(.is-style-outline) .wp-block-button__link:focus {
-	outline: 1px dotted var(--wp--preset--color--foreground);
+	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
+	outline: 1px dotted var(--wp--preset--color--primary);
 }
 
 .wp-block-search__button.wp-block-search__button,

--- a/curator/style.css
+++ b/curator/style.css
@@ -46,6 +46,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus {
 	color: var(--wp--preset--color--primary);
 	border-bottom: .15rem dotted var(--wp--preset--color--primary);
+	text-decoration: none;
 }
 .wp-block-button:is(.is-style-outline) .wp-block-button__link:focus {
 	background-color: var(--wp--preset--color--primary);

--- a/curator/style.css
+++ b/curator/style.css
@@ -45,8 +45,10 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus {
 	color: var(--wp--preset--color--primary);
-	border-bottom: .15rem dotted var(--wp--preset--color--primary);
-	text-decoration: none;
+	text-decoration-line: underline;
+	text-decoration-thickness: .08rem;
+	text-decoration-style: dotted;
+	text-underline-offset: .1rem;
 }
 .wp-block-button:is(.is-style-outline) .wp-block-button__link:focus {
 	background-color: var(--wp--preset--color--primary);

--- a/curator/style.css
+++ b/curator/style.css
@@ -140,7 +140,8 @@ a:not(
 
 :is(
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content
+	.wp-block-navigation-link__content,
+	.wp-block-navigation-item__content
 ):focus {
 	text-decoration-line: underline;
 	text-decoration-style: dotted;
@@ -148,9 +149,10 @@ a:not(
 
 :is(
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content
+	.wp-block-navigation-link__content,
+	.wp-block-navigation-item__content
 ):active {
-	background-color: var(--wp--preset--color--tertiary);
+	text-decoration: underline;
 }
 
 

--- a/curator/style.css
+++ b/curator/style.css
@@ -127,7 +127,9 @@ a:not(
 
 a:not(
 	.wp-block-search__button,
-	.wp-block-button__link
+	.wp-block-button__link,
+	.wp-block-navigation-link__content,
+	.wp-block-navigation-item__content
 ):active {
 	text-decoration: none;
 	background-color: var(--wp--preset--color--tertiary);

--- a/curator/style.css
+++ b/curator/style.css
@@ -28,9 +28,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
  * https://github.com/WordPress/gutenberg/issues/27075
  */
 
-.wp-block-button:not(.is-style-outline) .wp-block-button__link {
-	padding: 0;
-}
 .wp-block-button__link:visited {
 	color: currentColor;
 }

--- a/curator/style.css
+++ b/curator/style.css
@@ -23,13 +23,16 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 
 /*
- * Button hover styles.
+ * Button pseudo-class styles.
  * Necessary until the following issue is resolved in Gutenberg:
  * https://github.com/WordPress/gutenberg/issues/27075
  */
 
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
 	padding: 0;
+}
+.wp-block-button__link:visited {
+	color: currentColor;
 }
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
 	text-decoration: underline;

--- a/curator/style.css
+++ b/curator/style.css
@@ -28,6 +28,9 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
  * https://github.com/WordPress/gutenberg/issues/27075
  */
 
+ .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background) {
+	padding: 0;
+}
 .wp-block-button__link:visited {
 	color: currentColor;
 }

--- a/curator/style.css
+++ b/curator/style.css
@@ -50,6 +50,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 .wp-block-button:is(.is-style-outline) .wp-block-button__link:focus {
 	background-color: var(--wp--preset--color--primary);
+	border-color: var(--wp--preset--color--primary);
 	color: var(--wp--preset--color--background);
 	outline: 1px dotted var(--wp--preset--color--primary);
 }

--- a/curator/style.css
+++ b/curator/style.css
@@ -132,7 +132,8 @@ a:not(
 
 :is(
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content
+	.wp-block-navigation-link__content,
+	.wp-block-navigation-item__content
 ):hover {
 	text-decoration: underline;
 }

--- a/curator/style.css
+++ b/curator/style.css
@@ -78,7 +78,8 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 ):is(
 	:focus
 ) {
-	outline: 1px dashed var(--wp--preset--color--foreground);
+	border: 1px solid var(--wp--preset--color--background);
+	outline: 1px dotted var(--wp--preset--color--foreground);
 }
 
 /*
@@ -92,7 +93,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-file .wp-block-file__button {
 	background-color: var(--wp--preset--color--foreground);
 	border-radius: 0;
-	border: none;
+	border: 1px solid var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	font-size: var(--wp--preset--typography--font-size--normal);
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);

--- a/curator/style.css
+++ b/curator/style.css
@@ -33,18 +33,17 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 .wp-block-button__link:hover {
 	text-decoration: underline;
-	color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--primary);
 }
 .wp-block-button__link.wp-block-button__link:active {
-	color: var(--wp--preset--color--background);
-	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--primary);
 }
 .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus {
-	color: var(--wp--preset--color--foreground);
-	border-bottom: 1px dashed var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--primary);
+	border-bottom: .15rem dotted var(--wp--preset--color--primary);
 }
 .wp-block-button:is(.is-style-outline) .wp-block-button__link:focus {
-	outline: 1px dashed var(--wp--preset--color--foreground);
+	outline: 1px dotted var(--wp--preset--color--foreground);
 }
 
 .wp-block-search__button.wp-block-search__button,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR updates the link and button styles to match the mocks in #5996.

Default:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/1645628/169881686-c193ba0a-b555-43fe-b9e0-42ac440bb9be.png">

Hover:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/1645628/169881881-8946dea0-27e3-48ea-a162-a922a091f8c2.png">

Click/focus:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/1645628/169883199-001731aa-bc0b-413d-9291-d9b97a5d48ca.png">

Active:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/1645628/169883338-24b25542-d071-413d-8d8c-bb4d79467c95.png">

#### Related issue(s):
Closes #5996