### PR TITLE
Fix/missing tags

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -11,7 +11,7 @@ Version: 1.0.12
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: archeo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 
 Archeo WordPress Theme, (C) 2022 Automattic, Inc.
 Archeo is distributed under the terms of the GNU GPL.

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -11,7 +11,7 @@ Version: 1.0.12
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: archeo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
 
 Archeo WordPress Theme, (C) 2022 Automattic, Inc.
 Archeo is distributed under the terms of the GNU GPL.

--- a/blank-canvas-blocks/style.css
+++ b/blank-canvas-blocks/style.css
@@ -12,5 +12,5 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: blank-canvas-blocks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 */

--- a/livro/style.css
+++ b/livro/style.css
@@ -12,7 +12,7 @@ Version: 1.0.13
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: livro
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Livro WordPress Theme, (C) 2022 Automattic, Inc.
 Livro is distributed under the terms of the GNU GPL.

--- a/remote/style.css
+++ b/remote/style.css
@@ -11,7 +11,7 @@ Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Text Domain: remote
-Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 */
 
 /*

--- a/remote/style.css
+++ b/remote/style.css
@@ -11,7 +11,7 @@ Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Text Domain: remote
-Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
 */
 
 /*

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -11,7 +11,7 @@ Version: 1.0.44
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: skatepark
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, blog-homepage
 */
 /**
  * Required Variables

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -11,7 +11,7 @@ Version: 1.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: stewart
-Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Stewart WordPress Theme, (C) 2022 Automattic, Inc.
 Stewart is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-blue/style.css
+++ b/twentytwentytwo-blue/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-blue
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Twenty Twenty-Two (Blue) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Blue) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-mint/style.css
+++ b/twentytwentytwo-mint/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-mint
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Twenty Twenty-Two (Mint) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Mint) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-pink/style.css
+++ b/twentytwentytwo-pink/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-pink
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Twenty Twenty-Two (Pink) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Pink) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-red/style.css
+++ b/twentytwentytwo-red/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-yellow
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Twenty Twenty-Two (Red) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Red) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-swiss/style.css
+++ b/twentytwentytwo-swiss/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-swiss
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
 
 Twenty Twenty-Two (Swiss) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Swiss) is distributed under the terms of the GNU GPL.

--- a/vivre/style.css
+++ b/vivre/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template:
 Text Domain: vivre
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
 */
 
 /*


### PR DESCRIPTION
Fixes missing tags in multiple themes. This will fix a Theme Showcase bug where selecting "Replace homepage" in the "Activate" modal does nothing.

More context paYKcK-1WT-p2 
Related issue https://github.com/Automattic/wp-calypso/issues/65900