### PR TITLE
Update dotOrg publisher to include style variations

### DIFF
--- a/dotorg-exclude.txt
+++ b/dotorg-exclude.txt
@@ -1,9 +1,9 @@
 inc/headstart
 node_modules
+package.json
 .git
 *.DS_Store
 *.sh
-*.json
 *.map
 *wpcom*
 *.zip

--- a/dotorg-include.txt
+++ b/dotorg-include.txt
@@ -1,0 +1,2 @@
+theme.json
+styles/*.json

--- a/dotorg-include.txt
+++ b/dotorg-include.txt
@@ -1,2 +1,0 @@
-theme.json
-styles/*.json

--- a/package-dotorg.sh
+++ b/package-dotorg.sh
@@ -11,7 +11,7 @@ if [[ "$1" != "" ]]; then
 
 	cd $THEME && npm run build;
 	mkdir $THEME;
-	rsync -avz --include='theme.json' --exclude $THEME --exclude-from '../dotorg-exclude.txt' ./ $THEME
+	rsync -avz --include-from='../dotorg-include.txt' --exclude $THEME --exclude-from '../dotorg-exclude.txt' ./ $THEME
 	find $THEME -type f -name '*.map' -delete # for some reason rsync won't exclude map files
 	rm -rf $THEME/$THEME
 	zip -r -X $THEME.zip $THEME

--- a/package-dotorg.sh
+++ b/package-dotorg.sh
@@ -11,7 +11,7 @@ if [[ "$1" != "" ]]; then
 
 	cd $THEME && npm run build;
 	mkdir $THEME;
-	rsync -avz --include-from='../dotorg-include.txt' --exclude $THEME --exclude-from '../dotorg-exclude.txt' ./ $THEME
+	rsync -avz --exclude $THEME --exclude-from '../dotorg-exclude.txt' ./ $THEME
 	find $THEME -type f -name '*.map' -delete # for some reason rsync won't exclude map files
 	rm -rf $THEME/$THEME
 	zip -r -X $THEME.zip $THEME


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Include the `styles/*.json` in dorOrg publisher so that theme variations gets published.

#### Testing instructions

Validate the following to verify all the required theme files copied properly

```
cd pendant
rsync -avz --include-from='../dotorg-include.txt' --exclude 'pendant' --exclude-from '../dotorg-exclude.txt' ./ 'pendant'

# cleanup
rm -r pendant
```

#### Related issue(s):

#6248 