### PR TITLE
#6351: Pique: Fix wide/full width columns on mobile

### DIFF
--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -115,16 +115,8 @@ body.archive .wp-block-archives.alignfull {
 /* When sidebar is below the content */
 
 @media (max-width: 999px) {
-	body.pique-sidebar.pique-singular .alignwide {
-		margin-left: -15%;
-		margin-right: -15%;
-		width: auto;
-		max-width: 1400px;
-	}
-
+	body.pique-sidebar.pique-singular .alignwide,
 	body.pique-sidebar.pique-singular .alignfull {
-		margin-left: calc(50% - 50vw);
-		margin-right: calc(50% - 50vw);
 		width: auto;
 		max-width: 1400px;
 	}

--- a/pique/assets/css/blocks.css
+++ b/pique/assets/css/blocks.css
@@ -115,12 +115,7 @@ body.archive .wp-block-archives.alignfull {
 /* When sidebar is below the content */
 
 @media (max-width: 999px) {
-	body.pique-sidebar.pique-singular .alignwide,
-	body.pique-sidebar.pique-singular .alignfull {
-		width: auto;
-		max-width: 1400px;
-	}
-
+	
 	/* Make non image-based blocks a bit narrower, so they don't get cut off. */
 	body.pique-sidebar.pique-singular .wp-block-columns.alignfull,
 	body.pique-sidebar.pique-singular .wp-block-audio.alignfull,
@@ -132,6 +127,7 @@ body.archive .wp-block-archives.alignfull {
 		margin-left: calc(50% - 48vw);
 		margin-right: calc(50% - 48vw);
 	}
+
 }
 
 /* Make sure the full and wide blocks still stay in Twenty Thirteen's wide container */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

It looks like we can just remove the margin and it will allow the content to be visible on smaller screens.

##### Before
<img width="1924" alt="Screenshot on 2022-08-09 at 16-54-14" src="https://user-images.githubusercontent.com/45246438/183947829-df5cd566-0d76-40b0-a00e-a57c3dc4be2f.png">



##### After
<img width="1754" alt="Screenshot on 2022-08-10 at 09-56-58" src="https://user-images.githubusercontent.com/45246438/183947657-5e42630d-eb01-4cf2-8022-e2caa578e0c6.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6351