### PR TITLE
#6447: Pique: Remove border-top from social icons

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -1799,7 +1799,7 @@ blockquote
 	margin: 0;
 	padding: 0;
 }
-.widget ul a {
+.widget ul:not(.wp-block-social-links) a {
 	border-top: 1px solid rgba(233, 213, 192, 0.5);
 	color: #2d2a26;
 	display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

##### Before

<img width="526" alt="Screenshot on 2022-09-29 at 10-20-58" src="https://user-images.githubusercontent.com/45246438/193061215-d69d0177-5199-4a39-9792-a170ac6b36bc.png">


##### After
<img width="185" alt="Screenshot on 2022-09-29 at 10-37-29" src="https://user-images.githubusercontent.com/45246438/193061341-630dd2b0-4d3d-4d5b-b0bc-7462550ce440.png">



#### Related issue(s):

Fixes #6447