### PR TITLE
Filter out any fonts provided by Pendant from being loaded by Jetpack

### DIFF
--- a/pendant/functions.php
+++ b/pendant/functions.php
@@ -68,5 +68,28 @@ function pendant_register_block_pattern_categories() {
 	register_block_pattern_category( 'images', array( 'label' => __( 'Images', 'pendant' ) ) );
 	register_block_pattern_category( 'gallery', array( 'label' => __( 'Gallery', 'pendant' ) ) );
 }
-	
+
 add_action( 'init', 'pendant_register_block_pattern_categories', 9 );
+
+/**
+ * Jetpack may attempt to register fonts for the Google Font Provider.
+ * If Jetpack registeres fonts in the same family as what this theme offers
+ * then those are included instead (and may be different typeface choices
+ * than what are expressed here.)
+ * This filter eliminates the fonts that Pendant natively supplies.
+ *
+ * This will no longer be needed once this Jetpack issue has been resolved:
+ * https://github.com/Automattic/jetpack/issues/25987
+ */
+function pendant_filter_jetpack_google_fonts_list( $list_to_filter ) {
+	$filtered = array_filter(
+		$list_to_filter,
+		function( $font_family ) {
+			return 'Jost' !== $font_family && 'Literata' !== $font_family;
+		}
+	);
+	return $filtered;
+}
+
+add_filter( 'jetpack_google_fonts_list', 'pendant_filter_jetpack_google_fonts_list' );
+


### PR DESCRIPTION
This is a "band-aid" solution until this Jetpack issue is resolved: https://github.com/Automattic/jetpack/issues/25987

Filter out any fonts from being loaded by Jetpack that are defined by Pendant.

Before:
<img width="840" alt="image" src="https://user-images.githubusercontent.com/146530/193084224-22e64a66-e3f4-4f92-b272-2259290bac88.png">

After:

<img width="857" alt="image" src="https://user-images.githubusercontent.com/146530/193084298-fb9e372e-801c-4cb6-b7eb-d4ffc4a810c8.png">

