### PR TITLE
Heiwa: Update navigation width

### DIFF
--- a/heiwa/assets/theme.css
+++ b/heiwa/assets/theme.css
@@ -1,0 +1,28 @@
+/**
+ * It looks like the responsive navigation is forced to be the wide width. https://github.com/WordPress/gutenberg/pull/43576
+ */
+
+.wp-block-navigation__responsive-close {
+	max-width: none;
+}
+
+/**
+ * Override the default padding value from Gutenberg to avoid the icon jumping
+ */
+.wp-block-navigation__responsive-container.is-menu-open {
+	padding-top: var(--wp--custom--gap--vertical);
+}
+
+/**
+ * Override Blockbase ponyfill style that makes navigation items left aligned.
+ */
+.wp-block-navigation.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content {
+	align-items: var(--navigation-layout-justification-setting,inherit);
+}
+
+/**
+ * Override Blockbase ponyfill style that makes navigation items left aligned.
+ */
+.wp-block-navigation.is-responsive .is-menu-open .wp-block-navigation__container {
+	align-items: var(--navigation-layout-justification-setting,initial);
+}

--- a/heiwa/assets/theme.css
+++ b/heiwa/assets/theme.css
@@ -1,7 +1,6 @@
 /**
- * It looks like the responsive navigation is forced to be the wide width. https://github.com/WordPress/gutenberg/pull/43576
+ * We need this until https://github.com/WordPress/gutenberg/issues/44182 gets resolved
  */
-
 .wp-block-navigation__responsive-close {
 	max-width: none;
 }
@@ -11,18 +10,4 @@
  */
 .wp-block-navigation__responsive-container.is-menu-open {
 	padding-top: var(--wp--custom--gap--vertical);
-}
-
-/**
- * Override Blockbase ponyfill style that makes navigation items left aligned.
- */
-.wp-block-navigation.is-responsive .is-menu-open .wp-block-navigation__responsive-container-content {
-	align-items: var(--navigation-layout-justification-setting,inherit);
-}
-
-/**
- * Override Blockbase ponyfill style that makes navigation items left aligned.
- */
-.wp-block-navigation.is-responsive .is-menu-open .wp-block-navigation__container {
-	align-items: var(--navigation-layout-justification-setting,initial);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This intends to override the width of the navigation that is currently forced to `wide` width in Gutenberg. Ref. https://github.com/WordPress/gutenberg/issues/44182

| Old | New |
| ----------- | ----------- |
| ![Screen Recording 9-20-2022 at 7 05 PM](https://user-images.githubusercontent.com/908665/191331994-acbac963-9dda-45ad-b96b-1c1c8fd95b77.gif) | ![Screen Recording 9-20-2022 at 7 03 PM](https://user-images.githubusercontent.com/908665/191332059-4a6ce0ae-d937-480f-aab2-501c958e7a95.gif) |



