### PR TITLE
Curator: add mobile menu styling

### DIFF
--- a/curator/parts/header.html
+++ b/curator/parts/header.html
@@ -1,7 +1,7 @@
  <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dvertical)","top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dgap\u002d\u002dvertical)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
  <div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--gap--vertical);padding-bottom:var(--wp--custom--gap--vertical)"><!-- wp:site-title {"style":{"typography":{"fontSize":"1.375rem"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}}} /-->
 
-	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+	<!-- wp:navigation {"overlayBackgroundColor":"primary","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 	<!-- /wp:group -->
 	
 	<!-- wp:separator {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->

--- a/curator/style.css
+++ b/curator/style.css
@@ -199,6 +199,14 @@ a:not(
 }
 
 /*
+ * Needed until https://github.com/WordPress/gutenberg/issues/39142 is fixed.
+ */
+ .wp-block-navigation__responsive-container.is-menu-open ul {
+	font-size: var(--wp--preset--font-size--huge);
+	font-weight: 300;
+}
+
+/*
  * Hero post
  * The following style are required because variable fontSize doen't work in templates
  * Feature request: https://github.com/WordPress/gutenberg/issues/41859

--- a/curator/style.css
+++ b/curator/style.css
@@ -202,7 +202,7 @@ a:not(
  * Needed until https://github.com/WordPress/gutenberg/issues/39142 is fixed.
  */
  .wp-block-navigation__responsive-container.is-menu-open ul {
-	font-size: var(--wp--preset--font-size--huge);
+	font-size: 2.75rem;
 	font-weight: 300;
 }
 

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -187,11 +187,6 @@
 					"name": "Extra Large",
 					"size": "2rem",
 					"slug": "x-large"
-				},
-				{
-					"name": "Huge",
-					"size": "2.75rem",
-					"slug": "huge"
 				}
 			],
 			"lineHeight": true

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -187,6 +187,11 @@
 					"name": "Extra Large",
 					"size": "2rem",
 					"slug": "x-large"
+				},
+				{
+					"name": "Huge",
+					"size": "2.75rem",
+					"slug": "huge"
 				}
 			],
 			"lineHeight": true


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR adds styling for the mobile navigation in Curator. I worked off the styles in Figma but let me know if anything doesn't look right:

<img width="459" alt="image" src="https://user-images.githubusercontent.com/1645628/176266547-6fb63397-0557-4697-acf4-19b3be59dc63.png">

#### Related issue(s):
Closes #6095
