### PR TITLE
Rainfall: adjust featured image in single template

### DIFF
--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -18,7 +18,7 @@
 <!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:post-featured-image {"align":"wide"} /-->
+<!-- wp:post-featured-image {"align":"wide","height":"30rem"} /-->
 <!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/rainfall/templates/single.html
+++ b/rainfall/templates/single.html
@@ -18,7 +18,7 @@
 <!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:post-featured-image {"align":"full"} /-->
+<!-- wp:post-featured-image {"align":"wide"} /-->
 <!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR makes the featured image on the single template of Rainfall wide align, and gives it a set height of `30rem`.

| Before | After |
| ------- | ----- |
| <img width="1433" alt="image" src="https://user-images.githubusercontent.com/1645628/187736133-6d3ed738-a008-479b-8a47-7319b59831e6.png"> | <img width="1433" alt="image" src="https://user-images.githubusercontent.com/1645628/187736042-85ef1e09-0b57-482d-b636-8a919967bc69.png"> |

I guessed at the `30rem` value. @beafialho, did you have any particular size in mind for the height limit here?

#### Related issue(s):
Fixes #6433.