### PR TITLE
Core Sync Deploy: Replace $'s in commit log

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -398,6 +398,7 @@ async function buildCorePhabricatorCommitMessageSince(theme, sinceRevision){
 	// Remove any double or back quotes from commit messages
 	logs = logs.replace(/"/g, '');
 	logs = logs.replace(/`/g, "'");
+	logs = logs.replace(/\$/g, "%24");
 
 	return `${theme}: Merge latest core changes up to [wp${latestRevision}]
 
@@ -1030,6 +1031,10 @@ Subscribers:
 async function createPhabricatorDiff(commitMessage) {
 
 	console.log('creating Phabricator Diff');
+
+	console.log('======================');
+	console.log(commitMessage);
+	console.log('======================');
 
 	let result = await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1032,10 +1032,6 @@ async function createPhabricatorDiff(commitMessage) {
 
 	console.log('creating Phabricator Diff');
 
-	console.log('======================');
-	console.log(commitMessage);
-	console.log('======================');
-
 	let result = await executeOnSandbox(`
 		cd ${sandboxPublicThemesFolder};
 		git branch -D deploy


### PR DESCRIPTION
I discovered that [the issue with TwentyFifteen's deployment](https://github.com/Automattic/themes/pull/6292) was due to the $'s in the logs.  This change just swaps the char for %24 so that the command to build the Phabricator diff succeeds.

Tested with: `npm run deploy:core:sync twentyfifteen` to sucessfully build a Phabricator diff with synced changes.