### PR TITLE
#5242: Textbook: Fix Newspack blog blocks on posts

### DIFF
--- a/textbook/style.css
+++ b/textbook/style.css
@@ -5504,10 +5504,15 @@ body .jetpack-social-navigation li {
   padding: 0;
 }
 
+
 .single .hentry .wpnbpc .entry-meta,
 .single .hentry .wpnbpc .entry-meta a {
   background: transparent;
   color: #fff;
+}
+
+.single .wpnbha .entry-meta a {
+  width: unset;
 }
 
 /* ====================================================================================================================

--- a/textbook/style.css
+++ b/textbook/style.css
@@ -2945,11 +2945,6 @@ body {
   padding: 16.2px 16.2px 20.25px;
 }
 
-.single .hentry .entry-title a:hover {
-  color: #ce4639;
-  background: #222;
-}
-
 .single .hentry .entry-title span {
   color: #FFF;
   display: block;
@@ -2967,6 +2962,12 @@ body {
   justify-content: space-around;
   margin-right: -1px;
   order: 2;
+}
+
+.single .hentry .entry-title a:hover,
+.single .hentry .wpnbha .entry-title a:hover {
+  color: #ce4639;
+  background: #222;
 }
 
 .single .hentry .entry-meta:before {
@@ -5457,6 +5458,58 @@ body .jetpack-social-navigation li {
  * Contributing author: Tyler Smith (@mbmufffin)
  *
  */
+
+/* Newspack Blocks Compatibility */
+.single .hentry .wpnbha .entry-meta:before,
+.single .hentry .wpnbha .post-thumbnail:before, 
+.single .hentry .wpnbpc .entry-meta:before {
+  border: none;
+}
+
+.single .hentry .wpnbha .entry-meta,
+.single .hentry .wpnbha .post-thumbnail {
+  background: #fff;
+}
+
+.single .hentry .wpnbha .entry-title a {
+  color: #222;
+  padding-left: 0;
+}
+
+.single .hentry .wpnbha .entry-title a:hover,
+.single .hentry .wpnbpc .entry-title a:hover {
+  background: unset;
+}
+
+.single .hentry .wpnbha .entry-meta,
+.single .hentry .wpnbpc .entry-meta {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+.single .hentry .wpnbha .entry-meta .byline,
+.single .hentry .wpnbpc .entry-meta .byline {
+  margin: 0 10px ;
+  padding: 0;
+}
+
+.single .hentry .wpnbha .byline a,
+.single .hentry .wpnbpc .byline a {
+  vertical-align: unset;
+}
+
+.single .hentry .wpnbpc .entry-title a {
+  padding: 0;
+}
+
+.single .hentry .wpnbpc .entry-meta,
+.single .hentry .wpnbpc .entry-meta a {
+  background: transparent;
+  color: #fff;
+}
+
 /* ====================================================================================================================
  * RESETS
  * ====================================================================================================================*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

**Testing Instructions:**

Testing Requires the Newspack plugin to be installed.

1. Activate the TextBook theme on your site.
2. Create a new post.
3. Add the Homepage Posts block on it - you would want to have a couple of published posts that would show on the block.
4. Add the Post Carousel block.
5. Publish the post and check the post on the live site.


#### Changes proposed in this Pull Request:

Original issue was for the blog posts block, but the carousel also has issues. This PR fixes both.

##### Before

<img width="852" alt="Screenshot on 2022-08-11 at 10-06-06" src="https://user-images.githubusercontent.com/45246438/184174515-588d7b6e-bc45-47c9-8f45-7baa375b9ce1.png">

<img width="617" alt="Screenshot on 2022-08-11 at 11-12-10" src="https://user-images.githubusercontent.com/45246438/184174524-e62a6fd6-2314-4a54-9254-25bdd944d86e.png">


##### After

<img width="841" alt="Screenshot on 2022-08-11 at 11-20-04" src="https://user-images.githubusercontent.com/45246438/184174749-fac35f24-3442-4314-90b3-0783e07695d1.png">

<img width="583" alt="Screenshot on 2022-08-11 at 11-21-48" src="https://user-images.githubusercontent.com/45246438/184174793-cf1f7cbc-67dc-45a2-8673-c1fa60978f4b.png">

#### Related issue(s):

Fixes: #5242