### PR TITLE
#3851: Ixion: Fix pullquote custom border colors

### DIFF
--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -268,16 +268,35 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-pullquote {
 	margin: 0;
 	padding: 0;
+}
+
+.wp-block-pullquote:not(.has-border-color) {
 	border: 0;
 }
 
 .wp-block-pullquote blockquote {
-	border-top: 2px solid #d7b221;
-	border-bottom: 2px solid #d7b221;
 	font-style: italic;
 	font-size: 24px;
 	margin: 0 0 1.5em;
 	padding: .8em 0;
+}
+
+.wp-block-pullquote:not(.has-border-color) blockquote {
+	border-top: 2px solid #d7b221;
+	border-bottom: 2px solid #d7b221;
+}
+
+.wp-block-pullquote.has-border-color[style] {
+	border-bottom-width: 2px;
+	border-left: unset !important;
+	border-right: unset !important;
+	border-top-width: 2px;
+	padding: 0;
+	margin-bottom: 1.5em;
+}
+
+.wp-block-pullquote.has-border-color blockquote {
+	margin-bottom: 0;
 }
 
 .wp-block-pullquote cite {

--- a/ixion/editor-blocks.css
+++ b/ixion/editor-blocks.css
@@ -526,12 +526,37 @@
 }
 
 .wp-block-pullquote {
-	border-top: 2px solid #d7b221;
-	border-bottom: 2px solid #d7b221;
+	margin: 0;
+	padding: 0;
+}
+
+.wp-block-pullquote:not(.has-border-color) {
+	border: 0;
+}
+
+.wp-block-pullquote blockquote {
 	font-style: italic;
 	font-size: 24px;
 	margin: 0 0 1.5em;
 	padding: .8em 0;
+}
+
+.wp-block-pullquote:not(.has-border-color) blockquote {
+	border-top: 2px solid #d7b221;
+	border-bottom: 2px solid #d7b221;
+}
+
+.wp-block-pullquote.has-border-color[style] {
+	border-bottom-width: 2px;
+	border-left: unset !important;
+	border-right: unset !important;
+	border-top-width: 2px;
+	padding: 0;
+	margin-bottom: 1.5em;
+}
+
+.wp-block-pullquote.has-border-color blockquote {
+	margin-bottom: 0;
 }
 
 .wp-block-pullquote blockquote {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->


Testing:

1. Create a new post/page with pullquotes
2. Add pullquote and set a custom color
3. It now properly reflects on site and editor matches what displays on frontend

### Changes proposed in this Pull Request:

#### Before

##### Editor
<img width="1178" alt="Screenshot on 2022-07-12 at 09-45-34" src="https://user-images.githubusercontent.com/45246438/178507768-d078ba83-e8d6-4809-a3ce-daf5098c6afb.png">

##### Frontend
<img width="1139" alt="Screenshot on 2022-07-12 at 09-34-50" src="https://user-images.githubusercontent.com/45246438/178507805-d83b457c-ac83-4624-b1e9-56d7647ed320.png">


#### After


##### Editor

<img width="1334" alt="Screenshot on 2022-07-12 at 09-49-13" src="https://user-images.githubusercontent.com/45246438/178507990-b391fd40-4890-43ea-be23-127fb256e23c.png">

##### Frontend

<img width="1120" alt="Screenshot on 2022-07-12 at 09-54-10(1)" src="https://user-images.githubusercontent.com/45246438/178508268-de517554-d6c4-48db-90de-4939ec611d15.png">




### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/3851