### PR TITLE
Club: removing custom font size

### DIFF
--- a/club/parts/footer.html
+++ b/club/parts/footer.html
@@ -1,20 +1,20 @@
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-	<div class="wp-block-group"><!-- wp:site-title {"level":2,"style":{"typography":{"lineHeight":"1.6"}},"fontSize":"default-title"} /-->
+	<div class="wp-block-group"><!-- wp:site-title {"level":2,"style":{"typography":{"lineHeight":"1.6"}},"fontSize":"large"} /-->
 	
-	<!-- wp:paragraph {"fontSize":"default-title"} -->
-	<p class="has-default-title-font-size">Club 6 West 25th St, NY 10010</p>
+	<!-- wp:paragraph {"fontSize":"large"} -->
+	<p class="has-large-font-size">Club 6 West 25th St, NY 10010</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:group -->
 	
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
-	<div class="wp-block-group"><!-- wp:paragraph {"align":"right","fontSize":"default-title"} -->
-	<p class="has-text-align-right has-default-title-font-size">info@cl.ub</p>
+	<div class="wp-block-group"><!-- wp:paragraph {"align":"right","fontSize":"large"} -->
+	<p class="has-text-align-right has-large-font-size">info@cl.ub</p>
 	<!-- /wp:paragraph -->
 	
-	<!-- wp:paragraph {"align":"right","fontSize":"default-title"} -->
-	<p class="has-text-align-right has-default-title-font-size">+12345678910</p>
+	<!-- wp:paragraph {"align":"right","fontSize":"large"} -->
+	<p class="has-text-align-right has-large-font-size">+12345678910</p>
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->

--- a/club/theme.json
+++ b/club/theme.json
@@ -63,9 +63,6 @@
             "gap": {
                 "horizontal": "min(30px, 5vw)",
                 "vertical": "min(30px, 5vw)"
-            },
-            "fontSizes":{
-                "default-title": "clamp(1.25rem, calc(1.25rem + ((1vw - 0.48rem) * 2.4038)), 2.5rem)"
             }
         },
         "layout": {
@@ -153,13 +150,16 @@
                     "name": "Medium"
                 },
                 {
-                    "size": "1.75rem",
-                    "fluid": false,
+                    "size": "1.5rem",
+                    "fluid": {
+                        "min": "1.5rem",
+                        "max": "2.5rem"
+                    },
                     "slug": "large",
                     "name": "Large"
                 },
                 {
-                    "size": "2.5rem",
+                    "size": "3rem",
                     "fluid": false,
                     "slug": "x-large",
                     "name": "Extra Large"
@@ -292,7 +292,7 @@
             },
             "core/navigation": {
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
+                    "fontSize": "var(--wp--preset--font-size--large)"
                 }
             },
             "core/post-date": {
@@ -300,7 +300,7 @@
                     "text": "var(--wp--preset--color--foreground)"
                 },
                 "typography": {
-                    "fontSize": "var(--wp--custom--font-sizes--default-title)",
+                    "fontSize": "var(--wp--preset--font-size--large)",
                     "textTransform": "uppercase",
                     "letterSpacing": "-0.04em"
                     
@@ -322,7 +322,7 @@
                 "typography": {
                     "lineHeight": "1.125",
                     "fontWeight": "400",
-                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
+                    "fontSize": "var(--wp--preset--font-size--large)"
                 }
             },
             "core/pullquote": {
@@ -388,12 +388,12 @@
             "core/site-title": {
                 "typography": {
                     "lineHeight": ".8",
-                    "fontSize": "var(--wp--custom--font-sizes--default-title)"
+                    "fontSize": "var(--wp--preset--font-size--large)"
                 },
                 "elements": {
                     "link": {
                         "typography": {
-                            "fontSize": "var(--wp--custom--font-sizes--default-title)",
+                            "fontSize": "var(--wp--preset--font-size--large)",
                             "fontWeight": "700",
                             "textDecoration": "underline solid 1.5px",
                             "fontStyle": "italic",
@@ -415,7 +415,7 @@
             "core/read-more": {
                 "typography": {
                     "textTransform": "uppercase",
-                    "fontSize": "var(--wp--custom--font-sizes--default-title)",
+                    "fontSize": "var(--wp--preset--font-size--large)",
                     "letterSpacing": "-0.04em"
                 },
                 "border": {

--- a/club/theme.json
+++ b/club/theme.json
@@ -141,18 +141,18 @@
                     "name": "Small"
                 },
                 {
-                    "size": "1.25rem",
+                    "size": "1rem",
                     "fluid": {
-                        "min": "1.25rem",
-                        "max": "1.5rem"
+                        "min": "1rem",
+                        "max": "1.25rem"
                     },
                     "slug": "medium",
                     "name": "Medium"
                 },
                 {
-                    "size": "1.5rem",
+                    "size": "1.25rem",
                     "fluid": {
-                        "min": "1.5rem",
+                        "min": "1.25rem",
                         "max": "2.5rem"
                     },
                     "slug": "large",
@@ -532,7 +532,7 @@
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--spacemono)",
-            "fontSize": "clamp(0.875rem, calc(0.875rem + ((1vw - 0.48rem) * 0.7212)), 1.25rem)",
+            "fontSize": "var(--wp--preset--font-size--medium)",
             "lineHeight": "1.6"
         }
     },


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In this PR I'm changing the Club theme font sizes in this way:

About custom custom `default-title` and `large`:
- Removing the custom font size called `default-title`.
- The former `default-title` font size is now the `large` font size in the font sizes array from `theme.json`.
- The former `large` font size (not used in any of the theme elements) is no longer available because it was replaced by the previous changes.

About ad-hoc `default` and `medium`:
- Removing the ad-hoc definition of the default font size using clamp.
- Replace the `medium` size definition (not used in any of the theme elements) for the default size.
- Set the `medium` font size as the default for the site.
- Set the `min` size of `medium` to `1rem` instead of `0.875rem` to avoid repeated font sizes and this Gutenberg bug: https://github.com/WordPress/gutenberg/issues/42683  

Change the footer paragraphs to make the theme use a font size definition defined in the default font sizes array instead of a custom font size.

#### Why?
Because if we use a custom font size for these elements and the user switches the theme those elements will lose the intended hierarchy in terms of font size and it will return to a default font size.

