### PR TITLE
#5826: Barnsbury: Fix menu bg w/custom colors

### DIFF
--- a/barnsbury/sass/_extra-child-theme.scss
+++ b/barnsbury/sass/_extra-child-theme.scss
@@ -172,6 +172,20 @@ a {
 	}
 }
 
+.custom-colors .main-navigation > div > ul > li:focus-within li > a,
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a {
+	background: none;
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > ul::before {
+	border-bottom: unset;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > a {
+	color: inherit;
+}
+
 /**
  * Main
  */

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -4217,6 +4217,34 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	}
 }
 
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a,
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a {
+	background: none;
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within li > a,
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a {
+	background: none;
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li[focus-within] > ul::before {
+	border-bottom: unset;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > ul::before {
+	border-bottom: unset;
+}
+
+.custom-colors .main-navigation > div > ul > li[focus-within] > a {
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > a {
+	color: inherit;
+}
+
 /**
  * Main
  */

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -4246,6 +4246,34 @@ body.admin-bar .widget_eu_cookie_law_widget.widget.top {
 	}
 }
 
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a,
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a {
+	background: none;
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within li > a,
+.custom-colors .main-navigation > div > ul > li[focus-within] li > a {
+	background: none;
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li[focus-within] > ul::before {
+	border-bottom: unset;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > ul::before {
+	border-bottom: unset;
+}
+
+.custom-colors .main-navigation > div > ul > li[focus-within] > a {
+	color: inherit;
+}
+
+.custom-colors .main-navigation > div > ul > li:focus-within > a {
+	color: inherit;
+}
+
 /**
  * Main
  */


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Testing:

- This only happens on WPCOM
- Activate Barnsbury, change the color palette
- Hover over a sub-menu and right-click, it will show the default Barnsbury menu style which isn't consistent with the variations
- Apply PR and try again, it should fix the issue

##### Before

###### Dropdown Menu

<img width="322" alt="Screenshot on 2022-09-30 at 14-37-01" src="https://user-images.githubusercontent.com/45246438/193335663-9762b312-da6e-4899-9f35-ab0f98070d30.png">


###### Dropdown Menu when Right Clicking

<img width="356" alt="Screenshot on 2022-09-30 at 14-17-43" src="https://user-images.githubusercontent.com/45246438/193334403-a46d0801-5743-4873-ad81-ef5d4f30bb94.png">


##### After

![CLKUv1mVZB thumb](https://user-images.githubusercontent.com/45246438/193334644-819c7e50-bcef-4feb-942e-0669ee19fc08.png)


#### Related issue(s):

Fixes #5826