### PR TITLE
escape block attributes in patterns utility

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1179,14 +1179,48 @@ async function escapePatterns() {
 				});
 			}
 
-			if (startTag.tagName === 'p') {
-				console.log({tag: startTag, rawHtml})
-			}
 
 			rewriter.emitStartTag(startTag);
 		});
 
+		rewriter.on('comment', (comment, rawHtml) => {
+			if (comment.text.startsWith('?php')) {
+				rewriter.emitRaw(rawHtml);
+				return;
+			}
+			// escape the strings in blocks without a html such as wp:search
+			const block = escapeBlockAttrs(comment.text, themeSlug)
+			rewriter.emitComment({...comment, text: block})
+		});
+
 		return rewriter;
+	}
+
+	function escapeBlockAttrs(block, themeSlug) {
+		const allowedBlocks = ['wp:search', 'wp:read-more'];
+		const allowedAttrs=['label', 'placeholder', 'buttonText', 'content'];
+		const start = block.indexOf('{');
+		const end = block.lastIndexOf('}');
+		
+		const configPrefix = block.slice(0, start);
+		const config = block.slice(start, end+1);
+		const configSuffix = block.slice(end+1);
+
+		if (!allowedBlocks.includes(configPrefix.trim())) {
+			return block
+		}
+
+		try {
+			const configJson = JSON.parse(config);
+			allowedAttrs.forEach((attr) => {
+				if (!configJson[attr]) return;
+				configJson[attr] = escapeText(configJson[attr], themeSlug)
+			})
+			return configPrefix + JSON.stringify(configJson) + configSuffix;
+		} catch (error) {
+			// do nothing
+			return block
+		}
 	}
 
 	function escapeText(text, themeSlug, isAttr = false) {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Until now, the theme pattern escaping utility considered html string.
Because the blocks such as wp:search are represented as HTML comments they were ignored.

This PR extends the escaping to attributes of such blocks.

| Considered blocks | Considered Attrs |
| --- | --- |
| wp:search | label, placeholder, buttonText |
| wp:read-more | content |

More attributes, blocks can be included when a discovered during development of new patterns.

**Before:**
```
<!-- wp:search {"label":"","showLabel":false,"placeholder":"Search...","buttonText":"WHAT R U WAITING FOR?"} /-->
```

**After:**
```
<!-- wp:search {"label":"","showLabel":false,"placeholder":"<?php echo esc_html__( 'Search...', 'club' ); ?>","buttonText":"<?php echo esc_html__( 'WHAT R U WAITING FOR?', 'club' ); ?>"} /-->
```

#### Related issue(s):

Tools improvement.
