### PR TITLE
Block Canvas: add support for button elements

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -50,23 +50,6 @@ GNU General Public License for more details.
 }
 
 /*
- * Search and File Block button styles.
- * Necessary until the following issues are resolved in Gutenberg:
- * https://github.com/WordPress/gutenberg/issues/36444
- * https://github.com/WordPress/gutenberg/issues/27760
- */
-
-.wp-block-search__button,
-.wp-block-file .wp-block-file__button {
-	background-color: var(--wp--preset--color--foreground);
-	border-radius: 0;
-	border: none;
-	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--normal);
-	padding: calc(0.667em + 2px) calc(1.333em + 2px);
-}
-
-/*
  * Alignment styles, borrowed from Twenty Twenty-Two.
  * These rules are temporary, and should not be relied on or
  * modified too heavily by themes or plugins that build on

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -114,10 +114,7 @@
             "core/button": {
                 "border": {
                     "radius": "4px"
-                },
-				"color": {
-                    "background": "red"
-				}
+                }
             },
             "core/code": {
                 "border": {

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -115,15 +115,9 @@
                 "border": {
                     "radius": "4px"
                 },
-                "color": {
-                    "background": "var(--wp--preset--color--primary)",
-                    "text": "var(--wp--preset--color--background)"
-                },
-                "typography": {
-                    "fontSize": "var(--wp--preset--font-size--medium)",
-                    "fontWeight": "normal",
-                    "lineHeight": "2"
-                }
+				"color": {
+                    "background": "red"
+				}
             },
             "core/code": {
                 "border": {
@@ -256,6 +250,30 @@
             "text": "var(--wp--preset--color--foreground)"
         },
         "elements": {
+            "button": {
+				"border": {
+					"radius": "0"
+				},
+				"color": {
+                    "background": "var(--wp--preset--color--primary)",
+                    "text": "var(--wp--preset--color--background)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--system-font)",
+                    "fontSize": "var(--wp--preset--font-size--medium)",
+                    "fontWeight": "normal",
+					"lineHeight": "2",
+					"textDecoration": "none"
+				},
+				"spacing": {
+					"padding": {
+						"top": "calc(0.667em + 2px)",
+						"bottom": "calc(0.667em + 2px)",
+						"left": "calc(1.333em + 2px)",
+						"right": "calc(1.333em + 2px)"
+					}
+				}
+			},
             "h1": {
                 "typography": {
                     "fontSize": "3rem"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This implements the button element API on Block Canvas. This PR needs https://github.com/WordPress/gutenberg/pull/41934 for it to work correctly.

Before | After
--- | ---
<img width="874" alt="Screenshot 2022-06-24 at 17 10 12" src="https://user-images.githubusercontent.com/3593343/175564627-8aeef4da-c414-4051-8cff-2bc2791a8022.png"> | <img width="745" alt="Screenshot 2022-06-24 at 17 10 01" src="https://user-images.githubusercontent.com/3593343/175564635-475b1a77-9ae7-400b-a674-9dc897b0247e.png">

