### PR TITLE
Decibel: add footer template part

### DIFF
--- a/decibel/parts/footer.html
+++ b/decibel/parts/footer.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"decibel/footer"} /-->

--- a/decibel/patterns/footer.php
+++ b/decibel/patterns/footer.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Default footer
+ * Slug: decibel/footer
+ * Categories: footer
+ * Block Types: core/template-part/footer
+ */
+?>
+
+<!-- wp:spacer {"height":50} -->
+<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small","fontFamily":"rubik"} -->
+<p class="has-text-align-center has-rubik-font-family has-small-font-size" style="text-transform:uppercase">
+	<?php
+		/* Translators: Theme name. */
+		$theme_name = '<strong>' . esc_html__( 'Decibel Theme', 'decibel' ) . '</strong>';
+		/* Translators: WordPress link. */
+		$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'decibel' ) ) . '" rel="nofollow">WordPress</a>';
+		echo sprintf(
+		// Translators: Footer credits.
+			esc_html__( '%1$s, Proudly Powered by %2$s', 'decibel' ),
+			$theme_name,
+			$wordpress_link
+		);
+		?>
+</p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add footer template part, largely based on what @jffng did with Pixl's to keep things current.

#### Preview

<img width="722" alt="image" src="https://user-images.githubusercontent.com/1157901/189973471-a4fc536e-7b41-4bbe-99f9-71368608377b.png">

#### Related issue(s):
#6561
