### PR TITLE
#1815: Intergalactic 2: Fix Goodreads widget link colors

### DIFF
--- a/intergalactic-2/style.css
+++ b/intergalactic-2/style.css
@@ -1119,8 +1119,8 @@ a:active {
 .widget select {
 	max-width: 100%;
 }
-.widget a,
-.site-footer .widget a {
+.widget:not(.widget_goodreads) a,
+.site-footer .widget:not(.widget_goodreads) a {
 	color: white;
 }
 .widget a:hover {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

To test this, you can use Intergalactic 2 on a Jetpack site and add the Goodreads widget to the footer.

#### Changes proposed in this Pull Request:

##### Before

<img width="1800" alt="Screenshot on 2022-09-30 at 11-35-50" src="https://user-images.githubusercontent.com/45246438/193317934-22e97d5b-80e3-4b19-a1ae-6135430a4840.png">


##### Test
<img width="764" alt="Screenshot on 2022-09-30 at 12-38-03" src="https://user-images.githubusercontent.com/45246438/193317956-5e5be7fe-374f-412a-8b1d-020cb533f59f.png">



#### Related issue(s):

#1815 