### PR TITLE
Remove  block attribute from any theme not defining nav menu locations

### DIFF
--- a/disco/parts/header.html
+++ b/disco/parts/header.html
@@ -8,7 +8,7 @@
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+	<!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 	<!-- /wp:group -->
 
 	<!-- wp:spacer {"height":"2rem"} -->

--- a/pixl/parts/header.html
+++ b/pixl/parts/header.html
@@ -15,7 +15,7 @@
             </div>
             <!-- /wp:group -->
 
-            <!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+            <!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
         </div>
         <!-- /wp:group -->
     </div>

--- a/spearhead-blocks/parts/header.html
+++ b/spearhead-blocks/parts/header.html
@@ -10,7 +10,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/stewart/parts/header-title-nav.html
+++ b/stewart/parts/header-title-nav.html
@@ -6,6 +6,6 @@
 <!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","orientation":"horizontal"}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","orientation":"horizontal"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/stewart/patterns/header-traditional-background.php
+++ b/stewart/patterns/header-traditional-background.php
@@ -15,7 +15,7 @@
 <!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","orientation":"horizontal"}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","orientation":"horizontal"}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":100} -->

--- a/stewart/patterns/header-traditional.php
+++ b/stewart/patterns/header-traditional.php
@@ -15,6 +15,6 @@
 <!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","orientation":"horizontal"}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","orientation":"horizontal"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

A few themes had templates/patterns that were assigning `__unstableLocation` attributes to navigation blocks.  However, if navigation targets aren't defined by the theme (such as [here](https://github.com/Automattic/themes/blob/trunk/blockbase/functions.php#L38) in Blockbase) the attribute does nothing and is only confusing.

This change removes the attribute from any patterns and templates from themes that aren't defining those locations (which only Blockbase is doing).

#### Related issue(s):
