### PR TITLE
Disco: post navigation link to lowercase

### DIFF
--- a/disco/theme.json
+++ b/disco/theme.json
@@ -456,7 +456,8 @@
             "core/post-navigation-link": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--large)",
-                    "textDecoration": "none"
+                    "textDecoration": "none",
+                    "textTransform": "lowercase"
                 },
                 "elements": {
                     "link": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Disco: post navigation link to lowercase

Before:
![image](https://user-images.githubusercontent.com/1310626/185426428-a2357173-d630-4e64-89ef-011e9eb25612.png)




After:
![image](https://user-images.githubusercontent.com/1310626/185426307-799a2a7f-74e3-464b-b281-e57b4bc0653e.png)




#### Related issue(s):
Fixes: https://github.com/Automattic/themes/issues/6404