### PR TITLE
#5550: Pique: Fix dropdown menu w/image comparison block

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -845,7 +845,7 @@ a:active {
 	height: 240px;
 	position: relative;
 	text-align: center;
-	z-index: 5;
+	z-index: 99;
 }
 #masthead .pique-header {
 	bottom: 0;
@@ -3907,13 +3907,4 @@ figure {
 /* Tiled galleries */
 .tiled-gallery-caption {
 	text-shadow: none;
-}
-
-/*--------------------------------------------------------------
-## Image Comparison
---------------------------------------------------------------*/
-
-.wp-block-jetpack-image-compare {
-	position: relative;
-	z-index: 0;
 }

--- a/pique/style.css
+++ b/pique/style.css
@@ -42,6 +42,7 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/
 # Media
 	## Captions
 	## Galleries
+	## Image Comparison
 --------------------------------------------------------------*/
 /*--------------------------------------------------------------
 # Normalize
@@ -3906,4 +3907,13 @@ figure {
 /* Tiled galleries */
 .tiled-gallery-caption {
 	text-shadow: none;
+}
+
+/*--------------------------------------------------------------
+## Image Comparison
+--------------------------------------------------------------*/
+
+.wp-block-jetpack-image-compare {
+	position: relative;
+	z-index: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

When using the Jetpack Image Comparison block on desktop and mobile, dropdown menus appear "behind" the Comparison block.

#### Changes proposed in this Pull Request:

##### Before

<img width="761" alt="Screen Shot 2022-07-13 at 12 08 55" src="https://user-images.githubusercontent.com/45246438/178798846-9f963198-036c-4408-a5fa-295054a0d8fb.png">


##### After

<img width="763" alt="Screen Shot 2022-07-13 at 12 14 55" src="https://user-images.githubusercontent.com/45246438/178799127-754de28d-8df4-4aff-afe4-f2b802069da1.png">

<img width="365" alt="Screenshot on 2022-07-13 at 13-53-45(1)" src="https://user-images.githubusercontent.com/45246438/178799124-91112daa-fca7-4b35-8cbb-e3f63a8a89e5.png">

#### Related issue(s):

Fixes  https://github.com/Automattic/themes/issues/5550