### PR TITLE
#5097: Maywood: Fix image alignment

### DIFF
--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1700,10 +1700,6 @@ h6, .h6 {
 	line-height: 1.125;
 }
 
-.wp-block-image {
-	text-align: center;
-}
-
 .wp-block-image figcaption {
 	color: #686868;
 	font-size: 0.69444rem;

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1700,6 +1700,10 @@ h6, .h6 {
 	line-height: 1.125;
 }
 
+.wp-block-image {
+	text-align: center;
+}
+
 .wp-block-image figcaption {
 	color: #686868;
 	font-size: 0.69444rem;

--- a/varia/sass/blocks/image/_style.scss
+++ b/varia/sass/blocks/image/_style.scss
@@ -1,5 +1,4 @@
 .wp-block-image {
-	text-align: center;
 
 	figcaption {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Fixes image alignment in Maywood to bring frontend into parity with editor options

### Changes proposed in this Pull Request:

#### Before
----

Editor:

<img width="1359" alt="Screenshot on 2022-06-07 at 09-25-38" src="https://user-images.githubusercontent.com/45246438/172396535-11bccfe6-31fb-41df-95e3-c0abe6ff7120.png">

Frontend:

<img width="757" alt="Screenshot on 2022-06-07 at 09-25-59" src="https://user-images.githubusercontent.com/45246438/172397131-a5edc334-138c-4079-af01-5bc8cc18d8eb.png">


#### After
----

Editor:

<img width="1359" alt="Screenshot on 2022-06-07 at 09-25-38" src="https://user-images.githubusercontent.com/45246438/172396535-11bccfe6-31fb-41df-95e3-c0abe6ff7120.png">

Frontend:

<img width="803" alt="Screenshot on 2022-06-07 at 09-26-37" src="https://user-images.githubusercontent.com/45246438/172397314-6a00cbc6-3bdc-4474-aaf3-f5b4d3870a79.png">




### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/5097