### PR TITLE
#6025: Varia: Fix Jetpack map block close icon

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/alves/style.css
+++ b/alves/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.18
+Version: 1.3.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4026,6 +4026,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -4058,6 +4058,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.19
+Version: 1.3.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -4021,6 +4021,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -4053,6 +4053,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4018,6 +4018,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -4050,6 +4050,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.19
+Version: 1.3.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4019,6 +4019,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -4051,6 +4051,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.18
+Version: 1.5.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/exford/style.css
+++ b/exford/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4072,6 +4072,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/hever/style.css
+++ b/hever/style.css
@@ -4104,6 +4104,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
   * Child Theme Extra Styles
   */
 /**

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.17
+Version: 1.4.18
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/leven/style.css
+++ b/leven/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.17
+Version: 1.3.18
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4019,6 +4019,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -4051,6 +4051,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.18
+Version: 1.5.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.19
+Version: 1.6.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4047,6 +4047,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/morden/style.css
+++ b/morden/style.css
@@ -4079,6 +4079,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.17
+Version: 1.5.18
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -4021,6 +4021,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -4053,6 +4053,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.17
+Version: 1.3.18
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4020,6 +4020,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4052,6 +4052,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4058,6 +4058,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -4090,6 +4090,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4047,6 +4047,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4079,6 +4079,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.18
+Version: 1.5.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4062,6 +4062,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -4094,6 +4094,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4061,6 +4061,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4093,6 +4093,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/varia/sass/vendors/jetpack/_style.scss
+++ b/varia/sass/vendors/jetpack/_style.scss
@@ -2,6 +2,7 @@
 
 	&.wp-block-jetpack-gif,
 	&.wp-block-jetpack-tiled-gallery {
+
 		@extend %responsive-alignwide;
 	}
 }
@@ -10,6 +11,7 @@
 
 	&.wp-block-jetpack-gif,
 	&.wp-block-jetpack-tiled-gallery {
+
 		@extend %responsive-alignfull;
 	}
 }
@@ -39,6 +41,7 @@
  * Cookies & Consents Banner
  */
 body {
+
 	.widget_eu_cookie_law_widget {
 		background: transparent;
 		bottom: 0;
@@ -97,6 +100,7 @@ body {
 
 	// Position of the widget when Admin Bar is present
 	&.admin-bar .widget_eu_cookie_law_widget {
+
 		&.widget.top {
 			top: 32px;
 
@@ -111,6 +115,7 @@ body {
  * Mailchimp Subscription Form
  */
 .wp-block-jetpack-mailchimp {
+
 	p {
 		margin-top: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
 		margin-bottom: #{ 0.666 * map-deep-get($config-global, "spacing", "vertical") };
@@ -129,7 +134,7 @@ body {
 		}
 	}
 
-	input[type=email] {
+	input[type="email"] {
 		width: 100%;
 	}
 }
@@ -142,6 +147,7 @@ body {
  * Business Hours
  */
 .jetpack-business-hours {
+
 	dd {
 		padding-left: 0;
 	}
@@ -172,4 +178,16 @@ body {
 			}
 		}
 	}
+}
+
+/**
+ * Map Block
+ */
+
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.16
+Version: 1.6.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -3979,6 +3979,17 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**

--- a/varia/style.css
+++ b/varia/style.css
@@ -155,14 +155,10 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
  *   in-sync
  */
 button[data-load-more-btn],
-.button,
-button,
-input[type='submit'],
+.button, button,
+input[type="submit"],
 .wp-block-button__link,
-.wp-block-file__button,
-.a8c-posts-list__view-all,
-.wp-block-search .wp-block-search__button,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
+.wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
 	cursor: pointer;
@@ -178,23 +174,14 @@ body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 }
 
 button[data-load-more-btn]:before,
-.button:before,
-button:before,
-input[type='submit']:before,
+.button:before, button:before,
+input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before,
-.a8c-posts-list__view-all:before,
-.wp-block-search .wp-block-search__button:before,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before,
-button[data-load-more-btn]:after,
-.button:after,
-button:after,
-input[type='submit']:after,
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
+.button:after, button:after,
+input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after,
-.a8c-posts-list__view-all:after,
-.wp-block-search .wp-block-search__button:after,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
 	height: 0;
@@ -202,56 +189,34 @@ body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 }
 
 button[data-load-more-btn]:before,
-.button:before,
-button:before,
-input[type='submit']:before,
+.button:before, button:before,
+input[type="submit"]:before,
 .wp-block-button__link:before,
-.wp-block-file__button:before,
-.a8c-posts-list__view-all:before,
-.wp-block-search .wp-block-search__button:before,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
+.wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
 
 button[data-load-more-btn]:after,
-.button:after,
-button:after,
-input[type='submit']:after,
+.button:after, button:after,
+input[type="submit"]:after,
 .wp-block-button__link:after,
-.wp-block-file__button:after,
-.a8c-posts-list__view-all:after,
-.wp-block-search .wp-block-search__button:after,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
+.wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
 
-.button:not(.has-background):hover,
-button:not(.has-background):hover,
-input:not(.has-background):hover[type='submit'],
+
+.button:not(.has-background):hover, button:not(.has-background):hover,
+input:not(.has-background):hover[type="submit"],
 .wp-block-button__link:not(.has-background):hover,
-.wp-block-file__button:not(.has-background):hover,
-.a8c-posts-list__view-all:not(.has-background):hover,
-.wp-block-search .wp-block-search__button:not(.has-background):hover,
-body
-	.widget_eu_cookie_law_widget
-	#eu-cookie-law
-	input.accept:not(.has-background):hover,
-.button:focus,
-button:focus,
-input:focus[type='submit'],
+.wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
+.button:focus, button:focus,
+input:focus[type="submit"],
 .wp-block-button__link:focus,
-.wp-block-file__button:focus,
-.a8c-posts-list__view-all:focus,
-.wp-block-search .wp-block-search__button:focus,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
-.has-focus.button,
-button.has-focus,
-input.has-focus[type='submit'],
+.wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
+.has-focus.button, button.has-focus,
+input.has-focus[type="submit"],
 .has-focus.wp-block-button__link,
-.has-focus.wp-block-file__button,
-.has-focus.a8c-posts-list__view-all,
-.wp-block-search .has-focus.wp-block-search__button,
-body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
+.has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: indigo;
 }
@@ -451,9 +416,9 @@ select {
  * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-[type='button'],
-[type='reset'],
-[type='submit'] {
+[type="button"],
+[type="reset"],
+[type="submit"] {
 	-webkit-appearance: button;
 }
 
@@ -461,9 +426,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type='button']::-moz-focus-inner,
-[type='reset']::-moz-focus-inner,
-[type='submit']::-moz-focus-inner {
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
 	border-style: none;
 	padding: 0;
 }
@@ -472,9 +437,9 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring {
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
 	outline: 1px dotted ButtonText;
 }
 
@@ -524,8 +489,8 @@ textarea {
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
  */
-[type='checkbox'],
-[type='radio'] {
+[type="checkbox"],
+[type="radio"] {
 	box-sizing: border-box;
 	/* 1 */
 	padding: 0;
@@ -535,8 +500,8 @@ textarea {
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type='number']::-webkit-inner-spin-button,
-[type='number']::-webkit-outer-spin-button {
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
 	height: auto;
 }
 
@@ -544,7 +509,7 @@ textarea {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type='search'] {
+[type="search"] {
 	-webkit-appearance: textfield;
 	/* 1 */
 	outline-offset: -2px;
@@ -554,7 +519,7 @@ textarea {
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type='search']::-webkit-search-decoration {
+[type="search"]::-webkit-search-decoration {
 	-webkit-appearance: none;
 }
 
@@ -649,9 +614,7 @@ html {
 /**
  * Relax the definition a bit, to allow components to override it manually.
  */
-*,
-*::before,
-*::after {
+*, *::before, *::after {
 	box-sizing: inherit;
 }
 
@@ -736,7 +699,7 @@ a {
 }
 
 /* Do not show the outline on the skip link target. */
-#content[tabindex='-1']:focus {
+#content[tabindex="-1"]:focus {
 	outline: 0;
 }
 
@@ -752,7 +715,7 @@ a {
 .site-content:after,
 .site-footer:before,
 .site-footer:after {
-	content: '';
+	content: "";
 	display: table;
 	table-layout: fixed;
 }
@@ -895,10 +858,8 @@ footer {
 .entry-content > *,
 .entry-content-child,
 .wp-block-premium-content-container .wp-premium-content-logged-out-view > *,
-.wp-block-premium-content-container
-	.wp-block-premium-content-subscriber-view
-	> *,
-[class*='inner-container'] > *,
+.wp-block-premium-content-container .wp-block-premium-content-subscriber-view > *,
+[class*="inner-container"] > *,
 .widget-area > * {
 	margin-top: 21.312px;
 	margin-bottom: 21.312px;
@@ -911,10 +872,8 @@ footer {
 	.entry-content > *,
 	.entry-content-child,
 	.wp-block-premium-content-container .wp-premium-content-logged-out-view > *,
-	.wp-block-premium-content-container
-		.wp-block-premium-content-subscriber-view
-		> *,
-	[class*='inner-container'] > *,
+	.wp-block-premium-content-container .wp-block-premium-content-subscriber-view > *,
+	[class*="inner-container"] > *,
 	.widget-area > * {
 		margin-top: 32px;
 		margin-bottom: 32px;
@@ -926,13 +885,9 @@ footer {
 .site-main > .not-found > *:first-child,
 .entry-content > *:first-child,
 .entry-content-child:first-child,
-.wp-block-premium-content-container
-	.wp-premium-content-logged-out-view
-	> :first-child,
-.wp-block-premium-content-container
-	.wp-block-premium-content-subscriber-view
-	> :first-child,
-[class*='inner-container'] > *:first-child,
+.wp-block-premium-content-container .wp-premium-content-logged-out-view > :first-child,
+.wp-block-premium-content-container .wp-block-premium-content-subscriber-view > :first-child,
+[class*="inner-container"] > *:first-child,
 .widget-area > *:first-child {
 	margin-top: 0;
 }
@@ -942,13 +897,9 @@ footer {
 .site-main > .not-found > *:last-child,
 .entry-content > *:last-child,
 .entry-content-child:last-child,
-.wp-block-premium-content-container
-	.wp-premium-content-logged-out-view
-	> :last-child,
-.wp-block-premium-content-container
-	.wp-block-premium-content-subscriber-view
-	> :last-child,
-[class*='inner-container'] > *:last-child,
+.wp-block-premium-content-container .wp-premium-content-logged-out-view > :last-child,
+.wp-block-premium-content-container .wp-block-premium-content-subscriber-view > :last-child,
+[class*="inner-container"] > *:last-child,
 .widget-area > *:last-child {
 	margin-bottom: 0;
 }
@@ -996,16 +947,13 @@ footer {
 	/* Reset alignleft and alignright margins after alignfull */
 }
 
-.entry-content > *.alignleft,
-.entry-content > *.alignright,
+.entry-content > *.alignleft, .entry-content > *.alignright,
 .entry-content > *.alignleft:first-child + *,
-.entry-content > *.alignright:first-child + *,
-.entry-content > *.alignfull {
+.entry-content > *.alignright:first-child + *, .entry-content > *.alignfull {
 	margin-top: 0;
 }
 
-.entry-content > *:last-child,
-.entry-content > *.alignfull {
+.entry-content > *:last-child, .entry-content > *.alignfull {
 	margin-bottom: 0;
 }
 
@@ -1060,77 +1008,74 @@ blockquote > *:last-child {
 	margin-bottom: 0;
 }
 
-blockquote.alignleft,
-blockquote.alignright {
+blockquote.alignleft, blockquote.alignright {
 	padding-left: inherit;
 }
 
-blockquote.alignleft p,
-blockquote.alignright p {
+blockquote.alignleft p, blockquote.alignright p {
 	font-size: 1.44rem;
 	max-width: inherit;
 	width: inherit;
 }
 
 blockquote.alignleft cite,
-blockquote.alignleft footer,
-blockquote.alignright cite,
+blockquote.alignleft footer, blockquote.alignright cite,
 blockquote.alignright footer {
 	font-size: 0.69444rem;
 	letter-spacing: normal;
 }
 
-input[type='text'],
-input[type='email'],
-input[type='url'],
-input[type='password'],
-input[type='search'],
-input[type='number'],
-input[type='tel'],
-input[type='range'],
-input[type='date'],
-input[type='month'],
-input[type='week'],
-input[type='time'],
-input[type='datetime'],
-input[type='datetime-local'],
-input[type='color'],
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
 	color: black;
-	border: 1px solid #dddddd;
+	border: 1px solid #DDDDDD;
 	border-radius: 3px;
 	padding: 16px;
 }
 
-input[type='text']:focus,
-input[type='email']:focus,
-input[type='url']:focus,
-input[type='password']:focus,
-input[type='search']:focus,
-input[type='number']:focus,
-input[type='tel']:focus,
-input[type='range']:focus,
-input[type='date']:focus,
-input[type='month']:focus,
-input[type='week']:focus,
-input[type='time']:focus,
-input[type='datetime']:focus,
-input[type='datetime-local']:focus,
-input[type='color']:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
 textarea:focus {
 	color: black;
 	border-color: indigo;
 }
 
 select {
-	border: 1px solid #dddddd;
+	border: 1px solid #DDDDDD;
 }
 
 textarea {
 	width: 100%;
 }
 
-input[type='checkbox'] + label {
+input[type=checkbox] + label {
 	display: inline;
 	margin-left: 0.5em;
 	margin-right: 2em;
@@ -1190,8 +1135,7 @@ object {
 	min-width: inherit;
 }
 
-.wp-block-audio.alignleft,
-.wp-block-audio.alignright {
+.wp-block-audio.alignleft, .wp-block-audio.alignright {
 	min-width: 300px;
 }
 
@@ -1207,9 +1151,7 @@ object {
 	margin-left: 32px;
 }
 
-.wp-block-newspack-blocks-homepage-articles.image-alignbehind
-	.post-has-image
-	.entry-wrapper {
+.wp-block-newspack-blocks-homepage-articles.image-alignbehind .post-has-image .entry-wrapper {
 	padding: 32px;
 }
 
@@ -1265,17 +1207,11 @@ object {
 	margin-bottom: 16px;
 }
 
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-wrapper
-	> *:first-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:first-child {
 	margin-top: 0;
 }
 
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-wrapper
-	> *:last-child {
+.wp-block-newspack-blocks-homepage-articles article .entry-wrapper > *:last-child {
 	margin-bottom: 0;
 }
 
@@ -1283,21 +1219,9 @@ object {
 	color: blue;
 }
 
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a {
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a {
 	color: currentColor;
 }
 
@@ -1306,21 +1230,9 @@ object {
 	text-decoration: underline;
 }
 
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a:hover,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a:hover,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-title
-	a:hover {
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-title a:hover {
 	color: currentColor;
 }
 
@@ -1336,30 +1248,14 @@ object {
 	font-size: 0.83333rem;
 }
 
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta,
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links {
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links {
 	color: currentColor;
 }
 
@@ -1368,27 +1264,13 @@ object {
 	vertical-align: top;
 }
 
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	.byline:not(:last-child),
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	.byline:not(:last-child) {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .byline:not(:last-child),
+.wp-block-newspack-blocks-homepage-articles article .cat-links .byline:not(:last-child) {
 	margin-right: 16px;
 }
 
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	.published
-	+ .updated,
-.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	.published
-	+ .updated {
+.wp-block-newspack-blocks-homepage-articles article .entry-meta .published + .updated,
+.wp-block-newspack-blocks-homepage-articles article .cat-links .published + .updated {
 	display: none;
 }
 
@@ -1398,74 +1280,28 @@ object {
 	text-decoration: underline;
 }
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
-.wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+.wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
 .wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: indigo;
 	text-decoration: none;
 }
 
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:hover,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:hover,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:hover,
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:active,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:active,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.entry-meta
-	a:active,
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:hover,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:hover,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:hover,
-.has-background:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:active,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:active,
-[style*='background-color']
-	.wp-block-newspack-blocks-homepage-articles
-	article
-	.cat-links
-	a:active {
+.has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:hover, .has-background:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active,
+[style*="background-color"] .wp-block-newspack-blocks-homepage-articles article .entry-meta a:active, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:hover, .has-background:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active,
+[style*="background-color"]
+.wp-block-newspack-blocks-homepage-articles article .cat-links a:active {
 	color: currentColor;
 }
 
@@ -1474,14 +1310,14 @@ button[data-load-more-btn],
 	display: inline-block;
 }
 
-.has-background:not(.has-background-background-color)
-	button[data-load-more-btn],
-[class*='background-color']:not(.has-background-background-color)
-	button[data-load-more-btn],
-[style*='background-color'] button[data-load-more-btn],
-.has-background:not(.has-background-background-color) .button,
-[class*='background-color']:not(.has-background-background-color) .button,
-[style*='background-color'] .button {
+.has-background:not(.has-background-background-color) button[data-load-more-btn],
+[class*="background-color"]:not(.has-background-background-color) button[data-load-more-btn],
+[style*="background-color"] button[data-load-more-btn], .has-background:not(.has-background-background-color)
+.button,
+[class*="background-color"]:not(.has-background-background-color)
+.button,
+[style*="background-color"]
+.button {
 	background-color: transparent;
 	border: 2px solid currentColor;
 	color: currentColor;
@@ -1514,20 +1350,15 @@ button[data-load-more-btn],
 	color: blue;
 }
 
-.wp-block-button.is-style-outline.wp-block-button__link:hover,
-.wp-block-button.is-style-outline.wp-block-button__link:focus,
-.wp-block-button.is-style-outline.wp-block-button__link.has-focus,
+.wp-block-button.is-style-outline.wp-block-button__link:hover, .wp-block-button.is-style-outline.wp-block-button__link:focus, .wp-block-button.is-style-outline.wp-block-button__link.has-focus,
 .wp-block-button.is-style-outline .wp-block-button__link:hover,
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link.has-focus {
 	color: indigo;
 }
 
-.has-primary-background-color
-	.wp-block-button.is-style-outline.wp-block-button__link:not(.has-text-color),
-.has-primary-background-color
-	.wp-block-button.is-style-outline
-	.wp-block-button__link:not(.has-text-color) {
+.has-primary-background-color .wp-block-button.is-style-outline.wp-block-button__link:not(.has-text-color), .has-primary-background-color
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
 	color: white;
 }
 
@@ -1540,7 +1371,7 @@ button[data-load-more-btn],
 	color: #444444;
 	font-size: 0.83333rem;
 	padding: 16px;
-	border-color: #dddddd;
+	border-color: #DDDDDD;
 }
 
 .wp-block-code pre {
@@ -1688,15 +1519,13 @@ button[data-load-more-btn],
 	margin-bottom: 0;
 }
 
-.wp-block-cover.alignleft,
-.wp-block-cover.alignright,
+.wp-block-cover.alignleft, .wp-block-cover.alignright,
 .wp-block-cover-image.alignleft,
 .wp-block-cover-image.alignright {
 	margin-top: 0;
 }
 
-.wp-block-cover.alignleft > *,
-.wp-block-cover.alignright > *,
+.wp-block-cover.alignleft > *, .wp-block-cover.alignright > *,
 .wp-block-cover-image.alignleft > *,
 .wp-block-cover-image.alignright > * {
 	margin-top: calc(2 * 32px);
@@ -1706,8 +1535,7 @@ button[data-load-more-btn],
 	width: 100%;
 }
 
-.wp-block-cover.has-left-content,
-.wp-block-cover.has-right-content,
+.wp-block-cover.has-left-content, .wp-block-cover.has-right-content,
 .wp-block-cover-image.has-left-content,
 .wp-block-cover-image.has-right-content {
 	justify-content: center;
@@ -1721,8 +1549,7 @@ button[data-load-more-btn],
 	margin-right: 16px;
 }
 
-.wp-block-file .wp-block-file__button:before,
-.wp-block-file .wp-block-file__button:after {
+.wp-block-file .wp-block-file__button:before, .wp-block-file .wp-block-file__button:after {
 	display: inherit;
 }
 
@@ -1731,7 +1558,7 @@ button[data-load-more-btn],
 .wp-block-file a.wp-block-file__button:hover,
 .wp-block-file a.wp-block-file__button:visited {
 	color: white;
-	opacity: 0.85;
+	opacity: .85;
 }
 
 .wp-block-gallery {
@@ -1745,8 +1572,7 @@ button[data-load-more-btn],
 	font-size: 0.69444rem;
 }
 
-.wp-block-gallery.alignleft,
-.wp-block-gallery.alignright {
+.wp-block-gallery.alignleft, .wp-block-gallery.alignright {
 	max-width: 50%;
 }
 
@@ -1790,61 +1616,49 @@ button[data-load-more-btn],
 	padding-right: 16px;
 }
 
-h1,
-.h1,
-h2,
-.h2,
-h3,
-.h3,
-h4,
-.h4,
-h5,
-.h5,
-h6,
-.h6 {
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4,
+h5, .h5,
+h6, .h6 {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
 	font-weight: bold;
 	clear: both;
 }
 
-h1,
-.h1 {
+h1, .h1 {
 	font-size: 2.98598rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
-h2,
-.h2 {
+h2, .h2 {
 	font-size: 2.48832rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
-h3,
-.h3 {
+h3, .h3 {
 	font-size: 2.0736rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
-h4,
-.h4 {
+h4, .h4 {
 	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
-h5,
-.h5 {
+h5, .h5 {
 	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
-h6,
-.h6 {
+h6, .h6 {
 	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
@@ -1862,14 +1676,14 @@ h6,
 	text-align: center;
 }
 
-.entry-content > *[class='wp-block-image'],
-.entry-content [class*='inner-container'] > *[class='wp-block-image'] {
+.entry-content > *[class="wp-block-image"],
+.entry-content [class*="inner-container"] > *[class="wp-block-image"] {
 	margin-top: 0;
 	margin-bottom: 0;
 }
 
-.entry-content > *[class='wp-block-image'] + *,
-.entry-content [class*='inner-container'] > *[class='wp-block-image'] + * {
+.entry-content > *[class="wp-block-image"] + *,
+.entry-content [class*="inner-container"] > *[class="wp-block-image"] + * {
 	margin-top: 0;
 }
 
@@ -1948,14 +1762,8 @@ img {
 	line-height: 1.78;
 }
 
-.entry-content
-	[class*='inner-container']
-	.wp-block-latest-posts
-	.wp-block-latest-posts__post-date,
-.entry-content
-	.has-background
-	.wp-block-latest-posts
-	.wp-block-latest-posts__post-date {
+.entry-content [class*="inner-container"] .wp-block-latest-posts .wp-block-latest-posts__post-date,
+.entry-content .has-background .wp-block-latest-posts .wp-block-latest-posts__post-date {
 	color: currentColor;
 }
 
@@ -1971,7 +1779,7 @@ img {
 	padding-right: 16px;
 }
 
-.entry-content [class*='inner-container'] .wp-block-latest-posts.alignfull,
+.entry-content [class*="inner-container"] .wp-block-latest-posts.alignfull,
 .entry-content .has-background .wp-block-latest-posts.alignfull {
 	padding-left: 0;
 	padding-right: 0;
@@ -2170,8 +1978,7 @@ p.has-background {
 	color: currentColor;
 }
 
-.a8c-posts-list__item .a8c-posts-list-item__meta a:hover,
-.a8c-posts-list__item .a8c-posts-list-item__meta a:active {
+.a8c-posts-list__item .a8c-posts-list-item__meta a:hover, .a8c-posts-list__item .a8c-posts-list-item__meta a:active {
 	color: indigo;
 }
 
@@ -2184,9 +1991,9 @@ p.has-background {
 }
 
 .wp-block-pullquote {
-	border-top-color: #dddddd;
+	border-top-color: #DDDDDD;
 	border-top-width: 4px;
-	border-bottom-color: #dddddd;
+	border-bottom-color: #DDDDDD;
 	border-bottom-width: 4px;
 	color: #444444;
 }
@@ -2271,46 +2078,39 @@ p.has-background {
 	letter-spacing: normal;
 }
 
-.has-background:not(.has-background-background-color)
-	.wp-block-quote
-	.wp-block-quote__citation,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-quote
-	.wp-block-quote__citation,
-[style*='background-color'] .wp-block-quote .wp-block-quote__citation,
-.wp-block-cover[style*='background-image']
-	.wp-block-quote
-	.wp-block-quote__citation,
-.has-background:not(.has-background-background-color) .wp-block-quote cite,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-quote
-	cite,
-[style*='background-color'] .wp-block-quote cite,
-.wp-block-cover[style*='background-image'] .wp-block-quote cite,
-.has-background:not(.has-background-background-color) .wp-block-quote footer,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-quote
-	footer,
-[style*='background-color'] .wp-block-quote footer,
-.wp-block-cover[style*='background-image'] .wp-block-quote footer {
+.has-background:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+[class*="background-color"]:not(.has-background-background-color) .wp-block-quote .wp-block-quote__citation,
+[style*="background-color"] .wp-block-quote .wp-block-quote__citation,
+.wp-block-cover[style*="background-image"] .wp-block-quote .wp-block-quote__citation, .has-background:not(.has-background-background-color)
+.wp-block-quote cite,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-quote cite,
+[style*="background-color"]
+.wp-block-quote cite,
+.wp-block-cover[style*="background-image"]
+.wp-block-quote cite, .has-background:not(.has-background-background-color)
+.wp-block-quote footer,
+[class*="background-color"]:not(.has-background-background-color)
+.wp-block-quote footer,
+[style*="background-color"]
+.wp-block-quote footer,
+.wp-block-cover[style*="background-image"]
+.wp-block-quote footer {
 	color: currentColor;
 }
 
-.wp-block-quote[style*='text-align:right'],
-.wp-block-quote[style*='text-align: right'] {
+.wp-block-quote[style*="text-align:right"], .wp-block-quote[style*="text-align: right"] {
 	border-right-color: blue;
 }
 
-.wp-block-quote.is-style-large,
-.wp-block-quote.is-large {
+.wp-block-quote.is-style-large, .wp-block-quote.is-large {
 	/* Resetting margins to match _block-container.scss */
 	margin-top: 32px;
 	margin-bottom: 32px;
 	padding: 0;
 }
 
-.wp-block-quote.is-style-large p,
-.wp-block-quote.is-large p {
+.wp-block-quote.is-style-large p, .wp-block-quote.is-large p {
 	font-size: 2.0736rem;
 	letter-spacing: normal;
 	line-height: 1.125;
@@ -2318,8 +2118,7 @@ p.has-background {
 
 .wp-block-quote.is-style-large .wp-block-quote__citation,
 .wp-block-quote.is-style-large cite,
-.wp-block-quote.is-style-large footer,
-.wp-block-quote.is-large .wp-block-quote__citation,
+.wp-block-quote.is-style-large footer, .wp-block-quote.is-large .wp-block-quote__citation,
 .wp-block-quote.is-large cite,
 .wp-block-quote.is-large footer {
 	color: #767676;
@@ -2328,10 +2127,9 @@ p.has-background {
 }
 
 .has-background:not(.has-background-background-color) .wp-block-quote,
-[class*='background-color']:not(.has-background-background-color)
-	.wp-block-quote,
-[style*='background-color'] .wp-block-quote,
-.wp-block-cover[style*='background-image'] .wp-block-quote {
+[class*="background-color"]:not(.has-background-background-color) .wp-block-quote,
+[style*="background-color"] .wp-block-quote,
+.wp-block-cover[style*="background-image"] .wp-block-quote {
 	border-color: currentColor;
 }
 
@@ -2339,29 +2137,22 @@ p.has-background {
 	flex-wrap: wrap;
 }
 
-.wp-block-search.wp-block-search__button-inside
-	.wp-block-search__inside-wrapper {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 	background: white;
 	color: black;
-	border: 1px solid #dddddd;
+	border: 1px solid #DDDDDD;
 	border-radius: 3px;
 }
 
-.wp-block-search.wp-block-search__button-inside
-	.wp-block-search__inside-wrapper
-	.wp-block-search__input {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
 	padding: 16px;
 }
 
-.wp-block-search.wp-block-search__button-inside
-	.wp-block-search__inside-wrapper
-	.wp-block-search__button {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button {
 	padding: 16px 16px;
 }
 
-.wp-block-search.wp-block-search__button-inside
-	.wp-block-search__inside-wrapper
-	.wp-block-search__button.has-icon {
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__button.has-icon {
 	padding: 0;
 }
 
@@ -2371,7 +2162,7 @@ p.has-background {
 
 .wp-block-search .wp-block-search__input {
 	color: black;
-	border: 1px solid #dddddd;
+	border: 1px solid #DDDDDD;
 	border-radius: 3px;
 	padding: 16px;
 	font-size: 1rem;
@@ -2379,13 +2170,13 @@ p.has-background {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
 	max-width: inherit;
-	margin-right: calc(0.66 * 16px);
+	margin-right: calc( .66 * 16px);
 	background: white;
 }
 
 .wp-block-search .wp-block-search__input:focus {
 	color: black;
-	border-color: #dddddd;
+	border-color: #DDDDDD;
 }
 
 .wp-block-search .wp-block-search__button {
@@ -2396,8 +2187,8 @@ p.has-background {
 .wp-block-search .wp-block-search__button.has-icon {
 	transform: scaleX(-1);
 	padding: 0;
-	min-width: calc(2 * 16px + 1rem + 4px);
-	min-height: calc(2 * 16px + 1rem + 4px);
+	min-width: calc(2* 16px + 1rem + 4px);
+	min-height: calc(2* 16px + 1rem + 4px);
 }
 
 .wp-block-search .wp-block-search__button.has-icon svg {
@@ -2407,14 +2198,14 @@ p.has-background {
 }
 
 hr {
-	border-bottom: 2px solid #dddddd;
+	border-bottom: 2px solid #DDDDDD;
 	clear: both;
 	margin-left: auto;
 	margin-right: auto;
 }
 
 hr.wp-block-separator {
-	border-bottom: 2px solid #dddddd;
+	border-bottom: 2px solid #DDDDDD;
 	/**
 		 * Block Options
 		 */
@@ -2428,28 +2219,25 @@ hr.wp-block-separator.is-style-wide {
 	border-bottom-width: 2px;
 }
 
-hr.wp-block-separator.is-style-dots.has-background,
-hr.wp-block-separator.is-style-dots.has-text-color {
+hr.wp-block-separator.is-style-dots.has-background, hr.wp-block-separator.is-style-dots.has-text-color {
 	background-color: transparent !important;
 }
 
-hr.wp-block-separator.is-style-dots.has-background:before,
-hr.wp-block-separator.is-style-dots.has-text-color:before {
+hr.wp-block-separator.is-style-dots.has-background:before, hr.wp-block-separator.is-style-dots.has-text-color:before {
 	color: currentColor !important;
 }
 
 hr.wp-block-separator.is-style-dots:before {
-	color: #dddddd;
+	color: #DDDDDD;
 	font-size: 1.728rem;
 	letter-spacing: 0.83333rem;
 	padding-left: 0.83333rem;
 }
 
 .has-background:not(.has-background-background-color) hr.wp-block-separator,
-[class*='background-color']:not(.has-background-background-color)
-	hr.wp-block-separator,
-[style*='background-color'] hr.wp-block-separator,
-.wp-block-cover[style*='background-image'] hr.wp-block-separator {
+[class*="background-color"]:not(.has-background-background-color) hr.wp-block-separator,
+[style*="background-color"] hr.wp-block-separator,
+.wp-block-cover[style*="background-image"] hr.wp-block-separator {
 	border-color: currentColor;
 }
 
@@ -2470,7 +2258,7 @@ hr.wp-block-separator.is-style-dots:before {
 	}
 }
 
-.jetpack_subscription_widget input[type='text'] {
+.jetpack_subscription_widget input[type="text"] {
 	padding: 16px !important;
 	width: 100% !important;
 }
@@ -2492,13 +2280,13 @@ table td,
 table th,
 .wp-block-table td,
 .wp-block-table th {
-	padding: calc(0.5 * 16px);
+	padding: calc( 0.5 * 16px);
 	border: 1px solid;
 }
 
 table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
-	background-color: #fafafa;
+	background-color: #FAFAFA;
 	color: #444444;
 }
 
@@ -2620,11 +2408,11 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-light-color {
-	color: #fafafa;
+	color: #FAFAFA;
 }
 
 .has-background-dark-color {
-	color: #dddddd;
+	color: #DDDDDD;
 }
 
 .has-background-dim,
@@ -2696,7 +2484,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-light-background-color,
 .has-background-light-background-color.has-background-dim {
-	background-color: #fafafa;
+	background-color: #FAFAFA;
 }
 
 .has-background-light-background-color:not(.has-text-color),
@@ -2706,7 +2494,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 .has-background-dark-background-color,
 .has-background-dark-background-color.has-background-dim {
-	background-color: #dddddd;
+	background-color: #DDDDDD;
 }
 
 .has-background-dark-background-color:not(.has-text-color),
@@ -2763,7 +2551,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-drop-cap:not(:focus)::after {
-	content: '';
+	content: "";
 	display: table;
 	clear: both;
 	padding-top: 14px;
@@ -2921,8 +2709,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 	font-weight: bold;
 }
 
-.site-title a:link,
-.site-title a:visited {
+.site-title a:link, .site-title a:visited {
 	color: currentColor;
 }
 
@@ -3013,14 +2800,12 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover,
-.main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
 
-.main-navigation > div > ul li:hover,
-.main-navigation > div > ul li:focus-within {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li:focus-within {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -3053,8 +2838,7 @@ body:not(.fse-enabled) .site-description {
 	.main-navigation > div > ul > li > a {
 		line-height: 1;
 	}
-	.main-navigation > div > ul > li > a:before,
-	.main-navigation > div > ul > li > a:after {
+	.main-navigation > div > ul > li > a:before, .main-navigation > div > ul > li > a:after {
 		content: '';
 		display: block;
 		height: 0;
@@ -3112,8 +2896,7 @@ body:not(.fse-enabled) .site-description {
 	}
 }
 
-.main-navigation a:link,
-.main-navigation a:visited {
+.main-navigation a:link, .main-navigation a:visited {
 	color: blue;
 }
 
@@ -3137,12 +2920,12 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: '– ' counters(nested-list, '– ', none);
+	content: "– " counters(nested-list, "– ", none);
 }
 
 @media only screen and (min-width: 560px) {
 	.main-navigation > div > ul > .menu-item-has-children > a::after {
-		content: '\00a0\25BC';
+		content: "\00a0\25BC";
 		display: inline-block;
 		font-size: 0.69444rem;
 		height: inherit;
@@ -3183,7 +2966,7 @@ body:not(.fse-enabled) .main-navigation a {
 .social-navigation a {
 	color: blue;
 	display: inline-block;
-	padding: 0 calc(0.5 * calc(0.66 * 16px));
+	padding: 0 calc( 0.5 * calc(0.66 * 16px ));
 }
 
 .social-navigation a:hover {
@@ -3232,8 +3015,7 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.site-info a:link,
-.site-info a:visited {
+.site-info a:link, .site-info a:visited {
 	color: currentColor;
 }
 
@@ -3293,8 +3075,7 @@ body:not(.fse-enabled) .main-navigation a {
 	color: currentColor;
 }
 
-.footer-navigation .footer-menu a:link,
-.footer-navigation .footer-menu a:visited {
+.footer-navigation .footer-menu a:link, .footer-navigation .footer-menu a:visited {
 	color: currentColor;
 }
 
@@ -3348,8 +3129,7 @@ body:not(.fse-enabled) .footer-menu a {
 	color: currentColor;
 }
 
-.entry-meta a:hover,
-.entry-meta a:active,
+.entry-meta a:hover, .entry-meta a:active,
 .entry-footer a:hover,
 .entry-footer a:active {
 	color: indigo;
@@ -3384,7 +3164,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .entry-content .more-link:after {
-	content: '→' /*rtl:"←"*/;
+	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
 }
@@ -3407,24 +3187,14 @@ body:not(.fse-enabled) .footer-menu a {
 	padding-top: 0;
 }
 
-.home.page.hide-homepage-header.hide-homepage-title
-	.entry-content
-	> *:first-child {
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > *:first-child {
 	margin-top: 32px;
 }
 
-.home.page.hide-homepage-header.hide-homepage-title
-	.entry-content
-	> .wp-block-image.alignfull:first-child,
-.home.page.hide-homepage-header.hide-homepage-title
-	.entry-content
-	> .wp-block-cover.alignfull:first-child,
-.home.page.hide-homepage-header.hide-homepage-title
-	.entry-content
-	> .wp-block-media-text.alignfull:first-child,
-.home.page.hide-homepage-header.hide-homepage-title
-	.entry-content
-	> .wp-block-group.has-background.alignfull:first-child {
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-image.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-cover.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-media-text.alignfull:first-child,
+.home.page.hide-homepage-header.hide-homepage-title .entry-content > .wp-block-group.has-background.alignfull:first-child {
 	margin-top: -32px;
 }
 
@@ -3563,13 +3333,13 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Lists
  */
 .comment-list {
-	border-bottom: 1px solid #dddddd;
+	border-bottom: 1px solid #DDDDDD;
 	padding-left: 0;
 	list-style: none;
 }
 
 .comment-list > li {
-	border-top: 1px solid #dddddd;
+	border-top: 1px solid #DDDDDD;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
@@ -3580,7 +3350,7 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .comment-list .children > li {
-	border-top: 1px solid #dddddd;
+	border-top: 1px solid #DDDDDD;
 	margin-top: 32px;
 	margin-bottom: 32px;
 }
@@ -3595,7 +3365,7 @@ body:not(.fse-enabled) .footer-menu a {
  * Comment Meta
  */
 .comment-meta {
-	margin-right: calc(32px + (0.5 * 16px));
+	margin-right: calc( 32px + (0.5 * 16px));
 }
 
 .comment-meta .comment-author {
@@ -3641,8 +3411,7 @@ body:not(.fse-enabled) .footer-menu a {
 	color: currentColor;
 }
 
-.comment-meta .comment-metadata a:hover,
-.comment-meta .comment-metadata a:active {
+.comment-meta .comment-metadata a:hover, .comment-meta .comment-metadata a:active {
 	color: indigo;
 }
 
@@ -3763,9 +3532,9 @@ body:not(.fse-enabled) .footer-menu a {
 }
 
 .comment-form > p label,
-.comment-form > p input[type='email'],
-.comment-form > p input[type='text'],
-.comment-form > p input[type='url'],
+.comment-form > p input[type="email"],
+.comment-form > p input[type="text"],
+.comment-form > p input[type="url"],
 .comment-form > p textarea {
 	width: 100%;
 }
@@ -3788,14 +3557,13 @@ body:not(.fse-enabled) .footer-menu a {
 		width: auto;
 		display: inline-block;
 	}
-	.comment-form > p input[type='email'],
-	.comment-form > p input[type='text'],
-	.comment-form > p input[type='url'],
+	.comment-form > p input[type="email"],
+	.comment-form > p input[type="text"],
+	.comment-form > p input[type="url"],
 	.comment-form > p textarea {
 		width: 75%;
 	}
-	.comment-form > p.comment-notes,
-	.comment-form > p.logged-in-as {
+	.comment-form > p.comment-notes, .comment-form > p.logged-in-as {
 		display: block;
 	}
 }
@@ -3845,111 +3613,55 @@ body:not(.fse-enabled) .footer-menu a {
  * Page Layout Styles & Repsonsive Styles
  */
 /* Responsive width-content overrides */
-.responsive-max-width,
-.entry-content > .wp-block-button.aligncenter,
-hr.wp-block-separator.is-style-wide,
-.entry-content
-	> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 .entry-content > *:not(.wp-block-button),
-.entry-content
-	[class*='inner-container']
-	> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-.entry-content .wp-audio-shortcode,
-.post-navigation,
-.pagination {
+.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
 	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
 }
 
 @media only screen and (min-width: 560px) {
-	.responsive-max-width,
-	.entry-content > .wp-block-button.aligncenter,
-	hr.wp-block-separator.is-style-wide,
-	.entry-content
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+	.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 	.entry-content > *:not(.wp-block-button),
-	.entry-content
-		[class*='inner-container']
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-	.entry-content .wp-audio-shortcode,
-	.post-navigation,
-	.pagination {
-		max-width: calc(560px - 32px);
+	.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
+		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.responsive-max-width,
-	.entry-content > .wp-block-button.aligncenter,
-	hr.wp-block-separator.is-style-wide,
-	.entry-content
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+	.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 	.entry-content > *:not(.wp-block-button),
-	.entry-content
-		[class*='inner-container']
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-	.entry-content .wp-audio-shortcode,
-	.post-navigation,
-	.pagination {
-		max-width: calc(640px - 32px);
+	.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
+		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.responsive-max-width,
-	.entry-content > .wp-block-button.aligncenter,
-	hr.wp-block-separator.is-style-wide,
-	.entry-content
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+	.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 	.entry-content > *:not(.wp-block-button),
-	.entry-content
-		[class*='inner-container']
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-	.entry-content .wp-audio-shortcode,
-	.post-navigation,
-	.pagination {
-		max-width: calc(782px - 32px);
+	.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
+		max-width: calc( 782px - 32px);
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.responsive-max-width,
-	.entry-content > .wp-block-button.aligncenter,
-	hr.wp-block-separator.is-style-wide,
-	.entry-content
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+	.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 	.entry-content > *:not(.wp-block-button),
-	.entry-content
-		[class*='inner-container']
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-	.entry-content .wp-audio-shortcode,
-	.post-navigation,
-	.pagination {
-		max-width: calc(782px - 32px);
+	.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
+		max-width: calc( 782px - 32px);
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.responsive-max-width,
-	.entry-content > .wp-block-button.aligncenter,
-	hr.wp-block-separator.is-style-wide,
-	.entry-content
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
+	.responsive-max-width, .entry-content > .wp-block-button.aligncenter, hr.wp-block-separator.is-style-wide, .entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.wp-block-button):not(.entry-attachment),
 	.entry-content > *:not(.wp-block-button),
-	.entry-content
-		[class*='inner-container']
-		> *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator),
-	.entry-content .wp-audio-shortcode,
-	.post-navigation,
-	.pagination {
-		max-width: calc(782px - 32px);
+	.entry-content [class*="inner-container"] > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator), .entry-content .wp-audio-shortcode, .post-navigation, .pagination {
+		max-width: calc( 782px - 32px);
 	}
 }
 
-.entry-content > .alignwide,
-.entry-content > .alignwide.wp-block-jetpack-gif,
-.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: 100%;
@@ -3957,49 +3669,38 @@ hr.wp-block-separator.is-style-wide,
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide,
-	.entry-content > .alignwide.wp-block-jetpack-gif,
-	.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
-		max-width: calc(560px - 32px);
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+		max-width: calc( 560px - 32px);
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide,
-	.entry-content > .alignwide.wp-block-jetpack-gif,
-	.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
-		max-width: calc(640px - 32px);
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+		max-width: calc( 640px - 32px);
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide,
-	.entry-content > .alignwide.wp-block-jetpack-gif,
-	.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
-		max-width: calc(782px - 32px);
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+		max-width: calc( 782px - 32px);
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide,
-	.entry-content > .alignwide.wp-block-jetpack-gif,
-	.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
-		width: calc(calc(782px - 32px) + 256px);
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide,
-	.entry-content > .alignwide.wp-block-jetpack-gif,
-	.entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
-		width: calc(calc(782px - 32px) + 256px);
+	.entry-content > .alignwide, .entry-content > .alignwide.wp-block-jetpack-gif, .entry-content > .alignwide.wp-block-jetpack-tiled-gallery {
+		width: calc(calc( 782px - 32px) + 256px);
 		max-width: calc(100% - 32px);
 	}
 }
 
-.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-.entry-content > .alignfull [class*='inner-container'] > .alignwide {
+.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
 	width: calc(100% + 256px);
 	max-width: 100%;
 	margin-left: auto;
@@ -4007,48 +3708,41 @@ hr.wp-block-separator.is-style-wide,
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-	.entry-content > .alignfull [class*='inner-container'] > .alignwide {
-		width: calc(calc(560px - 32px) + 256px);
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
+		width: calc(calc( 560px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-	.entry-content > .alignfull [class*='inner-container'] > .alignwide {
-		width: calc(calc(640px - 32px) + 256px);
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
+		width: calc(calc( 640px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-	.entry-content > .alignfull [class*='inner-container'] > .alignwide {
-		width: calc(calc(782px - 32px) + 256px);
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
+		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-	.entry-content > .alignfull [class*='inner-container'] > .alignwide {
-		width: calc(calc(782px - 32px) + 256px);
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
+		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .alignwide [class*='inner-container'] > .alignwide,
-	.entry-content > .alignfull [class*='inner-container'] > .alignwide {
-		width: calc(calc(782px - 32px) + 256px);
+	.entry-content > .alignwide [class*="inner-container"] > .alignwide, .entry-content > .alignfull [class*="inner-container"] > .alignwide {
+		width: calc(calc( 782px - 32px) + 256px);
 		max-width: 100%;
 	}
 }
 
-.entry-content > .alignfull,
-.entry-content > .alignfull.wp-block-jetpack-gif,
-.entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 	margin-left: -16px;
 	margin-right: -16px;
 	width: calc(100% + 32px);
@@ -4057,9 +3751,7 @@ hr.wp-block-separator.is-style-wide,
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .alignfull,
-	.entry-content > .alignfull.wp-block-jetpack-gif,
-	.entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
+	.entry-content > .alignfull, .entry-content > .alignfull.wp-block-jetpack-gif, .entry-content > .alignfull.wp-block-jetpack-tiled-gallery {
 		margin-left: inherit;
 		margin-right: inherit;
 		width: inherit;
@@ -4074,8 +3766,8 @@ hr.wp-block-separator.is-style-wide,
 @media only screen and (min-width: 560px) {
 	.entry-content > .alignright {
 		/*rtl:ignore*/
-		margin-right: calc(0.5 * (100vw - calc(560px - 32px)));
-		max-width: calc(0.5 * calc(560px - 32px));
+		margin-right: calc( 0.5 * (100vw - calc( 560px - 32px)));
+		max-width: calc( 0.5 * calc( 560px - 32px));
 		margin-left: 16px;
 	}
 }
@@ -4083,83 +3775,77 @@ hr.wp-block-separator.is-style-wide,
 @media only screen and (min-width: 640px) {
 	.entry-content > .alignright {
 		/*rtl:ignore*/
-		margin-right: calc(0.5 * (100vw - calc(640px - 32px)));
-		max-width: calc(0.5 * calc(640px - 32px));
+		margin-right: calc( 0.5 * (100vw - calc( 640px - 32px)));
+		max-width: calc( 0.5 * calc( 640px - 32px));
 	}
 }
 
 @media only screen and (min-width: 782px) {
 	.entry-content > .alignright {
 		/*rtl:ignore*/
-		margin-right: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-right: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
 @media only screen and (min-width: 1024px) {
 	.entry-content > .alignright {
 		/*rtl:ignore*/
-		margin-right: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-right: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
 @media only screen and (min-width: 1280px) {
 	.entry-content > .alignright {
 		/*rtl:ignore*/
-		margin-right: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-right: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
-.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-.entry-content > .alignleft {
+.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 	/*rtl:ignore*/
 }
 
 @media only screen and (min-width: 560px) {
-	.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-	.entry-content > .alignleft {
+	.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(0.5 * (100vw - calc(560px - 32px)));
-		max-width: calc(0.5 * calc(560px - 32px));
+		margin-left: calc( 0.5 * (100vw - calc( 560px - 32px)));
+		max-width: calc( 0.5 * calc( 560px - 32px));
 		margin-right: 16px;
 	}
 }
 
 @media only screen and (min-width: 640px) {
-	.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-	.entry-content > .alignleft {
+	.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(0.5 * (100vw - calc(640px - 32px)));
-		max-width: calc(0.5 * calc(640px - 32px));
+		margin-left: calc( 0.5 * (100vw - calc( 640px - 32px)));
+		max-width: calc( 0.5 * calc( 640px - 32px));
 	}
 }
 
 @media only screen and (min-width: 782px) {
-	.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-	.entry-content > .alignleft {
+	.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-left: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
 @media only screen and (min-width: 1024px) {
-	.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-	.entry-content > .alignleft {
+	.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-left: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
 @media only screen and (min-width: 1280px) {
-	.entry-content > .wp-block-button:not(.alignleft):not(.alignright),
-	.entry-content > .alignleft {
+	.entry-content > .wp-block-button:not(.alignleft):not(.alignright), .entry-content > .alignleft {
 		/*rtl:ignore*/
-		margin-left: calc(0.5 * (100vw - calc(782px - 32px)));
-		max-width: calc(0.5 * calc(782px - 32px));
+		margin-left: calc( 0.5 * (100vw - calc( 782px - 32px)));
+		max-width: calc( 0.5 * calc( 782px - 32px));
 	}
 }
 
@@ -4212,7 +3898,7 @@ body .widget_eu_cookie_law_widget.widget.top {
 
 body .widget_eu_cookie_law_widget #eu-cookie-law {
 	background: white;
-	border: 1px solid #dddddd;
+	border: 1px solid #DDDDDD;
 	color: #444444;
 	font-size: 0.83333rem;
 	line-height: inherit;
@@ -4236,13 +3922,8 @@ body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept {
 	color: #444444;
 }
 
-body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover,
-body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus,
-body
-	.widget_eu_cookie_law_widget
-	#eu-cookie-law.negative
-	input.accept.has-focus {
-	background: #dddddd;
+body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:hover, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept:focus, body .widget_eu_cookie_law_widget #eu-cookie-law.negative input.accept.has-focus {
+	background: #DDDDDD;
 }
 
 body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
@@ -4291,7 +3972,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type='email'] {
+.wp-block-jetpack-mailchimp input[type=email] {
 	width: 100%;
 }
 
@@ -4321,16 +4002,23 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	}
 }
 
-.wp-block-jetpack-layout-grid
-	.wp-block-jetpack-layout-grid-column
-	> *:first-child {
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:first-child {
 	margin-top: 0;
 }
 
-.wp-block-jetpack-layout-grid
-	.wp-block-jetpack-layout-grid-column
-	> *:last-child {
+.wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column > *:last-child {
 	margin-bottom: 0;
+}
+
+/**
+ * Map Block
+ */
+.mapboxgl-popup-close-button {
+	padding: 6px;
+}
+
+.wp-block-jetpack-map .mapboxgl-popup h3 {
+	padding-top: 15px;
 }
 
 /**
@@ -4342,38 +4030,23 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-top: 0;
 }
 
-.fse-template-part .main-navigation .alignwide,
-.fse-template-part .main-navigation .alignfull {
+.fse-template-part .main-navigation .alignwide, .fse-template-part .main-navigation .alignfull {
 	width: 100%;
 }
 
-.fse-template-part
-	.main-navigation
-	.has-text-color
-	> .main-menu.footer-menu
-	> li
-	> a {
+.fse-template-part .main-navigation .has-text-color > .main-menu.footer-menu > li > a {
 	color: inherit;
 }
 
-.fse-template-part
-	.main-navigation
-	.has-text-align-left
-	> .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-left > .main-menu.footer-menu {
 	justify-content: flex-start;
 }
 
-.fse-template-part
-	.main-navigation
-	.has-text-align-center
-	> .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-center > .main-menu.footer-menu {
 	justify-content: center;
 }
 
-.fse-template-part
-	.main-navigation
-	.has-text-align-right
-	> .main-menu.footer-menu {
+.fse-template-part .main-navigation .has-text-align-right > .main-menu.footer-menu {
 	justify-content: flex-end;
 }
 
@@ -4382,20 +4055,12 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 @media only screen and (min-width: 560px) {
-	.fse-template-part
-		.main-navigation
-		.has-background
-		> .main-menu.footer-menu {
+	.fse-template-part .main-navigation .has-background > .main-menu.footer-menu {
 		padding: 16px;
 	}
 }
 
-.fse-template-part
-	.main-navigation
-	> div
-	> .main-menu.footer-menu
-	> .menu-item-has-children
-	> a::after {
+.fse-template-part .main-navigation > div > .main-menu.footer-menu > .menu-item-has-children > a::after {
 	font-size: 0.6em;
 	vertical-align: middle;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Added CSS to reduce the size of button and eliminate overlap with headings on Varia and its child themes. Tested on all themes listed in the original issue.

If I didn't commit the changes right, let me know. 

#### Varia

##### Before

<img width="777" alt="Screenshot on 2022-08-08 at 13-12-23" src="https://user-images.githubusercontent.com/45246438/183475124-a9625203-59a4-45c3-8e5d-f00a9fb7307b.png">


##### After

<img width="772" alt="Screenshot on 2022-08-08 at 11-51-07" src="https://user-images.githubusercontent.com/45246438/183475142-565a0673-a49a-476d-a305-ee53f77d7ab2.png">

#### Hever 

##### Before

<img width="822" alt="Screenshot on 2022-08-08 at 11-54-52" src="https://user-images.githubusercontent.com/45246438/183474561-496403b7-5c4d-428f-9a49-96a4e146093b.png">


##### After

<img width="842" alt="Screenshot on 2022-08-08 at 12-32-22" src="https://user-images.githubusercontent.com/45246438/183474491-e47ec1a0-4dcf-4e9d-b820-2336c806d0fb.png">


### Related issue(s):

Fixes #6025	