### PR TITLE
Block Canvas: replace alignment CSS

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -50,58 +50,6 @@ GNU General Public License for more details.
 }
 
 /*
- * Alignment styles, borrowed from Twenty Twenty-Two.
- * These rules are temporary, and should not be relied on or
- * modified too heavily by themes or plugins that build on
- * Twenty Twenty-Two. These are meant to be a precursor to
- * a global solution provided by the Block Editor.
- *
- * Relevant issues:
- * https://github.com/WordPress/gutenberg/issues/35607
- * https://github.com/WordPress/gutenberg/issues/35884
- */
-
-.wp-site-blocks,
-body > .is-root-container,
-.edit-post-visual-editor__post-title-wrapper,
-.wp-block-group.alignfull,
-.wp-block-group.has-background,
-.wp-block-columns.alignfull.has-background,
-.wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align='full'] > .wp-block-group,
-.is-root-container .wp-block[data-align='full'] > .wp-block-columns.has-background,
-.is-root-container .wp-block[data-align='full'] > .wp-block-cover {
-	padding-left: var(--wp--custom--gap--horizontal);
-	padding-right: var(--wp--custom--gap--horizontal);
-}
-
-.wp-site-blocks .alignfull,
-.wp-site-blocks > .wp-block-group.has-background,
-.wp-site-blocks > .wp-block-cover,
-.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
-.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-cover,
-body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
-body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-.is-root-container .wp-block[data-align='full'] {
-	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
-	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
-	max-width: unset;
-	width: unset;
-}
-
-/* Blocks inside columns don't have negative margins. */
-.wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
-.is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
-/* We also want to avoid stacking negative margins. */
-.wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
-.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
-	margin-left: auto !important;
-	margin-right: auto !important;
-	width: inherit;
-}
-
-/*
  * Responsive menu container padding.
  * This ensures the responsive container inherits the same
  * spacing defined above. This behavior may be built into

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -346,8 +346,8 @@
         "spacing": {
             "blockGap": "1.5rem",
             "padding": {
-                "right": "var(--wp--preset--spacing--30)",
-                "left": "var(--wp--preset--spacing--30)"
+                "right": "var(--wp--preset--spacing--60)",
+                "left": "var(--wp--preset--spacing--60)"
             }
         },
         "typography": {

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -347,7 +347,6 @@
             "blockGap": "1.5rem",
             "padding": {
                 "right": "var(--wp--preset--spacing--30)",
-                "bottom": "0px",
                 "left": "var(--wp--preset--spacing--30)"
             }
         },

--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -28,6 +28,7 @@
     ],
     "settings": {
         "appearanceTools": true,
+        "useRootPaddingAwareAlignments": true,
         "color": {
             "palette": [
                 {
@@ -343,7 +344,12 @@
             }
         },
         "spacing": {
-            "blockGap": "30px"
+            "blockGap": "1.5rem",
+            "padding": {
+                "right": "var(--wp--preset--spacing--30)",
+                "bottom": "0px",
+                "left": "var(--wp--preset--spacing--30)"
+            }
         },
         "typography": {
             "fontFamily": "var(--wp--preset--font-family--system-font)",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the alignment CSS in favor of the Gutenberg enabled site wide padding. 

To test, activate block canvas and ensure the site has some global padding (i.e. content does not reach the edge of the screen).

#### Related issue(s):

None, but as more folks use block canvas as a starting point it would be good to not include this CSS if it's not needed!