### PR TITLE
Vivre: fix font slug references

### DIFF
--- a/curator/patterns/post-navigation.php
+++ b/curator/patterns/post-navigation.php
@@ -14,13 +14,13 @@
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"className":"curator-post-navigation","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group curator-post-navigation">
 
-<!-- wp:post-navigation-link {"type":"previous","label":"← <?php echo esc_html__( 'Previous Post', 'curator' ); ?>","style":{"typography":{"textTransform":"uppercase","textDecoration":"none","fontWeight":"900"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"fontSize":"large","fontFamily":"heading-font"} /--></div>
+<!-- wp:post-navigation-link {"type":"previous","label":"← <?php echo esc_html__( 'Previous Post', 'curator' ); ?>","style":{"typography":{"textTransform":"uppercase","textDecoration":"none","fontWeight":"900"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"fontSize":"large","fontFamily":"work-sans"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"2px"}},"className":"curator-post-navigation","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-<div class="wp-block-group curator-post-navigation"><!-- wp:post-navigation-link {"label":"<?php echo esc_html__( 'Next Post', 'curator' ); ?> →","style":{"typography":{"textTransform":"uppercase","textDecoration":"none","fontWeight":"900"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"fontSize":"large","fontFamily":"heading-font"} /--></div>
+<div class="wp-block-group curator-post-navigation"><!-- wp:post-navigation-link {"label":"<?php echo esc_html__( 'Next Post', 'curator' ); ?> →","style":{"typography":{"textTransform":"uppercase","textDecoration":"none","fontWeight":"900"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"fontSize":"large","fontFamily":"work-sans"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>

--- a/curator/patterns/recipe.php
+++ b/curator/patterns/recipe.php
@@ -18,16 +18,16 @@
 <p class="has-small-font-size"><?php echo esc_html__( 'Prep Time: 11 mins · Servings: 2', 'curator' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"2"}},"fontSize":"x-large","fontFamily":"body-font"} -->
-<h2 class="has-body-font-font-family has-x-large-font-size" style="font-style:normal;font-weight:300;line-height:2"><?php echo esc_html__( 'Ingredients', 'curator' ); ?></h2>
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"2"}},"fontSize":"x-large","fontFamily":"petrona"} -->
+<h2 class="has-petrona-font-family has-x-large-font-size" style="font-style:normal;font-weight:300;line-height:2"><?php echo esc_html__( 'Ingredients', 'curator' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p><em><?php echo esc_html__( '1/4 cup old-fashioned oats or quick oats', 'curator' ); ?><br><?php echo esc_html__( '1 banana chopped into chunks and frozen', 'curator' ); ?><br><?php echo esc_html__( '1/2 cup unsweetened almond milk', 'curator' ); ?><br><?php echo esc_html__( '1 tablespoon creamy peanut butter', 'curator' ); ?><br><?php echo esc_html__( '1/2 tablespoon pure maple syrup plus additional to taste', 'curator' ); ?><br><?php echo esc_html__( '1/2 teaspoon pure vanilla extract', 'curator' ); ?><br><?php echo esc_html__( '1/2 teaspoon ground cinnamon', 'curator' ); ?><br><?php echo esc_html__( '1/8 teaspoon kosher salt', 'curator' ); ?><br><?php echo esc_html__( 'Ice (optional)', 'curator' ); ?></em></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"2"}},"fontSize":"x-large","fontFamily":"body-font"} -->
-<h2 class="has-body-font-font-family has-x-large-font-size" style="font-style:normal;font-weight:300;line-height:2"><?php echo esc_html__( 'Preparation', 'curator' ); ?></h2>
+<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"2"}},"fontSize":"x-large","fontFamily":"petrona"} -->
+<h2 class="has-petrona-font-family has-x-large-font-size" style="font-style:normal;font-weight:300;line-height:2"><?php echo esc_html__( 'Preparation', 'curator' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

https://github.com/Automattic/themes/pull/6166 renamed the font slugs from their semantic names, and we missed a couple patterns where the old slugs were being referenced. This PR changes them to the correct names.

#### Related issue(s):
