### PR TITLE
#6612: Penscratch 2: Fix nested lists in editor

### DIFF
--- a/penscratch-2/editor-style.css
+++ b/penscratch-2/editor-style.css
@@ -86,12 +86,6 @@ ol {
     list-style: decimal;
 }
 
-li > ul,
-li > ol {
-    margin-bottom: 0;
-    margin-left: 24px;
-}
-
 dt {
     font-weight: 600;
 }
@@ -298,8 +292,8 @@ ol ol ol {
     list-style: lower-roman;
 }
 
-li > ul,
-li > ol {
+.block-editor-block-list__block li > ul,
+.block-editor-block-list__block li > ol {
     margin-bottom: 0;
     margin-left: 27px;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

To test you need to activate Gutenberg v14.1 otherwise it doesn't happen. I also removed a duplicate declaration.

##### Before

<img width="1197" alt="Screenshot on 2022-09-26 at 15-29-55" src="https://user-images.githubusercontent.com/45246438/192364600-cde07fb4-4619-41e6-a52d-49359f43b297.png">

##### After

<img width="1050" alt="Screenshot on 2022-09-26 at 15-28-21" src="https://user-images.githubusercontent.com/45246438/192364614-048322b2-4fbd-40b7-8f67-10f4c0a519eb.png">

#### Related issue(s):

Fixes #6612