### PR TITLE
Blockbase theme: Fix missing --wp prefix for css var --custom--form--color--border

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -290,7 +290,7 @@ input[type=datetime-local]:focus,
 input[type=color]:focus,
 textarea:focus,
 select:focus {
-  border-color: var(--custom--form--color--border);
+  border-color: var(--wp--custom--form--color--border);
   color: var(--wp--custom--form--color--text);
   outline: 1px dotted currentcolor;
   outline-offset: 2px;

--- a/blockbase/sass/elements/_forms.scss
+++ b/blockbase/sass/elements/_forms.scss
@@ -25,7 +25,7 @@ select {
 	padding: var(--wp--custom--form--padding);
 
 	&:focus {
-		border-color: var(--custom--form--color--border);
+		border-color: var(--wp--custom--form--color--border);
 		color: var(--wp--custom--form--color--text);
 		outline: 1px dotted currentcolor;
 		outline-offset: 2px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In order to be able to set custom form color border in theme.json, add the proper prefix to the css variable --custom--form--color--border
