### PR TITLE
#4607: Pique: Front panel H2 heading centering issue

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -2342,7 +2342,7 @@ body:not(.no-background-fixed) .site-footer {
 		padding: 40px;
 	}
 }
-.pique-panel-content h2 {
+.pique-panel-content header h2 {
 	border: 2px solid #fcfbf9;
 	border-bottom: 0;
 	color: #fcfbf9;
@@ -2354,8 +2354,8 @@ body:not(.no-background-fixed) .site-footer {
 	word-break: break-word;
 	word-wrap: break-word;
 }
-.pique-panel-content h2::before,
-.pique-panel-content h2::after {
+.pique-panel-content header h2::before,
+.pique-panel-content header h2::after {
 	border-bottom: 2px solid #fcfbf9;
 	bottom: 0;
 	content: '';
@@ -2364,16 +2364,16 @@ body:not(.no-background-fixed) .site-footer {
 	position: absolute;
 	width: 50px;
 }
-.pique-panel-content h2::before {
+.pique-panel-content header h2::before {
 	left: 0;
 }
-.pique-panel-content h2::after {
+.pique-panel-content header h2::after {
 	right: 0;
 }
-.pique-panel-content h2 a {
+.pique-panel-content header h2 a {
 	color: #fcfbf9;
 }
-.pique-panel-content h2 a:hover {
+.pique-panel-content header h2 a:hover {
 	border: none;
 }
 .pique-panel-content .entry-content {
@@ -2408,7 +2408,7 @@ body:not(.no-background-fixed) .site-footer {
 }
 
 @media (min-width: 768px) {
-	.pique-panel-content h2 {
+	.pique-panel-content header h2 {
 		max-width: 700px;
 	}
 }


### PR DESCRIPTION
Adjust `style.css` to ensure the customization for H2 elements on the home page panels is only applied to the H2 under the header parent element.

#### Changes proposed in this Pull Request:

Applying customization on H2 HTML elements only on the H2 under the "header" area on the Pique panels. That also fixes the alignment issue for H2 elements.

**Before**

![pique#4607-before](https://user-images.githubusercontent.com/50875131/180618325-6b75fbca-a938-42f7-9ba0-cd6c037024aa.png)

---

**After**

![pique#4607-after](https://user-images.githubusercontent.com/50875131/180618327-85e12194-6b87-4455-acea-cb84aa4d0b4c.png)

#### Related issue(s):

Pique: Front panel H2 heading centering issue #4607

If we want to preserve the previous style applied to `H2`, we can keep this change only:

```
@media (min-width: 768px) {
	.pique-panel-content header h2 {
		max-width: 700px;
	}
}
```