### PR TITLE
Blockbase: Locked post content blocks 

### DIFF
--- a/arbutus/block-templates/page.html
+++ b/arbutus/block-templates/page.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /--></main>
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /--></main>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":40} -->

--- a/arbutus/block-templates/single.html
+++ b/arbutus/block-templates/single.html
@@ -7,7 +7,7 @@
 <div class="wp-block-group" style="padding-top:20px;padding-bottom:0px"><!-- wp:post-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.3"}},"textColor":"primary"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 </main>

--- a/blockbase/templates/blank.html
+++ b/blockbase/templates/blank.html
@@ -1,1 +1,1 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->

--- a/blockbase/templates/footer-only.html
+++ b/blockbase/templates/footer-only.html
@@ -1,3 +1,3 @@
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer-container"} /-->

--- a/blockbase/templates/header-footer-only.html
+++ b/blockbase/templates/header-footer-only.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/blockbase/templates/page.html
+++ b/blockbase/templates/page.html
@@ -7,11 +7,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main"} -->
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
 <main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/blockbase/templates/single.html
+++ b/blockbase/templates/single.html
@@ -6,11 +6,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main"} -->
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
 <main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 </main>

--- a/geologist/block-templates/page-without-title.html
+++ b/geologist/block-templates/page-without-title.html
@@ -6,7 +6,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/geologist/block-templates/page.html
+++ b/geologist/block-templates/page.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/geologist/block-templates/single.html
+++ b/geologist/block-templates/single.html
@@ -10,7 +10,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 	<!-- wp:template-part {"slug":"post-meta-icons"} /-->
 

--- a/mayland-blocks/block-templates/front-page.html
+++ b/mayland-blocks/block-templates/front-page.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 </main>
 <!-- /wp:group -->

--- a/mayland-blocks/block-templates/page.html
+++ b/mayland-blocks/block-templates/page.html
@@ -8,6 +8,6 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"footer","align":"full","tagName":"footer","className":"site-footer"} /-->

--- a/mayland-blocks/block-templates/single.html
+++ b/mayland-blocks/block-templates/single.html
@@ -13,7 +13,7 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">

--- a/quadrat/block-templates/page-without-title.html
+++ b/quadrat/block-templates/page-without-title.html
@@ -6,7 +6,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/quadrat/block-templates/page.html
+++ b/quadrat/block-templates/page.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -18,7 +18,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 	<!-- wp:spacer {"height":150} -->
 	<div style="height:150px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/remote/templates/page.html
+++ b/remote/templates/page.html
@@ -32,7 +32,7 @@
 			<!-- /wp:column -->
 
 			<!-- wp:column {"verticalAlignment":"center","width":"652px"} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:652px"><!-- wp:post-content /--></div>
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:652px"><!-- wp:post-content {"lock":{"move":false,"remove":true}} /--></div>
 			<!-- /wp:column --></div>
 		<!-- /wp:columns -->
 

--- a/remote/templates/single.html
+++ b/remote/templates/single.html
@@ -32,7 +32,7 @@
 			<!-- /wp:column -->
 
 			<!-- wp:column {"verticalAlignment":"center","width":"652px"} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:652px"><!-- wp:post-content /-->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:652px"><!-- wp:post-content {"lock":{"move":false,"remove":true}} /-->
 
 			<!-- wp:spacer {"height":"1.5em"} -->
 			<div style="height:1.5em" aria-hidden="true" class="wp-block-spacer"></div>

--- a/russell/block-templates/page.html
+++ b/russell/block-templates/page.html
@@ -11,7 +11,7 @@
 <main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/russell/block-templates/single.html
+++ b/russell/block-templates/single.html
@@ -10,7 +10,7 @@
 <main class="wp-block-group">
 <!-- wp:post-featured-image {"align":"full"} /-->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 </main>

--- a/seedlet-blocks/block-templates/archive.html
+++ b/seedlet-blocks/block-templates/archive.html
@@ -8,7 +8,7 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons","layout":{"inherit":true}} /-->
 

--- a/seedlet-blocks/block-templates/index.html
+++ b/seedlet-blocks/block-templates/index.html
@@ -7,7 +7,7 @@
 <div class="wp-block-group"><!-- wp:post-title {"isLink":true} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 

--- a/seedlet-blocks/block-templates/page.html
+++ b/seedlet-blocks/block-templates/page.html
@@ -4,7 +4,7 @@
 <main class="wp-block-group"><!-- wp:post-title /--></main>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 

--- a/seedlet-blocks/block-templates/single.html
+++ b/seedlet-blocks/block-templates/single.html
@@ -4,7 +4,7 @@
 <main class="wp-block-group"><!-- wp:post-title /--></main>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:template-part {"slug":"post-meta-icons"} /-->
 

--- a/videomaker/block-templates/header-footer-only.html
+++ b/videomaker/block-templates/header-footer-only.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
 <main class="wp-block-group" style="margin-top:0">
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/page.html
+++ b/videomaker/block-templates/page.html
@@ -25,7 +25,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/videomaker/block-templates/single.html
+++ b/videomaker/block-templates/single.html
@@ -25,7 +25,7 @@
     </div>
     <!-- /wp:group -->
 
-    <!-- wp:post-content {"layout":{"inherit":true}} /-->
+    <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 </main>
 <!-- /wp:group -->

--- a/zoologist/block-templates/page-without-title.html
+++ b/zoologist/block-templates/page-without-title.html
@@ -6,7 +6,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/zoologist/block-templates/page.html
+++ b/zoologist/block-templates/page.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/zoologist/block-templates/single.html
+++ b/zoologist/block-templates/single.html
@@ -10,7 +10,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 
 	<!-- wp:template-part {"slug":"post-meta-icons"} /-->
 


### PR DESCRIPTION
Locked post content blocks (and their containers) so that they can't be easily removed by the user.

I have noticed that the users often edit content templates thinking it's something like the homepage Page and then not see their content on any of the pages or posts.

Locking the post content blocks into those templates may help mitigate that scenario by making it more difficult to remove those blocks.

This change will only effect those themes that don't provide page/post/etc templates.  If we decide this is a thing to do then we should also change those child theme templates. 

Is it helpful to apply to all of our themes?

Before:
<img width="947" alt="image" src="https://user-images.githubusercontent.com/146530/181632927-4263a94e-39ef-4a99-bd6b-82a02ebc5c05.png">

After:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/146530/181633063-28a04875-f04c-4fb2-b81f-3c809c748cc0.png">
