### PR TITLE
Adding missing svg assets

### DIFF
--- a/loudness/patterns/illustration-1.php
+++ b/loudness/patterns/illustration-1.php
@@ -7,6 +7,6 @@
 ?>
 <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full">
-	<img src="<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/illustration_1.jpg'; ?>" />
+	<img src="<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/illustration-1.jpg'; ?>" />
 </figure>
 <!-- /wp:image -->

--- a/loudness/patterns/illustration-2.php
+++ b/loudness/patterns/illustration-2.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Illustration 2
- * Slug: loudness/illustration_b2
+ * Slug: loudness/illustration_2
  * Categories: illustrations
  */
 ?>

--- a/loudness/patterns/illustration-2.php
+++ b/loudness/patterns/illustration-2.php
@@ -7,6 +7,6 @@
 ?>
 <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full">
-	<img src="<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/illustration_2.jpg'; ?>" />
+	<img src="<?php echo esc_url( get_stylesheet_directory_uri() ) . '/assets/illustrations/illustration-2.jpg'; ?>" />
 </figure>
 <!-- /wp:image -->


### PR DESCRIPTION
These were removed when I mistakenly thought that SVG files weren't allowed in themes.  Turns out the issue was with the filename having underscores, not with the content of the file.

This just puts them back.  They may be refactored to be png or webp files.