### PR TITLE
Added a front-page template

### DIFF
--- a/loudness/patterns/front-page.php
+++ b/loudness/patterns/front-page.php
@@ -2,15 +2,17 @@
 /**
  * Title: Front Page
  * Slug: loudness/front-page
+ * Inserter: no
  */
 ?>
 
 <?php
 if ( 'posts' === get_option( 'show_on_front' ) ) {
 	// Show query
+	echo( '<!-- wp:spacer {"height":"var(--wp--preset--spacing--70)"} --><div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div><!-- /wp:spacer -->' );
 	echo( '<!-- wp:pattern {"slug":"loudness/posts-list"} /-->' );
 } else {
 	// show content
-	echo( '<!-- wp:post-content {"tagName":"main","layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->' );
+	echo( '<!-- wp:post-content {"tagName":"main","layout":{"inherit":true}} /-->' );
 }
 

--- a/loudness/patterns/front-page.php
+++ b/loudness/patterns/front-page.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Title: Front Page
+ * Slug: loudness/front-page
+ */
+?>
+
+<?php
+if ( 'posts' === get_option( 'show_on_front' ) ) {
+	// Show query
+	echo( '<!-- wp:pattern {"slug":"loudness/posts-list"} /-->' );
+} else {
+	// show content
+	echo( '<!-- wp:post-content {"tagName":"main","layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->' );
+}
+

--- a/loudness/patterns/post-list.php
+++ b/loudness/patterns/post-list.php
@@ -43,7 +43,7 @@
 <!-- /wp:columns -->
 
 <!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
-<hr class="wp-block-separator has-alpha-channel-opacity" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)"/>
+<hr class="wp-block-separator has-alpha-channel-opacity" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)"/>
 <!-- /wp:separator -->
 
 <!-- /wp:post-template -->

--- a/loudness/templates/front-page.html
+++ b/loudness/templates/front-page.html
@@ -7,7 +7,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"tagName":"main","layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+	<!-- wp:pattern {"slug":"loudness/front-page"} /-->	
 </div>
 <!-- /wp:group -->
 

--- a/loudness/templates/front-page.html
+++ b/loudness/templates/front-page.html
@@ -1,0 +1,14 @@
+<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group">
+
+	<!-- wp:group {"backgroundColor":"primary","layout":{"type":"default"}} -->
+	<div class="wp-block-group has-primary-background-color has-background">
+		<!-- wp:template-part {"slug":"header","theme":"themes/loudness","tagName":"header"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-content {"tagName":"main","layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
This change adds a stylized front-page template to loudness.

The background of the header is colored with the primary color.
There is no space between the header and content so that the design can be achieved.

Sample:

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/146530/191821611-7d2a48cc-f4ae-4db6-9de3-05b391816eeb.png">
