### PR TITLE
Club: implementing fluid typography

### DIFF
--- a/club/style.css
+++ b/club/style.css
@@ -37,6 +37,10 @@ GNU General Public License for more details.
 	-webkit-font-smoothing: antialiased;
 }
 
+a {
+	text-underline-offset: .3em;
+}
+
 /*
  * Button hover styles.
  * Necessary until the following issue is resolved in Gutenberg:

--- a/club/style.css
+++ b/club/style.css
@@ -38,7 +38,7 @@ GNU General Public License for more details.
 }
 
 a {
-	text-underline-offset: .3em;
+	text-underline-offset: .15em;
 }
 
 /*

--- a/club/theme.json
+++ b/club/theme.json
@@ -157,8 +157,8 @@
                 },
                 {
                     "size": "2.5rem",
-                    "slug": "Extra Large",
-                    "name": "x-large"
+                    "slug": "x-large",
+                    "name": "Extra Large"
                 },
                 {
                     "size": "3.75rem",

--- a/club/theme.json
+++ b/club/theme.json
@@ -343,7 +343,8 @@
                 },
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--default-title)",
-                    "textTransform": "uppercase"
+                    "textTransform": "uppercase",
+                    "letterSpacing": "-0.04em"
                     
                 },
                 "elements": {
@@ -436,7 +437,8 @@
                             "fontSize": "var(--wp--preset--font-size--default-title)",
                             "fontWeight": "700",
                             "textDecoration": "underline solid 1.5px",
-                            "fontStyle": "italic"
+                            "fontStyle": "italic",
+                            "letterSpacing": "-0.04em"
                         }
                     }
                 }
@@ -449,8 +451,8 @@
             "core/read-more": {
                 "typography": {
                     "textTransform": "uppercase",
-                    "lineHeight": "1em",
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "letterSpacing": "-0.04em"
                 },
                 "border": {
                     "color": "var(--wp--preset--color--foreground)",
@@ -503,32 +505,38 @@
 			},
             "h1": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-one)"
+                    "fontSize": "var(--wp--preset--font-size--header-one)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "h2": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-two)"
+                    "fontSize": "var(--wp--preset--font-size--header-two)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "h4": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-four)"
+                    "fontSize": "var(--wp--preset--font-size--header-four)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "h5": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default)"
+                    "fontSize": "var(--wp--preset--font-size--default)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "h6": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--small)"
+                    "fontSize": "var(--wp--preset--font-size--small)",
+                    "letterSpacing": "-0.04em"
                 }
             },
             "link": {

--- a/club/theme.json
+++ b/club/theme.json
@@ -142,21 +142,25 @@
                 },
                 {
                     "size": "1.25rem",
+                    "fluid": false,
                     "slug": "default",
                     "name": "Default"
                 },
                 {
                     "size": "1.5rem",
+                    "fluid": false,
                     "slug": "medium",
                     "name": "Medium"
                 },
                 {
                     "size": "1.75rem",
+                    "fluid": false,
                     "slug": "large",
                     "name": "Large"
                 },
                 {
                     "size": "2.5rem",
+                    "fluid": false,
                     "slug": "x-large",
                     "name": "Extra Large"
                 },

--- a/club/theme.json
+++ b/club/theme.json
@@ -317,7 +317,6 @@
             },
             "core/heading": {
                 "typography": {
-                    "fontWeight": "400",
                     "lineHeight": "1.125"
                 }
             },
@@ -522,37 +521,43 @@
             "h1": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--header-one)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "400"
                 }
             },
             "h2": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--header-two)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "400"
                 }
             },
             "h3": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--header-three)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "700"
                 }
             },
             "h4": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--header-four)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "700"
                 }
             },
             "h5": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--header-five)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "700"
                 }
             },
             "h6": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--small)",
-                    "letterSpacing": "-0.04em"
+                    "letterSpacing": "-0.04em",
+                    "fontWeight": "700"
                 }
             },
             "link": {

--- a/club/theme.json
+++ b/club/theme.json
@@ -343,8 +343,15 @@
                 },
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--default-title)",
-                    "textTransform": "uppercase",
-                    "textDecoration": "none"
+                    "textTransform": "uppercase"
+                    
+                },
+                "elements": {
+                    "link": {
+                        "typography": {
+                            "textDecoration": "none"
+                        }
+                    }
                 }
             },
             "core/post-title": {
@@ -355,8 +362,7 @@
                 },
                 "typography": {
                     "lineHeight": "1.125",
-                    "fontWeight": "400",
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontWeight": "400"
                 }
             },
             "core/pullquote": {
@@ -507,7 +513,7 @@
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-three)"
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
                 }
             },
             "h4": {

--- a/club/theme.json
+++ b/club/theme.json
@@ -63,6 +63,9 @@
             "gap": {
                 "horizontal": "min(30px, 5vw)",
                 "vertical": "min(30px, 5vw)"
+            },
+            "fontSizes":{
+                "default-title": "clamp(1.25rem, calc(1.25rem + ((1vw - 0.48rem) * 2.4038)), 2.5rem)"
             }
         },
         "layout": {
@@ -141,15 +144,6 @@
                     "name": "Small"
                 },
                 {
-                    "size": "1rem",
-                    "fluid": {
-                        "min": "0.875rem",
-                        "max": "1.25rem"
-                    },
-                    "slug": "default",
-                    "name": "Default"
-                },
-                {
                     "size": "1.25rem",
                     "fluid": {
                         "min": "1.25rem",
@@ -169,48 +163,6 @@
                     "fluid": false,
                     "slug": "x-large",
                     "name": "Extra Large"
-                },
-                {
-                    "size": "3.75rem",
-                    "fluid": {
-                        "min": "3.75rem",
-                        "max": "8.125rem"
-                    },
-                    "slug": "header-one",
-                    "name": "Header 1"
-                },
-                {
-                    "size": "3rem",
-                    "fluid": {
-                        "min": "2.51rem",
-                        "max": "6.875rem"
-                    },
-                    "slug": "header-two",
-                    "name": "Header 2"
-                },
-                {
-                    "size": "1.75rem",
-                    "fluid": {
-                        "min": "1.75rem",
-                        "max": "2rem"
-                    },
-                    "slug": "header-four",
-                    "name": "Header 4"
-                },
-                {
-                    "size": "1.25rem",
-                    "fluid": false,
-                    "slug": "header-five",
-                    "name": "Header 5"
-                },
-                {
-                    "size": "1.25rem",
-                    "fluid": {
-                        "min": "1.25rem",
-                        "max": "2.5rem"
-                    },
-                    "slug": "default-title",
-                    "name": "Default Title"
                 }
             ]
         }
@@ -340,7 +292,7 @@
             },
             "core/navigation": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
                 }
             },
             "core/post-date": {
@@ -348,7 +300,7 @@
                     "text": "var(--wp--preset--color--foreground)"
                 },
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "fontSize": "var(--wp--custom--font-sizes--default-title)",
                     "textTransform": "uppercase",
                     "letterSpacing": "-0.04em"
                     
@@ -370,7 +322,7 @@
                 "typography": {
                     "lineHeight": "1.125",
                     "fontWeight": "400",
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
                 }
             },
             "core/pullquote": {
@@ -436,12 +388,12 @@
             "core/site-title": {
                 "typography": {
                     "lineHeight": ".8",
-                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
                 },
                 "elements": {
                     "link": {
                         "typography": {
-                            "fontSize": "var(--wp--preset--font-size--default-title)",
+                            "fontSize": "var(--wp--custom--font-sizes--default-title)",
                             "fontWeight": "700",
                             "textDecoration": "underline solid 1.5px",
                             "fontStyle": "italic",
@@ -458,7 +410,7 @@
             "core/read-more": {
                 "typography": {
                     "textTransform": "uppercase",
-                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "fontSize": "var(--wp--custom--font-sizes--default-title)",
                     "letterSpacing": "-0.04em"
                 },
                 "border": {
@@ -512,35 +464,35 @@
 			},
             "h1": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-one)",
+                    "fontSize": "clamp(3.75rem, calc(3.75rem + ((1vw - 0.48rem) * 8.4135)), 8.125rem)",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "400"
                 }
             },
             "h2": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-two)",
+                    "fontSize": "clamp(2.5rem, calc(2.5rem + ((1vw - 0.48rem) * 8.4135)), 6.875rem)",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "400"
                 }
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "fontSize": "clamp(1.875rem, calc(1.875rem + ((1vw - 0.48rem) * 1.2019)), 2.5rem)",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },
             "h4": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-four)",
+                    "fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 0.4808)), 2rem)",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },
             "h5": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-five)",
+                    "fontSize": "1.25rem",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
@@ -576,7 +528,7 @@
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--spacemono)",
-            "fontSize": "var(--wp--preset--font-size--default)",
+            "fontSize": "clamp(0.875rem, calc(0.875rem + ((1vw - 0.48rem) * 0.7212)), 1.25rem)",
             "lineHeight": "1.6"
         }
     },

--- a/club/theme.json
+++ b/club/theme.json
@@ -355,7 +355,6 @@
                 },
                 "typography": {
                     "lineHeight": "1.125",
-                    "textDecoration": "underline solid 3px",
                     "fontWeight": "400",
                     "fontSize": "var(--wp--preset--font-size--default-title)"
                 }
@@ -529,6 +528,19 @@
             "link": {
                 "color": {
                     "text": "var(--wp--preset--color--primary)"
+                },
+                "typography": {
+                    "textDecoration": "underline solid 1px"
+                },
+                ":hover": {
+                    "typography": {
+                        "textDecoration": "none"
+                    }
+                },
+                ":active": {
+                    "typography": {
+                        "textDecoration": "underline dotted 1px"
+                    }
                 }
             }
         },

--- a/club/theme.json
+++ b/club/theme.json
@@ -462,45 +462,44 @@
 					}
 				}
 			},
+            "heading": {
+                "typography": {
+                    "letterSpacing": "-0.04em"
+                }
+            },
             "h1": {
                 "typography": {
                     "fontSize": "clamp(3.75rem, calc(3.75rem + ((1vw - 0.48rem) * 8.4135)), 8.125rem)",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "400"
                 }
             },
             "h2": {
                 "typography": {
                     "fontSize": "clamp(2.5rem, calc(2.5rem + ((1vw - 0.48rem) * 8.4135)), 6.875rem)",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "400"
                 }
             },
             "h3": {
                 "typography": {
                     "fontSize": "clamp(1.875rem, calc(1.875rem + ((1vw - 0.48rem) * 1.2019)), 2.5rem)",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },
             "h4": {
                 "typography": {
                     "fontSize": "clamp(1.75rem, calc(1.75rem + ((1vw - 0.48rem) * 0.4808)), 2rem)",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },
             "h5": {
                 "typography": {
                     "fontSize": "1.25rem",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },
             "h6": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--small)",
-                    "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }
             },

--- a/club/theme.json
+++ b/club/theme.json
@@ -189,15 +189,6 @@
                     "name": "Header 2"
                 },
                 {
-                    "size": "1.875rem",
-                    "fluid": {
-                        "min": "1.875rem",
-                        "max": "2.5rem"
-                    },
-                    "slug": "header-three",
-                    "name": "Header 3"
-                },
-                {
                     "size": "1.75rem",
                     "fluid": {
                         "min": "1.75rem",
@@ -349,7 +340,7 @@
             },
             "core/navigation": {
                 "typography": {
-                    "fontSize": "1.125rem"
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
                 }
             },
             "core/post-date": {
@@ -378,7 +369,8 @@
                 },
                 "typography": {
                     "lineHeight": "1.125",
-                    "fontWeight": "400"
+                    "fontWeight": "400",
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
                 }
             },
             "core/pullquote": {
@@ -534,7 +526,7 @@
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--header-three)",
+                    "fontSize": "var(--wp--preset--font-size--default-title)",
                     "letterSpacing": "-0.04em",
                     "fontWeight": "700"
                 }

--- a/club/theme.json
+++ b/club/theme.json
@@ -132,7 +132,7 @@
             "fluid": true,
             "fontSizes": [
                 {
-                    "size": "1rem",
+                    "size": "0.875rem",
                     "fluid": {
                         "min": "0.875rem",
                         "max": "1rem"
@@ -141,14 +141,20 @@
                     "name": "Small"
                 },
                 {
-                    "size": "1.25rem",
-                    "fluid": false,
+                    "size": "1rem",
+                    "fluid": {
+                        "min": "0.875rem",
+                        "max": "1.25rem"
+                    },
                     "slug": "default",
                     "name": "Default"
                 },
                 {
-                    "size": "1.5rem",
-                    "fluid": false,
+                    "size": "1.25rem",
+                    "fluid": {
+                        "min": "1.25rem",
+                        "max": "1.5rem"
+                    },
                     "slug": "medium",
                     "name": "Medium"
                 },
@@ -174,9 +180,9 @@
                     "name": "Header 1"
                 },
                 {
-                    "size": "2.5rem",
+                    "size": "3rem",
                     "fluid": {
-                        "min": "2.5rem",
+                        "min": "2.51rem",
                         "max": "6.875rem"
                     },
                     "slug": "header-two",
@@ -199,6 +205,12 @@
                     },
                     "slug": "header-four",
                     "name": "Header 4"
+                },
+                {
+                    "size": "1.25rem",
+                    "fluid": false,
+                    "slug": "header-five",
+                    "name": "Header 5"
                 },
                 {
                     "size": "1.25rem",
@@ -521,7 +533,7 @@
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "fontSize": "var(--wp--preset--font-size--header-three)",
                     "letterSpacing": "-0.04em"
                 }
             },
@@ -533,7 +545,7 @@
             },
             "h5": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--default)",
+                    "fontSize": "var(--wp--preset--font-size--header-five)",
                     "letterSpacing": "-0.04em"
                 }
             },

--- a/club/theme.json
+++ b/club/theme.json
@@ -129,26 +129,81 @@
 					]
 				}
 			],
+            "fluid": true,
             "fontSizes": [
                 {
-                    "name": "Small",
                     "size": "1rem",
-                    "slug": "small"
+                    "fluid": {
+                        "min": "0.875rem",
+                        "max": "1rem"
+                    },
+                    "slug": "small",
+                    "name": "Small"
                 },
                 {
-                    "name": "Medium",
+                    "size": "1.25rem",
+                    "slug": "default",
+                    "name": "Default"
+                },
+                {
                     "size": "1.5rem",
-                    "slug": "medium"
+                    "slug": "medium",
+                    "name": "Medium"
                 },
                 {
-                    "name": "Large",
                     "size": "1.75rem",
-                    "slug": "large"
+                    "slug": "large",
+                    "name": "Large"
                 },
                 {
-                    "name": "Extra Large",
-                    "size": "2rem",
-                    "slug": "x-large"
+                    "size": "2.5rem",
+                    "slug": "Extra Large",
+                    "name": "x-large"
+                },
+                {
+                    "size": "3.75rem",
+                    "fluid": {
+                        "min": "3.75rem",
+                        "max": "8.125rem"
+                    },
+                    "slug": "header-one",
+                    "name": "Header 1"
+                },
+                {
+                    "size": "2.5rem",
+                    "fluid": {
+                        "min": "2.5rem",
+                        "max": "6.875rem"
+                    },
+                    "slug": "header-two",
+                    "name": "Header 2"
+                },
+                {
+                    "size": "1.875rem",
+                    "fluid": {
+                        "min": "1.875rem",
+                        "max": "2.5rem"
+                    },
+                    "slug": "header-three",
+                    "name": "Header 3"
+                },
+                {
+                    "size": "1.75rem",
+                    "fluid": {
+                        "min": "1.75rem",
+                        "max": "2rem"
+                    },
+                    "slug": "header-four",
+                    "name": "Header 4"
+                },
+                {
+                    "size": "1.25rem",
+                    "fluid": {
+                        "min": "1.25rem",
+                        "max": "2.5rem"
+                    },
+                    "slug": "default-title",
+                    "name": "Default Title"
                 }
             ]
         }
@@ -287,8 +342,9 @@
                     "text": "var(--wp--preset--color--foreground)"
                 },
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--small)",
-                    "textTransform": "uppercase"
+                    "fontSize": "var(--wp--preset--font-size--default-title)",
+                    "textTransform": "uppercase",
+                    "textDecoration": "none"
                 }
             },
             "core/post-title": {
@@ -298,10 +354,10 @@
                     }
                 },
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--large)",
                     "lineHeight": "1.125",
                     "textDecoration": "underline solid 3px",
-                    "fontWeight": "400"
+                    "fontWeight": "400",
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
                 }
             },
             "core/pullquote": {
@@ -365,12 +421,17 @@
                 }
             },
             "core/site-title": {
+                "typography": {
+                    "lineHeight": ".8",
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
+                },
                 "elements": {
                     "link": {
                         "typography": {
-                            "fontSize": "1.125rem",
+                            "fontSize": "var(--wp--preset--font-size--default-title)",
                             "fontWeight": "700",
-                            "textDecoration": "underline solid 1.5px"
+                            "textDecoration": "underline solid 1.5px",
+                            "fontStyle": "italic"
                         }
                     }
                 }
@@ -383,7 +444,8 @@
             "core/read-more": {
                 "typography": {
                     "textTransform": "uppercase",
-                    "lineHeight": "1em"
+                    "lineHeight": "1em",
+                    "fontSize": "var(--wp--preset--font-size--default-title)"
                 },
                 "border": {
                     "color": "var(--wp--preset--color--foreground)",
@@ -436,28 +498,27 @@
 			},
             "h1": {
                 "typography": {
-                    "fontSize": "3rem"
+                    "fontSize": "var(--wp--preset--font-size--header-one)"
                 }
             },
             "h2": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--x-large)",
-                    "lineHeight": "0.8"
+                    "fontSize": "var(--wp--preset--font-size--header-two)"
                 }
             },
             "h3": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--large)"
+                    "fontSize": "var(--wp--preset--font-size--header-three)"
                 }
             },
             "h4": {
                 "typography": {
-                    "fontSize": "var(--wp--preset--font-size--medium)"
+                    "fontSize": "var(--wp--preset--font-size--header-four)"
                 }
             },
             "h5": {
                 "typography": {
-                    "fontSize": "1.125rem"
+                    "fontSize": "var(--wp--preset--font-size--default)"
                 }
             },
             "h6": {
@@ -476,7 +537,7 @@
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--spacemono)",
-            "fontSize": "1.125rem",
+            "fontSize": "var(--wp--preset--font-size--default)",
             "lineHeight": "1.6"
         }
     },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Club theme: Implement the [fluid type sizes API](https://github.com/WordPress/gutenberg/pull/39529) in theme.json.

:information_source:  Notes about how this new feature works in practice:
- `fluid.min` and `fluid.max`, obviously, works as max and min font sizes. `min` is applied in all the viewports below 768px wide. This value is enlarged progressively when the viewport grows. If the viewport is more that 1600px wide `max` is applied as font size.
- I've tested the API without Gutenberg activated and the `size` key is used as a fallback value. So leveraging the API won't imply a broken site for users not using the Gutenberg plugin. 

This PR is an alternative approach to this one https://github.com/Automattic/themes/pull/6255.
Thanks, @madhusudhand for working on it!

:warning: We still need to add the line height settings so I add this as a draft to discuss the fluid typography implementation.

#### Related issue(s):
https://github.com/Automattic/themes/issues/6213