### PR TITLE
#6232: Publication: Fix padding on inline text color

### DIFF
--- a/publication/style.css
+++ b/publication/style.css
@@ -439,7 +439,7 @@ acronym {
 	border-bottom: 1px dotted #222;
 	cursor: help;
 }
-mark,
+mark:not(.has-inline-color),
 ins {
 	background: #ef7d0b;
 	color: #fff;

--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -493,7 +493,7 @@ acronym {
 	cursor: help;
 }
 
-mark,
+mark:not(.has-inline-color),
 ins {
 	background: #3e69dc;
 	color: #fff;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Fixes inline text color issue in Publication and Shoreditch

### Changes proposed in this Pull Request:

#### Publication

##### Before

<img width="1490" alt="Screenshot on 2022-08-09 at 11-30-23" src="https://user-images.githubusercontent.com/45246438/183706954-991b61ec-5b24-4887-97b1-835272dc258a.png">

##### After

<img width="1668" alt="Screenshot on 2022-08-09 at 11-33-15" src="https://user-images.githubusercontent.com/45246438/183706980-d45317d8-a1af-4c55-a1a7-9783eb91d015.png">

#### Shoreditch

##### Before

<img width="1643" alt="Screenshot on 2022-08-09 at 11-40-35" src="https://user-images.githubusercontent.com/45246438/183707336-aa826a48-04a9-4d9e-ac47-6c248963813f.png">

##### After

<img width="1672" alt="Screenshot on 2022-08-09 at 11-43-30" src="https://user-images.githubusercontent.com/45246438/183707347-4f9aa04f-d73d-4d5a-9491-8c59e6fcc354.png">



### Related issue(s):

Addresses https://github.com/Automattic/themes/issues/7164 for Publication and Shoreditch. 