### PR TITLE
Blockbase: Changed the trigger to render social icons

### DIFF
--- a/blockbase/block-template-parts/header-default.html
+++ b/blockbase/block-template-parts/header-default.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header-linear.html
+++ b/blockbase/block-template-parts/header-linear.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"blockbase-responsive-navigation-linear","__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"className":"blockbase-responsive-navigation-linear","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header-minimal.html
+++ b/blockbase/block-template-parts/header-minimal.html
@@ -18,7 +18,7 @@
 	</div>
 	<!-- /wp:group -->
 	
-	<!-- wp:navigation {"className":"blockbase-responsive-navigation-minimal","overlayMenu":"always","__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"className":"blockbase-responsive-navigation-minimal","overlayMenu":"always","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 	
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header-rounded-logo.html
+++ b/blockbase/block-template-parts/header-rounded-logo.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/block-template-parts/header-wide.html
+++ b/blockbase/block-template-parts/header-wide.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"__unstableLocation":"primary","__unstableSocialLinks":"social","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.5em"}}} /-->
+		<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.5em"}}} /-->
 
 	</div>
 	<!-- /wp:group -->

--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -27,13 +27,15 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 			)
 		);
 
-		// Register two nav menus
-		register_nav_menus(
-			array(
-				'primary' => __( 'Primary Navigation', 'blockbase' ),
-				'social' => __( 'Social Navigation', 'blockbase' )
-			)
-		);
+		// Register two nav menus if Gutenberg is activated (otherwise the __experimentalMenuLocation attribute isn't available)
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+			register_nav_menus(
+				array(
+					'primary' => __( 'Primary Navigation', 'blockbase' ),
+					'social' => __( 'Social Navigation', 'blockbase' )
+				)
+			);
+		}
 
 		add_filter(
 			'block_editor_settings_all',

--- a/blockbase/inc/patterns/footer-separator.php
+++ b/blockbase/inc/patterns/footer-separator.php
@@ -19,7 +19,7 @@ return array(
 	<p class="has-small-font-size"><meta charset="utf-8"><strong>Proudly Powered by <a rel="nofollow" href="https://wordpress.org">WordPress</a></strong></p>
 	<!-- /wp:paragraph -->
 	
-	<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"never","__unstableSocialLinks":"social"} /--></div>
+	<!-- wp:navigation {"itemsJustification":"center","overlayMenu":"never","className":"social-links"} /--></div>
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->',
 );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -13,8 +13,21 @@ function blockbase_condition_to_render_social_menu( $block_content, $block ) {
 		return false;
 	}
 
-	// The block should have a social links attribute.
-	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
+	// The block should have an unstable location attribute.
+	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
+		return false;
+	}
+
+	// The block should be empty (no custom menu assigned)
+	if ( ! empty($block['attrs']['navigationMenuId']) || ! empty($block['attrs']['ref']) ) {
+		return false;
+	}
+	
+	// The block should have the class 'social-links'.
+	if ( empty( $block['attrs']['className'] ) ) {
+		return false;
+	}
+	if ( ! str_contains( $block['attrs']['className'], 'social-links' ) ) {
 		return false;
 	}
 
@@ -31,11 +44,8 @@ function blockbase_theme_has_navigation_social_links_settings( $theme_data ) {
 }
 
 function get_social_menu_as_social_links_block( $block ) {
-	if ( empty( $block['attrs']['__unstableSocialLinks'] ) ) {
-		return false;
-	}
 
-	$social_links_location = $block['attrs']['__unstableSocialLinks'];
+	$social_links_location = 'social';
 	$nav_menu_locations    = get_nav_menu_locations();
 	$social_menu_id        = $nav_menu_locations[ $social_links_location ];
 	$class_name            = 'is-style-logos-only';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This changes the trigger to add/style social media icons from the Block attribute `__unstableSocialLinks` to the class `social-links`

This was done because when the templates that contain navigation blocks with an `unstableSocialLinks` attribute when saved that attribute is removed, thus social links are no longer rendered.

A class is used instead because it will persist across edits.

The logic used to determine if the social bits should be rendered has been updated to ensure that:
* It's on a navigation block with the `__unstableLocation` attribute (which IS sanctioned by Gutenberg and that was already the case for all template instances)
* That no custom menus have been added (via the FSE).
* That the block has the `social-links` class.

Additionally instead of getting the target menu location previously defined via the `__unstableSocialLinks` attribute the location of `social` is assumed.  (All instances in the templates were using that location.)

Lastly all of the template parts/patterns that were leveraging the `__unstableSocialLinks` attribute have been changed to use the class `social-links` instead.

To test ensure the following scenarios work as expected:

A site using Blockbase (or Blockbase child) that has [primary|social] location(s) assigned  (via customizer) and have no other modifications to their header continue to show the primary menu and/or social menu as expected.  

With the change in place modify the header and make changes to any part of the header EXCEPT the navigation block.  Note that the navigation continues to render as expected.  (This is the bug noted in #6077)

Now modify the navigation block in the FSE (creating a menu from scratch, or assigning it an existing menu from, etc).  Note that the social navigation items are no longer being shown now that the menu has been edited via the FSE.

#### Related issue(s):

Fixes #6077