### PR TITLE
#6341: Penscratch 2: Fix button borders on Safari

### DIFF
--- a/penscratch-2/css/blocks.css
+++ b/penscratch-2/css/blocks.css
@@ -222,7 +222,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 	cursor: pointer;
 	border: 1px solid #ccc;
 	border-color: #ccc #ccc #bbb #ccc;
-	-webkit-appearance: button;
 }
 
 .wp-block-button__link {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Removes CSS `-webkit-appearance` as the button displays properly in Safari without it. Tested on macOS Safari v15.6. 


#### Before

<img width="763" alt="Screenshot on 2022-08-08 at 14-20-10" src="https://user-images.githubusercontent.com/45246438/183489084-ea9f7ad1-3e06-47ac-82a8-4821ef9f1557.png">


#### After

<img width="786" alt="Screenshot on 2022-08-08 at 14-28-49" src="https://user-images.githubusercontent.com/45246438/183489031-cedcd7f1-3db5-449f-b93d-3a433a061d61.png">



#### Related issue(s):

Fixes #6341
