### PR TITLE
Muscat: Remove Rubik font from headings

### DIFF
--- a/muscat/theme.json
+++ b/muscat/theme.json
@@ -522,7 +522,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontStyle": "normal",
 					"fontWeight": "400",
 					"letterSpacing": "-1px",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the Rubik font setting from the headings in Muscat so that they default to Albert Sans.