### PR TITLE
Filter out Jetpack fonts when Blockbase is activated

### DIFF
--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -6,14 +6,10 @@ require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 // Font Migration
 require get_template_directory() . '/inc/fonts/custom-font-migration.php';
 
-// If Jetpack is already providing these fonts we aren't going to fight it.
-// Just drop out of the running of trying to manage them. It provides all of the
-// fonts that we provide here, though it doesn't host them locally.
-if ( ! function_exists( 'jetpack_add_google_fonts_provider' ) ) {
-	add_action( 'init', 'enqueue_global_styles_fonts', 100 );
-	add_action( 'admin_init', 'enqueue_fse_font_styles' );
-	add_filter( 'pre_render_block', 'enqueue_block_fonts', 10, 2 );
-}
+add_action( 'init', 'enqueue_global_styles_fonts', 100 );
+add_action( 'admin_init', 'enqueue_fse_font_styles' );
+add_filter( 'pre_render_block', 'enqueue_block_fonts', 10, 2 );
+add_filter( 'jetpack_google_fonts_list', 'blockbase_filter_jetpack_google_fonts_list' );
 
 $blockbase_enqueued_font_slugs = array();
 
@@ -207,4 +203,14 @@ function enqueue_block_fonts( $content, $parsed_block ) {
 		}
 	}
 	return $content;
+}
+
+/**
+ * Jetpack may attempt to register fonts for the Google Font Provider.
+ * If that happens on a child theme then ONLY Jetpack fonts are registered.
+ * This 'filter' filters out all of the fonts Jetpack should register
+ * so that we depend exclusively on those provided by Blockbase.
+ */
+function blockbase_filter_jetpack_google_fonts_list( $list_to_filter ) {
+	return array();
 }

--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -6,10 +6,14 @@ require get_template_directory() . '/inc/customizer/wp-customize-fonts.php';
 // Font Migration
 require get_template_directory() . '/inc/fonts/custom-font-migration.php';
 
-add_action( 'init', 'enqueue_global_styles_fonts', 100 );
-add_action( 'admin_init', 'enqueue_fse_font_styles' );
-add_filter( 'pre_render_block', 'enqueue_block_fonts', 10, 2 );
-add_filter( 'jetpack_google_fonts_list', 'blockbase_filter_jetpack_google_fonts_list' );
+// If Jetpack is already providing these fonts we aren't going to fight it.
+// Just drop out of the running of trying to manage them. It provides all of the
+// fonts that we provide here, though it doesn't host them locally.
+if ( ! function_exists( 'jetpack_add_google_fonts_provider' ) ) {
+	add_action( 'init', 'enqueue_global_styles_fonts', 100 );
+	add_action( 'admin_init', 'enqueue_fse_font_styles' );
+	add_filter( 'pre_render_block', 'enqueue_block_fonts', 10, 2 );
+}
 
 $blockbase_enqueued_font_slugs = array();
 
@@ -203,23 +207,4 @@ function enqueue_block_fonts( $content, $parsed_block ) {
 		}
 	}
 	return $content;
-}
-
-/**
- * Jetpack may attempt to register fonts for the Google Font Provider.
- * Filter out any fonts that Blockbase is already handling.
- */
-function blockbase_filter_jetpack_google_fonts_list( $list_to_filter ) {
-	$filtered_list           = array();
-	$blockbase_fonts         = collect_fonts_from_blockbase();
-	$blockbase_font_families = array();
-	foreach ( $blockbase_fonts as $font ) {
-		$blockbase_font_families[] = $font['name'];
-	}
-	foreach ( $list_to_filter as $font_family ) {
-		if ( ! in_array( $font_family, $blockbase_font_families, true ) ) {
-			$filtered_list[] = $font_family;
-		}
-	}
-	return $filtered_list;
 }


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/65832

Blockbase and Jetpack are both trying to manage many of the same font faces.

Initially Blockbase was filtering out all of the font faces that it was managing from the list of font faces that Jetpack was handling via `blockbase_filter_jetpack_google_fonts_list`.  This only worked as expected when Blockbase filtered out ALL fonts; if some of them remained to be registered then ONLY those are made available to the user (the font faces configured in theme.json are excluded).  

Additionally when those fonts are added something different happens depending on if the activated theme is the Parent (Blockbase) or the Child.  All of the fonts expected to be used are in the parent.  When Jetpack adds additional fonts with the parent activated it just appends to that list.  When a child theme is activated it REPLACES that list. I suspect this is a bug in the Gutenberg webfont handling bits and expect to open an issue regarding that later.

In some situations (only on Atomic as far as I can tell) more font faces are provided via Jetpack's Google Font Provider than what are provided by Blockbase.  Thus in this situation ONLY those 'additional' typefaces are actually available.

To address this we're now filtering out ALL JETPACK FONTS from Blockbase themes and rely exclusively on Blockbase font handling.  Hopefully this can be re-evaluated with an update to WordPress 6.1 where we expect better webfont handling to be added to Blockbase.

The downside is that if Jetpack provides additional fonts (see the note about more fonts being available on Atomic sites) those will not be available in the theme.

When testing ensure that there are no "double registrations" of typefaces (check the Full Site Editor to ensure that when available type faces are available there are no duplicates).