### PR TITLE
#5306: Button 2: Fix Fancy Image JS

### DIFF
--- a/button-2/assets/js/main.js
+++ b/button-2/assets/js/main.js
@@ -2,38 +2,37 @@
  * Button 2 Javascript
  */
 
-( function( $ ) {
-
+(function ($) {
 	function fancyImages() {
-		var imgs = $( '.entry-content img.fancy, .entry-content .is-style-fancy, .entry-content .wp-block-image.fancy' );
+		var imgs = $(
+			'.entry-content img.fancy img, .entry-content .is-style-fancy img, .entry-content .wp-block-image.fancy img, .widget-area img.fancy img, .widget-area .is-style-fancy img, .widget-area .wp-block-image.fancy img'
+		);
 
-		for ( var i = 0, imgslength = imgs.length; i < imgslength; i++ ) {
-			if ( '' !== $( imgs[i] ) ) {
+		for (var i = 0, imgslength = imgs.length; i < imgslength; i++) {
+			if ('' !== $(imgs[i])) {
+				$(imgs[i]).wrap('<span class="fancy-image"></span>');
 
-				$( imgs[i] ).wrap( '<span class="fancy-image"></span>' );
+				var fancyImg = $(imgs[i]).closest('.fancy-image');
 
-				var fancyImg = $( imgs[i] ).closest( '.fancy-image' );
-
-				if ( '' == $( imgs[i] ).closest( 'figure' ) ) {
+				if ('' == $(imgs[i]).closest('figure')) {
 					//This image is not captioned; carry over the classes
-					fancyImg.addClass( $( imgs[i] ).attr( 'class' ) );
-					fancyImg.removeClass( 'fancy' );
+					fancyImg.addClass($(imgs[i]).attr('class'));
+					fancyImg.removeClass('fancy');
 				}
 
-				fancyImg.wrapInner( '<span class="corners"></span>' );
-				fancyImg.append( '<span class="shadow"></span>' );
+				fancyImg.wrapInner('<span class="corners"></span>');
+				fancyImg.append('<span class="shadow"></span>');
 			}
 		}
 	}
 
 	// After window loads
-	$( window ).load( function() {
+	$(window).load(function () {
 		fancyImages();
-	} );
+	});
 
 	// After infinite scroll loads new posts
-	$( window ).on( 'post-load', function() {
+	$(window).on('post-load', function () {
 		fancyImages();
-	} );
-
-} )( jQuery );
+	});
+})(jQuery);


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adjust selector in JS to properly apply fancy image style to fancy images.

Fixes issue in widget and in post content

##### Before

<img width="1145" alt="Screenshot on 2022-06-21 at 08-18-16" src="https://user-images.githubusercontent.com/45246438/174800374-1032d1a7-a650-4ab5-9a2b-4429896a71a2.png">

##### After

<img width="1144" alt="Screenshot on 2022-06-21 at 08-19-22" src="https://user-images.githubusercontent.com/45246438/174800312-4dce4519-75d9-4b69-8fe1-0d33329f6052.png">


<img width="1007" alt="Screenshot on 2022-06-21 at 08-24-33" src="https://user-images.githubusercontent.com/45246438/174800170-56613c86-6364-481f-9a61-b82bc022108b.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/5306