### PR TITLE
#6004: Seedlet: Fix link underline colors in Safari

### DIFF
--- a/seedlet/assets/css/style-editor.css
+++ b/seedlet/assets/css/style-editor.css
@@ -286,7 +286,9 @@
  */
 a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: underline 1px var(--global--color-secondary);
+	text-decoration-color: var(--global--color-secondary);
+	text-decoration-line: underline;
+	text-decoration-thickness: 1px;
 	text-underline-offset: 0.3em;
 	transition: text-decoration 0.1s ease-out;
 }

--- a/seedlet/assets/sass/base/_base.scss
+++ b/seedlet/assets/sass/base/_base.scss
@@ -1,7 +1,9 @@
 // Links styles
 a {
-	color: var( --wp--style--color--link, var(--global--color-primary) );
-	text-decoration: underline 1px var(--global--color-secondary);
+	color: var(--wp--style--color--link, var(--global--color-primary));
+	text-decoration-color: var(--global--color-secondary);
+	text-decoration-line: underline;
+	text-decoration-thickness: 1px;
 	text-underline-offset: 0.3em;
 	transition: text-decoration 0.1s ease-out;
 
@@ -19,13 +21,13 @@ a {
 	}
 
 	&:active {
-		color: var( --wp--style--color--link, var(--global--color-primary) );
+		color: var(--wp--style--color--link, var(--global--color-primary));
 	}
 
 	// If a custom link color has been assigned,
 	// switch the color of the bottom border too.
 	.has-link-color & {
-		text-decoration-color: var( --wp--style--color--link, var(--global--color-primary) );
+		text-decoration-color: var(--wp--style--color--link, var(--global--color-primary));
 
 		&:hover,
 		&:focus {

--- a/seedlet/assets/sass/style.scss
+++ b/seedlet/assets/sass/style.scss
@@ -7,7 +7,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.16-wpcom
+Version: 1.1.23-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.19-wpcom
+Version: 1.1.16-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
@@ -928,7 +928,9 @@ body {
 
 a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: underline 1px var(--global--color-secondary);
+	text-decoration-color: var(--global--color-secondary);
+	text-decoration-line: underline;
+	text-decoration-thickness: 1px;
 	text-underline-offset: 0.3em;
 	transition: text-decoration 0.1s ease-out;
 }

--- a/seedlet/style-rtl.css
+++ b/seedlet/style-rtl.css
@@ -8,7 +8,7 @@ Description: Seedlet is a free WordPress theme. A two-column layout and classica
 Requires at least: 5.5
 Tested up to: 5.5
 Requires PHP: 5.6.2
-Version: 1.1.16-wpcom
+Version: 1.1.23-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -928,7 +928,9 @@ body {
 
 a {
 	color: var(--wp--style--color--link, var(--global--color-primary));
-	text-decoration: underline 1px var(--global--color-secondary);
+	text-decoration-color: var(--global--color-secondary);
+	text-decoration-line: underline;
+	text-decoration-thickness: 1px;
 	text-underline-offset: 0.3em;
 	transition: text-decoration 0.1s ease-out;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Safari doesn't seem to fully support the `text-decoration` shorthand. By separating out the values I was able to fix this in Safari

#### Testing:

1. Create a blog post with a link
2. View and note that the link now shows the underline in Safari


#### Before

<img width="752" alt="Screenshot on 2022-07-12 at 14-54-35" src="https://user-images.githubusercontent.com/45246438/178581086-69eca45a-4694-4be0-b9a8-80a1958fb8fc.png">


#### After

<img width="751" alt="Screenshot on 2022-07-12 at 15-12-18" src="https://user-images.githubusercontent.com/45246438/178581131-0171dd2c-1563-4333-a9d0-90c84715607b.png">

### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6004