### PR TITLE
Removing thickness from text-decoration shorthand because it is not supported on WebKit

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -35,17 +35,17 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
  */
 a {
 	cursor: pointer;
-	text-underline-offset: 0.3em;
-	text-decoration-thickness: 0.05em;
 	text-decoration-line: none;
 }
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+:is(h1, h2, h3, h4, h5, h6) a:is(:hover, :focus) {
 	text-underline-offset: 0.15em;
 	text-decoration-thickness: 0.02em;
 }
 a:hover,
 a:focus {
 	text-decoration-line: underline;
+	text-underline-offset: 0.3em;
+	text-decoration-thickness: 0.05em;
 }
 .block-editor-block-list__layout a,
 .wp-block-post-content a {

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -349,7 +349,7 @@
 					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
-					"textDecoration": "none 0.02em"
+					"textDecoration": "none"
 				}
 			}
 		},

--- a/vivre/style.css
+++ b/vivre/style.css
@@ -152,8 +152,9 @@ a:not(
 	text-decoration: underline;
 }
 
-.wp-block-post-title a:hover {
+.wp-block-post-title a:where(:not(.wp-element-button)):is(:hover, :focus) {
 	text-underline-offset: 0.25rem;
+	text-decoration-thickness: 0.25rem;
 }
 
 /*

--- a/vivre/theme.json
+++ b/vivre/theme.json
@@ -346,14 +346,14 @@
 							"text": "var(--wp--preset--color--foreground)"
 						},
 						"typography": {
-							"textDecoration": "none 0.25rem"
+							"textDecoration": "none"
 						},
 						":hover": {
 							"color": {
 								"text": "var(--wp--preset--color--primary)"
 							},
 							"typography": {
-								"textDecoration": "underline 0.25rem"
+								"textDecoration": "underline"
 							}
 						}
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Vivre and Pendant: removing thickness from text-decoration shorthand because it is not supported on WebKit browsers as Safari


#### Related issue(s):
Part of: https://github.com/Automattic/themes/issues/6243