### PR TITLE
#4430: Stow: Add link underline

### DIFF
--- a/stow/sass/_extra-child-theme.scss
+++ b/stow/sass/_extra-child-theme.scss
@@ -21,18 +21,22 @@
 /**
  * 1. General Helper Styles
  */
- body {
+body {
 	font-weight: 300;
 }
 
-b, strong {
+b,
+strong {
 	font-weight: 700;
 }
 
 .home.page.hide-homepage-title {
+
 	.site-main {
 		padding: 0;
+
 		article {
+
 			.entry-content {
 				margin-top: 0;
 			}
@@ -41,6 +45,16 @@ b, strong {
 }
 
 a {
+	text-decoration: none;
+}
+
+.entry-content a:link,
+.entry-content a:active {
+	text-decoration: underline;
+}
+
+.entry-content a:hover,
+.entry-content a:active {
 	text-decoration: none;
 }
 
@@ -73,12 +87,17 @@ a {
 		padding: 3em 0 36px;
 	}
 	margin: 0 auto;
+
 	.social-navigation {
 		margin-bottom: #{map-deep-get($config-global, "spacing", "unit")};
+
 		ul {
+
 			li {
+
 				a {
 					color: #{map-deep-get($config-global, "color", "secondary", "default")};
+
 					&:hover {
 						color: #{map-deep-get($config-global, "color", "secondary", "hover")};
 					}
@@ -88,7 +107,8 @@ a {
 	}
 }
 
-body:not( .fse-enabled ) {
+body:not(.fse-enabled) {
+
 	.site-title {
 		font-size: #{map-deep-get($config-global, "font", "size", "xxl")};
 	}
@@ -111,16 +131,19 @@ body:not( .fse-enabled ) {
 }
 
 #page {
+
 	.entry-header,
 	.page-header,
 	.entry-footer,
 	.a8c-posts-list {
 		text-align: center;
 	}
+
 	.a8c-posts-list-item__excerpt {
 		text-align: left;
 	}
 }
+
 /**
  * 4. Navigation
  */
@@ -129,10 +152,12 @@ body:not( .fse-enabled ) {
 /**
  * 4.1 Main Navigation
  */
-body:not( .fse-enabled ) {
-	#site-navigation, .main-navigation {
+body:not(.fse-enabled) {
+
+	#site-navigation,
+	.main-navigation {
 		background-color: #{map-deep-get($config-global, "color", "secondary", "default")};
-		border-bottom: 2px solid rgba(0,0,0,.15);
+		border-bottom: 2px solid rgba(0, 0, 0, 0.15);
 		margin-left: 0;
 		margin-right: 0;
 		text-align: center;
@@ -149,34 +174,45 @@ body:not( .fse-enabled ) {
 			}
 
 			ul {
+
 				li {
+
 					&.current-menu-item {
+
 						a {
 							color: #{map-deep-get($config-global, "color", "primary", "default")};
 						}
 					}
+
 					a {
 						color: #{map-deep-get($config-global, "color", "background", "default")};
 						text-decoration: none;
+
 						&:hover {
 							color: #{map-deep-get($config-global, "color", "primary", "default")};
 						}
 					}
+
 					@include media(mobile) {
 						padding-left: 0;
 						padding-right: 0;
 						list-style-type: disc;
+
 						&.current-menu-item {
+
 							a {
 								color: #{map-deep-get($config-global, "color", "primary", "default")};
 							}
 						}
+
 						a {
 							color: #{map-deep-get($config-global, "color", "background", "default")};
 							font-size: #{map-deep-get($config-global, "font", "size", "sm")};
+
 							&:hover {
 								color: #{map-deep-get($config-global, "color", "primary", "default")};
 							}
+
 							&::after {
 								color: #{map-deep-get($config-global, "color", "background", "default")};
 								content: " \2022";
@@ -186,8 +222,11 @@ body:not( .fse-enabled ) {
 								opacity: 0.58;
 							}
 						}
+
 						&:last-child {
+
 							a {
+
 								&::after {
 									content: "";
 									margin-left: 0;
@@ -196,24 +235,33 @@ body:not( .fse-enabled ) {
 						}
 					}
 				}
+
 				ul {
+
 					@include media(mobile) {
 						background-color: #{map-deep-get($config-global, "color", "background", "default")};
+
 						li {
+
 							&.current-menu-item {
+
 								a {
 									color: #{map-deep-get($config-global, "color", "secondary", "default")};
 								}
 							}
+
 							a {
 								color: #{map-deep-get($config-global, "color", "primary", "default")};
+
 								&::after {
 									content: "";
 								}
+
 								&:hover {
 									color: #{map-deep-get($config-global, "color", "primary", "hover")};
 								}
 							}
+
 							&:hover {
 								background: #{map-deep-get($config-global, "color", "background", "light")};
 							}
@@ -221,11 +269,14 @@ body:not( .fse-enabled ) {
 					}
 				}
 			}
+
 			.main-menu {
+
 				& > li > a {
 					padding-left: 0;
 				}
 			}
+
 			#toggle-menu {
 				border-radius: 0;
 				width: 100% !important;
@@ -260,16 +311,19 @@ body:not( .fse-enabled ) {
  * 6.1. Column Block
  */
 .wp-block-coblocks-column {
+
 	h1,
 	h2,
 	h3,
 	h4,
 	h5,
 	h6 {
-		margin-bottom: .857em;
+		margin-bottom: 0.857em;
 	}
+
 	a {
 		color: #{map-deep-get($config-global, "color", "secondary", "default")};
+
 		&:hover {
 			color: #{map-deep-get($config-global, "color", "secondary", "hover")};
 		}
@@ -283,10 +337,13 @@ body:not( .fse-enabled ) {
 .wp-block-quote[style*="text-align:center"],
 .wp-block-quote[style*="text-align:right"] {
 	border: 1px solid #f2f2f2;
-	padding: #{map-deep-get($config-global, "spacing", "horizontal")};;
+	padding: #{map-deep-get($config-global, "spacing", "horizontal")};
+
 	p {
+
 		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
 	}
+
 	cite {
 		color: #{map-deep-get($config-global, "color", "secondary", "default")};
 	}
@@ -298,6 +355,7 @@ body:not( .fse-enabled ) {
 .wp-block-coblocks-hero__box,
 .wp-block-cover__inner-container {
 	padding: #{map-deep-get($config-global, "spacing", "vertical")};
+
 	h1,
 	h2,
 	h3,
@@ -306,6 +364,7 @@ body:not( .fse-enabled ) {
 	h6 {
 		padding: #{map-deep-get($config-global, "spacing", "horizontal")};
 	}
+
 	p {
 		padding: #{map-deep-get($config-global, "spacing", "horizontal")};
 	}
@@ -315,13 +374,16 @@ body:not( .fse-enabled ) {
  * 6.4. File Block
  */
 .wp-block-file {
+
 	a {
+
 		&.wp-block-file__button {
 			text-transform: uppercase;
 			line-height: #{map-deep-get($config-button, "font", "line-height")};
 			color: #{map-deep-get($config-button, "color", "text")};
 			cursor: pointer;
 			font-weight: #{map-deep-get($config-button, "font", "weight")};
+
 			@include font-family( map-deep-get($config-button, "font", "family") );
 			font-size: #{map-deep-get($config-button, "font", "size")};
 			background-color: #{map-deep-get($config-button, "color", "background")};
@@ -329,6 +391,7 @@ body:not( .fse-enabled ) {
 			border-width: #{map-deep-get($config-button, "border-width")};
 			padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 			display: inline-block;
+
 			&:focus,
 			&:hover,
 			&:visited {
@@ -344,8 +407,11 @@ body:not( .fse-enabled ) {
  * 6.5. Latest Comments Block
  */
 .wp-block-latest-comments {
+
 	.wp-block-latest-comments__comment-meta {
+
 		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+
 		.wp-block-latest-comments__comment-date {
 			font-size: #{map-deep-get($config-global, "font", "size", "xs")};
 		}
@@ -357,9 +423,9 @@ body:not( .fse-enabled ) {
  * 6.7. Posts List Block
  * 6.8. Search Block
  */
- .wp-block-button a.wp-block-button__link,
- .a8c-posts-list a.a8c-posts-list__view-all,
- .wp-block-search .wp-block-search__button {
+.wp-block-button a.wp-block-button__link,
+.a8c-posts-list a.a8c-posts-list__view-all,
+.wp-block-search .wp-block-search__button {
 	text-transform: uppercase;
 }
 
@@ -367,9 +433,11 @@ body:not( .fse-enabled ) {
  * 7. Widgets
  */
 .site-footer {
+
 	.widget-area {
+
 		.widget-title {
-			margin-bottom: .857em;
+			margin-bottom: 0.857em;
 		}
 	}
 }
@@ -378,8 +446,11 @@ body:not( .fse-enabled ) {
  * 6.1. Blog Posts (Newspack) Block
  */
 .wp-block-newspack-blocks-homepage-articles {
+
 	article {
+
 		.entry-title a {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -388,6 +459,7 @@ body:not( .fse-enabled ) {
 		}
 
 		.more-link {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -409,7 +481,9 @@ body:not( .fse-enabled ) {
 	}
 
 	&.image-alignbehind article {
+
 		.entry-title a {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -419,6 +493,7 @@ body:not( .fse-enabled ) {
 		}
 
 		.more-link {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -431,8 +506,11 @@ body:not( .fse-enabled ) {
 .has-background:not(.has-background-background-color),
 [class*="background-color"]:not(.has-background-background-color),
 [style*="background-color"] {
+
 	.wp-block-newspack-blocks-homepage-articles article {
-		.entry-title a{
+
+		.entry-title a {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -441,6 +519,7 @@ body:not( .fse-enabled ) {
 		}
 
 		.more-link {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -453,17 +532,21 @@ body:not( .fse-enabled ) {
 /**
  * Search block
  */
- .wp-block-search {
+.wp-block-search {
+
 	&.wp-block-search__button-inside {
-		.wp-block-search__inside-wrapper{
+
+		.wp-block-search__inside-wrapper {
 			border-radius: #{map-deep-get($config-button, "border-radius")};
 		}
+
 		.wp-block-search__input {
 			background: transparent;
 		}
 	}
+
 	.wp-block-search__input {
-		margin-right: calc( .1 * #{map-deep-get($config-button, "padding", "horizontal")} );
+		margin-right: calc(0.1 * #{map-deep-get($config-button, "padding", "horizontal")});
 		border-radius: #{map-deep-get($config-button, "border-radius")};
 	}
 }

--- a/stow/sass/style-child-theme-editor.scss
+++ b/stow/sass/style-child-theme-editor.scss
@@ -13,7 +13,9 @@
 */
 @import "global-variables";
 
-:root, body {
+:root,
+body {
+
 	@include global-variables();
 }
 
@@ -76,6 +78,16 @@ a {
 	text-decoration: none;
 }
 
+.block-editor-block-list__layout a:link,
+.block-editor-block-list__layout a:active {
+	text-decoration: underline;
+}
+
+.block-editor-block-list__layout a:hover,
+.block-editor-block-list__layout a:active {
+	text-decoration: none;
+}
+
 /**
  * 2. Block Specific Styles
  */
@@ -83,17 +95,20 @@ a {
 /**
  * 2.1. Column Block
  */
- .wp-block-coblocks-column {
+.wp-block-coblocks-column {
+
 	h1,
 	h2,
 	h3,
 	h4,
 	h5,
 	h6 {
-		margin-bottom: .857em;
+		margin-bottom: 0.857em;
 	}
+
 	a {
 		color: #{map-deep-get($config-global, "color", "secondary", "default")};
+
 		&:hover {
 			color: #{map-deep-get($config-global, "color", "secondary", "hover")};
 		}
@@ -103,30 +118,36 @@ a {
 /**
  * 2.2. Quote Block
  */
- .wp-block-quote,
- .wp-block-quote[style*="text-align:center"],
- .wp-block-quote[style*="text-align:right"] {
-	 border: 1px solid #f2f2f2;
-	 padding: #{map-deep-get($config-global, "spacing", "horizontal")};;
-	 p {
-		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
-	 }
-	 .wp-block-quote__citation {
-		 color: #{map-deep-get($config-global, "color", "secondary", "default")};
-	 }
- }
+.wp-block-quote,
+.wp-block-quote[style*="text-align:center"],
+.wp-block-quote[style*="text-align:right"] {
+	border: 1px solid #f2f2f2;
+	padding: #{map-deep-get($config-global, "spacing", "horizontal")};
 
- /**
+	p {
+
+		@include font-family( map-deep-get($config-global, "font", "family", "secondary") );
+	}
+
+	.wp-block-quote__citation {
+		color: #{map-deep-get($config-global, "color", "secondary", "default")};
+	}
+}
+
+/**
  * 2.3. File Block
  */
 .wp-block-file {
+
 	div {
+
 		&.wp-block-file__button {
 			text-transform: uppercase;
 			line-height: #{map-deep-get($config-button, "font", "line-height")};
 			color: #{map-deep-get($config-button, "color", "text")};
 			cursor: pointer;
 			font-weight: #{map-deep-get($config-button, "font", "weight")};
+
 			@include font-family( map-deep-get($config-button, "font", "family") );
 			font-size: #{map-deep-get($config-button, "font", "size")};
 			background-color: #{map-deep-get($config-button, "color", "background")};
@@ -134,6 +155,7 @@ a {
 			border-width: #{map-deep-get($config-button, "border-width")};
 			padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 			display: inline-block;
+
 			&:focus,
 			&:hover,
 			&:visited {
@@ -150,16 +172,19 @@ a {
  */
 .wp-block-preformatted,
 .wp-block-verse {
+
 	pre {
-		font-family: #{map-deep-get($config-global, "font", "family", "code")};
+		font-family: #{map-deep-get($config-global, "font", "family", "code") "}";
 	}
 }
 
 /**
  * 2.5. Button Block
  */
- .wp-block-button {
+.wp-block-button {
+
 	div {
+
 		&.wp-block-button__link {
 			text-transform: uppercase;
 		}
@@ -169,13 +194,15 @@ a {
 /**
  * 2.6. Search Block
  */
- .wp-block-search {
+.wp-block-search {
+
 	.wp-block-search__button {
 		text-transform: uppercase;
 		line-height: #{map-deep-get($config-button, "font", "line-height")};
 		color: #{map-deep-get($config-button, "color", "text")};
 		cursor: pointer;
 		font-weight: #{map-deep-get($config-button, "font", "weight")};
+
 		@include font-family( map-deep-get($config-button, "font", "family") );
 		font-size: #{map-deep-get($config-button, "font", "size")};
 		background-color: #{map-deep-get($config-button, "color", "background")};
@@ -183,6 +210,7 @@ a {
 		border-width: #{map-deep-get($config-button, "border-width")};
 		padding: #{map-deep-get($config-button, "padding", "vertical")} #{map-deep-get($config-button, "padding", "horizontal")};
 		display: inline-block;
+
 		&:focus,
 		&:hover,
 		&:visited {
@@ -196,7 +224,9 @@ a {
 }
 
 .wp-block-a8c-blog-posts {
+
 	.entry-title a {
+
 		&:active,
 		&:focus,
 		&:hover {
@@ -217,7 +247,9 @@ a {
 	}
 
 	&.image-alignbehind article {
+
 		.entry-title a {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -230,8 +262,11 @@ a {
 .has-background:not(.has-background-background-color),
 [class*="background-color"]:not(.has-background-background-color),
 [style*="background-color"] {
+
 	.wp-block-a8c-blog-posts {
-		.entry-title a{
+
+		.entry-title a {
+
 			&:active,
 			&:focus,
 			&:hover {
@@ -242,11 +277,11 @@ a {
 }
 
 .wp-block-a8c-blog-posts + .button {
-	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "xs")) + 0em);
+	font-size: (strip-unit(map-deep-get($config-global, "font", "size", "xs")) + 0);
 }
 
 /**
  * Full Site Editing
  * - Full Site Editing overrides
  */
- @import "full-site-editing-editor";
+@import "full-site-editing-editor";

--- a/stow/style-editor.css
+++ b/stow/style-editor.css
@@ -1470,6 +1470,16 @@ a {
 	text-decoration: none;
 }
 
+.block-editor-block-list__layout a:link,
+.block-editor-block-list__layout a:active {
+	text-decoration: underline;
+}
+
+.block-editor-block-list__layout a:hover,
+.block-editor-block-list__layout a:active {
+	text-decoration: none;
+}
+
 /**
  * 2. Block Specific Styles
  */

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -4026,7 +4026,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 
@@ -4118,6 +4118,16 @@ strong {
 }
 
 a {
+	text-decoration: none;
+}
+
+.entry-content a:link,
+.entry-content a:active {
+	text-decoration: underline;
+}
+
+.entry-content a:hover,
+.entry-content a:active {
 	text-decoration: none;
 }
 

--- a/stow/style.css
+++ b/stow/style.css
@@ -4055,7 +4055,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 
@@ -4147,6 +4147,16 @@ strong {
 }
 
 a {
+	text-decoration: none;
+}
+
+.entry-content a:link,
+.entry-content a:active {
+	text-decoration: underline;
+}
+
+.entry-content a:hover,
+.entry-content a:active {
 	text-decoration: none;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

Add underline style to links in content. This will gives users a non-color-based indication that a piece of text is a link.

#### Before

The editor and frontend both render links as plain black text and linked and non-linked text is indistinguishable until you mouse over:

<img width="840" alt="Screenshot on 2022-08-25 at 07-35-40" src="https://user-images.githubusercontent.com/45246438/186673329-05606ef0-356e-45a8-94e9-752b5861c36c.png">

#### After

##### Edtior
<img width="1294" alt="Screenshot on 2022-08-25 at 08-50-41" src="https://user-images.githubusercontent.com/45246438/186673458-9f414de6-fd6f-4f33-bf6a-1e10a4d6b6f6.png">


##### Frontend

<img width="826" alt="Screenshot on 2022-08-25 at 07-36-08" src="https://user-images.githubusercontent.com/45246438/186673440-53cd0999-0627-404b-ab6b-08d428aa301f.png">


### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/4430