### PR TITLE
Rebalance: #679: Fix overlapping content cards w/Lazy Load enabled

### DIFF
--- a/rebalance/inc/jetpack.php
+++ b/rebalance/inc/jetpack.php
@@ -278,3 +278,18 @@ function rebalance_remove_lazy_load_hooks() {
     add_action( 'wp_head', array( $instance, 'remove_filters' ), 10000 );
     remove_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_assets' ) );
 }
+
+/**
+ * Disable Lazy Loading on paged archives and homepage. Fixes overlapping content areas.
+ *
+ * @filter lazyload_is_enabled
+ * @return bool
+ */
+add_filter( 'lazyload_is_enabled', 'rebalance_lazyload_exclude', 15 );
+function rebalance_lazyload_exclude() {
+	if ( is_paged() || is_home() ) {
+		return false;
+	} else {
+		return true;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

With Lazy Load enabled content areas overlap. Fixed by excluding Jetpack Lazy Load from processing images on `is_paged()` and `is_home()` so that the JavaScript can size the containers properly.

##### Before With Lazy Load Enabled

<img width="759" alt="rebalance-01" src="https://user-images.githubusercontent.com/45246438/192340395-42945485-14e0-48b2-acc6-b14455b59521.png">

#####  Before Without Lazy Load Enabled:

<img width="778" alt="rebalance-02" src="https://user-images.githubusercontent.com/45246438/192340449-74b5e7e7-9331-4a3d-acf1-85a6bcf64629.png">

##### After Lazy Load Disabled via PHP:

<img width="759" alt="rebalance-03" src="https://user-images.githubusercontent.com/45246438/192340480-97002fb5-8f8f-49b3-889c-ecc855bc4756.png">


#### Related issue(s):

Fixes #679