### PR TITLE
Fix background color variable

### DIFF
--- a/blank-canvas-3/theme.json
+++ b/blank-canvas-3/theme.json
@@ -1,6 +1,7 @@
 {
 	"settings": {
 		"appearanceTools": true,
+		"useRootPaddingAwareAlignments": true,
 		"color": {
 			"custom": true,
 			"customGradient": true,
@@ -36,7 +37,6 @@
 			"contentSize": "700px",
 			"wideSize": "1160px"
 		},
-		"useRootPaddingAwareAlignments": true,
 		"spacing": {
 			"blockGap": true,
 			"units": [
@@ -199,7 +199,7 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--preset--color--base)",
+			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Theme was using --wp--preset--color--base variable for the background, while it should've been --wp--preset--color--background.

Corrected the assigned color for background.