### PR TITLE
#5379: Varia/Seedlet: Fix no posts found message

### DIFF
--- a/seedlet/template-parts/content/content-none.php
+++ b/seedlet/template-parts/content/content-none.php
@@ -21,7 +21,7 @@
 			?>
 
 			<p>
-			<?php _e( "Your site is set to show the the most recent posts on this page - but you don't have any Posts published.", 'seedlet' ); ?></p>
+			<?php _e( "Your site is set to show the most recent posts on this page - but you don't have any Posts published.", 'seedlet' ); ?></p>
 			<p>
 				<a href="<?php echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">
 					<?php

--- a/varia/template-parts/content/content-none.php
+++ b/varia/template-parts/content/content-none.php
@@ -22,7 +22,7 @@
 			?>
 
 			<p>
-			<?php _e( "Your site is set to show the the most recent posts on your homepage - but you don't have any Posts published.", 'varia' ); ?></p>
+			<?php _e( "Your site is set to show the most recent posts on this page - but you don't have any Posts published.", 'varia' ); ?></p>
 
 			<p>
 				<a href="<?php echo esc_url( admin_url( 'edit.php' ) ); ?>" class="button">


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

- Fix no posts found message in Varia.
- Remove extra "the" in no posts found message in Seedlet

### Before

<img width="1128" alt="Screenshot on 2022-07-11 at 14-27-19" src="https://user-images.githubusercontent.com/45246438/178336548-3a4f250a-6dd4-4d0c-8d2b-e6ce102ac463.png">

### After

Varia:

<img width="940" alt="Screenshot on 2022-07-11 at 14-37-18" src="https://user-images.githubusercontent.com/45246438/178336429-b57f32d8-6203-439e-b3a7-c23eeadbfff0.png">

Seedlet:

<img width="965" alt="Screenshot on 2022-07-11 at 14-42-32" src="https://user-images.githubusercontent.com/45246438/178336438-923333ed-dfea-4ead-958c-ec473ef87e6a.png">



### Related issue(s):

- Fixes https://github.com/Automattic/themes/issues/5379