### PR TITLE
#6648: Independent Publisher 2: Table Block Border Surrounds Caption

### DIFF
--- a/independent-publisher-2/css/editor-blocks.css
+++ b/independent-publisher-2/css/editor-blocks.css
@@ -494,7 +494,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Table */
 
-.wp-block-table,
+.wp-block-table table,
 .wp-block-table th,
 .wp-block-table td {
 	border: 1px solid #ddd;
@@ -503,7 +503,6 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-table  {
 	border-collapse: separate;
 	border-spacing: 0;
-	border-width: 1px 0 0 1px;
 	font-size: 90%;
 	margin: 0 0 1.75em;
 	table-layout: fixed;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

I'm updating the Table block code to ensure that in the page/post editor, borders will only be applied to the Table block, but not to captions below the table.

 <table>
    <thead>
      <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/195217118-829c4b4d-c498-4771-92ee-4914cf7ad02d.png"/></td>
        <td><img src="https://user-images.githubusercontent.com/50875131/195217123-167aa7d8-d8ea-457b-b51d-7eee8e273e9c.png"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):

Related issue: #6648