### PR TITLE
Blockbase: remove navigation close button styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -487,10 +487,6 @@ input[type=checkbox] + label {
   margin: 0;
   gap: var(--wp--custom--gap--baseline);
 }
-.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container-close {
-  right: var(--wp--custom--gap--horizontal);
-  top: var(--wp--custom--gap--vertical);
-}
 .wp-block-navigation.is-responsive .is-menu-open {
   font-size: var(--wp--preset--font-size--medium);
 }

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -23,11 +23,6 @@
 			margin: 0;
 			gap: var(--wp--custom--gap--baseline);
 		}
-
-		.wp-block-navigation__responsive-container-close {
-			right: var(--wp--custom--gap--horizontal);
-			top: var(--wp--custom--gap--vertical);
-		}
 	}
 
 	&.is-responsive .is-menu-open {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR removes the styles for the mobile navigation close button. It looks like these aren't needed anymore. See the gifs here: https://github.com/Automattic/themes/issues/5975

#### Related issue(s):
Closes #5975