### PR TITLE
Remove variations from build step

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -237,30 +237,6 @@ async function pushButtonDeploy() {
 	try {
 		await cleanSandbox();
 
-		//build variations
-		console.log('Building Variations');
-		await executeCommand(`node ./variations/build-variations.mjs git-add-changes`)
-		prompt = await inquirer.prompt([{
-			type: 'confirm',
-			message: 'Are you good with any staged theme variations changes? Make any manual adjustments now if necessary.',
-			name: "continue",
-			default: false
-		}]);
-
-		if (!prompt.continue) {
-			console.log(`Aborted Automated Deploy Process at variations building.`);
-			return;
-		}
-
-		try {
-			await executeCommand(`
-				git commit -m "Building Variations"
-			`);
-		} catch (err) {
-			// Most likely the error is that there are no variation changes to commit.
-			// Just swallowing that error for now
-		}
-
 		let hash = await getLastDeployedHash();
 		let thingsWentBump = await versionBumpThemes();
 

--- a/variations/build-variations.mjs
+++ b/variations/build-variations.mjs
@@ -47,7 +47,7 @@ async function buildVariation(source, variation) {
 		// then empty the old directory.
 		await fs.emptyDir( destDir );
 
-		const exclude = [ 'node_modules', 'sass', 'package.json', 'package-lock.json' ];
+		const exclude = [ 'node_modules', 'styles', 'sass', 'package.json', 'package-lock.json' ];
 
 		// Then copy the source directory.
 		await fs.copy( srcDir, destDir, {


### PR DESCRIPTION
With the recent change to Blockbase transitioning color palettes from theme.json custom collection (managed in the Customizer) to theme variations some of the themes that have "faux-variations" also have "real variations".  The step "building variations" copies those "real variations" into the "faux-variation" themes.

Variations don't need updating very often anyway, and only with there are changes to those parent themes.

This change stops the 'styles' folder from being copied to the variations.

This change also removes the 'build variations' automated step from the deploy process.  Variations can still be built manually (`npm run build:variations`) but is no longer part of the deploy process.
