### PR TITLE
Blockbase: Enabled navigation fallback

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -120,14 +120,6 @@ add_action(
 );
 
 /**
- * Disable the fallback for the core/navigation block.
- */
-function blockbase_core_navigation_render_fallback() {
-	return null;
-}
-add_filter( 'block_core_navigation_render_fallback', 'blockbase_core_navigation_render_fallback' );
-
-/**
  * Block Patterns.
  */
 require get_template_directory() . '/inc/block-patterns.php';


### PR DESCRIPTION
Removed the bits that disabled the navigation fallback so that navigation would work as expected.

This was causing an issue with sites with generated navigation (most specifically headstart-generated navigation). 