### PR TITLE
Vivre: exclude sticky posts from gallery

### DIFF
--- a/vivre/patterns/gallery.php
+++ b/vivre/patterns/gallery.php
@@ -13,7 +13,7 @@
 <h6><?php echo esc_html__( 'Recent photos', 'vivre' ); ?></h6>
 <!-- /wp:heading -->
 
-<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":2},"displayLayout":{"type":"flex","columns":2}} -->
+<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false,"perPage":2},"displayLayout":{"type":"flex","columns":2}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:post-featured-image /-->
 <!-- /wp:post-template --></div>


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Excludes sticky posts from the gallery query pattern, in order to get the demo site looking correct: 

Before | After
--- | ---
<img width="1624" alt="Screen Shot 2022-07-22 at 12 55 50 PM" src="https://user-images.githubusercontent.com/5375500/180517765-edccecbc-c74a-4cc5-9e7b-77729b03de18.png"> | <img width="1624" alt="Screen Shot 2022-07-22 at 12 55 12 PM" src="https://user-images.githubusercontent.com/5375500/180517700-28450d10-b575-4bcb-9d92-6ec20e56249e.png">


#### Related issue(s):
