### PR TITLE
Shoreditch: fixes php 7.4 warning on posts w/o featured img

### DIFF
--- a/shoreditch/inc/extras.php
+++ b/shoreditch/inc/extras.php
@@ -57,7 +57,7 @@ function shoreditch_background_image() {
 	}
 	else {
 		$image = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'post-thumbnail' );
-		$image = $image[0];
+		$image = ( ! empty( $image[0] ) ) ? $image[0] : null;
 	}
 
 	if ( ! $image ) {

--- a/shoreditch/inc/jetpack.php
+++ b/shoreditch/inc/jetpack.php
@@ -150,8 +150,8 @@ function shoreditch_testimonials_image() {
 	$jetpack_options = get_theme_mod( 'jetpack_testimonials' );
 	if ( isset( $jetpack_options['featured-image'] ) && '' != $jetpack_options['featured-image'] ) {
 		$image = wp_get_attachment_image_src( (int)$jetpack_options['featured-image'], 'post-thumbnail' );
-		$image = ( ! empty( $image[0] ) ) ? $image[0] : null;
-		printf( ' style="background-image: url(\'%s\');"', esc_url( $image[0] ) );
+		$url = ( ! empty( $image[0] ) ) ? $image[0] : null;
+		printf( ' style="background-image: url(\'%s\');"', esc_url( $url ) );
 	}
 }
 

--- a/shoreditch/inc/jetpack.php
+++ b/shoreditch/inc/jetpack.php
@@ -150,6 +150,7 @@ function shoreditch_testimonials_image() {
 	$jetpack_options = get_theme_mod( 'jetpack_testimonials' );
 	if ( isset( $jetpack_options['featured-image'] ) && '' != $jetpack_options['featured-image'] ) {
 		$image = wp_get_attachment_image_src( (int)$jetpack_options['featured-image'], 'post-thumbnail' );
+		$image = ( ! empty( $image[0] ) ) ? $image[0] : null;
 		printf( ' style="background-image: url(\'%s\');"', esc_url( $image[0] ) );
 	}
 }
@@ -232,7 +233,7 @@ function shoreditch_get_attachment_image_src( $post_id, $post_thumbnail_id, $siz
 		return jetpack_featured_images_fallback_get_image_src( $post_id, $post_thumbnail_id, $size );
 	} else {
 		$attachment = wp_get_attachment_image_src( $post_thumbnail_id, $size ); // Attachment array
-		$url = $attachment[0]; // Attachment URL
+		$url = ( ! empty( $attachment[0] ) ) ? $attachment[0] : null; // Attachment URL
 		return $url;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

PHP 7.4 / 8.0+ [throws a warning when trying to access an array offset on a non-array](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access). In the Shoreditch theme, this shows up (with `WP_DEBUG` enabled) when viewing posts or pages that don't have featured images because the `wp_get_attachment_image_src()` function returns `false` if there is no featured image.

```
Warning: Trying to access array offset on value of type bool in /Users/xxx/Sites/wordpress/web/app/themes/shoreditch/inc/extras.php on line 60
>
```

and

```
Warning: Trying to access array offset on value of type bool in /Users/xxx/Sites/wordpress/web/app/themes/shoreditch/inc/jetpack.php on line 235
> 
```

The code in this PR fixes this warning, matching the style and method of [other code](https://github.com/Automattic/themes/blob/v1.0.168/shoreditch/inc/jetpack.php#L196) in this theme.

#### Related issue(s):

#6191 