### PR TITLE
Disco: removing margin added when Gutenberg is disabled

### DIFF
--- a/club/style.css
+++ b/club/style.css
@@ -161,6 +161,10 @@ a {
 	min-width: unset;
 }
 
+.club-post-list-pattern .wp-block-post {
+	margin-top: 0; /* This is necesary to avoid a top margin when Gutenberg is disabled */
+}
+
 .club-post-list-pattern .wp-block-post > .wp-block-group > .wp-block-columns > .wp-block-column:first-child {
 	flex-grow: 3;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Club: removing this margin added when Gutenberg is disabled

![image](https://user-images.githubusercontent.com/1310626/184889440-3277bbf5-a36d-4cc7-8c95-6b900e7c49d3.png)
