### PR TITLE
Varia buttons: Fix custom text color when button background color is set to "foreground" or "background"

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Convincing design for your charity or organization’s online presence. Highlight your actions, causes and projects, Alves is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.5.20
+Version: 1.5.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #ffffff;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #394d55;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/alves/style.css
+++ b/alves/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #ffffff;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #394d55;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Balasana is a clean and minimalist business theme designed with health and wellness-focused sites in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.19
+Version: 1.3.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #303030;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3990,7 +3989,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #303030;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4019,7 +4018,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Barnsbury is an earthy and friendly theme design with farming and agriculture businesses in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.3.20
+Version: 1.3.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFDF6;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
-	color: #3C2323;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFDF6;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFDF6;
-	color: #3C2323;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Running a business is no small task. But with the right tools and support, creating a website doesn’t have to be another chore on your to-do list: enter Brompton, a simple yet powerful theme for small-business owners and entrepreneurs.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -2462,7 +2462,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2492,8 +2492,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #E8E4DD;
 }
 
@@ -2540,7 +2540,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
-	color: #252E36;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3985,7 +3984,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2469,7 +2469,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2499,8 +2499,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #E8E4DD;
 }
 
@@ -2547,7 +2547,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #E8E4DD;
-	color: #252E36;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4014,7 +4013,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2459,7 +2459,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2489,8 +2489,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2537,7 +2537,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3982,7 +3981,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2466,7 +2466,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2496,8 +2496,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2544,7 +2544,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4011,7 +4010,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio impressively awesome with Dalston. With the ability to beautifully highlight your illustration and other projects, Dalston is also versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.20
+Version: 1.3.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2460,7 +2460,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2490,8 +2490,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2538,7 +2538,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #1e1e1e;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3983,7 +3982,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2467,7 +2467,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2497,8 +2497,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2545,7 +2545,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #1e1e1e;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4012,7 +4011,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online presence as striking and stylish as your business with Exford.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #111111;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/exford/style.css
+++ b/exford/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #111111;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A fully responsive theme, ideal for creating a strong — yet beautiful — online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.20
+Version: 1.5.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2493,7 +2493,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2523,8 +2523,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2571,7 +2571,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4036,7 +4035,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/hever/style.css
+++ b/hever/style.css
@@ -2500,7 +2500,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2530,8 +2530,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2578,7 +2578,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4065,7 +4064,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6
-Version: 1.4.18
+Version: 1.4.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #f7f7f6;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/leven/style.css
+++ b/leven/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #f7f7f6;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #f7f7f6;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: WordPress 4.9.6
-Version: 1.3.18
+Version: 1.3.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2460,7 +2460,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2490,8 +2490,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #ffffff;
 }
 
@@ -2538,7 +2538,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #010101;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3983,7 +3982,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2467,7 +2467,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2497,8 +2497,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #ffffff;
 }
 
@@ -2545,7 +2545,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #ffffff;
-	color: #010101;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4012,7 +4011,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Maywood is a refined theme designed for restaurants and food-related businesses seeking a modern look.
 Requires at least: WordPress 4.9.6
-Version: 1.5.19
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #181818;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #181818;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Morden is a functional and responsive multi-purpose theme that is the perfect solution for your business's online presence.
 Requires at least: WordPress 4.9.6
-Version: 1.6.20
+Version: 1.6.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2488,7 +2488,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2518,8 +2518,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2566,7 +2566,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4011,7 +4010,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/morden/style.css
+++ b/morden/style.css
@@ -2495,7 +2495,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2525,8 +2525,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2573,7 +2573,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4040,7 +4039,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A simple theme with clean typography, created with entrepreneurs and small business owners in mind.
 Requires at least: WordPress 4.9.6
-Version: 1.5.18
+Version: 1.5.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Status: inactive
@@ -2462,7 +2462,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2492,8 +2492,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2540,7 +2540,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #222222;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3985,7 +3984,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2469,7 +2469,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2499,8 +2499,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #FFFFFF;
 }
 
@@ -2547,7 +2547,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #FFFFFF;
-	color: #222222;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4014,7 +4013,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rivington is a robust theme designed for single property real estate.
 Requires at least: WordPress 4.9.6
-Version: 1.3.18
+Version: 1.3.19
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2461,7 +2461,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2491,8 +2491,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #060f29;
 }
 
@@ -2539,7 +2539,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
-	color: #f2f2f2;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3984,7 +3983,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2468,7 +2468,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2498,8 +2498,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #060f29;
 }
 
@@ -2546,7 +2546,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #060f29;
-	color: #f2f2f2;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4013,7 +4012,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Rockfield is a refined theme designed for restaurants and food-related businesses seeking a classic, elegant look.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2489,7 +2489,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2519,8 +2519,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2567,7 +2567,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4022,7 +4021,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2496,7 +2496,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2526,8 +2526,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2574,7 +2574,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4051,7 +4050,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Shawburn is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.4.20
+Version: 1.4.21
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2489,7 +2489,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2519,8 +2519,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2567,7 +2567,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4011,7 +4010,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2496,7 +2496,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2526,8 +2526,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2574,7 +2574,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4040,7 +4039,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stow/style-rtl.css
+++ b/stow/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.21
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2493,7 +2493,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2523,8 +2523,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2571,7 +2571,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4211,7 +4210,8 @@ body:not(.fse-enabled) .site-description {
 /**
  * 4.1 Main Navigation
  */
-body:not(.fse-enabled) #site-navigation, body:not(.fse-enabled) .main-navigation {
+body:not(.fse-enabled) #site-navigation,
+body:not(.fse-enabled) .main-navigation {
 	background-color: var(--wp--preset--color--secondary);
 	border-bottom: 2px solid rgba(0, 0, 0, 0.15);
 	margin-right: 0;
@@ -4219,45 +4219,55 @@ body:not(.fse-enabled) #site-navigation, body:not(.fse-enabled) .main-navigation
 	text-align: center;
 }
 
-body:not(.fse-enabled) #site-navigation > div, body:not(.fse-enabled) .main-navigation > div {
+body:not(.fse-enabled) #site-navigation > div,
+body:not(.fse-enabled) .main-navigation > div {
 	text-align: right;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation > div, body:not(.fse-enabled) .main-navigation.main-navigation > div {
+body:not(.fse-enabled) #site-navigation.main-navigation > div,
+body:not(.fse-enabled) .main-navigation.main-navigation > div {
 	padding-right: 16px;
 	padding-left: 16px;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
 	color: var(--wp--preset--color--primary);
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li a,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
 	color: var(--wp--preset--color--background);
 	text-decoration: none;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
 	color: var(--wp--preset--color--primary);
 }
 
 @media only screen and (min-width: 560px) {
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li, body:not(.fse-enabled) .main-navigation.main-navigation ul li {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li {
 		padding-right: 0;
 		padding-left: 0;
 		list-style-type: disc;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
 		color: var(--wp--preset--color--background);
 		font-size: 0.83333rem;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul li a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a::after {
 		color: var(--wp--preset--color--background);
 		content: " \2022";
 		margin-right: 16px;
@@ -4265,38 +4275,47 @@ body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(
 		font-size: 1rem;
 		opacity: 0.58;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li:last-child a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul li:last-child a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li:last-child a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li:last-child a::after {
 		content: "";
 		margin-right: 0;
 	}
 }
 
 @media only screen and (min-width: 560px) {
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul, body:not(.fse-enabled) .main-navigation.main-navigation ul ul {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul {
 		background-color: var(--wp--preset--color--background);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li.current-menu-item a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li.current-menu-item a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li.current-menu-item a {
 		color: var(--wp--preset--color--secondary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a::after {
 		content: "";
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a:hover {
 		color: var(--wp--preset--color--primary-hover);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li:hover {
 		background: var(--wp--preset--color--background-high-contrast);
 	}
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation .main-menu > li > a, body:not(.fse-enabled) .main-navigation.main-navigation .main-menu > li > a {
+body:not(.fse-enabled) #site-navigation.main-navigation .main-menu > li > a,
+body:not(.fse-enabled) .main-navigation.main-navigation .main-menu > li > a {
 	padding-right: 0;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.fse-enabled) .main-navigation.main-navigation #toggle-menu {
+body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu,
+body:not(.fse-enabled) .main-navigation.main-navigation #toggle-menu {
 	border-radius: 0;
 	width: 100% !important;
 	text-align: center;
@@ -4331,7 +4350,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 .wp-block-coblocks-column h4,
 .wp-block-coblocks-column h5,
 .wp-block-coblocks-column h6 {
-	margin-bottom: .857em;
+	margin-bottom: 0.857em;
 }
 
 .wp-block-coblocks-column a {
@@ -4445,7 +4464,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
  * 7. Widgets
  */
 .site-footer .widget-area .widget-title {
-	margin-bottom: .857em;
+	margin-bottom: 0.857em;
 }
 
 /**
@@ -4516,7 +4535,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 }
 
 .wp-block-search .wp-block-search__input {
-	margin-left: calc( .1 * 16px);
+	margin-left: calc(0.1 * 16px);
 	border-radius: 9px;
 }
 

--- a/stow/style.css
+++ b/stow/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A bold and clean theme - Stow is the ideal choice for creating an online presence for your business.
 Requires at least: WordPress 4.9.6
-Version: 1.5.21
+Version: 1.5.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2500,7 +2500,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2530,8 +2530,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2578,7 +2578,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4240,7 +4239,8 @@ body:not(.fse-enabled) .site-description {
 /**
  * 4.1 Main Navigation
  */
-body:not(.fse-enabled) #site-navigation, body:not(.fse-enabled) .main-navigation {
+body:not(.fse-enabled) #site-navigation,
+body:not(.fse-enabled) .main-navigation {
 	background-color: var(--wp--preset--color--secondary);
 	border-bottom: 2px solid rgba(0, 0, 0, 0.15);
 	margin-left: 0;
@@ -4248,45 +4248,55 @@ body:not(.fse-enabled) #site-navigation, body:not(.fse-enabled) .main-navigation
 	text-align: center;
 }
 
-body:not(.fse-enabled) #site-navigation > div, body:not(.fse-enabled) .main-navigation > div {
+body:not(.fse-enabled) #site-navigation > div,
+body:not(.fse-enabled) .main-navigation > div {
 	text-align: left;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation > div, body:not(.fse-enabled) .main-navigation.main-navigation > div {
+body:not(.fse-enabled) #site-navigation.main-navigation > div,
+body:not(.fse-enabled) .main-navigation.main-navigation > div {
 	padding-left: 16px;
 	padding-right: 16px;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
 	color: var(--wp--preset--color--primary);
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li a,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
 	color: var(--wp--preset--color--background);
 	text-decoration: none;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
+body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover,
+body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
 	color: var(--wp--preset--color--primary);
 }
 
 @media only screen and (min-width: 560px) {
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li, body:not(.fse-enabled) .main-navigation.main-navigation ul li {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li {
 		padding-left: 0;
 		padding-right: 0;
 		list-style-type: disc;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li.current-menu-item a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li.current-menu-item a {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a {
 		color: var(--wp--preset--color--background);
 		font-size: 0.83333rem;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a:hover {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul li a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li a::after {
 		color: var(--wp--preset--color--background);
 		content: " \2022";
 		margin-left: 16px;
@@ -4294,38 +4304,47 @@ body:not(.fse-enabled) #site-navigation.main-navigation ul li a:hover, body:not(
 		font-size: 1rem;
 		opacity: 0.58;
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul li:last-child a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul li:last-child a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul li:last-child a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul li:last-child a::after {
 		content: "";
 		margin-left: 0;
 	}
 }
 
 @media only screen and (min-width: 560px) {
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul, body:not(.fse-enabled) .main-navigation.main-navigation ul ul {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul {
 		background-color: var(--wp--preset--color--background);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li.current-menu-item a, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li.current-menu-item a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li.current-menu-item a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li.current-menu-item a {
 		color: var(--wp--preset--color--secondary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a {
 		color: var(--wp--preset--color--primary);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a::after, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a::after {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a::after,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a::after {
 		content: "";
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li a:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li a:hover {
 		color: var(--wp--preset--color--primary-hover);
 	}
-	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li:hover, body:not(.fse-enabled) .main-navigation.main-navigation ul ul li:hover {
+	body:not(.fse-enabled) #site-navigation.main-navigation ul ul li:hover,
+	body:not(.fse-enabled) .main-navigation.main-navigation ul ul li:hover {
 		background: var(--wp--preset--color--background-high-contrast);
 	}
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation .main-menu > li > a, body:not(.fse-enabled) .main-navigation.main-navigation .main-menu > li > a {
+body:not(.fse-enabled) #site-navigation.main-navigation .main-menu > li > a,
+body:not(.fse-enabled) .main-navigation.main-navigation .main-menu > li > a {
 	padding-left: 0;
 }
 
-body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.fse-enabled) .main-navigation.main-navigation #toggle-menu {
+body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu,
+body:not(.fse-enabled) .main-navigation.main-navigation #toggle-menu {
 	border-radius: 0;
 	width: 100% !important;
 	text-align: center;
@@ -4360,7 +4379,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 .wp-block-coblocks-column h4,
 .wp-block-coblocks-column h5,
 .wp-block-coblocks-column h6 {
-	margin-bottom: .857em;
+	margin-bottom: 0.857em;
 }
 
 .wp-block-coblocks-column a {
@@ -4474,7 +4493,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
  * 7. Widgets
  */
 .site-footer .widget-area .widget-title {
-	margin-bottom: .857em;
+	margin-bottom: 0.857em;
 }
 
 /**
@@ -4545,7 +4564,7 @@ body:not(.fse-enabled) #site-navigation.main-navigation #toggle-menu, body:not(.
 }
 
 .wp-block-search .wp-block-search__input {
-	margin-right: calc( .1 * 16px);
+	margin-right: calc(0.1 * 16px);
 	border-radius: 9px;
 }
 

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Stratford is the perfect design for your business or educational institutes online presence. Highlight your products and services, Stratford is versatile enough to be your personal blog too.
 Requires at least: WordPress 4.9.6
-Version: 1.4.19
+Version: 1.4.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
@@ -2492,7 +2492,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2522,8 +2522,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2570,7 +2570,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4025,7 +4024,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2499,7 +2499,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2529,8 +2529,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: var(--wp--preset--color--background);
 }
 
@@ -2577,7 +2577,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--foreground);
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -4054,7 +4053,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/varia/sass/blocks/utilities/_style.scss
+++ b/varia/sass/blocks/utilities/_style.scss
@@ -176,7 +176,7 @@
 	h4:not(.has-text-color),
 	h5:not(.has-text-color),
 	h6:not(.has-text-color) {
-		color: currentColor;
+		color: currentcolor;
 	}
 }
 
@@ -207,8 +207,8 @@
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: #{map-deep-get($config-global, "color", "background", "default")};
 }
 
@@ -255,7 +255,6 @@
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: #{map-deep-get($config-global, "color", "background", "default")};
-	color: #{map-deep-get($config-global, "color", "foreground", "default")};
 }
 
 .has-background-background-color:not(.has-text-color),

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.21
+Version: 1.6.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -2420,7 +2420,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2450,8 +2450,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: white;
 }
 
@@ -2498,7 +2498,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3943,7 +3942,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 

--- a/varia/style.css
+++ b/varia/style.css
@@ -6,7 +6,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: A variable-based design system for WordPress sites built with Gutenberg.
 Requires at least: WordPress 4.9.6
-Version: 1.6.21
+Version: 1.6.20
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
@@ -2427,7 +2427,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background h4:not(.has-text-color),
 .has-background h5:not(.has-text-color),
 .has-background h6:not(.has-text-color) {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .has-primary-background-color,
@@ -2457,8 +2457,8 @@ table.is-style-stripes tbody tr:nth-child(odd),
 }
 
 .has-background-dim,
-.has-foreground-background-color,
-.has-foreground-background-color.has-background-dim {
+.has-foreground-background-color:not(.has-text-color),
+.has-foreground-background-color.has-background-dim:not(.has-text-color) {
 	color: white;
 }
 
@@ -2505,7 +2505,6 @@ table.is-style-stripes tbody tr:nth-child(odd),
 .has-background-background-color,
 .has-background-background-color.has-background-dim {
 	background-color: white;
-	color: #444444;
 }
 
 .has-background-background-color:not(.has-text-color),
@@ -3972,7 +3971,7 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	margin-bottom: 0;
 }
 
-.wp-block-jetpack-mailchimp input[type=email] {
+.wp-block-jetpack-mailchimp input[type="email"] {
 	width: 100%;
 }
 


### PR DESCRIPTION
**Description**

If the user selects the custom text color and background color for the button, the custom text color does not show on the live page. The color looks fine in the editor though.

**Changes proposed in this Pull Request:**

This PR ensures the custom text color selected by the user shows on the live site.

**Test instructions**

1. Add a button on a page.
2. Select a custom text color for the button.
3. Set the button background to "foreground" or "background" color.
4. The custom text color shows correctly in the editor. However, the color on the live page is not correct.

Note: The custom text color shows correctly if the user selects another color from the color palette. As in this case, the color is added via inline CSS. The issue is only visible when the user chooses the default theme color from the theme color palette.

**Also, this PR addresses only one part of the issue with the buttons on the Varia theme.**

| Before | After |
|---|---|
| ![DFLUdc.png](https://user-images.githubusercontent.com/21078987/188872627-2347dd29-4e2e-45c2-beed-994c49a8b9cd.png) | ![Varia colors fixed](https://user-images.githubusercontent.com/21078987/188873021-08215b2e-46f0-4670-bbed-03acdf6323c1.png) |

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/3365