### PR TITLE
Fixed the 'Theme URI' of loudness to point to the correct location

### DIFF
--- a/loudness/style.css
+++ b/loudness/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Loudness
-Theme URI: https://wordpress.com/loudness
+Theme URI: https://loudnessthemedemo.wordpress.com/
 Author: Automattic
 Author URI: https://automattic.com
 Description: A bold opinionated theme for music and learning 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Changed the theme URI to be the correct location: https://loudnessthemedemo.wordpress.com/

#### Related issue(s):
