### PR TITLE
#5189: Exford: Quote block: font size not respected

### DIFF
--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2101,7 +2101,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1022,10 +1022,10 @@ footer {
  */
 blockquote {
 	padding-right: 16px;
+	font-size: 1.2rem;
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }

--- a/exford/style.css
+++ b/exford/style.css
@@ -1022,10 +1022,10 @@ footer {
  */
 blockquote {
 	padding-left: 16px;
+	font-size: 1.2rem;
 }
 
 blockquote p {
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }
@@ -2101,7 +2101,6 @@ p.has-background {
 .wp-block-quote p {
 	font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	font-family: var(--font-headings, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif);
-	font-size: 1.2rem;
 	letter-spacing: normal;
 	line-height: 1.125;
 }


### PR DESCRIPTION
**The issue is already fixed on the parent Varia theme. PR pending merge. I'm not sure why I didn't notice that** 😵‍💫 

#### Changes proposed in this Pull Request:

The changes made on this commit ensure that: 

* When adding a quote block to a page, the size that shows in the editor will be respected on the live page. This will be the default font size for the blockquote element.

 <table>
    <thead>
      <tr>
        <th>Default Font Size: Editor vs Page</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/195934961-a7ec0aba-34f7-4088-bf1f-c8ae875e82db.png"/></td>
      </tr>
    </tbody>
  </table>

* Custom font sizes will have higher specificity and will overwrite the default font size – above.

<table>
    <thead>
      <tr>
        <th>Custom Font Size: Editor vs Page</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/195937002-f60a2a34-8252-4f78-a3d6-6d5bf8cee70f.png"/></td>
      </tr>
    </tbody>
  </table>

* When selecting one of the predefined font sizes (S, M, L, and XL), the classes that apply this change won't be overwritten by the default font size.

<table>
    <thead>
      <tr>
        <th>Predefined Font Size: Editor vs Page</th>
    </tr>
    </thead>
    <tbody>
      <tr>
        <td><img src="https://user-images.githubusercontent.com/50875131/195936962-68e5b522-cecf-41c4-8421-c5501ea913e3.png"/></td>
      </tr>
    </tbody>
  </table>

#### Related issue(s):
[Exford - Quote block: typography font size (Gutenberg) not respected.](https://github.com/Automattic/themes/issues/5189#top)
#5189 