### PR TITLE
Add appearance tools to all Varia themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "themes",
-	"version": "1.0.196",
+	"version": "1.0.210",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "themes",
-			"version": "1.0.196",
+			"version": "1.0.210",
 			"license": "GPL-2.0",
 			"workspaces": [
 				"*"
@@ -32,8 +32,8 @@
 				"table": "^6.8.0"
 			},
 			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
+				"node": ">=17.0.0",
+				"npm": ">=8.0.0"
 			}
 		},
 		"alves": {
@@ -177,7 +177,7 @@
 			}
 		},
 		"geologist": {
-			"version": "1.0.33",
+			"version": "1.0.34",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19431,7 +19431,7 @@
 			}
 		},
 		"quadrat": {
-			"version": "1.1.45",
+			"version": "1.1.46",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19626,7 +19626,7 @@
 			}
 		},
 		"zoologist": {
-			"version": "1.0.35",
+			"version": "1.0.36",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "themes",
-			"version": "1.0.192",
+			"version": "1.0.195",
 			"license": "GPL-2.0",
 			"workspaces": [
 				"*"
@@ -177,7 +177,7 @@
 			}
 		},
 		"geologist": {
-			"version": "1.0.34",
+			"version": "1.0.33",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -229,7 +229,7 @@
 			}
 		},
 		"mayland-blocks": {
-			"version": "2.1.32",
+			"version": "2.1.31",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19431,7 +19431,7 @@
 			}
 		},
 		"quadrat": {
-			"version": "1.1.46",
+			"version": "1.1.45",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19511,7 +19511,7 @@
 			}
 		},
 		"seedlet-blocks": {
-			"version": "2.1.31",
+			"version": "2.1.30",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19613,7 +19613,7 @@
 			}
 		},
 		"videomaker": {
-			"version": "1.0.22",
+			"version": "1.0.21",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",
@@ -19626,7 +19626,7 @@
 			}
 		},
 		"zoologist": {
-			"version": "1.0.36",
+			"version": "1.0.35",
 			"license": "GPLv2",
 			"devDependencies": {
 				"@wordpress/base-styles": "^4.0.4",

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -50,6 +50,9 @@ if ( ! function_exists( 'varia_setup' ) ) :
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );
 
+		// Enable appearance tools for Block Editor.
+		add_theme_support( 'appearance-tools' );
+
 		/*
 		 * Let WordPress manage the document title.
 		 * By adding theme support, we declare that this theme does not use a


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Flip the switch on appearance tools now that [that can be done via theme_supports](https://github.com/WordPress/gutenberg/pull/43337).

This effects all Varia and child themes.
alves
balasana
barnsbury
brompton
coutoire
dalston
exford
hever
leven
mayland
maywood
morden
redhill
rivington
rockfield
shawburn
stow
stratford


Before:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/146530/186013290-102e1d4b-fede-4b11-94f2-d2d28d99552a.png">

After:

<img width="281" alt="image" src="https://user-images.githubusercontent.com/146530/186013213-2b345ebd-9fa6-4942-9eb6-21daeadc7eb2.png">

Partially completes: #6411
Requires Gutenberg 14.0 to ship