### PR TITLE
Upsidedown: Remove zero spacing from header and footer

### DIFF
--- a/upsidedown/patterns/footer.php
+++ b/upsidedown/patterns/footer.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"0px","padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained","contentSize":"1200px"},"fontSize":"small"} -->
-<div class="wp-block-group has-small-font-size" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+<!-- wp:group {"layout":{"type":"constrained","contentSize":"1200px"},"fontSize":"small"} -->
+<div class="wp-block-group has-small-font-size">
     <!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"0px","padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"layout":{"type":"default"}} -->
     <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
         <!-- wp:spacer {"height":"2rem","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->

--- a/upsidedown/patterns/header.php
+++ b/upsidedown/patterns/header.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"0px"}},"layout":{"inherit":true,"type":"constrained","contentSize":"1200px"},"fontSize":"small"} -->
-<div class="wp-block-group has-small-font-size" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px">
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained","contentSize":"1200px"},"fontSize":"small"} -->
+<div class="wp-block-group has-small-font-size">
     <!-- wp:spacer {"height":"3.2rem","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
     <div style="margin-top:0px;margin-bottom:0px;height:3.2rem" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the margin and padding 0 styles from the header and footer of Upsidedown. This means that the global padding can work as expected at smaller resolutions, otherwise, the header and footer content have no padding at the edges of the page.

This is at 845px width:

| Before | After |
| ----- | ----- |
| <img width="846" alt="image" src="https://user-images.githubusercontent.com/1645628/208423816-6b5cbed2-4cbd-4598-b019-d3e6de96bfbf.png"> | <img width="847" alt="image" src="https://user-images.githubusercontent.com/1645628/208423725-8f0d42da-2015-4ff1-ab31-e199ab6cdfa4.png"> |

cc. @henriqueiamarino