### PR TITLE
add timeout to deployment script to kill the unresponsive process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"octokit": "^2.0.3",
 				"open": "^8.4.0",
 				"parse5-html-rewriting-stream": "^7.0.0",
+				"string-progressbar": "^1.0.4",
 				"table": "^6.8.0"
 			},
 			"engines": {
@@ -17022,6 +17023,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/string-progressbar": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string-progressbar/-/string-progressbar-1.0.4.tgz",
+			"integrity": "sha512-OpkcFxlFjn7kz5jTWmPGY+FFJVN21lQ9k0fkK0XS5GVvlCgS1stgDNEoMyqnkbZEcVP3Gv6IxqgG7tnD7ChBSw==",
+			"dev": true
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"octokit": "^2.0.3",
 		"open": "^8.4.0",
 		"parse5-html-rewriting-stream": "^7.0.0",
+		"string-progressbar": "^1.0.4",
 		"table": "^6.8.0"
 	},
 	"stylelint": {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -457,6 +457,7 @@ async function buildComZip(themeSlug) {
 }
 
 async function buildComZips(themes) {
+	console.log(`Building dotcom .zip files`);
 	const progress = startProgress(themes.length);
 	const failedThemes = []
 	for (let theme of themes) {
@@ -776,10 +777,18 @@ async function versionBumpTheme(theme, addChanges) {
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
 
 	for (let file of filesToUpdate) {
-		await executeCommand(`perl -pi -e 's/Version: (.*)$/"Version: '${currentVersion}'"/ge' ${file}`);
-		await executeCommand(`perl -pi -e 's/\\"version\\": (.*)$/"\\"version\\": \\"'${currentVersion}'\\","/ge' ${file}`);
+		const isPackageJson = file === `${theme}/package.json`;
+		if (isPackageJson) {
+			// update theme/package.json and package-lock.json
+			await executeCommand(`npm version ${currentVersion} --workspace=${theme} --silent`);
+		} else {
+			await executeCommand(`perl -pi -e 's/Version: (.*)$/"Version: '${currentVersion}'"/ge' ${file}`);
+		}
 		if (addChanges) {
 			await executeCommand(`git add ${file}`);
+			if (isPackageJson) {
+				await executeCommand(`git add package-lock.json`);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

**Change 1:**

When deploying multiple themes (more than 10) together, process sometimes stops at `deploy pub <theme>` because of the multiple connects and disconnects into sandbox.
Because of this, user has to kill the deployment process and manually find out what part of the process is remaining and retry again.

It happened multiple times when deploying large diffs such as D85430-code

This change sets a max timeout of `2 min` for any command to run on sandbox, and kills if it is not done within the time.
And it continues the deployment process with next set of themes and finally displays all the list of failed items, so that user can retry process only for the failed ones.

**Change 2:**

Introduced a progress bar to indicate the status.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/1935113/183420100-d707628f-a26d-4bbd-ae89-32eb981737e6.png">

**Change 3:**

Updated the version bump script to update package-lock.json (missed updating during workspace migration)

#### Testing:

Verified the changes by replacing `deploy pub <theme>` with `sleep 3`, and reducing the timeout to `2 sec`.
It is working great! Child process is killed and the theme listed at the end in the failed list.

#### Related issue(s):

Tools improvement.