### PR TITLE
Vivre: move link pseudo states to theme.json

### DIFF
--- a/curator/style.css
+++ b/curator/style.css
@@ -161,7 +161,6 @@ a:not(
 }
 
 .wp-block-post-title a:hover {
-	text-decoration-thickness: 0.25rem;
 	text-underline-offset: 0.25rem;
 }
 

--- a/curator/style.css
+++ b/curator/style.css
@@ -41,6 +41,7 @@ body {
 	background: var(--wp--preset--color--foreground);
 	border-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
+	text-decoration: none;
 }
 .wp-block-button__link.wp-block-button__link:active {
 	color: var(--wp--preset--color--primary);
@@ -106,16 +107,18 @@ body {
  * Link Styles
  */
 
+a:not(
+	.wp-block-search__button,
+	.wp-block-button__link
+) {
+	text-underline-offset: .1rem;
+}
+
 .wp-block-site-title a {
 	padding: .4rem 0;
 	text-decoration: inherit; /* Needed so the link styles will be inherited correctly from theme.json */
 	text-underline-offset: .1rem;
 }
-
-a:not(
-	.wp-block-search__button,
-	.wp-block-button__link
-):hover,
 
 .wp-block-site-title a:hover {
 	text-decoration: underline;

--- a/curator/style.css
+++ b/curator/style.css
@@ -120,21 +120,12 @@ a:not(
 	text-underline-offset: .1rem;
 }
 
-.wp-block-site-title a:hover {
-	text-decoration: underline;
-}
-
 a:not(
 	.wp-block-search__button,
 	.wp-block-button__link
 ):focus {
 	text-decoration: underline;
 	text-decoration-style: dotted;
-}
-
-.wp-block-site-title a:active {
-	text-decoration: none;
-	background-color: var(--wp--preset--color--tertiary);
 }
 
 /*
@@ -147,11 +138,6 @@ a:not(
 
 :is(
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content,
-	.wp-block-navigation-item__content,
-	.wp-block-site-title a,
-	.wp-block-post-navigation-link a,
-	.wp-block-post-terms a
 ):hover {
 	text-decoration: underline;
 }
@@ -169,19 +155,12 @@ a:not(
 }
 
 :is(
-	.wp-block-pages-list__item .wp-block-pages-list__item__link,
-	.wp-block-navigation-link__content,
-	.wp-block-navigation-item__content,
-	.wp-block-site-title a,
-	.wp-block-post-navigation-link a,
-	.wp-block-post-terms a
+	.wp-block-pages-list__item .wp-block-pages-list__item__link
 ):active {
 	text-decoration: underline;
 }
 
 .wp-block-post-title a:hover {
-	color: var(--wp--preset--color--primary);
-	text-decoration-line: underline;
 	text-decoration-thickness: 0.25rem;
 	text-underline-offset: 0.25rem;
 }

--- a/curator/style.css
+++ b/curator/style.css
@@ -86,19 +86,11 @@ body {
 }
 
 /*
- * Search and File Block button styles.
- * Necessary until the following issues are resolved in Gutenberg:
- * https://github.com/WordPress/gutenberg/issues/36444
- * https://github.com/WordPress/gutenberg/issues/27760
- */
-
-
-
-/*
  * Search input styles
  * Needed until this is resolved in Gutenberg:
  * https://github.com/WordPress/gutenberg/issues/34198
  */
+
 .wp-block-search__input {
 	border-color: var(--wp--preset--color--foreground);
 }

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -249,6 +249,25 @@
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
 				}
 			},
 			"core/post-terms": {
@@ -262,6 +281,21 @@
 							"fontWeight":"700",
 							"lineHeight": "0.8",
 							"letterSpacing": "-0.03em"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}
@@ -313,6 +347,35 @@
 						},
 						"typography": {
 							"textDecoration": "none"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							},
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/post-navigation-link": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}
@@ -443,6 +506,19 @@
 					"link":{
 						"typography":{
 							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":active": {
+							"color": {
+								"background": "var(--wp--preset--color--tertiary)"
+							},
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}
@@ -567,6 +643,11 @@
 					},
 					"typography": {
 						"textDecoration": "none"
+					}
+				},
+				":focus": {
+					"typography": {
+						"textDecoration": "underline"
 					}
 				}
 			}

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -554,7 +554,20 @@
 					"text": "var(--wp--preset--color--primary)"
 				},
 				"typography": {
-					"textDecoration": "none"
+					"textDecoration": "inherit"
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "underline"
+					}
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--tertiary)"
+					},
+					"typography": {
+						"textDecoration": "none"
+					}
 				}
 			}
 		},

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -362,6 +362,9 @@
 			"core/post-navigation-link": {
 				"elements": {
 					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
 						":hover": {
 							"typography": {
 								"textDecoration": "underline"
@@ -635,11 +638,11 @@
 					"text": "var(--wp--preset--color--primary)"
 				},
 				"typography": {
-					"textDecoration": "inherit"
+					"textDecoration": "underline"
 				},
 				":hover": {
 					"typography": {
-						"textDecoration": "underline"
+						"textDecoration": "none"
 					}
 				},
 				":active": {

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -346,14 +346,14 @@
 							"text": "var(--wp--preset--color--foreground)"
 						},
 						"typography": {
-							"textDecoration": "none"
+							"textDecoration": "none 0.25rem"
 						},
 						":hover": {
 							"color": {
 								"text": "var(--wp--preset--color--primary)"
 							},
 							"typography": {
-								"textDecoration": "underline"
+								"textDecoration": "underline 0.25rem"
 							}
 						}
 					}
@@ -393,6 +393,11 @@
 						},
 						"color": {
 							"text": "var(--wp--preset--color--foreground)"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Moved css to theme.json for `:hover`, `:focus` and `:active` states. There are few style left in css because the style properties aren't supported in theme.json. ex: `text-underline-offset`

#### Related issue(s):

#6108 
