### PR TITLE
Archeo: Improve block markup and fix block errors

### DIFF
--- a/archeo/patterns/footer.php
+++ b/archeo/patterns/footer.php
@@ -13,15 +13,15 @@
 	<div class="wp-block-group alignwide" style="padding-top: var(--wp--custom--spacing--medium); padding-bottom: var(--wp--custom--spacing--medium);">
 		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayMenu":"never","className":"site-footer","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":{"top":"0.5em","left":"2.5em","bottom":"0.5rem","right":"2.5em"}}},"fontSize":"small"} /-->
 		
-		<!-- wp:paragraph {"align":"left","style":{"spacing":{"margin":{"top":0}}},"fontSize":"small"} -->
-		<p class="has-text-align-left has-small-font-size" style="margin-top: 0;">
-			<?php
-			printf(
-				/* Translators: WordPress link. */
-				esc_html__( 'Proudly powered by %s', 'archeo' ),
-				'<a href="' . esc_url( __( 'https://wordpress.org', 'archeo' ) ) . '" rel="nofollow">WordPress</a>'
-			);
-			?>
+		<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
+		<p class="has-text-align-left has-small-font-size">
+		<?php
+		printf(
+			/* Translators: WordPress link. */
+			esc_html__( 'Proudly powered by %s', 'twentytwentythree' ),
+			'<a href="' . esc_url( __( 'https://wordpress.org', 'archeo' ) ) . '" rel="nofollow">WordPress</a>'
+		)
+		?>
 		</p>
 		<!-- /wp:paragraph -->
 	</div>

--- a/archeo/patterns/footer.php
+++ b/archeo/patterns/footer.php
@@ -12,8 +12,9 @@
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"},"style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--medium)","top":"var(--wp--custom--spacing--medium)"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top: var(--wp--custom--spacing--medium); padding-bottom: var(--wp--custom--spacing--medium);">
 		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"overlayMenu":"never","className":"site-footer","style":{"typography":{"fontStyle":"normal"},"spacing":{"blockGap":{"top":"0.5em","left":"2.5em","bottom":"0.5rem","right":"2.5em"}}},"fontSize":"small"} /-->
-		<!-- wp:paragraph {"align":"left","fontSize":"small","style":{"spacing":{"margin":{"top":0}}}} -->
-		<p class="has-small-font-size" style="margin-top: 0;">
+		
+		<!-- wp:paragraph {"align":"left","style":{"spacing":{"margin":{"top":0}}},"fontSize":"small"} -->
+		<p class="has-text-align-left has-small-font-size" style="margin-top: 0;">
 			<?php
 			printf(
 				/* Translators: WordPress link. */
@@ -21,6 +22,9 @@
 				'<a href="' . esc_url( __( 'https://wordpress.org', 'archeo' ) ) . '" rel="nofollow">WordPress</a>'
 			);
 			?>
-		</p><!-- /wp:paragraph -->
-	</div><!-- /wp:group -->
-</div><!-- /wp:group -->
+		</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/archeo/patterns/footer.php
+++ b/archeo/patterns/footer.php
@@ -18,7 +18,7 @@
 		<?php
 		printf(
 			/* Translators: WordPress link. */
-			esc_html__( 'Proudly powered by %s', 'twentytwentythree' ),
+			esc_html__( 'Proudly powered by %s', 'archeo' ),
 			'<a href="' . esc_url( __( 'https://wordpress.org', 'archeo' ) ) . '" rel="nofollow">WordPress</a>'
 		)
 		?>

--- a/archeo/patterns/layered-images-with-headline.php
+++ b/archeo/patterns/layered-images-with-headline.php
@@ -18,9 +18,10 @@
 				<div style="height:14vw" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
-				<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"100","lineHeight":"1"}}} -->
+				<!-- wp:paragraph {"style":{"typography":{"fontSize":"clamp(64px, 6vw, 100px)","textTransform":"uppercase","fontStyle":"normal","fontWeight":"100","lineHeight":"1"}}} -->
 				<p style="font-size:clamp(64px, 6vw, 100px);font-style:normal;font-weight:100;line-height:1;text-transform:uppercase"><?php echo wp_kses_post( __( 'Palace of <br>the Circus at <br>Chichen-Itza, <br><em>bas-relief</em> of <br>tigers', 'archeo' ) ); ?></p>
-				<!-- /wp:paragraph --></div>
+				<!-- /wp:paragraph -->
+			</div>
 			<!-- /wp:column -->
 
 			<!-- wp:column {"verticalAlignment":"top"} -->

--- a/archeo/patterns/layered-images-with-headline.php
+++ b/archeo/patterns/layered-images-with-headline.php
@@ -6,8 +6,8 @@
  */
 ?>
 
-<!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/palais-du-cirque.jpg","dimRatio":80,"overlayColor":"background","minHeight":100,"minHeightUnit":"vh","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0vw"},"margin":{"top":"0px"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-top:0px;padding-bottom:0vw;margin-top:0px;min-height:100vh"><span aria-hidden="true" class="has-background-background-color has-background-dim-80 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Photo of Palace of the Circus', 'archeo' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/palais-du-cirque.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container">
+<!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/palais-du-cirque.jpg","dimRatio":80,"overlayColor":"background","minHeight":100,"minHeightUnit":"vh","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"3vw","right":"0px","left":"0px"},"margin":{"top":"0px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-top:0px;padding-top:0px;padding-right:0px;padding-bottom:3vw;padding-left:0px;min-height:100vh"><span aria-hidden="true" class="has-background-background-color has-background-dim-80 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Photo of Palace of the Circus', 'archeo' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/palais-du-cirque.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container">
 	<!-- wp:group {"layout":{"inherit":"true"}} -->
 	<div class="wp-block-group">
 		<!-- wp:columns {"verticalAlignment":"top","align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0"}}}} -->

--- a/archeo/patterns/simple-list-of-posts-with-background.php
+++ b/archeo/patterns/simple-list-of-posts-with-background.php
@@ -23,7 +23,7 @@
 			<div class="wp-block-group simple-list-of-posts">
 				<!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
 
-				<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"}},"fontSize":"medium"} /-->
+				<!-- wp:post-author {"showAvatar":false,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"}},"fontSize":"medium"} /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- /wp:post-template -->

--- a/archeo/patterns/simple-list-of-posts-with-background.php
+++ b/archeo/patterns/simple-list-of-posts-with-background.php
@@ -16,21 +16,29 @@
 		<h3 class="has-medium-font-size" style="margin-bottom:40px"><?php _e( 'Selected Writings', 'archeo' ); ?></h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:query {"queryId":3,"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":3}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"className":"simple-list-of-posts","layout":{"type":"flex","allowOrientation":false}} -->
-		<div class="wp-block-group simple-list-of-posts"><!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
+		<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":3,"parents":[]}} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template -->
+			<!-- wp:group {"className":"simple-list-of-posts","layout":{"type":"flex","allowOrientation":false}} -->
+			<div class="wp-block-group simple-list-of-posts">
+				<!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
 
-		<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"}},"fontSize":"medium"} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template -->
-		<!-- wp:spacer {"height":"40px"} -->
-		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-		<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"space-between"}} -->
-		<!-- wp:query-pagination-previous /-->
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination --></div>
-		<!-- /wp:query --></div>
-	<!-- /wp:group --></div>
+				<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"}},"fontSize":"medium"} /-->
+			</div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template -->
+
+			<!-- wp:spacer {"height":"40px"} -->
+			<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"space-between"}} -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:query -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->

--- a/archeo/patterns/simple-list-of-posts.php
+++ b/archeo/patterns/simple-list-of-posts.php
@@ -9,20 +9,27 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium)","bottom":"var(--wp--custom--spacing--medium)"},"margin":{"top":"0px"}}}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--medium);padding-bottom:var(--wp--custom--spacing--medium);margin-top:0px">
-	<!-- wp:query {"queryId":3,"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":3}} -->
-	<div class="wp-block-query"><!-- wp:post-template -->
-	<!-- wp:group {"className":"simple-list-of-posts","layout":{"type":"flex","allowOrientation":false}} -->
-	<div class="wp-block-group simple-list-of-posts"><!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
+	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":3,"parents":[]}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
+		<!-- wp:group {"className":"simple-list-of-posts","layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group simple-list-of-posts">
+			<!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
 
-	<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"},"spacing":{"margin":{"top":"0px"}}},"fontSize":"medium"} /--></div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
-	<!-- wp:spacer {"height":"40px"} -->
-	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-	<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:query-pagination-previous /-->
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination --></div>
-	<!-- /wp:query --></div>
+			<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"},"spacing":{"margin":{"top":"0px"}}},"fontSize":"medium"} /-->
+		</div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:spacer {"height":"40px"} -->
+		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+
+		<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:query -->
+</div>
 <!-- /wp:group -->

--- a/archeo/patterns/simple-list-of-posts.php
+++ b/archeo/patterns/simple-list-of-posts.php
@@ -16,7 +16,7 @@
 		<div class="wp-block-group simple-list-of-posts">
 			<!-- wp:post-title {"isLink":true,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"},"spacing":{"margin":{"top":"1.25rem"}}},"fontSize":"huge"} /-->
 
-			<!-- wp:post-author-name {"style":{"typography":{"fontStyle":"normal","fontWeight":"100","lineHeight":"1.2"},"spacing":{"margin":{"top":"0px"}}},"fontSize":"medium"} /-->
+			<!-- wp:post-author {"showAvatar":false,"style":{"typography":{"lineHeight":"1.2","fontStyle":"normal","fontWeight":"100"}},"fontSize":"medium"} /-->
 		</div>
 		<!-- /wp:group -->
 		<!-- /wp:post-template -->

--- a/archeo/templates/404.html
+++ b/archeo/templates/404.html
@@ -2,10 +2,11 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-<!-- wp:pattern {"slug":"archeo/hidden-404"} /-->
-</div>
-<!-- /wp:group --></main>
+    <div class="wp-block-group">
+        <!-- wp:pattern {"slug":"archeo/hidden-404"} /-->
+    </div>
+    <!-- /wp:group -->
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/archive.html
+++ b/archeo/templates/archive.html
@@ -2,18 +2,19 @@
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">
-<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
-<!-- wp:post-template -->
-<!-- wp:template-part {"slug":"query"} /-->
-<!-- /wp:post-template -->
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:query-pagination-previous /-->
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
+	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
+	<!-- wp:post-template -->
+		<!-- wp:template-part {"slug":"query"} /-->
+	<!-- /wp:post-template -->
+	
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
 	</div>
-<!-- /wp:group -->
+	<!-- /wp:group -->
 </main>
 <!-- /wp:query -->
 

--- a/archeo/templates/home.html
+++ b/archeo/templates/home.html
@@ -4,7 +4,8 @@
 <div class="wp-block-group">
 	<!-- wp:pattern {"slug":"archeo/image-with-headline-description"} /-->
 	<!-- wp:pattern {"slug":"archeo/simple-list-of-posts-with-background"} /-->
-	<!-- wp:pattern {"slug":"archeo/layered-images-with-headline"} /--></div>
+	<!-- wp:pattern {"slug":"archeo/layered-images-with-headline"} /-->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"area":"footer","slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/index.html
+++ b/archeo/templates/index.html
@@ -2,17 +2,18 @@
 
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">
-<!-- wp:post-template -->
-<!-- wp:template-part {"slug":"query"} /-->
-<!-- /wp:post-template -->
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<!-- wp:query-pagination-previous /-->
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
+	<!-- wp:post-template -->
+		<!-- wp:template-part {"slug":"query"} /-->
+	<!-- /wp:post-template -->
+
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
 	</div>
-<!-- /wp:group -->
+	<!-- /wp:group -->
 </main>
 <!-- /wp:query -->
 

--- a/archeo/templates/page-no-title.html
+++ b/archeo/templates/page-no-title.html
@@ -1,11 +1,15 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
-<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)"}}}} /--></div>
-<!-- /wp:group -->
+<main class="wp-block-group">
+    <!-- wp:group {"layout":{"inherit":true}} -->
+    <div class="wp-block-group">
+        <!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)"}}}} /-->
+    </div>
+    <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /--></main>
+    <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/page.html
+++ b/archeo/templates/page.html
@@ -1,17 +1,21 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
-<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1} /-->
+<main class="wp-block-group">
+    <!-- wp:group {"layout":{"inherit":true}} -->
+    <div class="wp-block-group">
+        <!-- wp:post-title {"level":1} /-->
 
-<!-- wp:spacer {"height":1} -->
-<div style="height:1px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+        <!-- wp:spacer {"height":1} -->
+        <div style="height:1px" aria-hidden="true" class="wp-block-spacer"></div>
+        <!-- /wp:spacer -->
 
-<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)"}}}} /--></div>
-<!-- /wp:group -->
+        <!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)"}}}} /-->
+    </div>
+    <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /--></main>
+    <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/archeo/templates/search.html
+++ b/archeo/templates/search.html
@@ -3,20 +3,23 @@
 <!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
 <main class="wp-block-query">
 	<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
+
 	<!-- wp:spacer {"height":40} -->
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
+
 	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"60px"}}}} /-->
 	<!-- wp:post-template -->
-	<!-- wp:template-part {"slug":"query"} /-->
+		<!-- wp:template-part {"slug":"query"} /-->
 	<!-- /wp:post-template -->
+
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
-		<!-- wp:query-pagination-previous /-->
-		<!-- wp:query-pagination-next /-->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-next /-->
 		<!-- /wp:query-pagination -->
-		</div>
+	</div>
 	<!-- /wp:group -->
 </main>
 <!-- /wp:query -->

--- a/archeo/templates/single.html
+++ b/archeo/templates/single.html
@@ -83,7 +83,50 @@
 		<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
-		<!-- wp:post-comments /-->
+		<!-- wp:comments -->
+		<div class="wp-block-comments">
+			<!-- wp:comments-title /-->
+
+			<!-- wp:comment-template -->
+			<!-- wp:columns -->
+			<div class="wp-block-columns">
+				<!-- wp:column {"width":"40px"} -->
+				<div class="wp-block-column" style="flex-basis:40px">
+					<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+				</div>
+				<!-- /wp:column -->
+	
+				<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:comment-author-name {"fontSize":"small"} /-->
+	
+					<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
+					<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px">
+						<!-- wp:comment-date {"fontSize":"small"} /-->
+	
+						<!-- wp:comment-edit-link {"fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+	
+					<!-- wp:comment-content /-->
+	
+					<!-- wp:comment-reply-link {"fontSize":"small"} /-->
+				</div>
+				<!-- /wp:column -->
+			</div>
+			<!-- /wp:columns -->
+			<!-- /wp:comment-template -->
+	
+			<!-- wp:comments-pagination -->
+				<!-- wp:comments-pagination-previous /-->
+				<!-- wp:comments-pagination-numbers /-->
+				<!-- wp:comments-pagination-next /-->
+			<!-- /wp:comments-pagination -->
+		
+			<!-- wp:post-comments-form /-->
+		</div>
+		<!-- /wp:comments -->
+
 		<!-- wp:spacer {"height":"100px"} -->
 		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->

--- a/archeo/templates/single.html
+++ b/archeo/templates/single.html
@@ -3,17 +3,20 @@
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
 	<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"foreground","textColor":"background"} -->
-	<div class="wp-block-columns alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"bottom","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-	<div class="wp-block-column is-vertically-aligned-bottom" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
-	<!-- wp:cover {"overlayColor":"foreground","minHeight":80,"minHeightUnit":"vh","contentPosition":"bottom left","style":{"spacing":{"padding":{"top":"min(4vw, 90px)","right":"min(4vw, 90px)","bottom":"min(4vw, 90px)","left":"min(4vw, 90px)"}}}} -->
-	<div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="padding-top:min(4vw, 90px);padding-right:min(4vw, 90px);padding-bottom:min(4vw, 90px);padding-left:min(4vw, 90px);min-height:80vh"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:post-date {"style":{"typography":{"textTransform":"uppercase"}}} /-->
-	<!-- wp:post-title {"level":1,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"huge"} /--></div></div>
-	<!-- /wp:cover -->
+	<div class="wp-block-columns alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+		<!-- wp:column {"verticalAlignment":"bottom","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+		<div class="wp-block-column is-vertically-aligned-bottom" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+			<!-- wp:cover {"overlayColor":"foreground","minHeight":80,"minHeightUnit":"vh","contentPosition":"bottom left","style":{"spacing":{"padding":{"top":"min(4vw, 90px)","right":"min(4vw, 90px)","bottom":"min(4vw, 90px)","left":"min(4vw, 90px)"}}}} -->
+			<div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="padding-top:min(4vw, 90px);padding-right:min(4vw, 90px);padding-bottom:min(4vw, 90px);padding-left:min(4vw, 90px);min-height:80vh"><span aria-hidden="true" class="wp-block-cover__background has-foreground-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:post-date {"style":{"typography":{"textTransform":"uppercase"}}} /--><!-- wp:post-title {"level":1,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"huge"} /--></div></div><!-- /wp:cover -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:post-featured-image {"height":"80vh","style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} /-->
+		</div>
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:column -->
-	<!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:post-featured-image {"height":"80vh","style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} /--></div>
-	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 
 	<!-- wp:spacer {"height":"48px"} -->
@@ -27,44 +30,53 @@
     <!-- /wp:spacer -->
 
 	<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-	<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color"><!-- wp:spacer {"height":"100px"} -->
-	<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+	<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color">
+		<!-- wp:spacer {"height":"100px"} -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","allowOrientation":false}} -->
-	<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
-	<p class="has-small-font-size" style="text-transform:uppercase">Categories:</p>
-	<!-- /wp:paragraph -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+			<p class="has-small-font-size" style="text-transform:uppercase">Categories:</p>
+			<!-- /wp:paragraph -->
 
-	<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
+			<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
 
-	<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
-	<p class="has-small-font-size" style="text-transform:uppercase">· Tagged:</p>
-	<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+			<p class="has-small-font-size" style="text-transform:uppercase">· Tagged:</p>
+			<!-- /wp:paragraph -->
 
-	<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /--></div>
-	<!-- /wp:group -->
-
-	<!-- wp:spacer {"height":"48px"} -->
-	<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-
-	<!-- wp:columns {"isStackedOnMobile":false,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-		<div class="wp-block-columns alignwide is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator is-style-wide"/>
-		<!-- /wp:separator -->
-		<!-- wp:post-navigation-link {"type":"previous","label":"Previous Post"} /-->
+			<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
 		</div>
-		<!-- /wp:column -->
+		<!-- /wp:group -->
 
-		<!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator is-style-wide"/>
-		<!-- /wp:separator -->
-		<!-- wp:post-navigation-link {"textAlign":"right","label":"Next Post"} /-->
+		<!-- wp:spacer {"height":"48px"} -->
+		<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+
+		<!-- wp:columns {"isStackedOnMobile":false,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+		<div class="wp-block-columns alignwide is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:separator {"className":"is-style-wide"} -->
+				<hr class="wp-block-separator is-style-wide"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:post-navigation-link {"type":"previous","label":"Previous Post"} /-->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:separator {"className":"is-style-wide"} -->
+				<hr class="wp-block-separator is-style-wide"/>
+				<!-- /wp:separator -->
+				
+				<!-- wp:post-navigation-link {"textAlign":"right","label":"Next Post"} /-->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:column --></div>
 		<!-- /wp:columns -->
 
 		<!-- wp:spacer {"height":"48px"} -->
@@ -74,7 +86,8 @@
 		<!-- wp:post-comments /-->
 		<!-- wp:spacer {"height":"100px"} -->
 		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer --></div>
+		<!-- /wp:spacer -->
+	</div>
 	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR improves the block markup for Archeo, which should fix a couple of block markup errors:

- Fixes the footer block markup error (I think it was caused by whitespace, also removed the margin as it doesn't look like this was needed)
- Fixes the block markup error in the 'Layered images with headline' pattern (the font size was inconsistent between the JSON and HTML)
- Changes the query loops to inherit: true for the 'simple list of posts' patterns
- Updates the comments block to the new block to fix a block notice/warning in the editor
- Replaces the post-author-name block for the post-author block, as this isn't included in WP 6.1 (we don't use it in any other theme currently)
- Indents block markup where possible so code is easier to read

Archeo's headstart has also been updated to reflect these changes: D90211-code