### PR TITLE
#4628: Pique is not adding the default color palette css to the editor

### DIFF
--- a/pique/assets/css/editor-blocks.css
+++ b/pique/assets/css/editor-blocks.css
@@ -491,3 +491,63 @@ p.has-drop-cap:not(:focus)::first-letter {
 	letter-spacing: 0.05rem;
 	text-transform: uppercase;
 }
+
+/*--------------------------------------------------------------
+7.0 Blocks - Colors
+--------------------------------------------------------------*/
+
+.has-light-blue-color {
+	color: #83b6cc;
+}
+
+.has-light-blue-background-color {
+	background-color: #83b6cc;
+}
+
+.has-medium-blue-color {
+	color: #3c7993;
+}
+
+.has-medium-blue-background-color {
+	background-color: #3c7993;
+}
+
+.has-dark-blue-color {
+	color: #293940;
+}
+
+.has-dark-blue-background-color {
+	background-color: #293940;
+}
+
+.has-dark-brown-color {
+	color: #2d2a26;
+}
+
+.has-dark-brown-background-color {
+	background-color: #2d2a26;
+}
+
+.has-dark-gray-color {
+	color: #5d5d5d;
+}
+
+.has-dark-gray-background-color {
+	background-color: #5d5d5d;
+}
+
+.has-medium-gray-color {
+	color: #a9a9a9;
+}
+
+.has-medium-gray-background-color {
+	background-color: #a9a9a9;
+}
+
+.has-white-color {
+	color: #fff;
+}
+
+.has-white-background-color {
+	background-color: #fff;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adding CSS code for default theme colors to be applied on the page/post editor: `editor-blocks.css`. Whenever we try to apply one of the theme's default colors to text using the `highlight` option, the color change is not getting applied to the elements. However, when checking the published page, we can see that the color change does work.

<table>
    <thead>
      <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/183487743-9e542d4a-aefd-49e5-9fd3-21a99c7676cf.png"/></td>
        <td><img src="https://user-images.githubusercontent.com/50875131/183487797-d5addd44-55b5-40ae-9307-e119da2ce00d.png"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):

Pique theme is not adding the default color palette css to the editor #4628