### PR TITLE
Block canvas: removed redundant theme.json definitions

### DIFF
--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -28,16 +28,7 @@
     ],
     "settings": {
         "appearanceTools": true,
-        "border": {
-            "color": true,
-            "radius": true,
-            "style": true,
-            "width": true
-        },
         "color": {
-            "custom": true,
-            "customGradient": true,
-            "link": true,
             "palette": [
                 {
                     "color": "#776c4e",
@@ -77,9 +68,6 @@
             "wideSize": "1000px"
         },
         "spacing": {
-            "blockGap": true,
-            "margin": true,
-            "padding": true,
             "units": [
                 "%",
                 "px",
@@ -90,7 +78,6 @@
             ]
         },
         "typography": {
-            "customFontSize": true,
             "fontFamilies": [
                 {
                     "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
@@ -119,8 +106,7 @@
                     "size": "2rem",
                     "slug": "x-large"
                 }
-            ],
-            "lineHeight": true
+            ]
         }
     },
     "styles": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This brings the changes that [Carolina pointed out](https://github.com/WordPress/create-block-theme/pull/70#discussion_r901259555) on the create block theme plugin repo to our Block Canvas theme.

Docs for reference:

https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#appearancetools
https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#typography
