### PR TITLE
Refactor core sync utility to merge content locally before pushing to sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"deploy:preview": "node ./theme-utils.mjs deploy-preview",
 		"deploy:theme": "node ./theme-utils.mjs deploy-theme",
 		"deploy:zip": "node ./theme-utils.mjs build-com-zip",
+		"deploy:land": "node ./theme-utils.mjs land-diff",
 		"core:pull": "node ./theme-utils.mjs pull-core-themes",
 		"core:push": "node ./theme-utils.mjs push-core-themes",
 		"core:sync": "node ./theme-utils.mjs sync-core-theme",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -99,11 +99,6 @@ const commands = {
 		additionalArgs: '<theme-slug> <since-revision>',
 		run: (args) => syncCoreTheme(args?.[1], args?.[2])
 	},
-	"deploy-core-theme": {
-		helpText: 'Given a theme slug and SVN revision, deploy local changes to wpcom via Phabriactor',
-		additionalArgs: '<theme-slug> <since-revision>',
-		run: (args) => deployCoreTheme(args?.[1], args?.[2])
-	},
 	"deploy-sync-core-theme": {
 		helpText: 'Given a theme slug and SVN revision, sync the theme from the specified revision to the latest. This command contains additional prompts and error checking not provided by sync-core-theme.',
 		additionalArgs: '<theme-slug> <since-revision>',

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -81,18 +81,28 @@ const commands = {
 		additionalArgs: '<theme-slug>',
 		run: (args) => buildComZip([args?.[1]])
 	},
+	"checkout-core-theme": {
+		helpText: 'Use SVN to checkout the given core themes from the wpcom SVN repository.',
+		additionalArgs: '<theme-slug>',
+		run: (args) => checkoutCoreTheme(args?.[1])
+	},
 	"pull-core-themes": {
-		helpText: 'Use rsync to copy any changed public CORE theme files from your sandbox to your local machine. CORE themes are any of the Twenty<whatever> themes.',
+		helpText: 'Use rsync to copy all public CORE theme files from your sandbox to your local machine. CORE themes are any of the Twenty<whatever> themes.',
 		run: pullCoreThemes
 	},
 	"push-core-themes": {
-		helpText: 'Use rsync to copy any changed public CORE theme files from your local machine to your sandbox. CORE themes are any of the Twenty<whatever> themes.',
+		helpText: 'Use rsync to copy all public CORE theme files from your local machine to your sandbox. CORE themes are any of the Twenty<whatever> themes.',
 		run: pushCoreThemes
 	},
 	"sync-core-theme": {
-		helpText: 'Given a theme slug and SVN revision, sync the theme from the specified revision to the latest. This command is generally run by deploy-sync-core-theme and not by itself.',
+		helpText: 'Given a theme slug and SVN revision, sync the theme from the specified revision to the latest. This requires the core theme to be currently checked out from the wpcom svn repository.',
 		additionalArgs: '<theme-slug> <since-revision>',
 		run: (args) => syncCoreTheme(args?.[1], args?.[2])
+	},
+	"deploy-core-theme": {
+		helpText: 'Given a theme slug and SVN revision, deploy local changes to wpcom via Phabriactor',
+		additionalArgs: '<theme-slug> <since-revision>',
+		run: (args) => deployCoreTheme(args?.[1], args?.[2])
 	},
 	"deploy-sync-core-theme": {
 		helpText: 'Given a theme slug and SVN revision, sync the theme from the specified revision to the latest. This command contains additional prompts and error checking not provided by sync-core-theme.',
@@ -340,11 +350,12 @@ async function deploySyncCoreTheme(theme, sinceRevision) {
 
 	await cleanSandbox();
 
-	let latestRevision = await syncCoreTheme(theme, sinceRevision);
+	await checkoutCoreTheme(theme);
+	await syncCoreTheme(theme, sinceRevision);
 
 	let prompt = await inquirer.prompt([{
 		type: 'confirm',
-		message: `Changes have been synced to your sandbox.  Please resolve any conflicts (noted in .rej files).  Are you ready to continue?`,
+		message: `Changes have been synced locally.  Please resolve any conflicts now.  Are you ready to continue?`,
 		name: "continue",
 		default: false
 	}]);
@@ -354,6 +365,17 @@ async function deploySyncCoreTheme(theme, sinceRevision) {
 		return;
 	}
 
+	await pushThemeToSandbox(theme);
+	return deployCoreTheme(theme, sinceRevision);
+}
+
+/**
+ * Deploys the localy copy of a core theme to wpcom.
+ */
+async function deployCoreTheme(theme, sinceRevision) {
+
+	let latestRevision = await executeCommand(`svn info -r HEAD https://develop.svn.wordpress.org/trunk | grep Revision | egrep -o "[0-9]+"`);
+	
 	let logs = await executeCommand(`svn log https://core.svn.wordpress.org/trunk/wp-content/themes/${theme} -r${sinceRevision}:HEAD`)
 	let commitMessage = `${theme}: Merge latest core changes up to [wp${latestRevision}]
 
@@ -371,7 +393,7 @@ Subscribers:
 	let diffUrl = await createPhabricatorDiff(commitMessage);
 	let diffId = diffUrl.split('a8c.com/')[1];
 
-	prompt = await inquirer.prompt([{
+	let prompt = await inquirer.prompt([{
 		type: 'confirm',
 		message: 'Are you ready to land these changes?',
 		name: "continue",
@@ -913,6 +935,17 @@ async function pushChangesToSandbox() {
 	}
 }
 
+async function checkoutCoreTheme(theme) {
+	if (!theme) {
+		console.log('Must supply theme to sync and revision to start from');
+		return;
+	}
+	return executeCommand(`
+		rm -rf ./${theme}
+		svn checkout https://wpcom-themes.svn.automattic.com/${theme} ./${theme}
+	`);
+}
+
 async function pullCoreThemes() {
 	console.log("Pulling CORE themes from sandbox.");
 	for (let theme of coreThemes) {
@@ -937,22 +970,19 @@ async function syncCoreTheme(theme, sinceRevision) {
 		return;
 	}
 	if (!sinceRevision) {
-		sinceRevision = await executeOnSandbox(`cat ${sandboxPublicThemesFolder}/${theme}/.pub-svn-revision`);
+		sinceRevision = await executeCommand(`cat ./${theme}/.pub-svn-revision`);
 	}
-	let latestRevision = await executeCommand(`svn info -r HEAD https://core.svn.wordpress.org/trunk | grep Revision | egrep -o "[0-9]+"`);
-	console.log(`syncing core theme ${theme} from ${sinceRevision} to ${latestRevision} on your sandbox`);
+	let latestRevision = await executeCommand(`svn info -r HEAD https://develop.svn.wordpress.org/trunk | grep Revision | egrep -o "[0-9]+"`);
+	console.log(`syncing core theme ${theme} from ${sinceRevision} to ${latestRevision}`);
 	try {
-		await executeOnSandbox(`
-			cd ${sandboxPublicThemesFolder};
-			/usr/bin/svn diff --git -r ${sinceRevision}:HEAD https://core.svn.wordpress.org/trunk/wp-content/themes/${theme} | git apply --reject --ignore-space-change --ignore-whitespace -p4 --directory=${theme} -
+		await executeCommand(`
+			svn merge --accept postpone http://develop.svn.wordpress.org/trunk/src/wp-content/themes/${theme} ./${theme} -r${sinceRevision}:HEAD
+			echo '${latestRevision}' > ./${theme}/.pub-svn-revision
 		`, true);
 	}
 	catch (err) {
 		console.log('Error merging:', err);
 	}
-	await executeOnSandbox(`
-		echo '${latestRevision}' > ${sandboxPublicThemesFolder}/${theme}/.pub-svn-revision
-	`);
 	return latestRevision;
 }
 

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -420,7 +420,7 @@ Subscribers:
  */
 async function createCorePhabriactorDiff(theme, sinceRevision) {
 
-	let commitMessage = buildCorePhabricatorCommitMessageSince(theme, sinceRevision);
+	let commitMessage = await buildCorePhabricatorCommitMessageSince(theme, sinceRevision);
 
 	let diffUrl = await createPhabricatorDiff(commitMessage);
 	let diffId = diffUrl.split('a8c.com/')[1];

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -377,6 +377,11 @@ async function deployCoreTheme(theme, sinceRevision) {
 	let latestRevision = await executeCommand(`svn info -r HEAD https://develop.svn.wordpress.org/trunk | grep Revision | egrep -o "[0-9]+"`);
 	
 	let logs = await executeCommand(`svn log https://core.svn.wordpress.org/trunk/wp-content/themes/${theme} -r${sinceRevision}:HEAD`)
+
+	// Remove any double or back quotes from commit messages
+	logs = logs.replace(/"/g, '');
+	logs = logs.replace(/`/g, "'");
+
 	let commitMessage = `${theme}: Merge latest core changes up to [wp${latestRevision}]
 
 Summary:

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -352,7 +352,10 @@ async function pushButtonDeploy() {
 }
 
 async function deploySyncCoreTheme(theme, sinceRevision) {
-
+if (!theme) {
+console.log('Must supply theme to sync and revision to start from');
+return;
+}
 	await cleanSandbox();
 
 	await checkoutCoreTheme(theme);


### PR DESCRIPTION
This change refactors the core sync utility to do the syncing LOCALLY where the conflicts can be edited easily, then pushes the changes to the sandbox before creating a phabricator diff to review and land.

The ideal workflow is a single command: `npm run deploy:core:sync THEMESLUG`

This will pull the revision from the `.pub-svn-revision` file in each of the default theme directories to determine how far back to sync changes.  However at this moment none of the themes have a `.pub-svn-revision` file (it's created during this deploy process) so the revision needs to be supplied.  (I have been using `52221` as that seems to have been the last revision previously synced).

Thus: `npm run deploy:core:sync THEMESLUG 52221`

The `deploy:core:sync` command is a combination of the following commands:

```
node theme-utils.mjs clean-sandbox
node theme-utils.mjs checkout-core-theme THEMESLUG
node theme-utils.mjs sync-core-theme THEMESLUG REVISION
node theme-utils.mjs push-theme-to-sandbox THEMESLUG
node theme-utils.mjs create-core-phabricator-diff THEMESLUG REVISION
(TODO: land diff)
(TODO: deploy theme)
(TODO: build zip file)
```

The command needs to be ran for EACH core theme (there isn't a command that syncs ALL core themes to the latest since each theme should be carefully evaluated and deployed individually).  

Currently the script does NOT land the changes, deploy the changes or builds zip files; those steps will need to be completed manually for this stage.  That will make the workflow:
```
npm run deploy:core:sync THEMESLUG 52221
# (note the DIFF created from the previous step)
npm run deploy:land DIFFID
npm run deploy:theme THEMESLUG
npm run deploy:zip THEMESLUG
```

Using this process I have created the following diffs:

TwentyTwentyTwo: D84933-code
TwentyTwentyOne: D84937-code
TwentyTwenty: D84943-code
TwentyNineteen: D84944-code
TwentySeventeen: D84945-code
TwentySixteen: D84946-code
TwentyFifteen: (Currently there is an error processing this theme's logs that cause a failure.)
TwentyFourteen: D84948-code
TwentyThirteen: D84949-code
TwentyTwelve: D84950-code
TwentyEleven: D84951-code
TwentyTen: D84952-code