### PR TITLE
#66280: Pique: columns with wide alignment are getting cut off on mobile

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -116,8 +116,8 @@ body.archive .wp-block-archives.alignfull {
 
 @media (max-width: 999px) {
 	body.pique-sidebar.pique-singular .alignwide {
-		margin-left: -15%;
-		margin-right: -15%;
+		margin-left: auto;
+		margin-right: auto;
 		width: auto;
 		max-width: 1400px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix negative margin issue on mobile when column blocks are set to be wide. _This issue happens when users are also using a sidebar_.



<table>
    <thead>
      <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/182946196-385d19de-0ab5-4592-95ca-6bb5118fb0b5.jpeg"/></td>
        <td><img src="https://user-images.githubusercontent.com/50875131/182951698-045ea38b-0a7e-4ffe-9b4b-10c99cbb0f4a.jpeg"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):

Pique > Columns Block: columns with wide alignment are getting cut off on mobile #66280
