### PR TITLE
Update: Quadrat, Geologist & Zoologist quote block line height

### DIFF
--- a/geologist-blue/readme.txt
+++ b/geologist-blue/readme.txt
@@ -12,8 +12,11 @@ Geologist is a streamlined theme for modern bloggers. It consists of a simple si
 
 == Changelog ==
 
-= 1.0.29 =
+= 1.0.30 =
 * Blockbase 3 (#6167)
+
+= 1.0.29 =
+* migrate to npm workspaces (#6200)
 
 = 1.0.28 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/geologist-blue/theme.json
+++ b/geologist-blue/theme.json
@@ -225,7 +225,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/geologist-cream/readme.txt
+++ b/geologist-cream/readme.txt
@@ -12,8 +12,11 @@ Geologist is a streamlined theme for modern bloggers. It consists of a simple si
 
 == Changelog ==
 
-= 1.0.29 =
+= 1.0.30 =
 * Blockbase 3 (#6167)
+
+= 1.0.29 =
+* migrate to npm workspaces (#6200)
 
 = 1.0.28 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/geologist-cream/theme.json
+++ b/geologist-cream/theme.json
@@ -225,7 +225,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/geologist-slate/readme.txt
+++ b/geologist-slate/readme.txt
@@ -12,8 +12,11 @@ Geologist is a streamlined theme for modern bloggers. It consists of a simple si
 
 == Changelog ==
 
-= 1.0.29 =
+= 1.0.30 =
 * Blockbase 3 (#6167)
+
+= 1.0.29 =
+* migrate to npm workspaces (#6200)
 
 = 1.0.28 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/geologist-slate/theme.json
+++ b/geologist-slate/theme.json
@@ -224,7 +224,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/geologist-yellow/readme.txt
+++ b/geologist-yellow/readme.txt
@@ -12,8 +12,11 @@ Geologist is a streamlined theme for modern bloggers. It consists of a simple si
 
 == Changelog ==
 
-= 1.0.29 =
+= 1.0.30 =
 * Blockbase 3 (#6167)
+
+= 1.0.29 =
+* migrate to npm workspaces (#6200)
 
 = 1.0.28 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/geologist-yellow/theme.json
+++ b/geologist-yellow/theme.json
@@ -224,7 +224,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -224,7 +224,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat-black/readme.txt
+++ b/quadrat-black/readme.txt
@@ -12,8 +12,11 @@ Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts.
 
 == Changelog ==
 
-= 1.1.41 =
+= 1.1.42 =
 * Blockbase 3 (#6167)
+
+= 1.1.41 =
+* migrate to npm workspaces (#6200)
 
 = 1.1.40 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/quadrat-black/theme.json
+++ b/quadrat-black/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat-green/readme.txt
+++ b/quadrat-green/readme.txt
@@ -12,8 +12,11 @@ Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts.
 
 == Changelog ==
 
-= 1.1.41 =
+= 1.1.42 =
 * Blockbase 3 (#6167)
+
+= 1.1.41 =
+* migrate to npm workspaces (#6200)
 
 = 1.1.40 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/quadrat-green/theme.json
+++ b/quadrat-green/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat-red/readme.txt
+++ b/quadrat-red/readme.txt
@@ -12,8 +12,11 @@ Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts.
 
 == Changelog ==
 
-= 1.1.41 =
+= 1.1.42 =
 * Blockbase 3 (#6167)
+
+= 1.1.41 =
+* migrate to npm workspaces (#6200)
 
 = 1.1.40 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/quadrat-red/theme.json
+++ b/quadrat-red/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat-white/readme.txt
+++ b/quadrat-white/readme.txt
@@ -12,8 +12,11 @@ Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts.
 
 == Changelog ==
 
-= 1.1.41 =
+= 1.1.42 =
 * Blockbase 3 (#6167)
+
+= 1.1.41 =
+* migrate to npm workspaces (#6200)
 
 = 1.1.40 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/quadrat-white/theme.json
+++ b/quadrat-white/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat-yellow/readme.txt
+++ b/quadrat-yellow/readme.txt
@@ -12,8 +12,11 @@ Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts.
 
 == Changelog ==
 
-= 1.1.41 =
+= 1.1.42 =
 * Blockbase 3 (#6167)
+
+= 1.1.41 =
+* migrate to npm workspaces (#6200)
 
 = 1.1.40 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/quadrat-yellow/theme.json
+++ b/quadrat-yellow/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -235,7 +235,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {

--- a/videomaker-white/readme.txt
+++ b/videomaker-white/readme.txt
@@ -18,8 +18,11 @@ Videomaker is designed to work with the VideoPress plugin, although it will work
 
 == Changelog ==
 
-= 1.0.18 =
+= 1.0.19 =
 * Blockbase 3 (#6167)
+
+= 1.0.18 =
+* migrate to npm workspaces (#6200)
 
 = 1.0.17 =
 * Update all /pub themes so the theme-uri points to `https://wordpress.com/theme/<slug>` (#6033)

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -234,7 +234,7 @@
 				"typography": {
 					"fontSize": "1.5625rem",
 					"fontWeight": "normal",
-					"lineHeight": "40px"
+					"lineHeight": "1.6"
 				}
 			},
 			"core/pullquote": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR updates the quote block line-height for Quadrat and Geologist + variations. We were previously using a pixel value for the line-height, and this replaces that with a unitless value, as we do for other line-height values.

When I ran the `build:variations` script, the readme's for the variations were updated. This looks correct so I've left the changes in.

#### Related issue(s) / context:
p1658916922462169-slack-C029FM1EH