### PR TITLE
Update all /pub themes so the theme-uri points to wordpress.com instead of github.com

### DIFF
--- a/alves/style.css
+++ b/alves/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Alves
-Theme URI: https://github.com/Automattic/themes/varia
+Theme URI: https://wordpress.com/theme/alves
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.

--- a/arbutus/style.css
+++ b/arbutus/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Arbutus
-Theme URI: https://github.com/automattic/themes/tree/trunk/arbutus
+Theme URI: https://wordpress.com/theme/arbutus
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Arbutus is a simple blogging theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles.

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Archeo
-Theme URI: https://github.com/Automattic/themes/tree/trunk/archeo
+Theme URI: https://wordpress.com/theme/archeo
 Author: Automattic
 Author URI: https://automattic.com
 Description: A theme inspired by Mayan history and culture

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Balasana
-Theme URI: https://github.com/Automattic/themes/master/balasana
+Theme URI: https://wordpress.com/theme/balasana
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Barnsbury
-Theme URI: https://github.com/Automattic/themes/master/barnsbury
+Theme URI: https://wordpress.com/theme/barnsbury
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.

--- a/blank-canvas-blocks/style.css
+++ b/blank-canvas-blocks/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Blank Canvas
-Theme URI: https://github.com/Automattic/themes/tree/trunk/blank-canvas-blocks
+Theme URI: https://wordpress.com/theme/blank-canvas-blocks
 Author: Automattic
 Author URI: https://automattic.com
 Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets by default, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.

--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Blockbase
-Theme URI: https://github.com/Automattic/themes/tree/trunk/blockbase
+Theme URI: https://wordpress.com/theme/blockbase
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Blockbase is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Brompton
-Theme URI: https://github.com/Automattic/themes/brompton
+Theme URI: https://wordpress.com/theme/brompton
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.

--- a/calm-business/style.css
+++ b/calm-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Calm Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/calm-business
 Author: Automattic
 Author URI: https://wordpress.com
 Template: twentynineteen

--- a/calm-business/style.scss
+++ b/calm-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Calm Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/calm-business
 Author: Automattic
 Author URI: https://wordpress.com
 Template: twentynineteen

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Coutoire
-Theme URI: https://github.com/Automattic/themes/varia
+Theme URI: https://wordpress.com/theme/coutoire/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Dalston
-Theme URI: https://github.com/Automattic/themes/dalston
+Theme URI: https://wordpress.com/theme/dalston
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.

--- a/elegant-business/style.css
+++ b/elegant-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Elegant Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/elegant-business
 Author: Automattic
 Author URI: https://wordpress.org/
 Template: twentynineteen

--- a/elegant-business/style.scss
+++ b/elegant-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Elegant Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/elegant-business
 Author: Automattic
 Author URI: https://wordpress.org/
 Template: twentynineteen

--- a/exford/style.css
+++ b/exford/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Exford
-Theme URI: https://github.com/Automattic/themes/tree/master/exford
+Theme URI: https://wordpress.com/theme/exford
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.

--- a/friendly-business/style.css
+++ b/friendly-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Friendly Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/friendly-business
 Author: Automattic
 Author URI: https://wordpress.org/
 Template: twentynineteen

--- a/friendly-business/style.scss
+++ b/friendly-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Friendly Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/friendly-business
 Author: Automattic
 Author URI: https://wordpress.org/
 Template: twentynineteen

--- a/geologist-blue/style.css
+++ b/geologist-blue/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Geologist - Blue
-Theme URI: https://github.com/Automattic/themes/tree/trunk/geologist
+Theme URI: https://wordpress.com/theme/geologist-blue
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist-blue is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.

--- a/geologist-cream/style.css
+++ b/geologist-cream/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Geologist - Cream
-Theme URI: https://github.com/Automattic/themes/tree/trunk/geologist
+Theme URI: https://wordpress.com/theme/geologist-cream
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist-cream is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.

--- a/geologist-slate/style.css
+++ b/geologist-slate/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Geologist - Slate
-Theme URI: https://github.com/Automattic/themes/tree/trunk/geologist
+Theme URI: https://wordpress.com/theme/geologist-slate
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist-slate is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.

--- a/geologist-yellow/style.css
+++ b/geologist-yellow/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Geologist - Yellow
-Theme URI: https://github.com/Automattic/themes/tree/trunk/geologist
+Theme URI: https://wordpress.com/theme/geologist-yellow
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist-yellow is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Geologist
-Theme URI: https://github.com/Automattic/themes/tree/trunk/geologist
+Theme URI: https://wordpress.com/theme/geologist
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Geologist is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.

--- a/hever/style.css
+++ b/hever/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Hever
-Theme URI: https://github.com/Automattic/themes/hever
+Theme URI: https://wordpress.com/theme/hever
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.

--- a/leven/style.css
+++ b/leven/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Leven
-Theme URI: https://github.com/Automattic/themes/varia
+Theme URI: https://wordpress.com/theme/leven
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.

--- a/livro/style.css
+++ b/livro/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Livro
-Theme URI: https://github.com/Automattic/themes/tree/trunk/livro
+Theme URI: https://wordpress.com/theme/livro
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Livro is a simple theme designed to evoke the calm feeling you get when you settle in with a classic book.

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Mayland (Blocks)
-Theme URI: https://github.com/Automattic/themes/tree/master/mayland-blocks
+Theme URI: https://wordpress.com/theme/mayland-blocks
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Mayland
-Theme URI: https://github.com/Automattic/themes/tree/master/mayland
+Theme URI: https://wordpress.com/theme/mayland
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Maywood
-Theme URI: https://github.com/Automattic/themes/tree/master/maywood
+Theme URI: https://wordpress.com/theme/maywood
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Modern Business
-Theme URI: https://github.com/WordPress/twentynineteen
+Theme URI: https://wordpress.com/theme/modern-business
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.

--- a/modern-business/style.scss
+++ b/modern-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Modern Business
-Theme URI: https://github.com/WordPress/twentynineteen
+Theme URI: https://wordpress.com/theme/modern-business
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.

--- a/morden/style.css
+++ b/morden/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Morden
-Theme URI: https://github.com/Automattic/themes/morden
+Theme URI: https://wordpress.com/theme/morden
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Pendant
-Theme URI: https://github.com/Automattic/themes/tree/trunk/pendant
+Theme URI: https://wordpress.com/theme/pendant
 Author: Automattic
 Author URI: https://automattic.com
 Description: An elegant product-focused theme

--- a/professional-business/style.css
+++ b/professional-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Professional Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/professional-business
 Author: Automattic
 Author URI: https://wordpress.com/
 Template: twentynineteen

--- a/professional-business/style.scss
+++ b/professional-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Professional Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/professional-business
 Author: Automattic
 Author URI: https://wordpress.com/
 Template: twentynineteen

--- a/quadrat-black/style.css
+++ b/quadrat-black/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat Black
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat-black
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/quadrat-green/style.css
+++ b/quadrat-green/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat Green
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat-green
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/quadrat-red/style.css
+++ b/quadrat-red/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat Red
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat-red
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/quadrat-white/style.css
+++ b/quadrat-white/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat White
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat-white
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/quadrat-yellow/style.css
+++ b/quadrat-yellow/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat Yellow
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat-yellow
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Quadrat
-Theme URI: https://github.com/Automattic/themes/tree/trunk/quadrat
+Theme URI: https://wordpress.com/theme/quadrat
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Redhill
-Theme URI: https://github.com/Automattic/redhill
+Theme URI: https://wordpress.com/theme/redhill
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.

--- a/remote/style.css
+++ b/remote/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Remote
-Theme URI: https://github.com/Automattic/themes/tree/trunk/remote
+Theme URI: https://wordpress.com/theme/remote
 Author: Automattic
 Author URI: https://automattic.com
 Description: Remote is a dark, minimal block theme ideal for bloggers. Its default styles - a sans-serif font and dark background - contribute for a comfortable, immersive reading experience. It features a set of bold block patterns such as a large posts list and bordered categories and tags.

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Rivington
-Theme URI: https://github.com/Automattic/themes/tree/master/rivington
+Theme URI: https://wordpress.com/theme/rivington
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Rockfield
-Theme URI: https://github.com/Automattic/themes/tree/master/rockfield
+Theme URI: https://wordpress.com/theme/rockfield
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.

--- a/russell/style.css
+++ b/russell/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Russell
-Theme URI: https://github.com/automattic/themes/tree/trunk/russell
+Theme URI: https://wordpress.com/theme/russell
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Russell is a simple blogging theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles.

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Seedlet (Blocks)
-Theme URI: https://github.com/Automattic/themes/seedlet-blocks
+Theme URI: https://wordpress.com/theme/seedlet-blocks
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column block-based theme.

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Shawburn
-Theme URI: https://github.com/Automattic/themes/master/shawburn
+Theme URI: https://wordpress.com/theme/shawburn
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Skatepark
-Theme URI: https://github.com/Automattic/themes/tree/trunk/skatepark
+Theme URI: https://wordpress.com/theme/skatepark
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Skatepark is a bold and exciting WordPress theme designed for modern events and organizations. With its simple but vivid color default scheme, duotone support, and playful grid, Skatepark is a theme designed for work and play. Customize its colors or try out different font pairings to create your own unique look and feel.

--- a/sophisticated-business/style.css
+++ b/sophisticated-business/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Sophisticated Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/sophisticated-business
 Author: Automattic
 Author URI: https://automattic.com/
 Template: twentynineteen

--- a/sophisticated-business/style.scss
+++ b/sophisticated-business/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Sophisticated Business
-Theme URI: https://github.com/automattic/themes
+Theme URI: https://wordpress.com/theme/sophisticated-business
 Author: Automattic
 Author URI: https://automattic.com/
 Template: twentynineteen

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Stewart
-Theme URI: https://github.com/Automattic/themes/tree/trunk/stewart
+Theme URI: https://wordpress.com/theme/stewart
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Stewart is a modern blogging theme with a left sidebar. Its default color scheme is a striking combination of orange and light gray, to give your blog a sophisticated appearance from day one.

--- a/stow/style.css
+++ b/stow/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Stow
-Theme URI: https://github.com/Automattic/themes/tree/master/stow
+Theme URI: https://wordpress.com/theme/stow
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Stratford
-Theme URI: https://github.com/Automattic/themes/varia
+Theme URI: https://wordpress.com/theme/stratford
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.

--- a/twentytwentytwo-blue/style.css
+++ b/twentytwentytwo-blue/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two (Blue)
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.com/theme/twentytwentytwo-blue
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.

--- a/twentytwentytwo-mint/style.css
+++ b/twentytwentytwo-mint/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two (Mint)
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.com/theme/twentytwentytwo-mint
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.

--- a/twentytwentytwo-pink/style.css
+++ b/twentytwentytwo-pink/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two (Pink)
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.com/theme/twentytwentytwo-pink
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.

--- a/twentytwentytwo-red/style.css
+++ b/twentytwentytwo-red/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two (Red)
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.com/theme/twentytwentytwo-red
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.

--- a/twentytwentytwo-swiss/style.css
+++ b/twentytwentytwo-swiss/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two (Swiss)
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.com/theme/twentytwentytwo-swiss
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.

--- a/varia/style.css
+++ b/varia/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Theme Name: Varia
-Theme URI: https://github.com/Automattic/themes/tree/master/varia
+Theme URI: https://wordpress.com/theme/varia
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Varia
-Theme URI: https://github.com/Automattic/themes/tree/master/varia
+Theme URI: https://wordpress.com/theme/varia
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.

--- a/videomaker-white/style.css
+++ b/videomaker-white/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Videomaker White
-Theme URI: https://github.com/Automattic/themes/tree/trunk/videomaker
+Theme URI: https://wordpress.com/theme/videomaker-white
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Videomaker is a free, minimalistic WordPress theme ideal for film directors and video creators.

--- a/videomaker/style.css
+++ b/videomaker/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Videomaker
-Theme URI: https://github.com/Automattic/themes/tree/trunk/videomaker
+Theme URI: https://wordpress.com/theme/videomaker
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Videomaker is a free, minimalistic WordPress theme ideal for film directors and video creators.

--- a/zoologist/style.css
+++ b/zoologist/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Zoologist
-Theme URI: https://github.com/Automattic/themes/tree/trunk/zoologist
+Theme URI: https://wordpress.com/theme/zoologist
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Zoologist is a simple blogging theme that supports full-site editing.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>`

Previously, it was a mix of linking to Github vs. WordPress.com

#### Related issue(s):

Closes https://github.com/Automattic/wp-calypso/issues/55383