### PR TITLE
Blockbase children: update comments block

### DIFF
--- a/arbutus/block-templates/single.html
+++ b/arbutus/block-templates/single.html
@@ -18,7 +18,7 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->

--- a/arbutus/block-templates/single.html
+++ b/arbutus/block-templates/single.html
@@ -18,7 +18,7 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->

--- a/blockbase/block-templates/page.html
+++ b/blockbase/block-templates/page.html
@@ -20,7 +20,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-     <!-- wp:pattern {"slug":"blockbase/comments"} -->
+     <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/blockbase/block-templates/single.html
+++ b/blockbase/block-templates/single.html
@@ -21,7 +21,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:pattern {"slug":"blockbase/comments"} -->
+    <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 
 </div>
 <!-- /wp:group -->

--- a/geologist-blue/block-templates/page.html
+++ b/geologist-blue/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-blue/block-templates/page.html
+++ b/geologist-blue/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-cream/block-templates/page.html
+++ b/geologist-cream/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-cream/block-templates/page.html
+++ b/geologist-cream/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-slate/block-templates/page.html
+++ b/geologist-slate/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-slate/block-templates/page.html
+++ b/geologist-slate/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-yellow/block-templates/page.html
+++ b/geologist-yellow/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist-yellow/block-templates/page.html
+++ b/geologist-yellow/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist/block-templates/page.html
+++ b/geologist/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/geologist/block-templates/page.html
+++ b/geologist/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/mayland-blocks/block-templates/single.html
+++ b/mayland-blocks/block-templates/single.html
@@ -34,7 +34,7 @@
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:pattern {"slug":"blockbase/comments"} -->
+<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/mayland-blocks/block-templates/single.html
+++ b/mayland-blocks/block-templates/single.html
@@ -34,7 +34,7 @@
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-comments /-->
+<!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/meraki/templates/page.html
+++ b/meraki/templates/page.html
@@ -15,7 +15,7 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->

--- a/meraki/templates/page.html
+++ b/meraki/templates/page.html
@@ -15,7 +15,7 @@
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->

--- a/meraki/templates/single.html
+++ b/meraki/templates/single.html
@@ -21,7 +21,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:pattern {"slug":"blockbase/comments"} -->
+    <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/meraki/templates/single.html
+++ b/meraki/templates/single.html
@@ -21,7 +21,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:post-comments /-->
+    <!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/quadrat-black/block-templates/page.html
+++ b/quadrat-black/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-black/block-templates/page.html
+++ b/quadrat-black/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-black/block-templates/single.html
+++ b/quadrat-black/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-black/block-templates/single.html
+++ b/quadrat-black/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-green/block-templates/page.html
+++ b/quadrat-green/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-green/block-templates/page.html
+++ b/quadrat-green/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-green/block-templates/single.html
+++ b/quadrat-green/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-green/block-templates/single.html
+++ b/quadrat-green/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-red/block-templates/page.html
+++ b/quadrat-red/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-red/block-templates/page.html
+++ b/quadrat-red/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-red/block-templates/single.html
+++ b/quadrat-red/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-red/block-templates/single.html
+++ b/quadrat-red/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-white/block-templates/page.html
+++ b/quadrat-white/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-white/block-templates/page.html
+++ b/quadrat-white/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-white/block-templates/single.html
+++ b/quadrat-white/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-white/block-templates/single.html
+++ b/quadrat-white/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-yellow/block-templates/page.html
+++ b/quadrat-yellow/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-yellow/block-templates/page.html
+++ b/quadrat-yellow/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat-yellow/block-templates/single.html
+++ b/quadrat-yellow/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat-yellow/block-templates/single.html
+++ b/quadrat-yellow/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -43,7 +43,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 

--- a/russell/block-templates/single.html
+++ b/russell/block-templates/single.html
@@ -21,7 +21,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:pattern {"slug":"blockbase/comments"} -->
+    <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/russell/block-templates/single.html
+++ b/russell/block-templates/single.html
@@ -21,7 +21,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:post-comments /-->
+    <!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/seedlet-blocks/block-templates/page.html
+++ b/seedlet-blocks/block-templates/page.html
@@ -30,7 +30,7 @@
 <!-- wp:spacer {"height":50} -->
 <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:post-comments /-->
+<!-- wp:pattern {"slug":"blockbase/comments"} -->
 <!-- wp:spacer {"height":25} -->
 <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-templates/page.html
+++ b/seedlet-blocks/block-templates/page.html
@@ -30,7 +30,7 @@
 <!-- wp:spacer {"height":50} -->
 <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:pattern {"slug":"blockbase/comments"} -->
+<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 <!-- wp:spacer {"height":25} -->
 <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-templates/single.html
+++ b/seedlet-blocks/block-templates/single.html
@@ -30,7 +30,7 @@
 <!-- wp:spacer {"height":50} -->
 <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:post-comments /-->
+<!-- wp:pattern {"slug":"blockbase/comments"} -->
 <!-- wp:spacer {"height":25} -->
 <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/seedlet-blocks/block-templates/single.html
+++ b/seedlet-blocks/block-templates/single.html
@@ -30,7 +30,7 @@
 <!-- wp:spacer {"height":50} -->
 <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:pattern {"slug":"blockbase/comments"} -->
+<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 <!-- wp:spacer {"height":25} -->
 <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/videomaker-white/block-templates/page.html
+++ b/videomaker-white/block-templates/page.html
@@ -35,7 +35,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:post-comments /-->
+	<!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker-white/block-templates/page.html
+++ b/videomaker-white/block-templates/page.html
@@ -35,7 +35,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:pattern {"slug":"blockbase/comments"} -->
+	<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker-white/block-templates/single.html
+++ b/videomaker-white/block-templates/single.html
@@ -47,7 +47,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:pattern {"slug":"blockbase/comments"} -->
+    <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker-white/block-templates/single.html
+++ b/videomaker-white/block-templates/single.html
@@ -47,7 +47,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:post-comments /-->
+    <!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/page.html
+++ b/videomaker/block-templates/page.html
@@ -35,7 +35,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:post-comments /-->
+	<!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/page.html
+++ b/videomaker/block-templates/page.html
@@ -35,7 +35,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-	<!-- wp:pattern {"slug":"blockbase/comments"} -->
+	<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -47,7 +47,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:pattern {"slug":"blockbase/comments"} -->
+    <!-- wp:pattern {"slug":"blockbase/comments"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -47,7 +47,7 @@
     <!-- wp:spacer {"height":60} -->
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
-    <!-- wp:post-comments /-->
+    <!-- wp:pattern {"slug":"blockbase/comments"} -->
 </div>
 <!-- /wp:group -->
 

--- a/zoologist/block-templates/page.html
+++ b/zoologist/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/zoologist/block-templates/page.html
+++ b/zoologist/block-templates/page.html
@@ -14,7 +14,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-comments /--></div>
+<div class="wp-block-group"><!-- wp:pattern {"slug":"blockbase/comments"} --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/zoologist/block-templates/single.html
+++ b/zoologist/block-templates/single.html
@@ -37,7 +37,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"blockbase/comments"} -->
+		<!-- wp:pattern {"slug":"blockbase/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/zoologist/block-templates/single.html
+++ b/zoologist/block-templates/single.html
@@ -37,7 +37,7 @@
 		<!-- wp:spacer {"height":150} -->
 		<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-comments /-->
+		<!-- wp:pattern {"slug":"blockbase/comments"} -->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This is a follow up on https://github.com/Automattic/themes/pull/6080 and it's built on top of it. It should be merged right after #6080 to avoid much disruption when the CSS is removed. The loss of that CSS will not result on a broken site, it will simply show the default styling of the old Comment block, so I think it's not terrible for other users of the theme that may take longer to adopt this change if they are already overriding the templates that have the block on it.

@Automattic/serenity heads up on this change and Blockbase's too, for any premium themes that may need it.

Screenshot from Quadrat black:

<img width="893" alt="Screenshot 2022-07-01 at 17 11 14" src="https://user-images.githubusercontent.com/3593343/176921579-e840baf8-e441-4369-8bf5-688e97b8d499.png">

