### PR TITLE
#6155: Penscratch 2: Add spacing controls for blocks

### DIFF
--- a/penscratch-2/functions.php
+++ b/penscratch-2/functions.php
@@ -94,9 +94,6 @@ if ( ! function_exists( 'penscratch_2_setup' ) ) :
 		// Add support for responsive embeds.
 		add_theme_support( 'responsive-embeds' );
 
-		// Add support for responsive embeds.
-		add_theme_support( 'responsive-embeds' );
-
 		// Add support for custom padding.
 		add_theme_support( 'custom-spacing' );
 
@@ -273,7 +270,7 @@ function penscratch_2_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/penscratch-2/functions.php
+++ b/penscratch-2/functions.php
@@ -94,6 +94,12 @@ if ( ! function_exists( 'penscratch_2_setup' ) ) :
 		// Add support for responsive embeds.
 		add_theme_support( 'responsive-embeds' );
 
+		// Add support for responsive embeds.
+		add_theme_support( 'responsive-embeds' );
+
+		// Add support for custom padding.
+		add_theme_support( 'custom-spacing' );
+
 		// Add custom colors to Gutenberg
 		add_theme_support(
 			'editor-color-palette',


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Add support for spacing controls to Penscratch 2. I couldn't do the same for the others mentioned since they aren't in the `themes` repo. 

#### Changes proposed in this Pull Request:

##### Before

<img width="1248" alt="Screenshot on 2022-08-08 at 13-47-49" src="https://user-images.githubusercontent.com/45246438/183485673-0f0cdc20-b84c-4d41-99cf-205b77cffb7c.png">


##### After

<img width="1256" alt="Screenshot on 2022-08-08 at 13-51-36" src="https://user-images.githubusercontent.com/45246438/183485813-633e0e1a-a607-4ec3-8011-99b6cbb22e09.png">


<img width="1141" alt="Screenshot on 2022-08-08 at 13-57-57" src="https://user-images.githubusercontent.com/45246438/183485842-759e5e1f-fc91-4e81-8f95-657bc1a0f0c6.png">



#### Related issue(s):

Addresses #6155 for Penscratch 2