### PR TITLE
Curator: revise search template

### DIFF
--- a/curator/patterns/hidden-search-form.php
+++ b/curator/patterns/hidden-search-form.php
@@ -10,4 +10,4 @@
 <!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"bottom":"4rem"}}}} -->
 <h1 class="has-text-align-center" style="margin-bottom:4rem"><?php echo esc_html__( 'Search', 'curator' ); ?></h1>
 <!-- /wp:heading -->
-<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo esc_html__( 'Search', 'curator' ); ?>","buttonUseIcon":true,"borderColor":"foreground"} /-->
+<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo esc_html__( 'Search', 'curator' ); ?>","buttonUseIcon":true} /-->

--- a/curator/patterns/hidden-search-form.php
+++ b/curator/patterns/hidden-search-form.php
@@ -7,4 +7,7 @@
 
 ?>
 
+<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"bottom":"4rem"}}}} -->
+<h1 class="has-text-align-center" style="margin-bottom:4rem"><?php echo esc_html__( 'Search', 'curator' ); ?></h1>
+<!-- /wp:heading -->
 <!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo esc_html__( 'Search', 'curator' ); ?>","buttonUseIcon":true,"borderColor":"foreground"} /-->

--- a/curator/style.css
+++ b/curator/style.css
@@ -102,10 +102,18 @@ body {
 .wp-block-file .wp-block-file__button {
 	background-color: var(--wp--preset--color--foreground);
 	border-radius: 0;
-	border: 1px solid var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	font-size: var(--wp--preset--typography--font-size--normal);
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+}
+
+/*
+ * Search input styles
+ * Needed until this is resolved in Gutenberg:
+ * https://github.com/WordPress/gutenberg/issues/34198
+ */
+.wp-block-search__input {
+	border-color: var(--wp--preset--color--foreground);
 }
 
 /*

--- a/curator/templates/search.html
+++ b/curator/templates/search.html
@@ -6,8 +6,8 @@
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 	<!-- wp:pattern {"slug":"curator/search-form"} /-->
-	<!-- wp:spacer -->
-	<div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- wp:spacer {"height":"4rem"} -->
+	<div style="height:4rem;" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 	</div>
 	<!-- /wp:group -->

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -409,6 +409,15 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"lineHeight": "1.6"
+				},
+				"elements": {
+					"button": {
+						"spacing": {
+							"margin": {
+								"left": "0"
+							}
+						}
+					}
 				}
 			},
 			"core/separator": {

--- a/curator/theme.json
+++ b/curator/theme.json
@@ -416,6 +416,10 @@
 							"margin": {
 								"left": "0"
 							}
+						},
+						"border": {
+							"color": "var(--wp--preset--color--primary)",
+							"width": "1px"
 						}
 					}
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR makes some changes to the search template in Curator, to match the Figma design closer

Before | After
--- | ---
<img width="1790" alt="Screen Shot 2022-07-05 at 10 39 31 AM" src="https://user-images.githubusercontent.com/5375500/177353905-d58db6fa-6f0f-437f-a310-89cb8141b788.png"> | <img width="1782" alt="Screen Shot 2022-07-05 at 10 39 18 AM" src="https://user-images.githubusercontent.com/5375500/177353925-5f9902af-2903-4f24-9f44-6b299faa9e07.png">

@beafialho in the Figma, the template suggests the search button is black by default, but in the button states section it is burgundy. Can you confirm which is correct? 

Search Template | Button States 
---- | ----
<img width="952" alt="Captura de ecrã 2022-07-05, às 12 08 11" src="https://user-images.githubusercontent.com/65220155/177314584-9c368e6e-8e98-40f6-baa3-c81a11d5f84b.png"> | <img width="1444" alt="Captura de ecrã 2022-05-11, às 11 55 07" src="https://user-images.githubusercontent.com/65220155/167833525-360d12bb-cdf2-4bb1-b667-45663ba9f64c.png"> 

Also I didn't fix the issue with the button outlines because I think @matiasbenedetto is working on that as a part of #6142.

#### Related issue(s):

Closes #6157 