### PR TITLE
Add table CSS to Blockbase and Decibel

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -60,3 +60,24 @@ GNU General Public License for more details.
 	color: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--secondary);
 }
+
+/**
+ * Currently table styles are only available with 'wp-block-styles' theme support (block css) thus the following needs to be included
+ * since 'wp-block-styles' aren't used for this theme.
+ */
+.wp-block-table thead {
+	border-bottom: 3px solid;
+}
+.wp-block-table tfoot {
+	border-top: 3px solid;
+}
+.wp-block-table td,
+.wp-block-table th {
+	padding: var(--wp--preset--spacing--30);
+	border: 1px solid;
+	word-break: normal;
+}
+.wp-block-table figcaption {
+	font-size: var(--wp--preset--font-size--small);
+	text-align: center;
+}

--- a/decibel/style.css
+++ b/decibel/style.css
@@ -22,6 +22,27 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	background-color: var(--wp--preset--color--primary);
 }
 
+/**
+ * Currently table styles are only available with 'wp-block-styles' theme support (block css) thus the following needs to be included
+ * since 'wp-block-styles' aren't used for this theme.
+ */
+.wp-block-table thead {
+	border-bottom: 3px solid;
+}
+.wp-block-table tfoot {
+	border-top: 3px solid;
+}
+.wp-block-table td,
+.wp-block-table th {
+	padding: var(--wp--preset--spacing--30);
+	border: 1px solid;
+	word-break: normal;
+}
+.wp-block-table figcaption {
+	font-size: var(--wp--preset--font-size--small);
+	text-align: center;
+}
+
 /*
  * Provide styles for a Block Style for navigation links
  */


### PR DESCRIPTION
Before is shown in #6566

After (Block Canvas):
<img width="662" alt="image" src="https://user-images.githubusercontent.com/146530/191073741-40c49e8c-6b3b-4b58-abd6-166517a097b7.png">

After (Decibel):
<img width="685" alt="image" src="https://user-images.githubusercontent.com/146530/191073791-2dd4f0a1-adfc-44b7-ac3c-659f0038ba7e.png">

Fixes #6566 
