### PR TITLE
defaulted the vscode settings to tabs over spaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
-    "editor.formatOnSave": true,
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "editor.detectIndentation": false,
-    "editor.tabSize": 4,
-    "editor.insertSpaces": true,
+	"editor.formatOnSave": true,
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"editor.detectIndentation": false,
+	"editor.insertSpaces": false
 }


### PR DESCRIPTION
I'm a fan of standards.  I'm not too keen on [IDE settings being in the project.](https://github.com/Automattic/themes/pull/6579)

At a minimum though we should be defaulting to tabs not spaces.

My (pretty strong) 'druthers is to remove the configuration completely and keep those settings in .gitignore but I can probably get over it.