### PR TITLE
Pixl: add duotone for images

### DIFF
--- a/pixl/patterns/comments.php
+++ b/pixl/patterns/comments.php
@@ -13,7 +13,7 @@
 <!-- wp:comment-template -->
 <!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"10px"}}} -->
-<div class="wp-block-group"><!-- wp:avatar {"size":40,"style":{"spacing":{"margin":{"top":"10px"}},"border":{"width":"2px"}},"className":"pixl-shadow"} /-->
+<div class="wp-block-group"><!-- wp:avatar {"size":40,"style":{"spacing":{"margin":{"top":"10px","right":"var:preset|spacing|20"}},"border":{"width":"2px"}},"className":"pixl-shadow"} /-->
 
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:comment-author-name /-->

--- a/pixl/theme.json
+++ b/pixl/theme.json
@@ -29,6 +29,13 @@
     "settings": {
         "appearanceTools": true,
         "color": {
+            "duotone": [
+                {
+                    "colors": [ "#000000", "#FFFFFF" ],
+                    "slug": "default-filter",
+                    "name": "Default filter"
+                }
+            ],
             "palette": [
                 {
                     "color": "#040DE1",
@@ -256,6 +263,26 @@
                     }
                 }
             },
+            "core/image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+            "core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+            "core/cover": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+            "core/post-author": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
             "core/list": {
                 "spacing": {
                     "padding": {

--- a/pixl/theme.json
+++ b/pixl/theme.json
@@ -31,7 +31,7 @@
         "color": {
             "duotone": [
                 {
-                    "colors": [ "#000000", "#FFFFFF" ],
+                    "colors": [ "#000000", "#040DE100" ],
                     "slug": "default-filter",
                     "name": "Default filter"
                 }

--- a/pixl/theme.json
+++ b/pixl/theme.json
@@ -31,7 +31,10 @@
         "color": {
             "duotone": [
                 {
-                    "colors": [ "#000000", "#040DE100" ],
+                    "colors": [
+                        "#000000",
+                        "#040DE100"
+                    ],
                     "slug": "default-filter",
                     "name": "Default filter"
                 }
@@ -264,25 +267,25 @@
                 }
             },
             "core/image": {
-				"filter": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
-				}
-			},
+                "filter": {
+                    "duotone": "var(--wp--preset--duotone--default-filter)"
+                }
+            },
             "core/post-featured-image": {
-				"filter": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
-				}
-			},
+                "filter": {
+                    "duotone": "var(--wp--preset--duotone--default-filter)"
+                }
+            },
             "core/cover": {
-				"filter": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
-				}
-			},
+                "filter": {
+                    "duotone": "var(--wp--preset--duotone--default-filter)"
+                }
+            },
             "core/post-author": {
-				"filter": {
-					"duotone": "var(--wp--preset--duotone--default-filter)"
-				}
-			},
+                "filter": {
+                    "duotone": "var(--wp--preset--duotone--default-filter)"
+                }
+            },
             "core/list": {
                 "spacing": {
                     "padding": {
@@ -404,23 +407,23 @@
                 }
             },
             "core/query-pagination": {
-				"elements": {
-					"link": {
-						"typography": {
-							"textDecoration": "none"
-						}
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
+                "elements": {
+                    "link": {
+                        "typography": {
+                            "textDecoration": "none"
+                        }
+                    }
+                }
+            },
+            "core/query-pagination-next": {
+                "typography": {
+                    "fontWeight": "500"
+                }
+            },
             "core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "500"
-				},
+                "typography": {
+                    "fontWeight": "500"
+                },
                 "elements": {
                     "link": {
                         "typography": {
@@ -429,12 +432,12 @@
                         }
                     }
                 }
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "500"
-				}
-			},
+            },
+            "core/query-pagination-previous": {
+                "typography": {
+                    "fontWeight": "500"
+                }
+            },
             "core/quote": {
                 "border": {
                     "color": "var(--wp--preset--color--primary)",
@@ -473,6 +476,9 @@
                     "radius": "0",
                     "style": "solid",
                     "width": "2px"
+                },
+                "filter": {
+                    "duotone": "var(--wp--preset--duotone--default-filter)"
                 }
             },
             "core/site-tagline": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/1935113/189305850-76db2f7a-e3fd-4991-8f80-9cc9d8c48bdb.png">

Duotone applied to the image is also applied to the border, and the shadow stays as primary color thus creating a difference.

Created an upstream issue here: https://github.com/WordPress/gutenberg/issues/44184

@henriqueiamarino to confirm on this behavior.

#### Related issue(s):
