### PR TITLE
Removed font families from the child so that Blockbases are used instead

### DIFF
--- a/meraki/theme.json
+++ b/meraki/theme.json
@@ -70,40 +70,6 @@
 			}
 		},
 		"typography": {
-			"fontFamilies": [
-				{
-					"fontFamily": "\"Nunito\", sans-serif",
-					"slug": "nunito",
-					"name": "Nunito"
-				},
-				{
-					"fontFamily": "Jost, sans-serif",
-					"slug": "jost",
-					"name": "Jost",
-					"fontFace": [
-						{
-							"fontDisplay": "block",
-							"fontFamily": "Jost",
-							"fontWeight": "400",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [
-								"file:./assets/fonts/Jost-Regular.ttf"
-							]
-						},
-						{
-							"fontDisplay": "block",
-							"fontFamily": "Jost",
-							"fontWeight": "500 600",
-							"fontStyle": "normal",
-							"fontStretch": "normal",
-							"src": [
-								"file:./assets/fonts/Jost-Medium.ttf"
-							]
-						}
-					]
-				}
-			],
 			"fontSizes": [
 				{
 					"name": "Tiny",


### PR DESCRIPTION
Fixes issues with Meraki theme noted here: https://github.com/Automattic/wp-calypso/issues/63229
