### PR TITLE
#2044: Pique: Fix button block width on mobile

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -440,12 +440,6 @@ body.home .wp-block-table.alignwide .wp-block-table.alignfull {
 	color: #83b6cc;
 }
 
-@media (max-width: 767px) {
-	.wp-block-button .wp-block-button__link {
-		width: 75%;
-	}
-}
-
 /* Separator */
 
 .wp-block-separator {

--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -440,6 +440,13 @@ body.home .wp-block-table.alignwide .wp-block-table.alignfull {
 	color: #83b6cc;
 }
 
+@media (max-width: 767px) {
+	.wp-block-button .wp-block-button__link {
+		padding: 1em;
+		width: 100%;
+	}
+}
+
 /* Separator */
 
 .wp-block-separator {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Removed code that was setting a width of 75% for buttons on mobile.

#### Before
<img width="381" alt="Screenshot on 2022-06-17 at 11-07-11" src="https://user-images.githubusercontent.com/45246438/174327948-f13d113e-5339-4ee7-93fc-5020916d8edb.png">


#### After
<img width="359" alt="Screenshot on 2022-06-17 at 11-12-00" src="https://user-images.githubusercontent.com/45246438/174328014-739563dc-0456-4aed-89be-17c1ac9d3694.png">



### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/2044