### PR TITLE
Stewart: Move link and hover settings to theme.json

### DIFF
--- a/stewart/readme.txt
+++ b/stewart/readme.txt
@@ -1,7 +1,7 @@
 === Stewart ===
 Contributors: automattic
-Requires at least: 5.8
-Tested up to: 5.8
+Requires at least: 6.1
+Tested up to: 6.1
 Requires PHP: 5.6
 Stable tag: 1.0
 License: GPLv2 or later

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -57,16 +57,10 @@ a {
 	text-decoration: none;
 }
 
-.wp-block-navigation .wp-block-navigation-link a,
-.wp-block-navigation .wp-block-page-list a,
-.wp-block-navigation .wp-block-pages-list__item a,
 .wp-block-navigation .wp-block-post-title a {
 	text-decoration: underline;
 }
 
-.wp-block-navigation .wp-block-navigation-link a:hover,
-.wp-block-navigation .wp-block-page-list a:hover,
-.wp-block-navigation .wp-block-pages-list__item a:hover,
 .wp-block-navigation .wp-block-post-title a:hover {
 	text-decoration: none;
 }

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.com/theme/stewart
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Stewart is a modern blogging theme with a left sidebar. Its default color scheme is a striking combination of orange and light gray, to give your blog a sophisticated appearance from day one.
-Requires at least: 5.8
-Tested up to: 5.8
+Requires at least: 6.1
+Tested up to: 6.1
 Requires PHP: 5.7
 Version: 1.9
 License: GNU General Public License v2 or later

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -57,13 +57,6 @@ a {
 	text-decoration: none;
 }
 
-a:hover,
-.wp-block-site-title a:hover,
-.wp-block-post-title a:hover,
-.wp-block-post-date a:hover {
-	color: var(--wp--preset--color--primary);
-}
-
 .wp-block-navigation .wp-block-navigation-link a,
 .wp-block-navigation .wp-block-page-list a,
 .wp-block-navigation .wp-block-pages-list__item a,
@@ -75,7 +68,6 @@ a:hover,
 .wp-block-navigation .wp-block-page-list a:hover,
 .wp-block-navigation .wp-block-pages-list__item a:hover,
 .wp-block-navigation .wp-block-post-title a:hover {
-	color: var(--wp--preset--color--primary);
 	text-decoration: none;
 }
 

--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -374,6 +374,11 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
+					}
 				}
 			}
 		},

--- a/stewart/theme.json
+++ b/stewart/theme.json
@@ -237,6 +237,18 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"lineHeight": 2
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "underline"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "none"
+							}
+						}
+					}
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This moves link color and link hover color definitions from CSS to theme.json. 
Does the same thing for textDecoration.

#### Related issue(s):
