### PR TITLE
#66356: Lodestar: Home page: Full width blocks are not full width

### DIFF
--- a/lodestar/assets/css/blocks.css
+++ b/lodestar/assets/css/blocks.css
@@ -45,7 +45,8 @@ body:not(.has-sidebar) .site-content {
 }
 
 body:not(.has-sidebar) .alignfull,
-body:not(.has-sidebar).lodestar-front-page .lodestar-panel:not(.two-column) .alignfull {
+body:not(.has-sidebar).lodestar-front-page .lodestar-panel:not(.two-column) .alignfull, 
+body:not(.has-sidebar).lodestar-front-page .lodestar-intro:not(.two-column) .alignfull {
 	margin-left: calc(50% - 50vw);
 	margin-right: calc(50% - 50vw);
 	max-width: 1000%;

--- a/lodestar/assets/css/blocks.css
+++ b/lodestar/assets/css/blocks.css
@@ -44,7 +44,7 @@ body:not(.has-sidebar) .site-content {
 	}
 }
 
-body:not(.has-sidebar):not(.lodestar-front-page) .alignfull,
+body:not(.has-sidebar) .alignfull,
 body:not(.has-sidebar).lodestar-front-page .lodestar-panel:not(.two-column) .alignfull {
 	margin-left: calc(50% - 50vw);
 	margin-right: calc(50% - 50vw);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removing a CSS selector that was preventing full-width blocks from being full width on the Lodestar home page.

---
<table>
    <thead>
      <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/183492690-1e87f7ae-27ec-4e9d-a801-5264447aacbe.png"/></td>
        <td><img src="https://user-images.githubusercontent.com/50875131/183492699-bf74e276-a165-4ac9-96f5-4435ed17b842.png"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):

Lodestar: Home page: Full width blocks are not full width Automattic/themes#6352

Fixes: https://github.com/Automattic/themes/issues/6352