### PR TITLE
#6406: Publication: Fix Newspack Blocks Blog Post Image Alignment

### DIFF
--- a/publication/style.css
+++ b/publication/style.css
@@ -1651,12 +1651,21 @@ body {
 
 /* Post Thumbnail */
 .post-thumbnail {
-	background: #000;
 	display: block;
 	float: right;
 	margin: 0 0 12px 12px;
 	width: 60px;
 }
+
+.wpnbha .post-thumbnail {
+	background: none;
+}
+
+.wpnbha.image-aligntop .post-thumbnail {
+	float: unset;
+	width: 100%;
+}
+
 .post-thumbnail img {
 	display: block;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

To test this, you need to install the Newspack Blocks plugin and create a post/page with the blog post listing block present and set the image to full width.

I also added a line of CSS to prevent the black background on the feature images from stretching the height of the article container.

##### Editor View

<img width="710" alt="Screenshot on 2022-08-22 at 12-40-58" src="https://user-images.githubusercontent.com/45246438/185977077-1fe4799c-6240-4c85-95ca-8de34710fc6a.png">

##### Before

<img width="653" alt="Screenshot on 2022-08-22 at 12-41-17" src="https://user-images.githubusercontent.com/45246438/185977086-bfb96d67-1de9-425c-927a-195bf9edd7d2.png">

##### After


<img width="684" alt="Screenshot on 2022-08-22 at 13-00-52" src="https://user-images.githubusercontent.com/45246438/185977902-e8e9abba-2f9a-4880-b325-a019a5a2b635.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6406