### PR TITLE
Turn Pendant query loop inherit on by default

### DIFF
--- a/pendant/patterns/grid-of-posts.php
+++ b/pendant/patterns/grid-of-posts.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<!-- wp:query {"query":{"perPage":4,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"tagName":"main","displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
+<!-- wp:query {"query":{"perPage":4,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":true},"tagName":"main","displayLayout":{"type":"flex","columns":2},"layout":{"inherit":true}} -->
 <main class="wp-block-query"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"1em","bottom":"1.5em"}}}} -->
 	<div class="wp-block-group alignwide" style="padding-top:1em;padding-bottom: 1.5em"><!-- wp:post-template -->
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","bottom":"2em"}}}} -->


### PR DESCRIPTION
Fixes: #6485 

I'm not sure why this was shipped off by default.  The Query loop has been configured to be on by default.  The pattern this loop is in is used in the Archive template as well as Index and Search (all of which I think it should be set to "true"