### PR TITLE
Removed the 'unstableSocialLinks' from themes that shouldn't have it …

### DIFF
--- a/block-canvas/parts/header.html
+++ b/block-canvas/parts/header.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	
-		<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 	
 	</div>
 	<!-- /wp:group -->

--- a/curator/parts/header.html
+++ b/curator/parts/header.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 	
-		<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+		<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 	
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
…(it's a Blockbase exclusive)

This attribute really isn't harming anything but it's only leveraged by Blockbase and its children so there's no need for it to be on these template parts.