### PR TITLE
Masu: Set query loop to inherit by default

### DIFF
--- a/masu/patterns/grid-of-posts.php
+++ b/masu/patterns/grid-of-posts.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<!-- wp:query {"query":{"perPage":"8","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":4},"align":"wide"} -->
+<!-- wp:query {"query":{"perPage":"8","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":4},"align":"wide"} -->
 <div class="wp-block-query alignwide">
 	<!-- wp:post-template -->
 		<!-- wp:group {"style":{"visualizers":{"padding":{"top":true,"right":true,"bottom":true,"left":true}}},"layout":{"inherit":false}} -->


### PR DESCRIPTION
Fixes: #6682 

I suspect Masu was cloned from Pendant which had the same problem (#6485) with the 'grid-of-posts' pattern.  This change sets the 'inherit' flag to 'true'.