### PR TITLE
Tú: remove theme reference for the footer

### DIFF
--- a/tu/templates/home.html
+++ b/tu/templates/home.html
@@ -4,4 +4,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"tu","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
I realised this after moving the theme to WP.com. The theme reference makes the footer not appearing on the homepage.

| Before | After |
| ----------- | ----------- |
| ![tuthemedemo wordpress com_](https://user-images.githubusercontent.com/908665/206264273-b3411ff2-cea7-4832-be4b-66c61798aa40.png) | ![tuthemedemo wordpress com_ (1)](https://user-images.githubusercontent.com/908665/206264399-5682a636-8774-44fd-9694-150f01d9283d.png) |

