### PR TITLE
[Club] Fix read more button overlap on Safari

### DIFF
--- a/club/style.css
+++ b/club/style.css
@@ -11,7 +11,7 @@ Version: 0.0.14
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: club
-Tags: 
+Tags:
 
 Club WordPress Theme, (C) 2021 Automattic, Inc.
 Club is distributed under the terms of the GNU GPL.
@@ -32,7 +32,7 @@ GNU General Public License for more details.
  * Font smoothing
  */
 
- body {
+body {
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 }
@@ -44,39 +44,39 @@ GNU General Public License for more details.
  */
 
 :is(
-	.wp-block-search__button,
-	.wp-block-file .wp-block-file__button,
-	.wp-block-button__link,
-	.wp-elements-button,
-):where(:hover, :focus, :active) {
+.wp-block-search__button,
+.wp-block-file .wp-block-file__button,
+.wp-block-button__link,
+.wp-elements-button,)
+:where(:hover, :focus, :active) {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 	border: 1.5px solid var(--wp--preset--color--foreground);
 }
 
 :is(
-	.wp-block-search__button,
-	.wp-block-file .wp-block-file__button,
-	.wp-block-button__link,
-	.wp-elements-button,
-):where(:active) {
+.wp-block-search__button,
+.wp-block-file .wp-block-file__button,
+.wp-block-button__link,
+.wp-elements-button,)
+:where(:active) {
 	border-style: dotted;
 }
 
 :is(
-	.wp-block-search__button,
-	.wp-block-file .wp-block-file__button,
-	.wp-block-button__link,
-	.wp-elements-button,
-):where(:active) {
+.wp-block-search__button,
+.wp-block-file .wp-block-file__button,
+.wp-block-button__link,
+.wp-elements-button,)
+:where(:active) {
 	border-style: dotted;
 }
 
 :is(
-	.is-style-outline .wp-block-button__link,
-	.is-style-outline .wp-element-button,
-	.wp-block-post-comments-form input[type=submit],
-):is(
+.is-style-outline .wp-block-button__link,
+.is-style-outline .wp-element-button,
+.wp-block-post-comments-form input[type="submit"],)
+:is(
 	:hover,
 	:focus
 ) {
@@ -85,10 +85,10 @@ GNU General Public License for more details.
 }
 
 :is(
-	.is-style-outline .wp-block-button__link,
-	.is-style-outline .wp-element-button,
-	.wp-block-post-comments-form input[type=submit],
-):is(
+.is-style-outline .wp-block-button__link,
+.is-style-outline .wp-element-button,
+.wp-block-post-comments-form input[type="submit"],)
+:is(
 	:active
 ) {
 	background: var(--wp--preset--color--background);
@@ -105,16 +105,17 @@ GNU General Public License for more details.
 	border: 1px solid var(--wp--preset--color--foreground);
 }
 
-/* 
+/*
  * Styles for the post list pattern
  */
 
 .club-post-list-pattern .wp-block-post-title {
+
 	/* This is necesary to make the post list item the same height when the post has or lacks a featured image */
 	min-height: 60px; /* 60px is the height of the featured image used */
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
 }
 
 .club-post-list-pattern .wp-block-post-date {
@@ -140,6 +141,7 @@ GNU General Public License for more details.
 .club-post-list-pattern .wp-block-column {
 	align-items: center;
 	display: flex;
+	min-width: unset;
 }
 
 .club-post-list-pattern .wp-block-post > .wp-block-group > .wp-block-columns > .wp-block-column:first-child {
@@ -173,9 +175,9 @@ body > .is-root-container,
 .wp-block-group.has-background,
 .wp-block-columns.alignfull.has-background,
 .wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align='full'] > .wp-block-group,
-.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
-.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
+.is-root-container .wp-block[data-align="full"] > .wp-block-group,
+.is-root-container .wp-block[data-align="full"] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
 	padding-left: var(--wp--custom--gap--horizontal);
 	padding-right: var(--wp--custom--gap--horizontal);
 }
@@ -188,7 +190,7 @@ body > .is-root-container,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-.is-root-container .wp-block[data-align='full'] {
+.is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	max-width: unset;
@@ -225,18 +227,21 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
  */
 .wp-block-search__input {
 	border-radius: 999px;
-	padding: .5rem 2rem;
+	padding: 0.5rem 2rem;
 	background-color: transparent;
 	border-color: var(--wp--preset--color--primary);
 	border-width: 1.5px;
 }
+
 @media screen and (max-width: 768px) {
+
 	.wp-block-search__inside-wrapper {
-		flex-wrap: wrap
+		flex-wrap: wrap;
 	}
+
 	.wp-block-search__button {
 		flex-grow: 1;
 		margin-left: 0;
-		margin-top: .625rem;
+		margin-top: 0.625rem;
 	}
 }

--- a/club/style.css
+++ b/club/style.css
@@ -11,7 +11,7 @@ Version: 0.0.14
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: club
-Tags:
+Tags: 
 
 Club WordPress Theme, (C) 2021 Automattic, Inc.
 Club is distributed under the terms of the GNU GPL.
@@ -32,7 +32,7 @@ GNU General Public License for more details.
  * Font smoothing
  */
 
-body {
+ body {
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 }
@@ -44,39 +44,39 @@ body {
  */
 
 :is(
-.wp-block-search__button,
-.wp-block-file .wp-block-file__button,
-.wp-block-button__link,
-.wp-elements-button,)
-:where(:hover, :focus, :active) {
+	.wp-block-search__button,
+	.wp-block-file .wp-block-file__button,
+	.wp-block-button__link,
+	.wp-elements-button,
+):where(:hover, :focus, :active) {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 	border: 1.5px solid var(--wp--preset--color--foreground);
 }
 
 :is(
-.wp-block-search__button,
-.wp-block-file .wp-block-file__button,
-.wp-block-button__link,
-.wp-elements-button,)
-:where(:active) {
+	.wp-block-search__button,
+	.wp-block-file .wp-block-file__button,
+	.wp-block-button__link,
+	.wp-elements-button,
+):where(:active) {
 	border-style: dotted;
 }
 
 :is(
-.wp-block-search__button,
-.wp-block-file .wp-block-file__button,
-.wp-block-button__link,
-.wp-elements-button,)
-:where(:active) {
+	.wp-block-search__button,
+	.wp-block-file .wp-block-file__button,
+	.wp-block-button__link,
+	.wp-elements-button,
+):where(:active) {
 	border-style: dotted;
 }
 
 :is(
-.is-style-outline .wp-block-button__link,
-.is-style-outline .wp-element-button,
-.wp-block-post-comments-form input[type="submit"],)
-:is(
+	.is-style-outline .wp-block-button__link,
+	.is-style-outline .wp-element-button,
+	.wp-block-post-comments-form input[type=submit],
+):is(
 	:hover,
 	:focus
 ) {
@@ -85,10 +85,10 @@ body {
 }
 
 :is(
-.is-style-outline .wp-block-button__link,
-.is-style-outline .wp-element-button,
-.wp-block-post-comments-form input[type="submit"],)
-:is(
+	.is-style-outline .wp-block-button__link,
+	.is-style-outline .wp-element-button,
+	.wp-block-post-comments-form input[type=submit],
+):is(
 	:active
 ) {
 	background: var(--wp--preset--color--background);
@@ -105,17 +105,16 @@ body {
 	border: 1px solid var(--wp--preset--color--foreground);
 }
 
-/*
+/* 
  * Styles for the post list pattern
  */
 
 .club-post-list-pattern .wp-block-post-title {
-
 	/* This is necesary to make the post list item the same height when the post has or lacks a featured image */
 	min-height: 60px; /* 60px is the height of the featured image used */
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
 }
 
 .club-post-list-pattern .wp-block-post-date {
@@ -175,9 +174,9 @@ body > .is-root-container,
 .wp-block-group.has-background,
 .wp-block-columns.alignfull.has-background,
 .wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-columns.has-background,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+.is-root-container .wp-block[data-align='full'] > .wp-block-group,
+.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
+.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
 	padding-left: var(--wp--custom--gap--horizontal);
 	padding-right: var(--wp--custom--gap--horizontal);
 }
@@ -190,7 +189,7 @@ body > .is-root-container,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-.is-root-container .wp-block[data-align="full"] {
+.is-root-container .wp-block[data-align='full'] {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	max-width: unset;
@@ -227,21 +226,18 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
  */
 .wp-block-search__input {
 	border-radius: 999px;
-	padding: 0.5rem 2rem;
+	padding: .5rem 2rem;
 	background-color: transparent;
 	border-color: var(--wp--preset--color--primary);
 	border-width: 1.5px;
 }
-
 @media screen and (max-width: 768px) {
-
 	.wp-block-search__inside-wrapper {
-		flex-wrap: wrap;
+		flex-wrap: wrap
 	}
-
 	.wp-block-search__button {
 		flex-grow: 1;
 		margin-left: 0;
-		margin-top: 0.625rem;
+		margin-top: .625rem;
 	}
 }


### PR DESCRIPTION
This keeps the Read More button from overlapping with the date text, in
Safari. It does not affect Firefox, nor Chrome.

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Unset `max-width` on `.club-post-list-pattern .wp-block-column`, which is causing overlapping issues on Safari.

#### Related issue(s):

Fixes: https://github.com/Automattic/themes/issues/6306

#### Preview

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/1157901/182202246-63e5b7f5-5260-467b-887d-11f6d8780fab.png">

