### PR TITLE
Migrate antonia fonts to new Blockbase format

### DIFF
--- a/antonia/theme.json
+++ b/antonia/theme.json
@@ -11,6 +11,7 @@
 		"blocks": {
 			"core/heading": {
 				"typography": {
+                    			"fontFamily": "var:preset|font-family|dm-sans",
 					"fontStyle": "normal",
 					"lineHeight": "1.4",
 					"fontWeight": "300"
@@ -18,6 +19,7 @@
 			},
 			"core/post-title": {
 				"typography": {
+                    			"fontFamily": "var:preset|font-family|dm-sans",
 					"lineHeight": "1.4"
 				}
 			},
@@ -28,6 +30,7 @@
 			}
 		},
 		"typography": {
+            		"fontFamily": "var:preset|font-family|inter",
 			"fontStyle": "normal",
 			"fontWeight": "400",
 			"fontSize": "var:preset|font-size|small"
@@ -67,24 +70,6 @@
 					"slug": "tertiary",
 					"color": "#F0F0F0",
 					"name": "Tertiary"
-				}
-			]
-		},
-		"typography": {
-			"fontFamilies": [
-				{
-					"fontFamily": "\"Inter\", sans-serif",
-					"slug": "body-font",
-					"name": "Body (Inter)",
-					"google": "family=Inter:wght@100..900",
-					"fontSlug": "inter"
-				},
-				{
-					"fontFamily": "\"DM Sans\", sans-serif",
-					"slug": "heading-font",
-					"name": "Heading (DM Sans)",
-					"google": "family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700",
-					"fontSlug": "dm-sans"
 				}
 			]
 		}


### PR DESCRIPTION
When child fonts were migrated for Blockbase 3 this one was missed.  The result was that the fonts no longer loaded properly.

This change migrates the fonts configuration.  This should partially address [this Calypso issue](https://github.com/Automattic/wp-calypso/issues/65832).

To test:
Activate Antonia (with no customizations).  Load the view and ensure the body font is rendering Inter and the heading font is rendering DM Sans.

Navigate to the Full Site Editor and adjust the body font.  Ensure that all of the Blockbase fonts are available for selection there.  Ensure that choosing one of those fonts, and saving in the FSE "sticks".  (Reload the FSE, ensure the selection is still made.  Load the view, ensure the newly selected font is used.)

<img width="301" alt="image" src="https://user-images.githubusercontent.com/146530/180222460-6720b38c-845c-4228-a353-58cbc240bcbe.png">
