### PR TITLE
Block canvas regressions

### DIFF
--- a/block-canvas/parts/post-meta.html
+++ b/block-canvas/parts/post-meta.html
@@ -1,8 +1,12 @@
-<!-- wp:group {"layout":{"type":"flex"}} -->
+<!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
-	<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
-	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
-	<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
+	<!-- wp:group {"layout":{"type":"flex"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-date {"isLink":true,"style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:post-terms {"term": "post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -180,7 +180,7 @@
             },
             "core/navigation": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--medium)"
+                    "fontSize": "1.125rem"
                 }
             },
             "core/post-date": {
@@ -232,7 +232,7 @@
                     }
                 },
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--medium)",
+                    "fontSize": "1.125rem",
                     "fontStyle": "normal"
                 }
             },
@@ -259,7 +259,7 @@
             },
             "core/site-title": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--medium)",
+                    "fontSize": "1.125rem",
                     "fontWeight": "700",
                     "textDecoration": "none"
                 }

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -40,17 +40,17 @@
             "link": true,
             "palette": [
                 {
-                    "color": "#776c4e",
+                    "color": "#007cba",
                     "name": "Primary",
                     "slug": "primary"
                 },
                 {
-                    "color": "#a19982",
+                    "color": "#006ba1",
                     "name": "Secondary",
                     "slug": "secondary"
                 },
                 {
-                    "color": "#000000",
+                    "color": "#333333",
                     "name": "Foreground",
                     "slug": "foreground"
                 },
@@ -60,7 +60,7 @@
                     "slug": "background"
                 },
                 {
-                    "color": "#f1ede6",
+                    "color": "#F0F0F0",
                     "name": "Tertiary",
                     "slug": "tertiary"
                 }
@@ -311,7 +311,7 @@
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--system-font)",
-            "fontSize": "var(--wp--preset--font-size--medium)",
+            "fontSize": "1.125rem",
             "lineHeight": "1.6"
         }
     },


### PR DESCRIPTION
This PR fixes a few regressions and bugs I found while working on https://github.com/Automattic/themes/pull/6109

I found that after https://github.com/Automattic/themes/pull/5700 got merged, some of the pendant options like the colors were showing on Block Canvas, plus the font sizes were very big. Apparently at some point we removed the "normal" font size and that is ok, since it's not a default font size in core, but the previous blocks assigned to the normal font size were replaced by medium, which is too big for the original design (as much as we are not making this a 1:1 clone of Blockbase, it was looking very strange. 

What I did:

- Replace the Pendant color with the Blockbase ones
- Replaced the old instances of the normal custom font size with the actual value of the font size.
- Fixed the post meta that was looking left aligned

Before | After
--- | ---
![Screenshot 2022-06-22 at 10-54-15 Hello world! – maggie](https://user-images.githubusercontent.com/3593343/174988669-c76f79e7-414b-494f-890f-4338704fe274.png) | ![Screenshot 2022-06-22 at 10-54-01 Hello world! – maggie](https://user-images.githubusercontent.com/3593343/174988687-76d4b32a-9716-4012-bd5a-ddc74d192dfd.png)

