### PR TITLE
Adding license information for resources used in Loudness

### DIFF
--- a/loudness/assets/illustrations/license.txt
+++ b/loudness/assets/illustrations/license.txt
@@ -1,0 +1,1 @@
+Loudness Illustrations by Kjell Reigstad is marked with CC0 1.0. To view a copy of this license, visit http://creativecommons.org/publicdomain/zero/1.0

--- a/loudness/readme.txt
+++ b/loudness/readme.txt
@@ -84,3 +84,23 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
+This theme bundles the following third-party resources:
+
+StockSnap
+License : Creative Commons CC0
+	https://stocksnap.io/photo/stylish-boy-03P9JTLVF7
+	https://stocksnap.io/photo/male-model-Q7PO9ADJHS
+	https://stocksnap.io/photo/fitness-male-CWWCRACUJ6
+	https://stocksnap.io/photo/smiling-woman-WD9GZ6WUOA
+	https://stocksnap.io/photo/girl-sunglasses-K5J3ZCGCYZ
+	https://stocksnap.io/photo/people-man-ZPC6ULHO0Y
+	https://stocksnap.io/photo/wall-art-GSS62FLFJO
+	https://stocksnap.io/photo/people-girl-VZ6M02LHDN
+	https://stocksnap.io/photo/people-man-8O83EE9RGN
+
+Included
+License : Creative Commons CC0
+	/assets/illustrations/illustration-1.svg
+	/assets/illustrations/illustration-2.svg
+	/assets/illustrations/texture.png


### PR DESCRIPTION
I have added the license information for the images found in the theme.  They are all from Stocksnap.

The illustrations were created by @kjellr and aren't currently hosted and licensed anywhere.  I have included a CC0 license reference for those images.

Is this an appropriate way to attribute and license this?