### PR TITLE
 #5989: Dara: Exclude featured images from Jetpack Lazy Loading

### DIFF
--- a/dara/components/post/content-featured.php
+++ b/dara/components/post/content-featured.php
@@ -18,7 +18,7 @@ if ( empty( $featured ) )
 				<div class="hero-content-wrapper">
 					<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
 						<?php if ( dara_has_post_thumbnail() ) { ?>
-							<?php the_post_thumbnail( 'dara-hero-thumbnail' ); ?>
+							<?php the_post_thumbnail( 'dara-hero-thumbnail', array( 'class' => 'skip-lazy' )  ); ?>
 						<?php } else { ?>
 							<div class="thumbnail-placeholder"></div>
 						<?php } ?>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The original issue (#5989) highlighted that when a user has Jetpack Lazy Loading there is a large black space that shows before the image loads. It is especially visible on slow connections (I throttled to slow 3G in dev tools to see it).

##### Before without Lazy Loading


https://user-images.githubusercontent.com/45246438/184018886-2a4f6049-5e1c-4543-8609-ffe6fad9c2e7.mp4



##### Before with Lazy Loading

https://user-images.githubusercontent.com/45246438/184018783-81119805-9b3d-4550-a942-90f81ec0d28e.mp4


##### After Disabling Lazy Loading

https://user-images.githubusercontent.com/45246438/184017750-3161d3a9-4e40-4f68-8d6f-328ffec1fdaf.mp4


#### Testing

1. Activate Dara
2. Install Jetpack and turn on Lazy Loading
3. Confirm that Lazy Loading no longer is set for featured images

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/5989