### PR TITLE
Allow multiple themes in 'deploy:theme' and 'deploy:zip' commands

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -74,12 +74,12 @@ const commands = {
 	"deploy-theme": {
 		helpText: 'This runs "deploy pub <theme>" on the provided list of themes.',
 		additionalArgs: '<array of theme slugs>',
-		run: (args) => deployThemes([args?.[1]])
+		run: (args) => deployThemes(args?.[1].split(','))
 	},
 	"build-com-zip": {
 		helpText: 'Build the production zip file for the specified theme.',
 		additionalArgs: '<theme-slug>',
-		run: (args) => buildComZip([args?.[1]])
+		run: (args) => buildComZips(args?.[1].split(','))
 	},
 	"pull-core-themes": {
 		helpText: 'Use rsync to copy any changed public CORE theme files from your sandbox to your local machine. CORE themes are any of the Twenty<whatever> themes.',


### PR DESCRIPTION
The most common use of `npm run deploy:theme THEMESLUG` and `deploy:zip THEMESLUG` is when the `npm run deploy` command fails for some reason during or before those steps have finished.

This results in the need to do those steps manually, one theme at a time.

This change allows the themes to be a comma delimited list.

before:
```
npm run deploy:theme apples
npm run deploy:theme bananas
npm run deploy:zip apples
npm run deploy:zip bananas
```

after:
```
npm run deploy:theme apples,bananas
npm run deploy:zip apples,bananas
```