### PR TITLE
#6086: Heiwa: Fix list indents

### DIFF
--- a/heiwa/theme.json
+++ b/heiwa/theme.json
@@ -124,6 +124,13 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/list": {
+				"spacing": {
+					"padding": {
+						"left": "var(--wp--custom--gap--horizontal)"
+					}
+				}
+			},
 			"core/post-title": {
 				"typography": {
 					"lineHeight": "1.39"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

I added default left padding in `theme.json` to fix this. 

##### Before

<img width="683" alt="Screenshot on 2022-09-30 at 12-49-31" src="https://user-images.githubusercontent.com/45246438/193321617-ab3ae07a-5840-42e2-872e-9d5b23708d28.png">


##### After

<img width="539" alt="Screenshot on 2022-09-30 at 12-59-46" src="https://user-images.githubusercontent.com/45246438/193321639-25733d02-bc65-4b5f-b4cd-343171d57842.png">


#### Related issue(s):

Fixes #6086