### PR TITLE
Russell: adjust featured image in single template

### DIFF
--- a/russell/block-templates/single.html
+++ b/russell/block-templates/single.html
@@ -8,7 +8,7 @@
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
 <main class="wp-block-group">
-<!-- wp:post-featured-image {"align":"full"} /-->
+<!-- wp:post-featured-image {"align":"wide","height":"30rem"} /-->
 
 <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
 


### PR DESCRIPTION
**Description**
The featured image size on single posts is huge, and the user has to scroll through the image to read the content.

#### Changes proposed in this Pull Request:

This PR makes the featured image on the single template of Russell theme wide align, and gives it a set height of 30rem.

**Test instructions**

1. Add a Post Featured Image block on the post page.
2. Open the page preview. The featured image should be wide aligned with constrained height.

### Screenshots

| Before | After |
|---|---|
| ![russell-full-width-featured-image](https://user-images.githubusercontent.com/21078987/188125565-c3a8d612-b284-4a50-a5d4-8eea2f5bab0c.png) | ![russell-intended-size-featured-image](https://user-images.githubusercontent.com/21078987/188125655-aa180709-f316-4ea0-9c3a-de70a2133d58.png) |

#### Related issue(s):

Fixes https://github.com/Automattic/wp-calypso/issues/67300
