### PR TITLE
Introduced some padding to Block Canvas' 404 template 

### DIFF
--- a/block-canvas/parts/header.html
+++ b/block-canvas/parts/header.html
@@ -24,6 +24,6 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":var(--wp--preset--spacing--50)} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
+<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/block-canvas/templates/404.html
+++ b/block-canvas/templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var(--wp--preset--spacing--80)","margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|60"}}}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--80)">
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|60"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--60)">
 	
 	<!-- wp:pattern {"slug":"block-canvas/404"} /-->
 	<!-- wp:search {"label":""} /-->

--- a/block-canvas/templates/404.html
+++ b/block-canvas/templates/404.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-group">
-
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"},"style":{"spacing":{"blockGap":"var(--wp--preset--spacing--80)","margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|60"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--80)">
+	
 	<!-- wp:pattern {"slug":"block-canvas/404"} /-->
 	<!-- wp:search {"label":""} /-->
 


### PR DESCRIPTION
(to be used in Decibel)


There were no comps in the figma for 404 page so I was planning to just roll the default and see how that shook out in the design review.  However the default was looking a mite crowded so instead of making a new template I updated the Block Canvas template.

Fixes #6556 

Before:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/146530/189982574-338c8003-9e22-4ba5-8581-ead7fa2f8756.png">

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/146530/189982524-4c4a806c-39db-48b1-99de-9b4545079aed.png">

<img width="371" alt="image" src="https://user-images.githubusercontent.com/146530/189982424-ebaf8d3e-16c2-4a64-93a8-69a7838766cf.png">
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/146530/189982463-b3ecb6ed-178e-4e4c-81e2-154a8067aec3.png">


After:
<img width="377" alt="image" src="https://user-images.githubusercontent.com/146530/189982188-104da0aa-3989-45c8-a7d8-e89d511ff780.png">
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/146530/189982224-74979b50-8c92-4c33-a977-a8510c8b5a07.png">
<img width="372" alt="image" src="https://user-images.githubusercontent.com/146530/189982362-b2953481-e538-4604-97a8-60cd8a1de584.png">
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/146530/189982307-3bd2cc6b-2331-44a7-9856-17b85601706a.png">
