### PR TITLE
DRAFT: Test PR for validating shadow support in templates

### DIFF
--- a/bibimbap/templates/index.html
+++ b/bibimbap/templates/index.html
@@ -9,7 +9,19 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"50px","left":"0px"},"blockGap":"var:preset|spacing|40"}},"layout":{"inherit":false}} -->
 <div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:50px;padding-left:0px"><!-- wp:post-featured-image {"height":"500px"} /-->
 
-<!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-title {"isLink":true,"fontSize":"small","shadow":"natural"} /-->
+<!-- wp:post-title {"isLink":true,"fontSize":"small","style":{"shadow": "var(--wp--preset--shadow--natural)"}} /-->
+
+<!-- wp:buttons {"fontSize":"small"} -->
+<div class="wp-block-buttons has-custom-font-size has-small-font-size">
+    <!-- wp:button {"textColor":"pale-cyan-blue","shadow":"natural"} -->
+    <div class="wp-block-button"><a class="wp-block-button__link has-pale-cyan-blue-color has-text-color wp-element-button">Test Shadow Prop</a></div>
+    <!-- /wp:button -->
+    <!-- wp:button {"textColor":"pale-cyan-blue","style":{"shadow": "var(--wp--preset--shadow--natural)"}} -->
+    <div class="wp-block-button"><a class="wp-block-button__link has-pale-cyan-blue-color has-text-color wp-element-button">Test Shadow Style</a></div>
+    <!-- /wp:button -->
+</div>
+<!-- /wp:buttons -->
 
 <!-- wp:post-excerpt {"moreText":""} /-->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR is to verify the changes related to https://github.com/WordPress/gutenberg/pull/46896

Shadow definition works well for `site-title` but the same doesn't work for `button` or `heading`

