### PR TITLE
Club: remove clamp from blockGap setting because is not working on Gutenberg 13.8.2

### DIFF
--- a/club/parts/header.html
+++ b/club/parts/header.html
@@ -11,8 +11,8 @@
 	<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 	<!-- /wp:group -->
 
-	<!-- wp:spacer {"height":"clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem)"} -->
-<div style="height:clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- wp:spacer {"height":"2rem"} -->
+<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 	</div>

--- a/club/parts/header.html
+++ b/club/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"className":"gapless-group","layout":{"inherit":"true"}} -->
-<div class="wp-block-group gapless-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"1rem","top":"1rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull" style="padding-top:1rem;padding-bottom:1rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+<div class="wp-block-group gapless-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"1.5rem","top":"1.5rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:1.5rem;padding-bottom:1.5rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 	<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 	
 	<!-- wp:group -->

--- a/club/templates/index.html
+++ b/club/templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"calc(-1 * clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem))","top":"calc(-1 * clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem))"}}},"className":"alignfull"} -->
-<hr class="wp-block-separator has-alpha-channel-opacity alignfull" style="margin-top:calc(-1 * clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem));margin-bottom:calc(-1 * clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem))"/>
+<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"-2rem","top":"-2rem"}}},"className":"alignfull"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity alignfull" style="margin-top:-2rem;margin-bottom:-2rem"/>
 <!-- /wp:separator -->
 
 <!-- wp:pattern {"slug":"club/posts-list"} /-->

--- a/club/theme.json
+++ b/club/theme.json
@@ -598,7 +598,7 @@
             }
         },
         "spacing": {
-            "blockGap": "clamp(1rem, calc(1rem + ((1vw - 0.48rem) * 5.7692)), 2rem)"
+            "blockGap": "2rem"
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--spacemono)",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Club: remove CSS `clamp()` from blockGap setting because is not working on Gutenberg 13.8.2

Testing with Gutenberg 13.8.2:

Before:
![image](https://user-images.githubusercontent.com/1310626/185170601-dce4692b-c498-43e5-82eb-803c6f6c3bfb.png)




After:
![image](https://user-images.githubusercontent.com/1310626/185170636-0e1ded43-6097-479f-a7b1-bb3e720eeeb2.png)
