### PR TITLE
Allow Jetpack to register fonts that Blockbase has not.

### DIFF
--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -207,10 +207,20 @@ function enqueue_block_fonts( $content, $parsed_block ) {
 
 /**
  * Jetpack may attempt to register fonts for the Google Font Provider.
- * If that happens on a child theme then ONLY Jetpack fonts are registered.
- * This 'filter' filters out all of the fonts Jetpack should register
- * so that we depend exclusively on those provided by Blockbase.
+ * This filters out all of the fonts Blockbase has already registered.
  */
 function blockbase_filter_jetpack_google_fonts_list( $list_to_filter ) {
-	return array();
+	$font_families = array();
+	$filtered_list = array();
+	$fonts         = collect_fonts_from_blockbase();
+	foreach ( $fonts as $font ) {
+		$font_families[] = $font['name'];
+	}
+	foreach ( $list_to_filter as $jetpack_font_family ) {
+		if ( ! in_array( $jetpack_font_family, $font_families, true ) ) {
+			$filtered_list[] = $jetpack_font_family;
+		}
+	}
+	return $filtered_list;
 }
+


### PR DESCRIPTION
I'm not sure that this works like it's supposed to but here's an idea for a fix to allow Jetpack curated fonts to work with blockbase.

This removes the "filter out all jetpack fonts" and instead just filters out those fonts that Blockbase is already providing.

I THINK that this was previously attempted but rejected because it was causing fonts from Blockbase not to work.  That doesn't seem to be the case any more (I think) so hopefully something has changed since then to allow this to work OK.

Fixes: #6765 

To test you'll need to have this running in an environment where Jetpack is providing fonts.  WPCOM is the easiest place to test this.  With this branch you should see additional Fonts that Jetpack is providing (at the time of my testing those were the following:

<img width="262" alt="image" src="https://user-images.githubusercontent.com/146530/207130064-b6825e6e-6920-46dc-891a-946cf07dab10.png">

NOTE: Remember to update blockbase-premium as well!
