### PR TITLE
#5724: Gazette: Fix blog posts read more links

### DIFF
--- a/gazette/css/blocks.css
+++ b/gazette/css/blocks.css
@@ -194,6 +194,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-bottom: 30px;
 }
 
+/* Newspack Blog Posts */
+
+.wpnbha p .more-link {
+	display: none;
+}
+
 /*--------------------------------------------------------------
 5.0 Blocks - Widgets
 --------------------------------------------------------------*/

--- a/gazette/css/editor-blocks.css
+++ b/gazette/css/editor-blocks.css
@@ -475,6 +475,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	text-align: right;
 }
 
+/* Newspack Blog Posts */
+
+.wpnbha p .more-link {
+	display: none;
+}
+
 /*--------------------------------------------------------------
 5.0 Blocks - Layout Elements
 --------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

To test this one, you need to have the Newspack plugin installed with a Homepage Posts block added.

#### Before

##### Editor with no "Read More" Link

<img width="1139" alt="Screenshot on 2022-08-12 at 14-16-39" src="https://user-images.githubusercontent.com/45246438/184423398-89624ed8-4b09-490d-a96e-a70a270a4fe3.png">

##### Frontend with no "Read More" Link

<img width="738" alt="Screenshot on 2022-08-12 at 14-17-28" src="https://user-images.githubusercontent.com/45246438/184423509-a563a5a7-9f0a-4f00-8369-cce6c3de55f4.png">

##### Editor with "Read More" Enabled

<img width="1126" alt="Screenshot on 2022-08-12 at 14-17-02" src="https://user-images.githubusercontent.com/45246438/184423580-5ee7c897-c5fe-41f2-a973-ba49fb322478.png">

##### Frontend with "Read More" Enabled

<img width="707" alt="Screenshot on 2022-08-12 at 14-18-01" src="https://user-images.githubusercontent.com/45246438/184423614-acb3a409-e9b9-4d6e-8ab9-cfd7d7154b29.png">


#### After

##### Editor
<img width="1135" alt="Screenshot on 2022-08-12 at 14-20-04" src="https://user-images.githubusercontent.com/45246438/184423133-9bab5052-aa41-44a5-9755-98f2868d3bec.png">

##### Frontend with "Read More" link set
<img width="696" alt="Screenshot on 2022-08-12 at 14-19-37" src="https://user-images.githubusercontent.com/45246438/184423254-20d23351-83a4-42ac-a344-51b8b2335eb2.png">



##### Frontend with no "Read More" link set
<img width="702" alt="Screenshot on 2022-08-12 at 14-20-42" src="https://user-images.githubusercontent.com/45246438/184423143-664e3942-04db-4d16-9c98-246d78ae2537.png">


 
#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/5724