### PR TITLE
Ignore tt3 screenshot

### DIFF
--- a/.sandbox-ignore
+++ b/.sandbox-ignore
@@ -25,3 +25,4 @@ inc/headstart
 languages
 *.map
 .DS_Store
+**/*/twentytwentythree/screenshot.png


### PR DESCRIPTION
Doctom and Dotorg screenshots for this theme are different, so we need to avoid syncing when updating the theme, unless we explicitly intend to change the Dotcom image.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
