### PR TITLE
#4567: Radcliffe 2: Fix editor post title alignment

### DIFF
--- a/radcliffe-2/assets/css/editor-style.css
+++ b/radcliffe-2/assets/css/editor-style.css
@@ -71,10 +71,6 @@ Description: Used to style Gutenberg Blocks in the editor.
 	}
 }
 
-.edit-post-visual-editor .editor-post-title {
-	max-width: 100%;
-}
-
 /* Headings */
 
 .edit-post-visual-editor h1,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Removed editor style for post title.

Test:

1. Create new post.
2. Observe title now lines up.

##### Before

<img width="1960" alt="Screenshot on 2022-07-13 at 11-43-58" src="https://user-images.githubusercontent.com/45246438/178777190-ad5dae15-4784-497c-8914-db2352dc1ac9.png">


##### After

<img width="1953" alt="Screenshot on 2022-07-13 at 11-44-53" src="https://user-images.githubusercontent.com/45246438/178777119-29c8052c-0dd8-4c28-9069-df3b566668d0.png">

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4567