### PR TITLE
Blockbase + children: remove __unstableLocation

### DIFF
--- a/antonia/parts/header.html
+++ b/antonia/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal","flexWrap":"wrap"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal","flexWrap":"wrap"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/appleton/parts/header.html
+++ b/appleton/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/blockbase/inc/patterns/footer-columns.php
+++ b/blockbase/inc/patterns/footer-columns.php
@@ -33,7 +33,7 @@ return array(
 		<h3 style="font-size:14px;"><strong>' . esc_html__( 'More info', 'blockbase' ) . '</strong></h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
+		<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /--></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->

--- a/blockbase/inc/patterns/footer-left.php
+++ b/blockbase/inc/patterns/footer-left.php
@@ -11,7 +11,7 @@ return array(
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","bottom":"30px"}}},"layout":{"inherit":true}} -->
 	<div class="wp-block-group alignfull" style="padding-top:30px;padding-bottom:30px">
-	<!-- wp:navigation {"__unstableLocation":"primary","fontSize":"small"} /-->
+	<!-- wp:navigation {"fontSize":"small"} /-->
 	
 	<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
 	<div class="wp-block-group"><!-- wp:site-title {"fontSize":"small"} /-->

--- a/blockbase/inc/patterns/footer-primary.php
+++ b/blockbase/inc/patterns/footer-primary.php
@@ -19,7 +19,7 @@ return array(
 	<!-- /wp:paragraph --></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} /--></div>
+	<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} /--></div>
 	<!-- /wp:group --></div>
 	<!-- /wp:group -->',
 );

--- a/blockbase/inc/social-navigation.php
+++ b/blockbase/inc/social-navigation.php
@@ -13,11 +13,6 @@ function blockbase_condition_to_render_social_menu( $block_content, $block ) {
 		return false;
 	}
 
-	// The block should have an unstable location attribute.
-	if ( empty( $block['attrs']['__unstableLocation'] ) ) {
-		return false;
-	}
-
 	// The block should be empty (no custom menu assigned)
 	if ( ! empty($block['attrs']['navigationMenuId']) || ! empty($block['attrs']['ref']) ) {
 		return false;

--- a/blockbase/parts/header-centered.html
+++ b/blockbase/parts/header-centered.html
@@ -14,7 +14,7 @@
 <!-- wp:spacer {"height":20} -->
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"}} /-->
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center","orientation":"horizontal"}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/parts/header-default.html
+++ b/blockbase/parts/header-default.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/parts/header-linear.html
+++ b/blockbase/parts/header-linear.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"className":"blockbase-responsive-navigation-linear","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"className":"blockbase-responsive-navigation-linear","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/parts/header-minimal.html
+++ b/blockbase/parts/header-minimal.html
@@ -18,7 +18,7 @@
 	</div>
 	<!-- /wp:group -->
 	
-	<!-- wp:navigation {"className":"blockbase-responsive-navigation-minimal","overlayMenu":"always","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+	<!-- wp:navigation {"className":"blockbase-responsive-navigation-minimal","overlayMenu":"always","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 	
 </div>
 <!-- /wp:group -->

--- a/blockbase/parts/header-rounded-logo.html
+++ b/blockbase/parts/header-rounded-logo.html
@@ -16,7 +16,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 
 </div>
 <!-- /wp:group -->

--- a/blockbase/parts/header-wide.html
+++ b/blockbase/parts/header-wide.html
@@ -16,7 +16,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.5em"}}} /-->
+		<!-- wp:navigation {"className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.5em"}}} /-->
 
 	</div>
 	<!-- /wp:group -->

--- a/geologist/inc/patterns/header-with-rounded-site-logo.php
+++ b/geologist/inc/patterns/header-with-rounded-site-logo.php
@@ -13,7 +13,7 @@ return array(
 <header class="wp-block-group site-header" style="padding-bottom:90px">
 	<!-- wp:site-logo {"className":"is-style-rounded"} /-->
 	<!-- wp:site-title /-->
-	<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
+	<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /-->
 </header>
 <!-- /wp:group -->',
 );

--- a/heiwa/parts/header.html
+++ b/heiwa/parts/header.html
@@ -6,6 +6,6 @@
 <!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayMenu":"always","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"huge"} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"huge"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/meraki/parts/header-minimal.html
+++ b/meraki/parts/header-minimal.html
@@ -10,6 +10,6 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","className":"blockbase-responsive-navigation-linear","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"className":"blockbase-responsive-navigation-linear","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/videomaker/inc/patterns/footer.php
+++ b/videomaker/inc/patterns/footer.php
@@ -14,7 +14,7 @@ return array(
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between"},"style":{"spacing":{"padding":{"top":"30px","bottom":"min(30px, 5vw)"}}}} -->
 		<div class="wp-block-group alignwide" style="padding-top: 30px;padding-bottom: min(30px, 5vw)">	<!-- wp:group -->
 			<div class="wp-block-group">
-				<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"footer","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"},"spacing":{"blockGap":"0px"}}} /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:group {"className":"footer-credit"} -->

--- a/videomaker/inc/patterns/full-width-homepage.php
+++ b/videomaker/inc/patterns/full-width-homepage.php
@@ -15,7 +15,7 @@ return array(
 	<!-- /wp:column -->
 
 	<!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
+	<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"typography":{"textTransform":"uppercase"}}} /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 

--- a/videomaker/inc/patterns/header-description-and-grid-of-projects.php
+++ b/videomaker/inc/patterns/header-description-and-grid-of-projects.php
@@ -17,7 +17,7 @@ return array(
 		<h3 style="font-weight:300">' . esc_html__( 'Jonah is Creative Director of Hano, a production studio that specializes in combining storytelling with visual design.', 'videomaker' ) . '</h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
+		<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 		</div>
 		<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

https://github.com/WordPress/gutenberg/pull/45976 added a fallback for classic menus assigned to the `primary` location or named `primary`. 

Once that lands in the plugin (14.8), we should be able to safely remove this attribute without breaking user's navigations. 

**To test**

- Activate one of these themes and create a classic menu, assign it to the primary location
- Switch to this PR
- Verify the navigation appears as expected in the front end and site editor

#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/6738