### PR TITLE
#6085: Zoologist: Add underline to links

### DIFF
--- a/geologist-blue/assets/theme.css
+++ b/geologist-blue/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/geologist-cream/assets/theme.css
+++ b/geologist-cream/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/geologist-slate/assets/theme.css
+++ b/geologist-slate/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/geologist-yellow/assets/theme.css
+++ b/geologist-yellow/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/geologist/sass/elements/_links.scss
+++ b/geologist/sass/elements/_links.scss
@@ -1,4 +1,4 @@
-.wp-block-post-content p a {
+.wp-block-post-content a {
 	text-decoration-line: underline;
 
 	&:hover {
@@ -9,9 +9,10 @@
 
 // Select the focus states of all non-wpadmin and screen reader links
 a:not(.ab-item):not(.screen-reader-shortcut) {
+
 	&:active,
 	&:focus {
-		outline: 1px dotted currentColor;
+		outline: 1px dotted currentcolor;
 		text-decoration: none;
 	}
 }

--- a/quadrat-black/assets/theme.css
+++ b/quadrat-black/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat-green/assets/theme.css
+++ b/quadrat-green/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat-red/assets/theme.css
+++ b/quadrat-red/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat-white/assets/theme.css
+++ b/quadrat-white/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat-yellow/assets/theme.css
+++ b/quadrat-yellow/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -57,8 +57,7 @@
 }
 .vertical-query-pattern img {
   aspect-ratio: 16/9;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 div.horizontal-query-pattern {
@@ -83,8 +82,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image {
 }
 div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   aspect-ratio: 1.12;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   height: 100%;
 }
 @media (min-width: 600px) {
@@ -163,8 +161,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
   }
 }
 .is-style-quadrat-diamond-posts .wp-block-post-featured-image img {
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   width: 100%;
   height: 300px;
 }
@@ -325,11 +322,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/quadrat/sass/elements/_links.scss
+++ b/quadrat/sass/elements/_links.scss
@@ -1,4 +1,4 @@
-.wp-block-post-content p a {
+.wp-block-post-content a {
 	text-decoration-line: underline;
 
 	&:hover {
@@ -9,9 +9,10 @@
 
 // Select the focus states of all non-wpadmin and screen reader links
 a:not(.ab-item):not(.screen-reader-shortcut) {
+
 	&:active,
 	&:focus {
-		outline: 1px dotted currentColor;
+		outline: 1px dotted currentcolor;
 		text-decoration: none;
 	}
 }

--- a/zoologist/assets/theme.css
+++ b/zoologist/assets/theme.css
@@ -158,11 +158,11 @@ ul ul {
   color: var(--wp--preset--color--background);
 }
 
-.wp-block-post-content p a {
+.wp-block-post-content a {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
 }
-.wp-block-post-content p a:hover {
+.wp-block-post-content a:hover {
   text-decoration: none;
 }
 

--- a/zoologist/assets/theme.css
+++ b/zoologist/assets/theme.css
@@ -167,7 +167,7 @@ ul ul {
 }
 
 a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
-  outline: 1px dotted currentColor;
+  outline: 1px dotted currentcolor;
   text-decoration: none;
 }
 

--- a/zoologist/sass/elements/_links.scss
+++ b/zoologist/sass/elements/_links.scss
@@ -1,4 +1,4 @@
-.wp-block-post-content p a {
+.wp-block-post-content a {
 	text-decoration-line: underline;
 
 	&:hover {
@@ -9,9 +9,10 @@
 
 // Select the focus states of all non-wpadmin and screen reader links
 a:not(.ab-item):not(.screen-reader-shortcut) {
+
 	&:active,
 	&:focus {
-		outline: 1px dotted currentColor;
+		outline: 1px dotted currentcolor;
 		text-decoration: none;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Adds the underline styles to Zoologist, Geologist, Quadrat, and their variations.

##### Before

<img width="828" alt="Screenshot on 2022-08-11 at 15-59-27" src="https://user-images.githubusercontent.com/45246438/184238921-8ff53671-c9a7-49b2-ac71-d29c99f5882f.png">


##### After


<img width="747" alt="Screenshot on 2022-08-11 at 16-18-22" src="https://user-images.githubusercontent.com/45246438/184238914-31f579bf-dd4d-4848-b158-1ce255c36d6f.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6085