### PR TITLE
Club: implement button styles for interactive states in the read more block button

### DIFF
--- a/club/style.css
+++ b/club/style.css
@@ -47,6 +47,11 @@ a {
  * https://github.com/WordPress/gutenberg/issues/27075
  */
 
+ .wp-block-read-more:is(:hover, :focus) {
+	background-color: var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--background);
+ }
+
 :is(
 	.wp-block-search__button,
 	.wp-block-file .wp-block-file__button,
@@ -63,6 +68,7 @@ a {
 	.wp-block-file .wp-block-file__button,
 	.wp-block-button__link,
 	.wp-elements-button,
+	.wp-block-read-more,
 ):where(:active) {
 	border-style: dotted;
 }

--- a/club/style.css
+++ b/club/style.css
@@ -74,15 +74,6 @@ a {
 }
 
 :is(
-	.wp-block-search__button,
-	.wp-block-file .wp-block-file__button,
-	.wp-block-button__link,
-	.wp-elements-button,
-):where(:active) {
-	border-style: dotted;
-}
-
-:is(
 	.is-style-outline .wp-block-button__link,
 	.is-style-outline .wp-element-button,
 	.wp-block-post-comments-form input[type=submit],

--- a/club/style.css
+++ b/club/style.css
@@ -94,7 +94,7 @@ a {
 ) {
 	background: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
-	border-style: dotted;
+	border-style: dashed;
 }
 
 /* This is necesary to fix the outline style for the button in the editor */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Club: implement button styles for interactive states in the read more block button

![image](https://user-images.githubusercontent.com/1310626/183666899-878ea37b-2220-4465-9d90-7219e9eab3f1.png)
