### PR TITLE
#6017: Apostrophe 2: Fix Recent Comments widget display

### DIFF
--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -3052,9 +3052,9 @@ Primarily tablets and teensy desktops.
 	}
 
 	/* Arrange posts into grid structure on archive pages */
-	.archive article,
-	.blog article,
-	.search article,
+	.archive #posts-wrapper article,
+	.blog #posts-wrapper article,
+	.search #posts-wrapper article,
 	.blog article.apostrophe-2-featured:nth-child(4n+2),
 	.blog article.apostrophe-2-featured:nth-child(4n+3) {
 		-moz-box-sizing: border-box;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Fixes Recent Comments widget 

##### Before

<img width="2163" alt="Screenshot on 2022-06-20 at 13-40-29" src="https://user-images.githubusercontent.com/45246438/174656083-452d99b6-2715-4982-ac6b-b3d8f864a662.png">

##### After

<img width="2166" alt="Screenshot on 2022-06-20 at 13-41-18" src="https://user-images.githubusercontent.com/45246438/174656067-55a516a5-fc68-45b6-98e1-5bc65e89754c.png">

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6017