### PR TITLE
#6642: Pique: Fix social link widget background color

### DIFF
--- a/pique/style.css
+++ b/pique/style.css
@@ -1805,7 +1805,7 @@ blockquote
 	display: block;
 	padding: 7px 0;
 }
-.widget ul a:hover {
+.widget ul:not(.wp-block-social-links) a:hover {
 	background-color: rgba(233, 213, 192, 0.15);
 	border-bottom: none;
 }
@@ -2133,7 +2133,7 @@ body:not(.no-background-fixed) .site-footer {
 #tertiary .widget:not(.widget_wpcom_social_media_icons_widget):not(.jetpack_widget_social_icons) ul a {
 	color: #fcfbf9;
 }
-#tertiary .widget:not(.widget_wpcom_social_media_icons_widget):not(.jetpack_widget_social_icons) ul a:hover {
+#tertiary .widget:not(.widget_wpcom_social_media_icons_widget):not(.jetpack_widget_social_icons) ul:not(.wp-block-social-links) a:hover {
 	background-color: rgba(45, 42, 38, 0.95);
 }
 #tertiary .widget_archive ul li::before,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Footer widget now has the same style as sidebar

##### Before

<img width="521" alt="Screen Shot 2022-09-30 at 10 18 58" src="https://user-images.githubusercontent.com/45246438/193293366-70556ba9-b753-4a2c-a525-3e308f9daa87.png">


##### After

<img width="550" alt="Screen Shot 2022-09-30 at 10 24 11" src="https://user-images.githubusercontent.com/45246438/193293493-3eddad8b-5800-4288-9fa1-842572aaaec4.png">


#### Related issue(s):

Fixes #6642 