### PR TITLE
Actions: add Repo gardening action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,133 @@
+name: Bug Report
+description: Helps us improve our product!
+labels: "Needs triage, [Type] Bug"
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for contributing!
+
+        Please write a clear title, then fill in as much details as possible.
+
+        __Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.__
+        Instead, attach screenshot(s) or recording(s) directly in any of the text areas below: click, then drag and drop.
+  - type: textarea
+    id: summary
+    attributes:
+        label: Quick summary
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start at `site-domain.com/blog`.
+        2. Click on any blog post.
+        3. Click on the 'Like' button.
+        4. ...
+
+        Attach any media by drag and dropping or selecting upload.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+      placeholder: |
+        e.g. The post should be liked.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      placeholder: |
+        e.g. Clicking the button does nothing visibly.
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: (You may select more than one)
+      options:
+        - Google Chrome/Chromium
+        - Mozilla Firefox
+        - Microsoft Edge
+        - Apple Safari
+        - iOS Safari
+        - Android Chrome
+      multiple: true
+  - type: input
+    id: issue_context
+    attributes:
+      label: Context
+      placeholder: |
+        e.g. Customer report, details of your exploratory testing, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Additional context
+
+        The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.
+  - type: dropdown
+    id: site-type
+    attributes:
+      label: Platform (Simple, Atomic, or both?)
+      description: (You may select more than one)
+      options:
+        - Simple
+        - Atomic
+        - Self-hosted
+      multiple: true
+  - type: textarea
+    id: other_notes
+    attributes:
+      label: Other notes
+      placeholder: |
+        e.g. Logs, CLI or console errors, notes, observations, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Issue severity
+
+        Please provide details around how often the issue is reproducible & how many users are affected.
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+    validations:
+      required: true
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: How many users are impacted? A guess is fine.
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, closed]
   issue_comment: # To gather support references in issue comments.
     types: [created]
 concurrency:
@@ -40,4 +40,6 @@ jobs:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_token: ${{ secrets.SLACK_TOKEN }}
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,flagOss,triageNewIssues,gatherSupportReferences'
+         slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+         slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,43 @@
+name: Repo gardening
+
+on:
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, closed]
+  issues: # For auto-triage of issues.
+    types: [opened, reopened, edited]
+  issue_comment: # To gather support references in issue comments.
+    types: [created]
+concurrency:
+  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # Don't cancel any for other events, accomplished by grouping on the unique run_id.
+  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  repo-gardening:
+    name: 'Perform automated triage tasks on PRs and issues'
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v3
+
+     - name: Setup Node
+       uses: actions/setup-node@v3
+       with:
+         node-version: 16
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@trunk
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,flagOss,triageNewIssues,gatherSupportReferences'

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,8 +1,8 @@
 name: Repo gardening
 
 on:
-  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
-    types: [opened, reopened, synchronize, edited, closed]
+  pull_request_target: # When a PR is opened or closed
+    types: [opened, closed]
   issues: # For auto-triage of issues.
     types: [opened, reopened, edited, closed]
   issue_comment: # To gather support references in issue comments.
@@ -42,4 +42,4 @@ jobs:
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder'
+         tasks: 'cleanLabels,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR introduces a new action that will run on all issues and PRs in this repo.

More details about the action here:
https://github.com/Automattic/action-repo-gardening

The action is already used in the Calypso and Jetpack repos.

I've enabled 6 of the tasks the action offers so far:

1. Assign Issues (`assignIssues`): Adds assignee for issues which are being worked on, and adds the "In Progress" label.
2. Clean Labels (`cleanLabels`): Removes Status labels once a PR has been merged.
3. Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message to the #themes channel.
4. Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content. For this to work, I've also added a new "Bug Report" issue template, similar to the ones in use in the Calypso and the Jetpack repos, and that should help gathering information when issues are opened.
5. Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue, and message in Slack when an issue starts getting a lot of tickets. More details about this in pcLjiI-Rb-p2 and pciE2j-1iy-p2
6. Reply to customers Reminder ( `replyToCustomersReminder` ): sends a Slack message about closed issues to remind Automatticians to update customers. Reference: pcLjiI-Ro-p2

**What do you think about the changes?**

I think we could start with those, and either add more or remove some of them in the future depending on how this first experiment goes.
I'm hoping this will help standardize some of the repo experience of both developers and HEs, with tools and automations that are similar in the different Automattic repos.

Here are a few screenshots of the tools in action in other repos; we cannot test this easily in this repo until this PR gets merged.

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/426388/179200243-2fef88e5-12e7-4852-8924-50b7a866861f.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/426388/179200312-143b4f7b-0c59-4c15-b36c-0126321f11bd.png">
<img width="591" alt="image" src="https://user-images.githubusercontent.com/426388/179200473-7a8413f4-b567-42cf-9c7e-951bee4b2438.png">
<img width="906" alt="image" src="https://user-images.githubusercontent.com/426388/179200626-f09dd02f-912f-4f0d-be2a-7332562db757.png">

Internal reference: p1657879153257599-slack-C029FM1EH