### PR TITLE
Pixel: set correct foreground color

### DIFF
--- a/pixel/theme.json
+++ b/pixel/theme.json
@@ -36,7 +36,7 @@
                     "slug": "primary"
                 },
                 {
-                    "color": "#040D41",
+                    "color": "#040DE1",
                     "name": "Foreground",
                     "slug": "foreground"
                 },


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Jumped the gun on merging https://github.com/Automattic/themes/pull/6478; the design actually uses `#040DE1` as Foreground color (same as Primary.)