### PR TITLE
Loudness: Add quote styles 

### DIFF
--- a/loudness/patterns/pullquote.php
+++ b/loudness/patterns/pullquote.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Title: Pullquote
+ * Slug: loudness/pullquote
+ * Categories: featured, text
+ */
+?>
+
+<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/texture.png'; ?>","id":1557,"dimRatio":0,"focalPoint":{"x":0.54,"y":0.48},"align":"full"} -->
+<div class="wp-block-cover alignfull"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-1557" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/texture.png'; ?>" style="object-position:54% 48%" data-object-fit="cover" data-object-position="54% 48%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|80","bottom":"var:preset|spacing|70","left":"var:preset|spacing|80"},"blockGap":"0"},"border":{"width":"3px"}},"borderColor":"foreground","backgroundColor":"background"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color has-background-background-color has-background" style="border-width:3px;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--80)"><!-- wp:paragraph {"align":"center","backgroundColor":"background","textColor":"foreground","fontSize":"large"} -->
+<p class="has-text-align-center has-foreground-color has-background-background-color has-text-color has-background has-large-font-size"><?php echo esc_html__( 'Has anyone ever said, "I wish I could go to more meetings today"?', 'loudness' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase"}},"backgroundColor":"background","textColor":"foreground","fontSize":"large","fontFamily":"rubik"} -->
+<p class="has-text-align-center has-foreground-color has-background-background-color has-text-color has-background has-rubik-font-family has-large-font-size" style="text-transform:uppercase"><strong><?php echo esc_html__( 'Matt Mullenweg', 'loudness' ); ?></strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -86,3 +86,49 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-navigation.wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container {
 	width: 100%;
 }
+
+/* Quote styles */
+.wp-block-quote {
+	font-size: var(--wp--preset--font-size--large);
+}
+
+.wp-block-quote cite {
+	text-transform: uppercase;
+	font-style: normal;
+	font-size: var(--wp--preset--font-size--medium);
+}
+
+.wp-block-quote cite::before {
+	content: "— ";
+}
+
+
+/* Pullquote Styles */
+.wp-block-pullquote {
+	background-image: url(./assets/illustrations/texture.png);
+	background-repeat: no-repeat;
+	background-size: cover;
+	border: none;
+}
+
+.wp-block-pullquote:not(.alignleft):not(.alignright):not(.alignwide) {
+	max-width: none !important;
+}
+
+.wp-block-pullquote blockquote {
+	background-color: var(--wp--preset--color--background);
+	padding: var(--wp--preset--spacing--70);
+	font-size: var(--wp--preset--font-size--large);
+	color: var(--wp--preset--color--foreground);
+	border: 3px solid var(--wp--preset--color--secondary);
+	max-width: var(--wp--style--global--content-size);
+	margin: 0 auto;
+}
+
+.wp-block-pullquote blockquote cite {
+	font-family: var(--wp--preset--font-family--rubik);
+	font-weight: 600;
+	text-transform: uppercase;
+	font-style: normal;
+}
+

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -92,12 +92,13 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 	font-size: var(--wp--preset--font-size--large);
 }
 
-.wp-block-quote cite {
+.wp-block-quote cite,
+.wp-block-pullquote cite {
 	text-transform: uppercase;
 	font-style: normal;
 	font-size: var(--wp--preset--font-size--medium);
 }
 
 .wp-block-quote cite::before {
-	content: "— ";
+	content: "- ";
 }

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -101,34 +101,3 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-quote cite::before {
 	content: "— ";
 }
-
-
-/* Pullquote Styles */
-.wp-block-pullquote {
-	background-image: url(./assets/illustrations/texture.png);
-	background-repeat: no-repeat;
-	background-size: cover;
-	border: none;
-}
-
-.wp-block-pullquote:not(.alignleft):not(.alignright):not(.alignwide) {
-	max-width: none !important;
-}
-
-.wp-block-pullquote blockquote {
-	background-color: var(--wp--preset--color--background);
-	padding: var(--wp--preset--spacing--70);
-	font-size: var(--wp--preset--font-size--large);
-	color: var(--wp--preset--color--foreground);
-	border: 3px solid var(--wp--preset--color--secondary);
-	max-width: var(--wp--style--global--content-size);
-	margin: 0 auto;
-}
-
-.wp-block-pullquote blockquote cite {
-	font-family: var(--wp--preset--font-family--rubik);
-	font-weight: 600;
-	text-transform: uppercase;
-	font-style: normal;
-}
-

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -88,10 +88,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 }
 
 /* Quote styles */
-.wp-block-quote {
-	font-size: var(--wp--preset--font-size--large);
-}
-
 .wp-block-quote cite,
 .wp-block-pullquote cite {
 	text-transform: uppercase;

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -86,15 +86,3 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 .wp-block-navigation.wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container {
 	width: 100%;
 }
-
-/* Quote styles */
-.wp-block-quote cite,
-.wp-block-pullquote cite {
-	text-transform: uppercase;
-	font-style: normal;
-	font-size: var(--wp--preset--font-size--medium);
-}
-
-.wp-block-quote cite::before {
-	content: "- ";
-}

--- a/loudness/theme.json
+++ b/loudness/theme.json
@@ -2,18 +2,18 @@
 	"customTemplates": [
 		{
 			"name": "blank",
-			"postTypes": ["page", "post"],
+			"postTypes": [
+				"page",
+				"post"
+			],
 			"title": "Blank"
 		},
 		{
-			"name": "header-footer-only",
-			"postTypes": ["page", "post"],
-			"title": "Header and Footer Only"
-		},
-		{
-			"name": "footer-only",
-			"postTypes": ["page", "post"],
-			"title": "Footer Only"
+			"name": "landing-page",
+			"postTypes": [
+				"page"
+			],
+			"title": "Landing Page"
 		}
 	],
 	"settings": {
@@ -52,7 +52,14 @@
 			"wideSize": "1200px"
 		},
 		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
+			"units": [
+				"%",
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
 		},
 		"typography": {
 			"fluid": true,
@@ -64,7 +71,9 @@
 							"fontFamily": "DM Mono",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"src": ["file:./assets/fonts/DMMono-Regular.ttf"]
+							"src": [
+								"file:./assets/fonts/DMMono-Regular.ttf"
+							]
 						}
 					],
 					"fontFamily": "'DM Mono', monospace",
@@ -79,7 +88,9 @@
 							"fontStretch": "normal",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": ["file:./assets/fonts/Rubik-Regular.woff2"]
+							"src": [
+								"file:./assets/fonts/Rubik-Regular.woff2"
+							]
 						},
 						{
 							"fontDisplay": "block",
@@ -87,7 +98,9 @@
 							"fontStretch": "normal",
 							"fontStyle": "normal",
 							"fontWeight": "500",
-							"src": ["file:./assets/fonts/Rubik-Medium.woff2"]
+							"src": [
+								"file:./assets/fonts/Rubik-Medium.woff2"
+							]
 						}
 					],
 					"fontFamily": "Rubik, sans-serif",
@@ -257,7 +270,17 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontStyle": "italic"
+					"fontStyle": "normal"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontStyle": "normal",
+							"textTransform": "uppercase",
+							"letterSpacing": "0.15em",
+							"fontSize": "var(--wp--preset--font-size--small)"
+						}
+					}
 				}
 			},
 			"core/query-pagination": {
@@ -281,7 +304,17 @@
 				},
 				"typography": {
 					"fontStyle": "normal",
-					"fontSize": "var(--wp--preset--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontStyle": "normal",
+							"textTransform": "uppercase",
+							"letterSpacing": "0.15em",
+							"fontSize": "var(--wp--preset--font-size--small)"
+						}
+					}
 				}
 			},
 			"core/search": {

--- a/loudness/theme.json
+++ b/loudness/theme.json
@@ -2,26 +2,17 @@
 	"customTemplates": [
 		{
 			"name": "blank",
-			"postTypes": [
-				"page",
-				"post"
-			],
+			"postTypes": ["page", "post"],
 			"title": "Blank"
 		},
 		{
 			"name": "header-footer-only",
-			"postTypes": [
-				"page",
-				"post"
-			],
+			"postTypes": ["page", "post"],
 			"title": "Header and Footer Only"
 		},
 		{
 			"name": "footer-only",
-			"postTypes": [
-				"page",
-				"post"
-			],
+			"postTypes": ["page", "post"],
 			"title": "Footer Only"
 		}
 	],
@@ -61,14 +52,7 @@
 			"wideSize": "1200px"
 		},
 		"spacing": {
-			"units": [
-				"%",
-				"px",
-				"em",
-				"rem",
-				"vh",
-				"vw"
-			]
+			"units": ["%", "px", "em", "rem", "vh", "vw"]
 		},
 		"typography": {
 			"fluid": true,
@@ -80,9 +64,7 @@
 							"fontFamily": "DM Mono",
 							"fontStretch": "normal",
 							"fontStyle": "normal",
-							"src": [
-								"file:./assets/fonts/DMMono-Regular.ttf"
-							]
+							"src": ["file:./assets/fonts/DMMono-Regular.ttf"]
 						}
 					],
 					"fontFamily": "'DM Mono', monospace",
@@ -97,9 +79,7 @@
 							"fontStretch": "normal",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/Rubik-Regular.woff2"
-							]
+							"src": ["file:./assets/fonts/Rubik-Regular.woff2"]
 						},
 						{
 							"fontDisplay": "block",
@@ -107,9 +87,7 @@
 							"fontStretch": "normal",
 							"fontStyle": "normal",
 							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/Rubik-Medium.woff2"
-							]
+							"src": ["file:./assets/fonts/Rubik-Medium.woff2"]
 						}
 					],
 					"fontFamily": "Rubik, sans-serif",
@@ -302,7 +280,8 @@
 					}
 				},
 				"typography": {
-					"fontStyle": "normal"
+					"fontStyle": "normal",
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"core/search": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Add styles for the Quote and Pullquote blocks.

Also, I'm approaching the Pullquote design in two ways; either as a Pattern, or by styling the block with CSS. The reason for this is that I find the CSS to get the default Pullquote block to look like we want it to a bit too involved. They look identical, except for the paragraph spacing on the Pattern one:

![image](https://user-images.githubusercontent.com/1157901/191436969-f4c5c4fe-fed8-468c-98e6-5b279e358a4f.png)


I would like to get your opinion on which option we should adopt. I'm leaning towards Patterns, as it allows us to show off how simple it is to implement this, as well as being safer in terms of customization — I'm not sure how well the CSS solution survives user customization.



#### Related issue(s):
Fixes: #6553
