### PR TITLE
#5875: Illustratr - Remove gallery from top of gallery posts

### DIFF
--- a/illustratr/content-gallery.php
+++ b/illustratr/content-gallery.php
@@ -11,26 +11,20 @@ if ( isset( $GLOBALS['content_width'] ) ) {
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-	<?php if ( get_post_gallery() && ! post_password_required() ) : ?>
-		<div class="entry-gallery">
-			<?php echo get_post_gallery(); ?>
-		</div><!-- .entry-gallery -->
-	<?php endif; ?>
-
 	<header class="entry-header">
 		<?php
-			if ( is_single() ) {
-				the_title( '<h1 class="entry-title">', '</h1>' );
-			} else {
-				the_title( '<h1 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h1>' );
-			}
+		if ( is_single() ) {
+			the_title( '<h1 class="entry-title">', '</h1>' );
+		} else {
+			the_title( '<h1 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h1>' );
+		}
 		?>
 
 		<?php
 			/* translators: used between list items, there is a space after the comma */
 			$categories_list = get_the_category_list( __( ', ', 'illustratr' ) );
-			if ( 'post' == get_post_type() && $categories_list && illustratr_categorized_blog() ) :
-		?>
+		if ( 'post' == get_post_type() && $categories_list && illustratr_categorized_blog() ) :
+			?>
 			<span class="cat-links"><?php echo $categories_list; ?></span>
 		<?php endif; ?>
 	</header><!-- .entry-header -->
@@ -43,11 +37,13 @@ if ( isset( $GLOBALS['content_width'] ) ) {
 	<div class="entry-content">
 		<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'illustratr' ) ); ?>
 		<?php
-			wp_link_pages( array(
-				'before'   => '<div class="page-links clear">',
-				'after'    => '</div>',
-				'pagelink' => '<span class="page-link">%</span>',
-			) );
+			wp_link_pages(
+				array(
+					'before'   => '<div class="page-links clear">',
+					'after'    => '</div>',
+					'pagelink' => '<span class="page-link">%</span>',
+				)
+			);
 		?>
 	</div><!-- .entry-content -->
 	<?php endif; ?>
@@ -59,7 +55,8 @@ if ( isset( $GLOBALS['content_width'] ) ) {
 
 		<?php
 			/* translators: used between list items, there is a space after the comma */
-			the_tags( sprintf( '<span class="tags-links">%s ', esc_html__( 'Tagged', 'illustratr' ) ), esc_html__( ', ', 'illustratr' ), '</span>' ); ?>
+			the_tags( sprintf( '<span class="tags-links">%s ', esc_html__( 'Tagged', 'illustratr' ) ), esc_html__( ', ', 'illustratr' ), '</span>' );
+		?>
 
 		<?php if ( ! post_password_required() && ( comments_open() || '0' != get_comments_number() ) ) : ?>
 			<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'illustratr' ), __( '1 Comment', 'illustratr' ), __( '% Comments', 'illustratr' ) ); ?></span>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

## Changes proposed in this Pull Request:

- Removed duplicate gallery from top of posts
- I removed the PHP code calling this rather than using CSS, but if this is used somewhere else that I'm missing, I'm happy to adjust the approach.
- It also looks like the PHP linter fixed some spacing issues. 

### Before

#### Individual Post
<img width="1164" alt="Screenshot on 2022-05-26 at 15-05-07" src="https://user-images.githubusercontent.com/45246438/170560928-0acad41a-744b-4c18-8d2f-f44129bc44b6.png">

#### Category Page
<img width="1161" alt="Screenshot on 2022-05-26 at 15-06-55" src="https://user-images.githubusercontent.com/45246438/170560938-3d4a89af-48cb-4f4d-b61c-7b32f0a248b8.png">


### After

#### Individual Post

<img width="941" alt="Screenshot on 2022-05-26 at 15-09-27" src="https://user-images.githubusercontent.com/45246438/170561044-6d74247b-c82a-4851-b4d3-bd47630bc3b0.png">

#### Category Page

<img width="995" alt="Screenshot on 2022-05-26 at 15-09-55" src="https://user-images.githubusercontent.com/45246438/170561083-1e6df151-73af-46ff-8853-9ec04c1fa322.png">

## Related issue(s):

https://github.com/Automattic/themes/issues/5875