### PR TITLE
#4914: Shoreditch: Fix padding on group block

### DIFF
--- a/shoreditch/css/blocks.css
+++ b/shoreditch/css/blocks.css
@@ -320,6 +320,19 @@ p.has-drop-cap:not(:focus)::first-letter {
 	width: 100%;
 }
 
+/* Group */
+
+.wp-block-group {
+	margin-bottom: 1.5em;
+	padding: 1.5em;
+}
+
+.wp-block-group > * {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 900px;
+}
+
 /*--------------------------------------------------------------
 4.0 Blocks - Formatting
 --------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

To test, add group block and change background colors. Frontend now reflects what is shown in the editor.

#### Changes proposed in this Pull Request:

##### Before

<img width="1520" alt="Screenshot on 2022-08-23 at 13-21-39" src="https://user-images.githubusercontent.com/45246438/186234907-18898d2a-5bfe-4537-8e16-82e54ed40eda.png">


##### After

<img width="1861" alt="Screenshot on 2022-08-23 at 14-17-15" src="https://user-images.githubusercontent.com/45246438/186234898-ae4de14c-811f-44e2-ae9d-c8bbfdb824d1.png">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4914