### PR TITLE
#2817: Pique: Overrides paragraph block alignment added on cover block on home page

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -2575,7 +2575,7 @@ body:not(.no-background-fixed) .site-footer {
 #pique-hero .pique-panel-content .entry-content {
 	text-align: center;
 }
-#pique-hero .pique-panel-content .entry-content p {
+#pique-hero .pique-panel-content .entry-content p:not(*) {
 	text-align: left;
 }
 #pique-hero .pique-panel-content .entry-content p:first-of-type {

--- a/pique/style.css
+++ b/pique/style.css
@@ -2575,7 +2575,7 @@ body:not(.no-background-fixed) .site-footer {
 #pique-hero .pique-panel-content .entry-content {
 	text-align: center;
 }
-#pique-hero .pique-panel-content .entry-content p:not(*) {
+:where(#pique-hero .pique-panel-content .entry-content) p {
 	text-align: left;
 }
 #pique-hero .pique-panel-content .entry-content p:first-of-type {


### PR DESCRIPTION
Ensuring paragraph alignment is preserved on hero banners on `Pique` home page.

#### Changes proposed in this Pull Request:

Fixing alignment issues on hero banner on `Pique` home page.

<table>
    <thead>
      <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/180620488-d10c98e9-4df8-47c2-b45a-b8b1045923d0.png"/></td>
        <td><img src="https://user-images.githubusercontent.com/50875131/180620497-2031ca16-a249-4f5c-b7b0-fd64d520311f.png"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):

Pique Theme: Overrides paragraph block alignment added on cover block on home page #2817