### PR TITLE
Update theme url

### DIFF
--- a/antonia/style.css
+++ b/antonia/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Antonia
-Theme URI: https://github.com/automattic/themes/tree/trunk/antonia
+Theme URI: https://www.wordpress.com/theme/antonia
 Author: Automattic
 Author URI: https://automattic.com
 Description: Antonia is a theme for selling products with the help of payments block.

--- a/antonia/style.css
+++ b/antonia/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Antonia
-Theme URI: https://www.wordpress.com/theme/antonia
+Theme URI: https://wordpress.com/theme/antonia
 Author: Automattic
 Author URI: https://automattic.com
 Description: Antonia is a theme for selling products with the help of payments block.


### PR DESCRIPTION
Fix the wrong theme Theme URI from the GH url to https://www.wordpress.com/theme/antonia
