### PR TITLE
Club: fix typography size in pattern

### DIFF
--- a/club/patterns/post-list.php
+++ b/club/patterns/post-list.php
@@ -18,7 +18,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-title {"level":3,"isLink":true} /--></div>
+<div class="wp-block-column"><!-- wp:post-title {"level":3,"isLink":true,"fontSize":"large"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:column -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Club: fix typography size in a pattern

I found that we were using not the correct font size for these titles on mobile view. 

Before:
![image](https://user-images.githubusercontent.com/1310626/184876531-e3f970e1-9c80-41f1-adf7-c6f2d3659c37.png)



After:
![image](https://user-images.githubusercontent.com/1310626/184876545-1d281275-7625-49b8-b4e7-523312b53072.png)


Design:
![image](https://user-images.githubusercontent.com/1310626/184876650-af3ef732-5e58-4688-bffc-09b8697beb66.png)

