### PR TITLE
#5189: Varia: Fix quote block font sizes

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.8rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 1.04167rem;
 	letter-spacing: normal;
 }
 

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Lora", Georgia, sans-serif;
-	font-family: var(--font-headings, "Lora", Georgia, sans-serif);
-	font-size: 1.8em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Lora", Georgia, sans-serif;
-	font-family: var(--font-headings, "Lora", Georgia, sans-serif);
-	font-size: 2.16em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.20
+Version: 1.5.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.8rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 1.04167rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Lora", Georgia, sans-serif;
 	font-family: var(--font-headings, "Lora", Georgia, sans-serif);
-	font-size: 1.8rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #4d6974;
-	font-size: 1.04167rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/alves/style.css
+++ b/alves/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.8rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 1.04167rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Lora", Georgia, sans-serif;
 	font-family: var(--font-headings, "Lora", Georgia, sans-serif);
-	font-size: 1.8rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #4d6974;
-	font-size: 1.04167rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/balasana/style-editor.css
+++ b/balasana/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.19
+Version: 1.3.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #505050;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3990,7 +3986,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Roboto Condensed", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #505050;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4019,7 +4015,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
-	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
-	font-size: 1.64303em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
-	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
-	font-size: 1.93878em;
 	letter-spacing: normal;
 	line-height: 1.15;
 }

--- a/barnsbury/style-editor.css
+++ b/barnsbury/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.64303rem;
 	letter-spacing: normal;
 	line-height: 1.15;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.84746rem;
 	letter-spacing: normal;
 }
 

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.20
+Version: 1.3.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.64303rem;
 	letter-spacing: normal;
 	line-height: 1.15;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.84746rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
 	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
-	font-size: 1.64303rem;
 	letter-spacing: normal;
 	line-height: 1.15;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #844d4d;
-	font-size: 0.84746rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.64303rem;
 	letter-spacing: normal;
 	line-height: 1.15;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.84746rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;
 	font-family: var(--font-headings, "Rubik", Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif);
-	font-size: 1.64303rem;
 	letter-spacing: normal;
 	line-height: 1.15;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #844d4d;
-	font-size: 0.84746rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
-	font-family: var(--font-base, Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
-	font-family: var(--font-base, Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/brompton/style-editor.css
+++ b/brompton/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1026,14 +1026,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2107,7 +2105,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
 	font-family: var(--font-base, Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2116,7 +2113,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3985,7 +3981,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1026,14 +1026,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2107,7 +2105,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
 	font-family: var(--font-base, Lora, Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2116,7 +2113,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4014,7 +4010,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -890,9 +890,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "EB Garamond", serif;
-	font-family: var(--font-headings, "EB Garamond", serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -902,9 +899,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "EB Garamond", serif;
-	font-family: var(--font-headings, "EB Garamond", serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1;
 }

--- a/coutoire/style-editor.css
+++ b/coutoire/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1023,14 +1023,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2104,7 +2102,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1;
 }
@@ -2113,7 +2110,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3982,7 +3978,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1023,14 +1023,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2104,7 +2102,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "EB Garamond", serif;
 	font-family: var(--font-headings, "EB Garamond", serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1;
 }
@@ -2113,7 +2110,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4011,7 +4007,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
-	font-size: 1.52087em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
-	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
-	font-size: 1.74901em;
 	letter-spacing: normal;
 	line-height: 1.2;
 }

--- a/dalston/style-editor.css
+++ b/dalston/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.2;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.20
+Version: 1.3.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1024,14 +1024,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.2;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2105,7 +2103,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
 	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.2;
 }
@@ -2114,7 +2111,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -3983,7 +3979,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1024,14 +1024,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.2;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2105,7 +2103,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
 	font-family: var(--font-headings, "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.2;
 }
@@ -2114,7 +2111,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -4012,7 +4008,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.44em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #6E6E6E;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/exford/style.css
+++ b/exford/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #6E6E6E;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -254,14 +254,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -921,9 +921,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087em;
 	letter-spacing: normal;
 }
 
@@ -933,9 +930,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.74901em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.20
+Version: 1.5.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -4036,7 +4032,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/hever/style.css
+++ b/hever/style.css
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "PT Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -4065,7 +4061,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.78256rem;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.82474rem;
 	letter-spacing: normal;
 }
 

--- a/leven/style-editor.css
+++ b/leven/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.78256em;
 	letter-spacing: -0.02em;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 2.16136em;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.78256rem;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.82474rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.78256rem;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.82474rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/leven/style.css
+++ b/leven/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.78256rem;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.82474rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.78256rem;
 	letter-spacing: -0.02em;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.82474rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -892,9 +892,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: Poppins, sans-serif;
-	font-family: var(--font-headings, Poppins, sans-serif);
-	font-size: 1.2em;
 	letter-spacing: normal;
 }
 
@@ -904,9 +901,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: Poppins, sans-serif;
-	font-family: var(--font-headings, Poppins, sans-serif);
-	font-size: 1.44em;
 	letter-spacing: -0.015em;
 	line-height: 1.125;
 }

--- a/mayland/style-editor.css
+++ b/mayland/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.18
+Version: 1.3.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2105,7 +2103,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2114,7 +2111,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3983,7 +3979,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2105,7 +2103,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Poppins, sans-serif;
 	font-family: var(--font-headings, Poppins, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2114,7 +2111,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4012,7 +4008,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -908,9 +908,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2em;
 	letter-spacing: normal;
 }
 
@@ -920,9 +917,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.44em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #686868;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #686868;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -253,14 +253,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -920,9 +920,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087em;
 	letter-spacing: normal;
 }
 
@@ -932,9 +929,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.74901em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.20
+Version: 1.6.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1052,14 +1052,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2133,7 +2131,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2142,7 +2139,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -4011,7 +4007,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/morden/style.css
+++ b/morden/style.css
@@ -1052,14 +1052,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -2133,7 +2131,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.52087rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2142,7 +2139,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.86957rem;
 	letter-spacing: normal;
 }
 
@@ -4040,7 +4036,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -905,9 +905,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
-	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
-	font-size: 1.44em;
 	letter-spacing: normal;
 }
 
@@ -917,9 +914,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
-	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/redhill/style-editor.css
+++ b/redhill/style-editor.css
@@ -238,14 +238,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.18
+Version: 1.5.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -1026,14 +1026,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2107,7 +2105,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
 	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
-	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2116,7 +2113,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3985,7 +3981,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1026,14 +1026,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2107,7 +2105,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif;
 	font-family: var(--font-headings, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Times, "Times New Roman", serif);
-	font-size: 1.44rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2116,7 +2113,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #666666;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4014,7 +4010,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -226,14 +226,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.25rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.8rem;
 	letter-spacing: normal;
 }
 

--- a/rivington/style-editor.css
+++ b/rivington/style-editor.css
@@ -893,9 +893,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.25em;
 	letter-spacing: normal;
 }
 
@@ -905,9 +902,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	font-family: var(--font-headings, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.5625em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.18
+Version: 1.3.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.25rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.8rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.25rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: white;
-	font-size: 0.8rem;
 	letter-spacing: normal;
 }
 
@@ -3984,7 +3980,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1025,14 +1025,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.25rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.8rem;
 	letter-spacing: normal;
 }
 
@@ -2106,7 +2104,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.25rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2115,7 +2112,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: white;
-	font-size: 0.8rem;
 	letter-spacing: normal;
 }
 
@@ -4013,7 +4009,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -252,14 +252,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/rockfield/style-editor.css
+++ b/rockfield/style-editor.css
@@ -919,9 +919,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: Lora, Baskerville, Georgia, Times, serif;
-	font-family: var(--font-headings, Lora, Baskerville, Georgia, Times, serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -931,9 +928,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: Lora, Baskerville, Georgia, Times, serif;
-	font-family: var(--font-headings, Lora, Baskerville, Georgia, Times, serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1049,14 +1049,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2130,7 +2128,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Lora, Baskerville, Georgia, Times, serif;
 	font-family: var(--font-headings, Lora, Baskerville, Georgia, Times, serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2139,7 +2136,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4022,7 +4018,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1049,14 +1049,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2130,7 +2128,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: Lora, Baskerville, Georgia, Times, serif;
 	font-family: var(--font-headings, Lora, Baskerville, Georgia, Times, serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2139,7 +2136,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4051,7 +4047,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -254,14 +254,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -921,9 +921,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "PT Sans", Arial, sans-serif;
-	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
-	font-size: 1.2em;
 	letter-spacing: normal;
 }
 
@@ -933,9 +930,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "PT Sans", Arial, sans-serif;
-	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
-	font-size: 1.44em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.20
+Version: 1.4.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "PT Sans", Arial, sans-serif;
 	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4011,7 +4007,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "PT Sans", Arial, sans-serif;
 	font-family: var(--font-base, "PT Sans", Arial, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4040,7 +4036,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -254,14 +254,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -921,9 +921,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Source Sans Pro", Arial, sans-serif;
-	font-family: var(--font-base, "Source Sans Pro", Arial, sans-serif);
-	font-size: 1.2em;
 	letter-spacing: normal;
 }
 
@@ -933,9 +930,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Source Sans Pro", Arial, sans-serif;
-	font-family: var(--font-base, "Source Sans Pro", Arial, sans-serif);
-	font-size: 1.44em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", Arial, sans-serif;
 	font-family: var(--font-base, "Source Sans Pro", Arial, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4026,7 +4022,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stow/style.css
+++ b/stow/style.css
@@ -1053,14 +1053,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2134,7 +2132,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", Arial, sans-serif;
 	font-family: var(--font-base, "Source Sans Pro", Arial, sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2143,7 +2140,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4055,7 +4051,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -254,14 +254,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/stratford/style-editor.css
+++ b/stratford/style-editor.css
@@ -921,9 +921,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: "Poppins", sans-serif;
-	font-family: var(--font-headings, "Poppins", sans-serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -933,9 +930,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: "Poppins", sans-serif;
-	font-family: var(--font-headings, "Poppins", sans-serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -1052,14 +1052,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2133,7 +2131,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Poppins", sans-serif;
 	font-family: var(--font-headings, "Poppins", sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2142,7 +2139,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4025,7 +4021,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1052,14 +1052,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2133,7 +2131,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Poppins", sans-serif;
 	font-family: var(--font-headings, "Poppins", sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2142,7 +2139,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: var(--wp--preset--color--foreground-low-contrast);
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -4054,7 +4050,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/varia/sass/blocks/quote/_editor.scss
+++ b/varia/sass/blocks/quote/_editor.scss
@@ -3,8 +3,6 @@
 	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
 
 	p {
-		@include font-family( map-deep-get($config-quote, "font", "family") );
-		font-size: (strip-unit(map-deep-get($config-heading, "font", "size", "h4")) + 0em);
 		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h4")};
 		line-height: #{map-deep-get($config-global, "font", "line-height", "h4")};
 	}
@@ -15,8 +13,6 @@
 		padding: 0;
 
 		p {
-			@include font-family( map-deep-get($config-quote, "font", "family") );
-			font-size: (strip-unit(map-deep-get($config-heading, "font", "size", "h3")) + 0em);
 			letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h3")};
 			line-height: #{map-deep-get($config-heading, "font", "line-height", "h3")};
 		}
@@ -26,19 +22,19 @@
 	[class*="background-color"]:not(.has-background-background-color) &,
 	[style*="background-color"]:not(.has-background-background-color) &,
 	.wp-block-cover[style*="background-image"] & {
-			border-color: currentColor;
+		border-color: currentcolor;
 	}
 
 	.wp-block-quote__citation {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};
-		font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0em);
+		font-size: (strip-unit(map-deep-get($config-global, "font", "size", "sm")) + 0);
 		letter-spacing: #{map-deep-get($config-global, "font", "letter-spacing", "sm")};
 
 		.has-background:not(.has-background-background-color) &,
 		[class*="background-color"]:not(.has-background-background-color) &,
 		[style*="background-color"]:not(.has-background-background-color) &,
 		.wp-block-cover[style*="background-image"] & {
-			color: currentColor;
+			color: currentcolor;
 		}
 	}
 }

--- a/varia/sass/blocks/quote/_style.scss
+++ b/varia/sass/blocks/quote/_style.scss
@@ -18,8 +18,8 @@
 	}
 
 	p {
+
 		@include font-family( map-deep-get($config-quote, "font", "family") );
-		font-size: #{map-deep-get($config-heading, "font", "size", "h4")};
 		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h4")};
 		line-height: #{map-deep-get($config-heading, "font", "line-height", "h4")};
 	}
@@ -28,14 +28,13 @@
 	cite,
 	footer {
 		color: #{map-deep-get($config-global, "color", "foreground", "light")};
-		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
 		letter-spacing: #{map-deep-get($config-global, "font", "letter-spacing", "sm")};
 
 		.has-background:not(.has-background-background-color) &,
 		[class*="background-color"]:not(.has-background-background-color) &,
 		[style*="background-color"] &,
 		.wp-block-cover[style*="background-image"] & {
-			color: currentColor;
+			color: currentcolor;
 		}
 	}
 
@@ -49,6 +48,7 @@
 
 	&.is-style-large,
 	&.is-large {
+
 		/* Resetting margins to match _block-container.scss */
 		margin-top: #{map-deep-get($config-global, "spacing", "vertical")};
 		margin-bottom: #{map-deep-get($config-global, "spacing", "vertical")};
@@ -73,6 +73,6 @@
 	[class*="background-color"]:not(.has-background-background-color) &,
 	[style*="background-color"] &,
 	.wp-block-cover[style*="background-image"] & {
-		border-color: currentColor;
+		border-color: currentcolor;
 	}
 }

--- a/varia/sass/elements/_blockquote.scss
+++ b/varia/sass/elements/_blockquote.scss
@@ -3,7 +3,6 @@ blockquote {
 	padding-left: #{map-deep-get($config-global, "spacing", "horizontal")};
 
 	p {
-		font-size: #{map-deep-get($config-heading, "font", "size", "h4")};
 		letter-spacing: #{map-deep-get($config-heading, "font", "letter-spacing", "h4")};
 		line-height: #{map-deep-get($config-heading, "font", "line-height", "h4")};
 	}
@@ -11,7 +10,6 @@ blockquote {
 	cite,
 	footer {
 		color: #{map-deep-get($config-global, "color", "forground-light")};
-		font-size: #{map-deep-get($config-global, "font", "size", "sm")};
 		letter-spacing: #{map-deep-get($config-global, "font", "letter-spacing", "sm")};
 	}
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -240,14 +240,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -907,9 +907,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote p {
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	font-size: 1.728em;
 	letter-spacing: normal;
 }
 
@@ -919,9 +916,6 @@ p.has-background:not(.has-background-background-color) a {
 }
 
 .wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
-	font-family: sans-serif;
-	font-family: var(--font-headings, sans-serif);
-	font-size: 2.0736em;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.19
+Version: 1.6.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -984,14 +984,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2065,7 +2063,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2074,7 +2071,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3943,7 +3939,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -984,14 +984,12 @@ blockquote {
 }
 
 blockquote p {
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
 
 blockquote cite,
 blockquote footer {
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -2065,7 +2063,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: sans-serif;
 	font-family: var(--font-headings, sans-serif);
-	font-size: 1.728rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2074,7 +2071,6 @@ p.has-background {
 .wp-block-quote cite,
 .wp-block-quote footer {
 	color: #767676;
-	font-size: 0.83333rem;
 	letter-spacing: normal;
 }
 
@@ -3972,7 +3968,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

##### Before

###### Editor

<img width="1264" alt="Screenshot on 2022-08-12 at 10-46-58(1)" src="https://user-images.githubusercontent.com/45246438/184390291-6c39040c-4057-48f3-a886-bc2bbe66db14.png">

###### Frontend

<img width="730" alt="Screenshot on 2022-08-12 at 12-06-33" src="https://user-images.githubusercontent.com/45246438/184397118-02d76747-14fe-4c73-9ea3-5bb7d12f451e.png">


##### After

###### Frontend - Huge
<img width="734" alt="Screenshot on 2022-08-12 at 11-40-15" src="https://user-images.githubusercontent.com/45246438/184391234-ad66c3c2-f0a1-4f5e-b710-bbb19906653c.png">


###### Frontend - Small

<img width="431" alt="Screenshot on 2022-08-12 at 11-41-22" src="https://user-images.githubusercontent.com/45246438/184391979-6e62c096-b886-4b8e-b5c1-b33eae66be51.png">

###### Changes on Vaia Child Themes:

<img width="747" alt="Screenshot on 2022-08-12 at 10-57-39" src="https://user-images.githubusercontent.com/45246438/184392350-2ae9065e-41b3-49f3-91c2-1a4da91b185d.png">
<img width="775" alt="Screenshot on 2022-08-12 at 10-56-54" src="https://user-images.githubusercontent.com/45246438/184392352-713b43f4-5cef-4b86-a477-e16f71c67b26.png">




#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/5189 and Fixes https://github.com/Automattic/themes/issues/5581https://github.com/Automattic/themes/issues/5581