### PR TITLE
Adding styling and layout for query lists pages index, archive, search

### DIFF
--- a/decibel/patterns/post-list.php
+++ b/decibel/patterns/post-list.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Title: Posts list
+ * Slug: decibel/posts-list
+ * Inserter: no
+ */
+?>
+
+<!-- wp:query {"tagName":"main"} -->
+<main class="wp-block-query">
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"var:style|root|padding-right","bottom":"0","left":"var:style|root|padding-left"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group" style="padding-top:0;padding-right:var(--wp--style--root--padding-right);padding-bottom:0;padding-left:var(--wp--style--root--padding-left)">
+
+<!-- wp:post-template -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns">
+
+	<!-- wp:column {"width":"215px"} -->
+	<div class="wp-block-column" style="flex-basis:215px">
+		<!-- wp:post-date {"isLink":true} /-->
+		<!-- wp:post-terms {"term":"category"} /-->
+		<!-- wp:post-terms {"term": "post_tag"} /-->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
+		<!-- wp:post-author {"showAvatar":false,"showBio":false} /-->
+		<!-- wp:post-excerpt /-->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column {"width":"215px"} -->
+	<div class="wp-block-column" style="flex-basis:215px">
+		<!-- wp:post-featured-image {"isLink":true} /-->
+	</div>
+	<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+<hr class="wp-block-separator has-alpha-channel-opacity" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)"/>
+<!-- /wp:separator -->
+
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination {"align":"wide", "paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-numbers /-->
+	<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+</div>
+<!-- /wp:group -->
+
+</main>
+<!-- /wp:query -->

--- a/decibel/templates/archive.html
+++ b/decibel/templates/archive.html
@@ -1,33 +1,13 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-query">
-<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"100px"}}}} /-->
-<!-- wp:post-template -->
-<!-- wp:group -->
-<div class="wp-block-group">
-	<!-- wp:post-title {"isLink":true} /-->
-	<!-- wp:post-featured-image {"isLink":true} /-->
-	<!-- wp:post-excerpt /-->
-	<!-- wp:template-part {"slug":"post-meta","layout":{"inherit":true}} /-->
-	<!-- wp:spacer {"height":40} -->
-	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"var:style|root|padding-right","bottom":"var:preset|spacing|60","left":"var:style|root|padding-left"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group" style="padding-top:0;padding-right:var(--wp--style--root--padding-right);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--style--root--padding-left)">
+
+<!-- wp:query-title {"type":"archive"} /-->
+
 </div>
 <!-- /wp:group -->
-<!-- /wp:post-template -->
-<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-	<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-previous /-->
 
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
-	</div>
-	<!-- /wp:group -->
-</main>
-<!-- /wp:query -->
+<!-- wp:pattern {"slug":"decibel/posts-list"} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/decibel/templates/index.html
+++ b/decibel/templates/index.html
@@ -1,33 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-	<!-- wp:group -->
-	<div class="wp-block-group">
-		<!-- wp:post-title {"isLink":true} /-->
-		<!-- wp:post-featured-image {"isLink":true} /-->
-		<!-- wp:post-excerpt /-->
-		<!-- wp:template-part {"slug":"post-meta"} /-->
-		<!-- wp:spacer {"height":40} -->
-		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-	</div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
-	<!-- wp:group {"layout":{"inherit":true}} -->
-		<div class="wp-block-group">
-		<!-- wp:query-pagination -->
-			<!-- wp:query-pagination-previous /-->
+<!-- wp:pattern {"slug":"decibel/posts-list"} /-->
 	
-			<!-- wp:query-pagination-numbers /-->
-	
-			<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-		</div>
-		<!-- /wp:group -->
-	</main>
-	<!-- /wp:query -->
-	
-	<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
-	
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/decibel/templates/search.html
+++ b/decibel/templates/search.html
@@ -10,38 +10,6 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:query {"layout":{"inherit":true}} -->
-<main class="wp-block-query">
-	<!-- wp:post-template -->
-	<!-- wp:group -->
-	<div class="wp-block-group">
-		<!-- wp:post-title {"isLink":true} /-->
-
-		<!-- wp:post-featured-image {"isLink":true} /-->
-
-		<!-- wp:post-excerpt /-->
-
-		<!-- wp:template-part {"slug":"post-meta","layout":{"inherit":true}} /-->
-
-		<!-- wp:spacer {"height":40} -->
-		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-	</div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
-
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-		<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-previous /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-	</div>
-	<!-- /wp:group -->
-</main>
-<!-- /wp:query -->
+<!-- wp:pattern {"slug":"decibel/posts-list"} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/decibel/theme.json
+++ b/decibel/theme.json
@@ -233,6 +233,11 @@
 					"textTransform": "uppercase"
 				}
 			},
+			"core/post-author": {
+				"typography": {
+					"textTransform": "uppercase"
+				}
+			},
 			"core/post-content": {
 				"elements": {
 					"link": {
@@ -243,11 +248,13 @@
 				}
 			},
 			"core/post-date": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
-				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
+					"textTransform": "uppercase"
+				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"textTransform": "uppercase"
 				}
 			},
 			"core/post-title": {
@@ -273,6 +280,14 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontStyle": "italic"
+				}
+			},
+			"core/query-pagination": {
+				"typography": {
+					"fontFamily": "rubik",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "500",
+					"textTransform": "uppercase"
 				}
 			},
 			"core/quote": {


### PR DESCRIPTION
This uses the style expressed in the figma for the 'Archive' templates in the index, search and archive templates.

Result:

Index:
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/146530/191322551-78c3fc08-84b0-4307-865b-b649b4926752.png">
<img width="374" alt="image" src="https://user-images.githubusercontent.com/146530/191322758-8f604a74-abbc-4571-b94d-9085a7b77ab7.png">

Search:
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/146530/191322660-9c41ea79-cea0-4740-ba23-a93361147346.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/146530/191322710-03438ee0-50b2-42c0-8199-c87852b954e2.png">

Archive:
<img width="1387" alt="image" src="https://user-images.githubusercontent.com/146530/191322854-747746ac-ffd3-4261-9702-0c484a031e4c.png">

<img width="373" alt="image" src="https://user-images.githubusercontent.com/146530/191322819-9b26633c-5da1-40d3-8ff8-ffd8de0229d1.png">

Fixes: #6555
Fixes: #6559
