### PR TITLE
Exclude node_modules from version bump

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -704,7 +704,7 @@ async function versionBumpTheme(theme, addChanges) {
 	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
 	let currentVersion = getThemeMetadata(styleCss, 'Version');
 
-	let filesToUpdate = await executeCommand(`find ${theme} -path "*/node_modules/*" -prune -name package.json -o -name style.scss -o -name style-child-theme.scss -maxdepth 3 -print`);
+	let filesToUpdate = await executeCommand(`find ${theme} -not \\( -path "*/node_modules/*" -prune \\) -and \\( -name package.json -or -name style.scss -or -name style-child-theme.scss \\) -maxdepth 3`);
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
 
 	for (let file of filesToUpdate) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -704,7 +704,7 @@ async function versionBumpTheme(theme, addChanges) {
 	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
 	let currentVersion = getThemeMetadata(styleCss, 'Version');
 
-	let filesToUpdate = await executeCommand(`find ${theme} -name package.json -o -name style.scss -o -name style-child-theme.scss -maxdepth 3`);
+	let filesToUpdate = await executeCommand(`find ${theme} -path "*/node_modules/*" -prune -name package.json -o -name style.scss -o -name style-child-theme.scss -maxdepth 3 -print`);
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
 
 	for (let file of filesToUpdate) {


### PR DESCRIPTION
A recent change to this script upped the maxdepth from 2 to 3.  However that causes the find command to delve into node_modules to adjust package.json files found there which results in a git error when those changes are attempted to be committed.

This change excludes `node_modules` folder from the find command so it will delve deep enough to adjust *.scss files but stay out of node_modules.