### PR TITLE
#3500: Illustratr: Fix overflowing column content

### DIFF
--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -104,9 +104,6 @@ div[class$="inner-container"] .wp-block-columns:not(.alignwide, .alignfull) {
 /*--------------------------------------------------------------
 2.0 Blocks - Common Blocks
 --------------------------------------------------------------*/
-/* Columns */
-
-
 /* Paragraph */
 
 p.has-drop-cap:not(:focus)::first-letter {

--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -71,12 +71,12 @@ Description: Used to style Gutenberg Blocks.
 
 /* Wide Width */
 
-:is(.wp-block-cover, .wp-block-group) .wp-block-columns {
+div[class$="inner-container"] .wp-block-columns {
 	margin: 0 auto;
 	width: 100%;
 }
 
-:is(.wp-block-cover, .wp-block-group) .wp-block-columns:not(.alignwide, .alignfull) {
+div[class$="inner-container"] .wp-block-columns:not(.alignwide, .alignfull) {
 	max-width: 840px;
 }
 
@@ -89,7 +89,7 @@ Description: Used to style Gutenberg Blocks.
 		position: relative;
 	}
 
-	:is(.wp-block-cover:is(.alignfull), .wp-block-group:is(.alignfull)) .wp-block-columns.alignwide {
+	div[class$="inner-container"] .wp-block-columns.alignwide {
 		width: calc(840px + 10%);
 		max-width: 100%;
 		margin: 0 auto;

--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -71,6 +71,15 @@ Description: Used to style Gutenberg Blocks.
 
 /* Wide Width */
 
+.wp-block-cover .wp-block-columns {
+	margin: 0 auto;
+	width: 100%;
+}
+
+.wp-block-cover .wp-block-columns:not(.alignwide, .alignfull) {
+	max-width: 840px;
+}
+
 @media (min-width: 1024px) {
 	.alignwide {
 		width: 120%;
@@ -78,6 +87,12 @@ Description: Used to style Gutenberg Blocks.
 		margin-left: -10%;
 		margin-right: -10%;
 		position: relative;
+	}
+
+	.wp-block-cover:is(.alignfull) .wp-block-columns.alignwide {
+		width: calc(840px + 10%);
+		max-width: 100%;
+		margin: 0 auto;
 	}
 
 	.wp-block-embed.is-type-video.alignwide iframe {
@@ -89,6 +104,8 @@ Description: Used to style Gutenberg Blocks.
 /*--------------------------------------------------------------
 2.0 Blocks - Common Blocks
 --------------------------------------------------------------*/
+/* Columns */
+
 
 /* Paragraph */
 

--- a/illustratr/blocks.css
+++ b/illustratr/blocks.css
@@ -71,12 +71,12 @@ Description: Used to style Gutenberg Blocks.
 
 /* Wide Width */
 
-.wp-block-cover .wp-block-columns {
+:is(.wp-block-cover, .wp-block-group) .wp-block-columns {
 	margin: 0 auto;
 	width: 100%;
 }
 
-.wp-block-cover .wp-block-columns:not(.alignwide, .alignfull) {
+:is(.wp-block-cover, .wp-block-group) .wp-block-columns:not(.alignwide, .alignfull) {
 	max-width: 840px;
 }
 
@@ -89,7 +89,7 @@ Description: Used to style Gutenberg Blocks.
 		position: relative;
 	}
 
-	.wp-block-cover:is(.alignfull) .wp-block-columns.alignwide {
+	:is(.wp-block-cover:is(.alignfull), .wp-block-group:is(.alignfull)) .wp-block-columns.alignwide {
 		width: calc(840px + 10%);
 		max-width: 100%;
 		margin: 0 auto;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

This adjusts interior column blocks so they don't exceed the size of the containing block.

The front-end of the site now reflects what is shown in the editor.

#### Before

![Screenshot 2022-06-21 at 11-39-10 themes](https://user-images.githubusercontent.com/45246438/174853041-5be61a4e-d4be-46d0-95a2-56d5ac3962ca.jpg)

#### After

![Screenshot 2022-06-21 at 11-56-20 themes](https://user-images.githubusercontent.com/45246438/174853257-b8e80dde-6990-4846-97ec-9e8633493bef.jpg)



### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/3500