### PR TITLE
Update sass build scripts to import from node_modules

### DIFF
--- a/blockbase/package.json
+++ b/blockbase/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "chokidar \"sass/**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/ponyfill.scss assets/ponyfill.css --style=expanded && postcss assets/ponyfill.css --use autoprefixer --output assets/ponyfill.css --map"
+    "build:scss": "sass sass/ponyfill.scss assets/ponyfill.css --style=expanded --load-path ../node_modules && postcss assets/ponyfill.css --use autoprefixer --output assets/ponyfill.css --map"
   },
   "author": "Automattic",
   "license": "GPLv2"

--- a/blockbase/sass/base/_breakpoints.scss
+++ b/blockbase/sass/base/_breakpoints.scss
@@ -1,7 +1,8 @@
-@import '../../node_modules/@wordpress/base-styles/breakpoints';
-@import '../../node_modules/@wordpress/base-styles/mixins';
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 @mixin break-small-only() {
+
 	@media (max-width: #{ ($break-small - 1) }) {
 		@content;
 	}

--- a/geologist/package.json
+++ b/geologist/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
   },
   "author": "",
   "license": "GPLv2"

--- a/mayland-blocks/package.json
+++ b/mayland-blocks/package.json
@@ -18,7 +18,7 @@
 	"scripts": {
 		"start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
 		"build": "npm run build:scss",
-		"build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+		"build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
 	},
 	"author": "",
 	"license": "GPLv2"

--- a/quadrat/package.json
+++ b/quadrat/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
   },
   "author": "",
   "license": "GPLv2"

--- a/seedlet-blocks/package.json
+++ b/seedlet-blocks/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
   },
   "author": "",
   "license": "GPLv2"

--- a/seedlet-blocks/sass/blocks/_latest-posts.scss
+++ b/seedlet-blocks/sass/blocks/_latest-posts.scss
@@ -1,5 +1,5 @@
-@import '../../node_modules/@wordpress/base-styles/breakpoints';
-@import '../../node_modules/@wordpress/base-styles/mixins';
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .wp-block-latest-posts {
 	padding-left: 0;
@@ -87,6 +87,7 @@
 }
 
 @include break-medium {
+
 	.wp-block-latest-posts.is-style-seedlet-alternating-grid {
 
 		// Necessary so that the block boundaries are respected.

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -773,7 +773,7 @@ async function versionBumpTheme(theme, addChanges) {
 	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
 	let currentVersion = getThemeMetadata(styleCss, 'Version');
 
-	let filesToUpdate = await executeCommand(`find ${theme} -not \\( -path "*/node_modules/*" -prune \\) -and \\( -name package.json -or -name style.scss -or -name style-child-theme.scss \\) -maxdepth 3`);
+	let filesToUpdate = await executeCommand(`find ${theme} -not \\( -path "*/node_modules/*" -prune \\) -and \\( -name package.json -or -name style.scss -or -name style-rtl.css -or -name style-child-theme.scss \\) -maxdepth 3`);
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
 
 	for (let file of filesToUpdate) {

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -651,16 +651,16 @@ async function versionBumpThemes() {
 	return changesWereMade;
 }
 
-export function getThemeMetadata(styleCss, attribute) {
+export function getThemeMetadata(styleCss, attribute, trimWPCom = true) {
 	if (!styleCss || !attribute) {
 		return null;
 	}
 	switch (attribute) {
 		case 'Version':
-			return styleCss
+			const version = styleCss
 				.match(/(?<=Version:\s*).*?(?=\s*\r?\n|\rg)/gs)[0]
-				.trim()
-				.replace('-wpcom', '');
+				.trim();
+			return trimWPCom ? version.replace('-wpcom', '') : version;
 		case 'Requires at least':
 			return styleCss
 				.match(/(?<=Requires at least:\s*).*?(?=\s*\r?\n|\rg)/gs);
@@ -771,7 +771,7 @@ async function versionBumpTheme(theme, addChanges) {
 	await executeCommand(`git add ${theme}/style.css`);
 
 	let styleCss = fs.readFileSync(`${theme}/style.css`, 'utf8');
-	let currentVersion = getThemeMetadata(styleCss, 'Version');
+	let currentVersion = getThemeMetadata(styleCss, 'Version', false);
 
 	let filesToUpdate = await executeCommand(`find ${theme} -not \\( -path "*/node_modules/*" -prune \\) -and \\( -name package.json -or -name style.scss -or -name style-rtl.css -or -name style-child-theme.scss \\) -maxdepth 3`);
 	filesToUpdate = filesToUpdate.split('\n').filter(item => item != '');
@@ -780,7 +780,7 @@ async function versionBumpTheme(theme, addChanges) {
 		const isPackageJson = file === `${theme}/package.json`;
 		if (isPackageJson) {
 			// update theme/package.json and package-lock.json
-			await executeCommand(`npm version ${currentVersion} --workspace=${theme} --silent`);
+			await executeCommand(`npm version ${currentVersion.replace('-wpcom', '')} --workspace=${theme} --silent`);
 		} else {
 			await executeCommand(`perl -pi -e 's/Version: (.*)$/"Version: '${currentVersion}'"/ge' ${file}`);
 		}

--- a/videomaker/package.json
+++ b/videomaker/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
   },
   "author": "",
   "license": "GPLv2"

--- a/zoologist/package.json
+++ b/zoologist/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
     "build": "npm run build:scss",
-    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
+    "build:scss": "sass sass/theme.scss assets/theme.css --style=expanded --load-path ../node_modules && postcss assets/theme.css --use autoprefixer --output assets/theme.css --map"
   },
   "author": "",
   "license": "GPLv2"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Remove relative path references to `@wordpress/base-styles`
* include `node_modules` to sass compilation load path
* Add `style-rts.css` to deployment script to avoid version mismatch
* update deployment script to not trim `-wpcom` from `style.scss`

#### Related issue(s):

#6365 #6200 