### PR TITLE
#2906: Libretto: Search bar overlaps menu items

### DIFF
--- a/libretto/style.css
+++ b/libretto/style.css
@@ -2834,6 +2834,7 @@ object {
     -webkit-transition: all 0.25s linear;
             transition: all 0.25s linear;
     width: 400px;
+    z-index: 999;
   }
 
   #site-navigation .search-form label::before {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adding a `z-index` value to the search bar so it becomes accessible again and expands over the site's menu.

#### Related issue(s):

Fixes #2906 

**Before**

https://user-images.githubusercontent.com/50875131/171514012-78df705b-a872-46d5-a722-0aeae54298ea.mp4

**After**

https://user-images.githubusercontent.com/50875131/171513809-810f35fa-6188-4199-a55b-394745f7ba48.mp4