### PR TITLE
Pixel: update block styles

### DIFF
--- a/pixel/parts/header.html
+++ b/pixel/parts/header.html
@@ -1,12 +1,16 @@
 <!-- wp:group {"layout":{"inherit":"true","type":"constrained"},"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"calc(2 * var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002douter))","bottom":"0","left":"calc(2 * var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002douter))"}}}} -->
-<div class="wp-block-group" style="padding-top:0;padding-right:calc(2 * var(--wp--custom--spacing--outer));padding-bottom:0;padding-left:calc(2 * var(--wp--custom--spacing--outer))"><!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30","top":"var:preset|spacing|30","right":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"0"},"border":{"width":"2px"}},"className":"pixel-shadow"} -->
-<div class="wp-block-group alignfull pixel-shadow" style="border-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"}}}} -->
-<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)">
-
-<!-- wp:site-title /--></div>
+<div class="wp-block-group" style="padding-top:0;padding-right:calc(2 * var(--wp--custom--spacing--outer));padding-bottom:0;padding-left:calc(2 * var(--wp--custom--spacing--outer))"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","verticalAlignment":"top"},"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"width":"2px"},"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"borderColor":"primary","className":"pixel-shadow"} -->
+<div class="wp-block-group pixel-shadow has-border-color has-primary-border-color" style="border-width:2px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:site-logo {"width":50} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30","top":"var:preset|spacing|30","right":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"0"},"border":{"width":"2px"}},"className":"pixel-shadow pixel-header"} -->
+<div class="wp-block-group alignfull pixel-shadow pixel-header" style="border-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:site-title /--></div>
+<!-- /wp:group -->
+
+<!-- wp:navigation {"ref":1956,"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/pixel/parts/header.html
+++ b/pixel/parts/header.html
@@ -1,15 +1,13 @@
 <!-- wp:group {"layout":{"inherit":"true","type":"constrained"},"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"calc(2 * var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002douter))","bottom":"0","left":"calc(2 * var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002douter))"}}}} -->
 <div class="wp-block-group" style="padding-top:0;padding-right:calc(2 * var(--wp--custom--spacing--outer));padding-bottom:0;padding-left:calc(2 * var(--wp--custom--spacing--outer))"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","verticalAlignment":"top"},"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"width":"2px"},"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"borderColor":"primary","className":"pixel-shadow"} -->
-<div class="wp-block-group pixel-shadow has-border-color has-primary-border-color" style="border-width:2px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:site-logo {"width":50} /--></div>
-<!-- /wp:group -->
+<div class="wp-block-group alignfull"><!-- wp:site-logo {"width":44,"className":"pixel-shadow","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /-->
 
 <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"},"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30","top":"var:preset|spacing|30","right":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"0"},"border":{"width":"2px"}},"className":"pixel-shadow pixel-header"} -->
 <div class="wp-block-group alignfull pixel-shadow pixel-header" style="border-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"}}}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":1956,"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/pixel/style.css
+++ b/pixel/style.css
@@ -85,3 +85,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	font-weight: 300;
 	line-height: 1.6;
 }
+
+.pixel-header {
+    flex-grow: 1;
+}

--- a/pixel/style.css
+++ b/pixel/style.css
@@ -85,7 +85,8 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	font-weight: 300;
 	line-height: 1.6;
 }
-// Necessary so the header containing the navigation fills the entire remaining horizontal space, since it is positioned in a flex group with the site logo.
+
+/* Necessary so the header containing the navigation fills the entire remaining horizontal space, since it is positioned in a flex group with the site logo. */
 .pixel-header {
     flex-grow: 1;
 }

--- a/pixel/style.css
+++ b/pixel/style.css
@@ -85,7 +85,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	font-weight: 300;
 	line-height: 1.6;
 }
-
+// Necessary so the header containing the navigation fills the entire remaining horizontal space, since it is positioned in a flex group with the site logo.
 .pixel-header {
     flex-grow: 1;
 }

--- a/pixel/theme.json
+++ b/pixel/theme.json
@@ -200,11 +200,11 @@
         "blocks": {
             "core/code": {
                 "border": {
-                    "color": "#CCCCCC",
-                    "radius": "0px",
+                    "color": "var(--wp--preset--color--primary)",
                     "style": "solid",
                     "width": "2px"
                 },
+                "shadow": "var(--wp--custom--shadow)",
                 "spacing": {
                     "padding": {
                         "bottom": "var(--wp--custom--gap--vertical)",

--- a/pixel/theme.json
+++ b/pixel/theme.json
@@ -359,6 +359,14 @@
                     "text": "var(--wp--preset--color--foreground)"
                 }
             },
+            "core/site-logo": {
+                "border": {
+                    "color": "var(--wp--preset--color--primary)",
+                    "radius": "0",
+                    "style": "solid",
+                    "width": "2px"
+                }
+            },
             "core/site-tagline": {
                 "typography": {
                     "fontSize": "0.825rem"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This addresses the following.

Update `code` block styles
| Before | After |
| --- | --- |
| <img width="364" alt="image" src="https://user-images.githubusercontent.com/1935113/188615454-5dbb108c-0030-472a-a838-a6d0a5d4bf11.png"> | <img width="364" alt="image" src="https://user-images.githubusercontent.com/1935113/188615529-655aff04-8925-4add-9cd9-45a7d77f9272.png"> |

Adds site logo to match the designs.
<img width="817" alt="image" src="https://user-images.githubusercontent.com/1935113/188616768-8d90c0f7-b183-4a81-baf6-7a8fb28d358a.png">

@henriqueiamarino @beafialho 
The above design is achievable and works good only with a square image. 
The UI breaks in the following scenarios.

- horizontal image
<img width="257" alt="image" src="https://user-images.githubusercontent.com/1935113/188617225-3c96f780-73f4-4670-b0a1-dbacaa434dc7.png">

- vertical image
<img width="362" alt="image" src="https://user-images.githubusercontent.com/1935113/188617548-8caba87c-5660-4ccd-bf2b-9ce352f6e41c.png">

- When menu wraps into multiple lines
<img width="387" alt="image" src="https://user-images.githubusercontent.com/1935113/188617924-906060cc-b9ee-4eca-a0e6-2d28ec2591a7.png">

Suggest if its okay to keep this behaviour or change the alinement such as always align top.

#### Related issue(s):

Relates to: #6460 

