### PR TITLE
Livro: fix button hover styles and button outline

### DIFF
--- a/livro/style.css
+++ b/livro/style.css
@@ -85,6 +85,21 @@ a:active {
 	opacity: 0.90;
 }
 
+
+.wp-block-button__link:not(.has-text-color) {
+	color: var(--wp--preset--color--background);
+}
+
+.is-style-outline > .wp-block-button__link,
+.wp-block-button__link.is-style-outline {
+	border-width: 2px;
+}
+
+.is-style-outline > .wp-block-button__link:not(.has-text-color),
+.wp-block-button__link.is-style-outline:not(.has-text-color) {
+	color: var(--wp--preset--color--foreground);
+}
+
 /*
  * Alignment styles.
  * These rules are temporary, and should not be relied on or


### PR DESCRIPTION
#### Problem

After adding Cream and White variations for Livro, hover color on buttons started behaving differently among variations, making button text illegible on buttons depending on whether the background was clear or dark.

Also, editor styles setting `border-width: 0` were making button outlines invisible.
![Kapture 2022-08-22 at 18 01 21](https://user-images.githubusercontent.com/1157901/186026726-248abd35-0fa3-4bc3-8c4a-0118efb8a79e.gif)
 

#### Changes proposed in this Pull Request:

Set the correct hover color depending on the type of button (regular/outline).
Define the border-width for outline buttons.