### PR TITLE
Rainfall: Fix spacing issues

### DIFF
--- a/rainfall/templates/page-header-black.html
+++ b/rainfall/templates/page-header-black.html
@@ -2,8 +2,8 @@
 <div class="wp-block-group has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide"} -->
-<div class="wp-block-group alignwide"><!-- wp:columns -->
+<div class="wp-block-group"><!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"55rem"} -->
 <div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->

--- a/rainfall/templates/page-no-sidebar.html
+++ b/rainfall/templates/page-no-sidebar.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide"} -->
-<div class="wp-block-group alignwide"><!-- wp:columns -->
+<div class="wp-block-group"><!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"55rem"} -->
 <div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->

--- a/rainfall/templates/page.html
+++ b/rainfall/templates/page.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide"} -->
-<div class="wp-block-group alignwide"><!-- wp:columns -->
+<div class="wp-block-group"><!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"55rem"} -->
 <div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide"} -->
-<div class="wp-block-group alignwide"><!-- wp:columns -->
+<div class="wp-block-group"><!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"55rem"} -->
 <div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -11,21 +11,23 @@
 <div class="wp-block-column"><!-- wp:post-date {"textAlign":"right","format":"M j, Y","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":"12px"} -->
-<div style="height:12px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:group -->
-
+<!-- wp:spacer {"height":"10px"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 <!-- wp:post-featured-image {"align":"full"} /-->
+<!-- wp:spacer {"height":"10px"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:columns {"style":{"spacing":{"blockGap":"9.36rem"}}} -->
 <div class="wp-block-columns"><!-- wp:column {"layout":{"inherit":false}} -->
 <div class="wp-block-column"><!-- wp:post-content /-->
 
-	<!-- wp:spacer {"height":"10px"} -->
+<!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -7,8 +7,8 @@
 <div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-date {"textAlign":"right","format":"M j, Y","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+<!-- wp:column {"verticalAlignment":"bottom"} -->
+<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:post-date {"textAlign":"right","format":"M j, Y","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -43,9 +43,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-<div class="wp-block-group has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer {"height":"10px"} -->
-<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<div class="wp-block-group has-white-color has-black-background-color has-text-color has-background has-link-color">
 
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":""} -->

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -3,12 +3,13 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:group {"align":"full"} -->
 <div class="wp-block-group alignfull"><!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"55rem"} -->
-<div class="wp-block-column" style="flex-basis:55rem"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+<div class="wp-block-columns"><!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%"><!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"bottom"} -->
-<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:post-date {"textAlign":"right","format":"M j, Y","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+<!-- wp:column {"width":"20%","verticalAlignment":"bottom"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:20%">
+	<!-- wp:post-date {"textAlign":"right","format":"M j, Y","style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -25,12 +25,21 @@
 <div class="wp-block-columns"><!-- wp:column {"layout":{"inherit":false}} -->
 <div class="wp-block-column"><!-- wp:post-content /-->
 
+	<!-- wp:spacer {"height":"10px"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:post-navigation-link {"type":"previous","showTitle":true,"linkLabel":true} /-->
 
 <!-- wp:post-navigation-link {"showTitle":true,"linkLabel":true} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"10px"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+</div><!-- /wp:column -->
 
 <!-- wp:column {"width":"18rem"} -->
 <div class="wp-block-column" style="flex-basis:18rem"><!-- wp:template-part {"slug":"sidebar"} /--></div>
@@ -44,6 +53,9 @@
 
 <!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
 <div class="wp-block-group has-white-color has-black-background-color has-text-color has-background has-link-color">
+<!-- wp:spacer {"height":"10px"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":""} -->

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -18,7 +18,7 @@
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
 
-<!-- wp:post-featured-image /-->
+<!-- wp:post-featured-image {"align":"full"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:columns {"style":{"spacing":{"blockGap":"9.36rem"}}} -->

--- a/rainfall/theme.json
+++ b/rainfall/theme.json
@@ -200,6 +200,10 @@
 						"spacing": {
 							"margin": {
 								"left": "0px"
+							},
+							"padding": {
+								"bottom": "10px",
+								"top": "10px"
 							}
 						}
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This addresses the concerns raised in https://github.com/Automattic/themes/issues/6246

1. Makes the post title, post date and featured image full width, on post and page templates.
2. Adds some spacing below and above the navigation links at the bottom of single templates.
3. Adds some spacing either side of the post featured image block
4. Fixes the post title column to 80% to stop the date column from collapsing at tablet sizes
5. Reduces the height of the search button in the search block (this will also apply on the search template, but I thought it looked ok there).
<img width="979" alt="Screenshot 2022-07-25 at 15 53 27" src="https://user-images.githubusercontent.com/275961/180806867-e60085db-ef7e-493a-9243-f8111a1229ba.png">
<img width="981" alt="Screenshot 2022-07-25 at 15 53 05" src="https://user-images.githubusercontent.com/275961/180806871-1a8472e8-6c0c-4e27-b8d6-53704ff96864.png">
<img width="1113" alt="Screenshot 2022-07-25 at 15 52 49" src="https://user-images.githubusercontent.com/275961/180806874-95d774b3-bec7-42c6-b804-5c4d3b1ce817.png">

