### PR TITLE
Remote: move link styles to theme.json

### DIFF
--- a/remote/readme.txt
+++ b/remote/readme.txt
@@ -1,7 +1,7 @@
 === Remote ===
 Contributors: 
-Requires at least: 6.0
-Tested up to: 6.0
+Requires at least: 6.1
+Tested up to: 6.1
 Requires PHP: 5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/remote/style.css
+++ b/remote/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.com/theme/remote
 Author: Automattic
 Author URI: https://automattic.com
 Description: Remote is a dark, minimal block theme ideal for bloggers. Its default styles - a sans-serif font and dark background - contribute for a comfortable, immersive reading experience. It features a set of bold block patterns such as a large posts list and bordered categories and tags.
-Requires at least: 6.0
-Tested up to: 6.0
+Requires at least: 6.1
+Tested up to: 6.1
 Requires PHP: 5.7
 Version: 1.0.6
 License: GNU General Public License v2 or later

--- a/remote/style.css
+++ b/remote/style.css
@@ -173,28 +173,8 @@ body > .is-root-container,
  * Link Details
  */
 
- a {
-	text-decoration-thickness: 0.075ex;
+a {
 	text-underline-offset: 0.125em;
-	text-decoration: underline;
-}
-
-a:not(
-	.wp-block-search__button,
-	.wp-block-button__link
-):hover {
-	color: var(--wp--preset--color--primary);
-	text-decoration: none;
-}
-
-a:not(
-	.wp-block-search__button,
-	.wp-block-button__link,
-	.wp-block-site-title a,
-	.wp-block-post-title a
-):active {
-	color: var(--wp--preset--color--primary);
-	text-decoration: underline;
 }
 
 a:not(
@@ -203,9 +183,7 @@ a:not(
 	.wp-block-site-title a,
 	.wp-block-post-title a
 ):focus {
-	color: var(--wp--preset--color--primary);
 	outline: 1px dotted var(--wp--preset--color--primary);
-	text-decoration: none;
 	outline-offset: 3px;
 }
 

--- a/remote/theme.json
+++ b/remote/theme.json
@@ -198,6 +198,17 @@
 						}
 					}
 				}
+			},
+			"core/navigation": {
+				"elements": {
+					"link": {
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							}
+						}
+					}
+				}
 			}
 		},
 		"color": {
@@ -244,6 +255,27 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
+					},
+					"typography": {
+						"textDecoration": "none"
+					}
+				},
+				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
+					}
+				},
+				":focus": {
+					"color": {
+						"text": "var(--wp--preset--color--primary)"
+					},
+					"typography": {
+						"textDecoration": "none"
+					}
 				}
 			}
 		},

--- a/remote/theme.json
+++ b/remote/theme.json
@@ -256,6 +256,9 @@
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				},
+				"typography": {
+					"textDecoration": "underline 0.075ex"
+				},
 				":hover": {
 					"color": {
 						"text": "var(--wp--preset--color--primary)"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Move the link pseudo state styles to theme.json

### Testing instructions

1. Activate remote theme
2. Verify Link and navigation styles. They should work same as trunk on `:hover`, `:active` and `:focus`.
3. Also, verify the same for other style variations.

**Note:** This would be a breaking change before WP 6.1

#### Related issue(s):

#6108 