### PR TITLE
Try using media query for Livro color schemes

### DIFF
--- a/livro/patterns/header-title-tagline-social.php
+++ b/livro/patterns/header-title-tagline-social.php
@@ -16,7 +16,7 @@
 <!-- wp:site-tagline {"textAlign":"center","fontSize":"x-small"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","iconBackgroundColor":"background","iconBackgroundColorValue":"var(--wp--preset--color--background)","layout":{"type":"flex","justifyContent":"right"}} -->
+<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--custom--color--foreground)","iconBackgroundColor":"background","iconBackgroundColorValue":"var(--wp--custom--color--background)","layout":{"type":"flex","justifyContent":"right"}} -->
 <ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 <!-- /wp:social-links --></div>
 <!-- /wp:group -->

--- a/livro/patterns/page-contact.php
+++ b/livro/patterns/page-contact.php
@@ -39,7 +39,7 @@
 <p class="has-text-align-right has-small-font-size"><em><?php echo esc_html__( 'Follow us:', 'livro' ); ?></em></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:social-links {"iconColor":"secondary","iconColorValue":"var(--wp--preset--color--secondary)","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"}} -->
+<!-- wp:social-links {"iconColor":"secondary","iconColorValue":"var(--wp--custom--color--secondary)","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"}} -->
 <ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"twitter"} /-->
 
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->

--- a/livro/style.css
+++ b/livro/style.css
@@ -65,10 +65,10 @@ a:active {
 
 .wp-block-search__button,
 .wp-block-file .wp-block-file__button {
-	background-color: var(--wp--preset--color--foreground);
+	background-color: var(--wp--custom--color--foreground);
 	border-radius: 0;
 	border: none;
-	color: var(--wp--preset--color--background);
+	color: var(--wp--custom--color--background);
 	font-size: var(--wp--preset--font-size--medium);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
@@ -170,14 +170,14 @@ input {
 
 textarea,
 input:not([type="submit"]):not([type="button"]) {
-	color: var(--wp--preset--color--foreground);
-	background: var(--wp--preset--color--background);
-	border-color: var(--wp--preset--color--foreground);
+	color: var(--wp--custom--color--foreground);
+	background: var(--wp--custom--color--background);
+	border-color: var(--wp--custom--color--foreground);
 }
 
 textarea:focus,
 input:not([type="submit"]):not([type="button"]):focus {
-	border-color: var(--wp--preset--color--secondary);
+	border-color: var(--wp--custom--color--secondary);
 }
 
 .comment-form label {
@@ -216,4 +216,13 @@ input:not([type="submit"]):not([type="button"]):focus {
 .archive .post_format-post-format-aside .wp-block-post-title,
 .blog .post_format-post-format-aside .wp-block-post-title {
 	display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.editor-styles-wrapper,
+  body {
+    --wp--custom--color--foreground: var(--wp--preset--color--foreground-dark);
+    --wp--custom--color--background: var(--wp--preset--color--background-dark);
+    --wp--custom--color--secondary: var(--wp--preset--color--secondary-dark);
+  }
 }

--- a/livro/theme.json
+++ b/livro/theme.json
@@ -24,32 +24,42 @@
 			"palette": [
 				{
 					"slug": "foreground",
-					"color": "#DBDBDB",
+					"color": "#1E1E1E",
 					"name": "Foreground"
 				},
 				{
 					"slug": "background",
-					"color": "#1E1E1E",
-					"name": "Background"
-				},
-				{
-					"slug": "primary",
-					"color": "#DDDCDA",
+					"color": "#fbf9f2",
 					"name": "Background"
 				},
 				{
 					"slug": "secondary",
-					"color": "#FFFFFF",
-					"name": "Background"
+					"color": "#000000",
+					"name": "Secondary"
 				},
 				{
-					"slug": "tertiary",
-					"color": "#333232",
-					"name": "Background"
-				}
+					"slug": "foreground-dark",
+					"color": "#DBDBDB",
+					"name": "Foreground (dark)"
+				},
+				{
+					"slug": "background-dark",
+					"color": "#1E1E1E",
+					"name": "Background (dark)"
+				},
+				{
+					"slug": "secondary-dark",
+					"color": "#FFFFFF",
+					"name": "Secondary (dark)"
+				}	
 			]
 		},
 		"custom": {
+			"color": {
+				"foreground": "var(--wp--preset--color--foreground)",
+				"background": "var(--wp--preset--color--background)",
+				"secondary": "var(--wp--preset--color--secondary)"
+			},
 			"spacing": {
 				"small": "max(1.25rem, 2vw)",
 				"medium": "clamp(2rem, 8vw, calc(4 * var(--wp--style--block-gap)))",
@@ -136,8 +146,8 @@
 					"radius": "0"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--secondary)",
-					"text": "var(--wp--preset--color--background)"
+					"background": "var(--wp--custom--color--secondary)",
+					"text": "var(--wp--custom--color--background)"
 				},
 				"spacing": {
 					"padding": "1.25em 1.15em 1.15em 1.15em"
@@ -195,8 +205,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
+			"background": "var(--wp--custom--color--background)",
+			"text": "var(--wp--custom--color--foreground)"
 		},
 		"elements": {
 			"h1": {
@@ -247,7 +257,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"text": "var(--wp--custom--color--foreground)"
 				}
 			}
 		},


### PR DESCRIPTION
After thinking about the [same potential in Spearhead](https://github.com/Automattic/themes/pull/6331#issuecomment-1208412603) I gave using media queries a try for enabling dark/light mode on Livro.

The result is a palette that's 6 items (only 3 of the palette colors currently in the theme are actually useful, X 2).

<img width="328" alt="image" src="https://user-images.githubusercontent.com/146530/183742935-69110055-6a82-4685-a469-43bc62164dde.png">

There's a custom "routing variable" in theme.json (`--wp--custom--color--foreground`, etc) that we can point either towards the light or dark palette colors.  (`--wp--preset--color--foreground-dark`, etc) 

This then changes both the editor and view to use the dark or light colors depending on the user preferences.
<img width="643" alt="image" src="https://user-images.githubusercontent.com/146530/183743521-c719973b-f931-41b6-89d4-9b77d9794531.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/146530/183743547-69e1c5f6-0e3c-4b0e-9e1d-524b27d84996.png">

Additionally, perhaps it would be possible to include style variations that permitted only light mode or dark modes.