### PR TITLE
Curator: fix single template comments

### DIFF
--- a/curator/patterns/post-comments.php
+++ b/curator/patterns/post-comments.php
@@ -62,4 +62,5 @@
 <!-- wp:comments-pagination-next /-->
 <!-- /wp:comments-pagination --></div>
 <!-- /wp:comments-query-loop --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Fixes a bug where the comments were missing a closing group block markup, so the footer was not the correct width:

Before | After
--- | ---
<img width="1771" alt="Screen Shot 2022-06-23 at 12 26 50 PM" src="https://user-images.githubusercontent.com/5375500/175348524-3ecf628e-bed6-4cc6-a896-f63cd3a6fad6.png"> | <img width="1766" alt="Screen Shot 2022-06-23 at 12 26 36 PM" src="https://user-images.githubusercontent.com/5375500/175348556-6b2e00f4-8ac9-42db-ab65-9d44258bff7a.png">


#### Related issue(s):
