### PR TITLE
Videomaker: Fix primary color usage

### DIFF
--- a/videomaker-white/theme.json
+++ b/videomaker-white/theme.json
@@ -53,8 +53,8 @@
 			"color": {
 				"foreground": "var(--wp--preset--color--foreground)",
 				"background": "var(--wp--preset--color--background)",
-				"primary": "var(--wp--preset--color--foreground)",
-				"secondary": "var(--wp--preset--color--foreground)",
+				"primary": "var(--wp--preset--color--primary)",
+				"secondary": "var(--wp--preset--color--secondary)",
 				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"fontSizes": {

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -53,8 +53,8 @@
 			"color": {
 				"foreground": "var(--wp--preset--color--foreground)",
 				"background": "var(--wp--preset--color--background)",
-				"primary": "var(--wp--preset--color--foreground)",
-				"secondary": "var(--wp--preset--color--foreground)",
+				"primary": "var(--wp--preset--color--primary)",
+				"secondary": "var(--wp--preset--color--secondary)",
 				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"fontSizes": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Currently, when setting a custom primary color, the foreground color is used instead, as described here: https://github.com/Automattic/wp-calypso/issues/65609

![image](https://user-images.githubusercontent.com/3801502/194165336-3816cddd-257d-4fff-8647-196d78cbbc23.png)


I've tracked the issue to the global variable `--wp--custom--color--primary` being set to `--wp--preset--color--foreground`.

![image](https://user-images.githubusercontent.com/3801502/194164819-9c3458f8-2023-4e9e-8055-d07135746fe8.png)

as opposed to what happens in other themes:

![image](https://user-images.githubusercontent.com/3801502/194164882-57d689ef-16bb-4f9f-9a14-9d6319d91e17.png)

This PR changes `theme.json` to fix that for both Videomaker and Videomaker White.

Closes https://github.com/Automattic/wp-calypso/issues/65609