### PR TITLE
Block canvas: remove unneeded CSS

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -36,10 +36,10 @@ body {
 }
 
 /*
-* Control the hover stylings of outline block style.
-* Unnecessary once block styles are configurable via theme.json
-* https://github.com/WordPress/gutenberg/issues/42794 and https://github.com/WordPress/gutenberg/issues/44417
-*/
+ * Control the hover stylings of outline block style.
+ * Unnecessary once block styles are configurable via theme.json
+ * https://github.com/WordPress/gutenberg/issues/42794 and https://github.com/WordPress/gutenberg/issues/44417
+ */
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--secondary);
 	color: var(--wp--preset--color--background);

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -37,16 +37,23 @@ body {
 }
 
 /*
+<<<<<<< Updated upstream
  * Control the hover stylings of outline block style.
  * Unnecessary once block styles are configurable via theme.json
  * https://github.com/WordPress/gutenberg/issues/42794
  */
+=======
+* Control the hover stylings of outline block style.
+* Unnecessary once block styles are configurable via theme.json
+*/
+>>>>>>> Stashed changes
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--secondary);
 	color: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--secondary);
 }
 
+<<<<<<< Updated upstream
 /**
  * Currently table styles are only available with 'wp-block-styles' 
  * theme support (block css) thus the following needs to be included
@@ -69,6 +76,8 @@ body {
 	font-size: var(--wp--preset--font-size--small);
 	text-align: center;
 }
+=======
+>>>>>>> Stashed changes
 
 /*
  * Link styles

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -50,5 +50,5 @@ body {
  */
 a {
 	text-decoration-thickness: .0625em !important;
-	text-underline-offset: .15em
+	text-underline-offset: .15em;
 }

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -48,6 +48,7 @@ body {
 
 /*
  * Link styles
+ * https://github.com/WordPress/gutenberg/issues/42319
  */
 a {
 	text-decoration-thickness: .0625em !important;

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -38,6 +38,7 @@ body {
 /*
 * Control the hover stylings of outline block style.
 * Unnecessary once block styles are configurable via theme.json
+* https://github.com/WordPress/gutenberg/issues/42794 and https://github.com/WordPress/gutenberg/issues/44417
 */
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--secondary);

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -5,9 +5,9 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Block Canvas is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.0
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 5.7
-Version: 0.0.20
+Version: 0.0.18
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: block-canvas
@@ -29,7 +29,6 @@ GNU General Public License for more details.
 
 /*
  * Font smoothing
- * https://github.com/WordPress/gutenberg/issues/35934
  */
 body {
 	-moz-osx-font-smoothing: grayscale;
@@ -37,53 +36,19 @@ body {
 }
 
 /*
-<<<<<<< Updated upstream
- * Control the hover stylings of outline block style.
- * Unnecessary once block styles are configurable via theme.json
- * https://github.com/WordPress/gutenberg/issues/42794
- */
-=======
 * Control the hover stylings of outline block style.
 * Unnecessary once block styles are configurable via theme.json
 */
->>>>>>> Stashed changes
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: var(--wp--preset--color--secondary);
 	color: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--secondary);
 }
 
-<<<<<<< Updated upstream
-/**
- * Currently table styles are only available with 'wp-block-styles' 
- * theme support (block css) thus the following needs to be included
- * since 'wp-block-styles' aren't used for this theme.
- * https://github.com/WordPress/gutenberg/issues/45065
- */
-.wp-block-table thead {
-	border-bottom: 3px solid;
-}
-.wp-block-table tfoot {
-	border-top: 3px solid;
-}
-.wp-block-table td,
-.wp-block-table th {
-	padding: var(--wp--preset--spacing--30);
-	border: 1px solid;
-	word-break: normal;
-}
-.wp-block-table figcaption {
-	font-size: var(--wp--preset--font-size--small);
-	text-align: center;
-}
-=======
->>>>>>> Stashed changes
-
 /*
  * Link styles
- * https://github.com/WordPress/gutenberg/issues/42319
  */
 a {
 	text-decoration-thickness: .0625em !important;
-	text-underline-offset: .15em;
+	text-underline-offset: .15em
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes some CSS that has since been added to Gutenberg (PR 45069)

#### Related issue(s):
