### PR TITLE
Adjusted index template to remove padding

### DIFF
--- a/twentytwentythree/templates/home.html
+++ b/twentytwentythree/templates/home.html
@@ -2,8 +2,7 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
+	<!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"x-large"} /-->
 
 	<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 
@@ -21,8 +20,7 @@
 
 	<!-- wp:spacer {"height":112} -->
 	<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer --></div>
-	<!-- /wp:group -->
+	<!-- /wp:spacer -->
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->


### PR DESCRIPTION
Remove a `wp:group` from the query loop to eliminate a div that had global padding applied pushing the contents out of alignment with the header.

Before:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/146530/183902037-5041060d-a4b3-4ffa-8bf4-6715b6032237.png">

After:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/146530/183901893-2db27e93-7b63-4294-920a-1bc29f3d836e.png">
