### PR TITLE
#3957: Ixion: Add padding to group block

### DIFF
--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -402,6 +402,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin: 0 auto;
 }
 
+.wp-block-group.has-background {
+	padding: 20px 30px;
+}
+
 /* Seperator */
 
 hr.wp-block-separator {

--- a/ixion/blocks.css
+++ b/ixion/blocks.css
@@ -406,6 +406,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 20px 30px;
 }
 
+.wp-block-group p.has-background {
+	padding: 0;
+}
+
 /* Seperator */
 
 hr.wp-block-separator {

--- a/ixion/editor-blocks.css
+++ b/ixion/editor-blocks.css
@@ -665,6 +665,10 @@ table.wp-block-table th {
 	padding: 20px 30px;
 }
 
+.wp-block-group p.has-background {
+	padding: 0;
+}
+
 /*--------------------------------------------------------------
 6.0 Blocks - Widgets
 --------------------------------------------------------------*/

--- a/ixion/editor-blocks.css
+++ b/ixion/editor-blocks.css
@@ -655,9 +655,14 @@ table.wp-block-table th {
 	margin-bottom: 1.5em;
 }
 
-
 .wp-block-separator.is-style-wide {
 	max-width: 100%;
+}
+
+/* Group */
+
+.wp-block-group.has-background {
+	padding: 20px 30px;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:

- Added code to bring parity to editor and frontend view. St
- Standardized group block padding to use the same value if background is set and if border is set

#### Before

##### Editor:

<img width="722" alt="Screenshot on 2022-09-29 at 14-38-51" src="https://user-images.githubusercontent.com/45246438/193118386-fcfd71ee-09b6-40ca-931e-31bd54e91605.png">

##### Frontend:

<img width="780" alt="Screenshot on 2022-09-29 at 14-30-19" src="https://user-images.githubusercontent.com/45246438/193118364-7db97bba-8ff9-4c8c-9557-ad8fa3a095ea.png">

#### After

##### Frontend:
<img width="755" alt="Screenshot on 2022-09-29 at 14-40-58" src="https://user-images.githubusercontent.com/45246438/193118592-8f91d465-d478-4221-a1ae-e2096a742a58.png">

#### Related issue(s):

Fixes #3957 