### PR TITLE
A fix for a quirk of odd-numbered widgets in Rockfield

### DIFF
--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -617,7 +617,7 @@ table,
 	}
 
 	@include media(laptop) {
-		column-gap: 16px;
+		column-gap: #{map-deep-get($config-global, "spacing", "horizontal")};
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -627,7 +627,7 @@ table,
 		}
 
 		.widget {
-			flex: calc(50% - 16px});
+			flex: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
 		}
 	}
 }

--- a/rockfield/sass/_extra-child-theme.scss
+++ b/rockfield/sass/_extra-child-theme.scss
@@ -617,16 +617,17 @@ table,
 	}
 
 	@include media(laptop) {
+		column-gap: 16px;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 
-		& > *:nth-child(2) {
+		& > *:nth-child(n + 2) {
 			margin-top: 0;
 		}
 
 		.widget {
-			width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
+			flex: calc(50% - 16px});
 		}
 	}
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4618,15 +4618,16 @@ table th,
 
 @media only screen and (min-width: 782px) {
 	.widget-area {
+		column-gap: 16px;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 	}
-	.widget-area > *:nth-child(2) {
+	.widget-area > *:nth-child(n + 2) {
 		margin-top: 0;
 	}
 	.widget-area .widget {
-		width: calc(50% - 16px);
+		flex: calc(50% - 16px);
 	}
 }
 

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -4647,15 +4647,16 @@ table th,
 
 @media only screen and (min-width: 782px) {
 	.widget-area {
+		column-gap: 16px;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
 	}
-	.widget-area > *:nth-child(2) {
+	.widget-area > *:nth-child(n + 2) {
 		margin-top: 0;
 	}
 	.widget-area .widget {
-		width: calc(50% - 16px);
+		flex: calc(50% - 16px);
 	}
 }
 


### PR DESCRIPTION
A fix for a trait seemingly specific to Rockfield and and not any other Varia-based themes I could see, where even if there is only a single widget in the footer area, the widget will take up only half the widget area.

![Before Rockfield Widgets](https://user-images.githubusercontent.com/71042895/183301691-b2bb537c-dd13-42ce-ae81-42fd92793652.png)

These are CSS changes on lines 4648-4660 of the original CSS file, and essentially involve adding a column-gap and flex rule in place of a width rule.

Advantages:

1) A single widget will take up the whole widget area.

2) An even number of widgets should behave essentially as they do now.

3) One can use group blocks, column blocks, layout grid blocks, etc, to achieve custom layouts in the footer, without the need for additional CSS with this fix.

![after rockfield widget fix (comments)](https://user-images.githubusercontent.com/71042895/183301708-f7e3afdb-ee20-4df1-879e-dad3ab2e5fd8.png)

Potential tweaks:

1) I wasn't sure if odd-numbered widget areas beyond the second should be full width or extend in columns beneath. I decided the flexible option was better, but I can see reasons that columns might be desirable. Because of point 3 above, it may not even matter.

I believe the `:nth-child(2)` code in the original might have been left over after a different functionality was updated. I updated it to `:nth-child(n + 2)` because I think it's meant to be for additional lines of widgets, but since in this context that only applies after the third widget, `(n + 3)` would likely be "more correct," though I don't believe it matters either way.

(This is my first time using Github to propose code changes, forgive me if I did something wrong. Thank you!


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The old code is, from 4648-4660 of the style.css file:

```
@media only screen and (min-width: 782px) {
	.widget-area {
		display: flex;
		flex-wrap: wrap;
		justify-content: space-between;
	}
	.widget-area > *:nth-child(2) {
		margin-top: 0;
	}
	.widget-area .widget {
		width: calc(50% - 16px);
	}
}
```

and my proposed change is:

```
@media only screen and (min-width: 782px) {
	.widget-area {
    column-gap: 16px;
		display: flex;
		flex-wrap: wrap;
		justify-content: space-between;
	}
	.widget-area > *:nth-child(n + 2) {
		margin-top: 0;
	}
	.widget-area .widget {
		flex: calc(50% - 16px);
	}
}
```

Or from the _extra_child_theme.scss at lines 619-632:

```
	@include media(laptop) {
		display: flex;
		flex-wrap: wrap;
		justify-content: space-between;

		& > *:nth-child(2) {
			margin-top: 0;
		}

		.widget {
			width: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
		}
	}
```

to

```
	@include media(laptop) {
		column-gap: #{map-deep-get($config-global, "spacing", "horizontal")};
		display: flex;
		flex-wrap: wrap;
		justify-content: space-between;

		& > *:nth-child(n + 2) {
			margin-top: 0;
		}

		.widget {
			flex: calc(50% - #{map-deep-get($config-global, "spacing", "horizontal")});
		}
	}

```