### PR TITLE
Pendant: Add missing tags

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -13,7 +13,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: 
 Text Domain: pendant
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
 */
 
 /*


### PR DESCRIPTION
Fixes triggering home page replacement from Calypso on the Pendant theme.

related D84737-code