### PR TITLE
Pendant: Removing default text decoration for link elements

### DIFF
--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -347,6 +347,9 @@
 			"link": {
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
+				},
+				"typography": {
+					"textDecoration": "none"
 				}
 			}
 		},

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -349,7 +349,7 @@
 					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
-					"textDecoration": "none"
+					"textDecoration": "none 0.02em"
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Pendant theme:
The latest changes to Gutenberg links resulted in links being underlined by default. In this PR I'm removing default text-decoration for link elements

#### Related issue(s):
https://github.com/Automattic/themes/issues/6170