### PR TITLE
#3991: Varia: Fix related post alignment

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1.25em;
+	font-size: 1.25;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #4d6974;
-	font-size: 1.04167em;
+	font-size: 1.04167;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.5em;
+	font-size: 1.5;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/alves/style.css
+++ b/alves/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #505050;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -4039,6 +4039,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -4068,6 +4068,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #844d4d;
-	font-size: 0.84746em;
+	font-size: 0.84746;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.18em;
+	font-size: 1.18;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -4034,6 +4034,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -4063,6 +4063,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -534,7 +534,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -545,8 +545,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -4031,6 +4031,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -4060,6 +4060,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.86957em;
+	font-size: 0.86957;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.15em;
+	font-size: 1.15;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -4032,6 +4032,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -4061,6 +4061,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #6E6E6E;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/exford/style.css
+++ b/exford/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -364,11 +364,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -409,7 +409,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -420,7 +420,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -429,7 +429,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -445,13 +445,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957em;
+	font-size: 0.86957;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -462,7 +462,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -477,7 +477,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -503,7 +503,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -563,7 +563,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.15em;
+	font-size: 1.15;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -574,8 +574,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -4085,6 +4085,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
   * Child Theme Extra Styles
   */
 /**

--- a/hever/style.css
+++ b/hever/style.css
@@ -4114,6 +4114,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
   * Child Theme Extra Styles
   */
 /**

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.82474em;
+	font-size: 0.82474;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2125em;
+	font-size: 1.2125;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/leven/style.css
+++ b/leven/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -4032,6 +4032,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -4061,6 +4061,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -351,11 +351,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -396,7 +396,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -407,7 +407,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -416,7 +416,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -432,13 +432,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #686868;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -449,7 +449,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -464,7 +464,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -490,7 +490,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -550,7 +550,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -561,8 +561,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -363,11 +363,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -408,7 +408,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -419,7 +419,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -428,7 +428,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -444,13 +444,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957em;
+	font-size: 0.86957;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -461,7 +461,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -476,7 +476,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -502,7 +502,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -562,7 +562,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.15em;
+	font-size: 1.15;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -573,8 +573,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -4060,6 +4060,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/morden/style.css
+++ b/morden/style.css
@@ -4089,6 +4089,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -348,11 +348,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -393,7 +393,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -404,7 +404,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -413,7 +413,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -429,13 +429,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #666666;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -446,7 +446,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -461,7 +461,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -487,7 +487,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -547,7 +547,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -558,8 +558,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -4034,6 +4034,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -4063,6 +4063,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -336,11 +336,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -381,7 +381,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -392,7 +392,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -401,7 +401,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -417,13 +417,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: white;
-	font-size: 0.8em;
+	font-size: 0.8;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -434,7 +434,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -449,7 +449,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -475,7 +475,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -535,7 +535,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.25em;
+	font-size: 1.25;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -546,8 +546,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -4033,6 +4033,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -4062,6 +4062,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -362,11 +362,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -407,7 +407,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -418,7 +418,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -427,7 +427,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -443,13 +443,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -460,7 +460,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -475,7 +475,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -501,7 +501,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -561,7 +561,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -572,8 +572,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -4071,6 +4071,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -4100,6 +4100,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -364,11 +364,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -409,7 +409,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -420,7 +420,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -429,7 +429,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -445,13 +445,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -462,7 +462,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -477,7 +477,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -503,7 +503,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -563,7 +563,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -574,8 +574,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -4060,6 +4060,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -4089,6 +4089,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/stow/style.css
+++ b/stow/style.css
@@ -4104,6 +4104,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -364,11 +364,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -409,7 +409,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -420,7 +420,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -429,7 +429,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -445,13 +445,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -462,7 +462,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -477,7 +477,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -503,7 +503,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -563,7 +563,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -574,8 +574,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -4074,6 +4074,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -4103,6 +4103,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Child Theme Extra Styles
  */
 /**

--- a/varia/sass/vendors/jetpack/_style.scss
+++ b/varia/sass/vendors/jetpack/_style.scss
@@ -191,3 +191,11 @@ body {
 .wp-block-jetpack-map .mapboxgl-popup h3 {
 	padding-top: 15px;
 }
+
+/**
+ * Related Posts
+ */
+
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -350,11 +350,11 @@ object {
 }
 
 .wp-block-a8c-blog-posts.image-alignbehind .post-has-image a:hover {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .article-section-title {
-	font-size: 1em;
+	font-size: 1;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -395,7 +395,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-title a:hover {
@@ -406,7 +406,7 @@ object {
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-title a,
 [style*="background-color"] .wp-block-a8c-blog-posts .entry-title a {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .more-link {
@@ -415,7 +415,7 @@ object {
 	margin-top: 16px;
 }
 
-.wp-block-a8c-blog-posts .more-link:after {
+.wp-block-a8c-blog-posts .more-link::after {
 	content: "→" /*rtl:"←"*/;
 	display: inline-block;
 	margin-left: 0.5em;
@@ -431,13 +431,13 @@ object {
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:hover, .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts .more-link:active,
 [style*="background-color"] .wp-block-a8c-blog-posts .more-link:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta,
 .wp-block-a8c-blog-posts .cat-links {
 	color: #767676;
-	font-size: 0.83333em;
+	font-size: 0.83333;
 }
 
 .has-background:not(.has-background-background-color) .wp-block-a8c-blog-posts .entry-meta,
@@ -448,7 +448,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-a8c-blog-posts .entry-meta .byline:not(:last-child),
@@ -463,7 +463,7 @@ object {
 
 .wp-block-a8c-blog-posts .entry-meta a,
 .wp-block-a8c-blog-posts .cat-links a {
-	color: currentColor;
+	color: currentcolor;
 	text-decoration: underline;
 }
 
@@ -489,7 +489,7 @@ object {
 .wp-block-a8c-blog-posts .cat-links a:active,
 [style*="background-color"]
 .wp-block-a8c-blog-posts .cat-links a:active {
-	color: currentColor;
+	color: currentcolor;
 }
 
 /**
@@ -549,7 +549,7 @@ object {
  */
 .wp-block-a8c-blog-posts + .button {
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.2;
 }
 
 .wp-block-a8c-blog-posts + .button:hover {
@@ -560,8 +560,8 @@ object {
 [class*="background-color"]:not(.has-background-background-color) .wp-block-a8c-blog-posts + .button,
 [style*="background-color"] .wp-block-a8c-blog-posts + .button {
 	background-color: transparent;
-	border: 2px solid currentColor;
-	color: currentColor;
+	border: 2px solid currentcolor;
+	color: currentcolor;
 }
 
 .wpnbha article p > .more-link:not([rel]) {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -3992,6 +3992,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Full Site Editing
  * - Full Site Editing overrides
  */

--- a/varia/style.css
+++ b/varia/style.css
@@ -4021,6 +4021,13 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 }
 
 /**
+ * Related Posts
+ */
+.entry-content #jp-relatedposts {
+	margin: 0 auto;
+}
+
+/**
  * Full Site Editing
  * - Full Site Editing overrides
  */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Fixes alignment in Jetpack Related Posts to align it to the center along with the content in Varia child themes. I tested on Varia, Hever, and Exford.

##### Hever

###### Before
<img width="1236" alt="Screenshot on 2022-08-09 at 10-35-11" src="https://user-images.githubusercontent.com/45246438/183688705-4e8be209-783d-41bf-9008-5118a3374ee1.png">

###### After

<img width="1177" alt="Screenshot on 2022-08-09 at 11-07-11" src="https://user-images.githubusercontent.com/45246438/183688759-eb677cdb-46ed-4343-a498-4b40a4817b0e.png">

##### Exford

###### Before

<img width="1094" alt="Screenshot on 2022-08-09 at 11-05-12" src="https://user-images.githubusercontent.com/45246438/183689056-b296f5ef-29ba-4dca-aa0d-69d00d0fa070.png">

###### After

<img width="1181" alt="Screenshot on 2022-08-09 at 11-06-12" src="https://user-images.githubusercontent.com/45246438/183689099-f3f2b185-039c-4ac0-99c6-f479683bf021.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/3991