### PR TITLE
update deploy script to consider level 3 files for version bump

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -728,7 +728,7 @@ async function versionBumpTheme(theme, addChanges) {
 	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
 	let currentVersion = getThemeMetadata(styleCss, 'Version');
 
-	let filesToUpdate = await executeCommand(`find ${theme} -name package.json -o -name style.scss -o -name style-child-theme.scss -maxdepth 2`);
+	let filesToUpdate = await executeCommand(`find ${theme} -name package.json -o -name style.scss -o -name style-child-theme.scss -maxdepth 3`);
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
 
 	for (let file of filesToUpdate) {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Themes such as seedlet has the `.scss` files under level 3 and the script would not version bump them.
These leaves `style.scss` and `style.css` at different versions and when the theme is rebuild it lowers the theme version.

### Question: Do we need to maintain `-wpcom` version suffix ?

The above script overrides the source file with a version without a `-wpcom` suffix and I left it because many themes doesn't have a suffix.

#### Related issue(s):

Resolves https://github.com/Automattic/themes/pull/6199#discussion_r921990603