### PR TITLE
#5788: Shawburn: Pullquote Block(full-Width): centered text isn't working on small screens

### DIFF
--- a/libretto/style.css
+++ b/libretto/style.css
@@ -2834,6 +2834,7 @@ object {
     -webkit-transition: all 0.25s linear;
             transition: all 0.25s linear;
     width: 400px;
+    z-index: 999;
   }
 
   #site-navigation .search-form label::before {

--- a/libretto/style.css
+++ b/libretto/style.css
@@ -2834,7 +2834,6 @@ object {
     -webkit-transition: all 0.25s linear;
             transition: all 0.25s linear;
     width: 400px;
-    z-index: 999;
   }
 
   #site-navigation .search-form label::before {

--- a/shawburn/sass/_extra-child-theme.scss
+++ b/shawburn/sass/_extra-child-theme.scss
@@ -424,3 +424,8 @@ table,
 		margin-right: calc( .1 * #{map-deep-get($config-button, "padding", "horizontal")} );
 	}
 }
+
+/* center pullquote block when set to be full width */
+.wp-block-pullquote.alignfull blockquote {
+	margin: auto;
+}

--- a/shawburn/sass/style-child-theme.scss
+++ b/shawburn/sass/style-child-theme.scss
@@ -1,6 +1,6 @@
 /*
 Theme Name: Shawburn
-Theme URI: https://github.com/Automattic/themes/master/shawburn
+Theme URI: https://wordpress.com/theme/shawburn
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1,12 +1,12 @@
 @charset "UTF-8";
 /*
 Theme Name: Shawburn
-Theme URI: https://github.com/Automattic/themes/master/shawburn
+Theme URI: https://wordpress.com/theme/shawburn
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.15
+Version: 1.4.17
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4440,6 +4440,11 @@ table th,
  */
 .wp-block-search .wp-block-search__input {
 	margin-left: calc( .1 * 24px);
+}
+
+/* center pullquote block when set to be full width */
+.wp-block-pullquote.alignfull blockquote {
+	margin: auto;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4154,11 +4154,6 @@ hr.wp-block-separator.is-style-wide,
 	width: calc(100% - 64px);
 }
 
-/* center pullquote block when set to be full width */
-.wp-block-pullquote.alignfull blockquote {
-	margin: auto;
-}
-
 /**
  * Header
  */
@@ -4474,6 +4469,11 @@ table th,
  */
 .wp-block-search .wp-block-search__input {
 	margin-right: calc( .1 * 24px);
+}
+
+/* center pullquote block when set to be full width */
+.wp-block-pullquote.alignfull blockquote {
+	margin: auto;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4154,6 +4154,11 @@ hr.wp-block-separator.is-style-wide,
 	width: calc(100% - 64px);
 }
 
+/* center pullquote block when set to be full width */
+.wp-block-pullquote.alignfull blockquote {
+	margin: auto;
+}
+
 /**
  * Header
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Centering parent blockquote HTML element when the pullquote block is set to be full width.

**Before**

![Markup on 2022-06-01 at 19:10:39](https://user-images.githubusercontent.com/50875131/171521941-c696db45-6cb8-4142-b1b2-fa73f54fd4bb.png)

**After** - centered paragraph

![full width and text center](https://user-images.githubusercontent.com/50875131/171522011-3cb53c75-2c98-4d33-832e-9cd2241478af.png)

**After** - paragraph with a different alignment

![full width only](https://user-images.githubusercontent.com/50875131/171522007-1962635a-04f8-4080-be30-89f13f14f7eb.png)

#### Related issue(s):

Fixes #5788 