### PR TITLE
#115: Apostrophe 2: Fix duplicate featured images w/Jetpack Lazy Loading

### DIFF
--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -1474,7 +1474,7 @@ figure.entry-thumbnail {
 }
 
 /* Hide duplicate image thumbnail with Jetpack Lazy Loading */
-.home .entry-thumbnail > img.jetpack-lazy-image ~ img.attachment-post-thumbnail {
+.entry-thumbnail > img.jetpack-lazy-image ~ img.attachment-post-thumbnail {
 	display: none;
 }
 

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -1473,6 +1473,11 @@ figure.entry-thumbnail {
 	margin: 0 0 1.5em;
 }
 
+/* Hide duplicate image thumbnail with Jetpack Lazy Loading */
+.home .entry-thumbnail > img.jetpack-lazy-image ~ img.attachment-post-thumbnail {
+	display: none;
+}
+
 /* Entry/post headers */
 .entry-format::before {
 	background: #e6e6e6;
@@ -2178,6 +2183,7 @@ object {
 .sd-sharing-enabled iframe {
 	margin: 0;
 }
+
 
 /*--------------------------------------------------------------
 12.1 Captions


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Fixes duplicate featured image when Jetpack Lazy Loading is enabled and no featured image is chosen. This will fix it on homepage and archive pages.

##### Before

<img width="1524" alt="Screenshot on 2022-08-09 at 15-00-54" src="https://user-images.githubusercontent.com/45246438/183742901-750316d1-cc3b-47f0-886f-35af68e068e2.png">

##### After

<img width="1520" alt="Screenshot on 2022-08-09 at 15-03-59" src="https://user-images.githubusercontent.com/45246438/183742920-eee2d0fb-d320-4aef-af8a-1ab2bdceac6d.png">

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/155