### PR TITLE
refactored singular template's padding configuration

### DIFF
--- a/loudness/templates/singular.html
+++ b/loudness/templates/singular.html
@@ -1,15 +1,13 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group">
-
-	<!-- wp:post-featured-image {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}}} /-->
-
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:post-featured-image {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} /-->
 	<!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}}} /-->
-
-	<!-- wp:post-content {"layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
-</main>
+</div>
 <!-- /wp:group -->
+
+<!-- wp:post-content {"tagName":"main","layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
 
 <!-- wp:spacer {"height":"4rem"} -->
 <div style="height:4rem" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
This change moves the post-content out of a group which eliminates the odd padding behavior that was noted.

Before:
<img width="1616" alt="image" src="https://user-images.githubusercontent.com/146530/191819980-cb71c41a-a1c5-4127-9912-e78fbfb533a2.png">

After:
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/146530/191820475-90b90e06-1544-4bf8-a00e-c5ab5d55d684.png">
