### PR TITLE
Remove 'button' style from navigation links in the responsive menu

### DIFF
--- a/loudness/style.css
+++ b/loudness/style.css
@@ -48,15 +48,22 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 /*
  * Provide styles for a Block Style for navigation links
  */
-.wp-block-navigation-link.is-style-navigation-link-button a {
+
+.wp-block-navigation .wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation-link.is-style-navigation-link-button a {
 	background-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	padding: 20px 30px !important;
 }
-
-.wp-block-navigation-link.is-style-navigation-link-button a:hover {
+.wp-block-navigation .wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation-link.is-style-navigation-link-button a:hover {
 	background-color: var(--wp--preset--color--primary);
 	color: var(--wp--preset--color--foreground);
+}
+
+/*
+ * Links in containers with the primary background color get special treatment
+ */
+.has-primary-background-color a:hover {
+	--wp--preset--color--primary: var(--wp--preset--color--background);
 }
 
 /*


### PR DESCRIPTION
Discussed during design review session.


Desktop (both before and after):

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/146530/192328202-5b1ba936-9889-4848-969c-c360502c6659.png">

Before:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/146530/192328354-de6de6b6-954c-47d9-bf69-2c9c8af76bd3.png">


After:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/146530/192328465-5388d2b8-ea3b-49c2-8ede-a9b76b4af603.png">
