### PR TITLE
Block Canvas: Try removing font-smoothing CSS

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -28,15 +28,6 @@ GNU General Public License for more details.
 */
 
 /*
- * Font smoothing
- * https://github.com/WordPress/gutenberg/issues/35934
- */
-body {
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-font-smoothing: antialiased;
-}
-
-/*
  * Control the hover stylings of outline block style.
  * Unnecessary once block styles are configurable via theme.json
  * https://github.com/WordPress/gutenberg/issues/42794


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This PR is to discuss the inclusion of the `antialiased` font-smoothing styles that are applied to the `body` in Block Canvas. It's worth noting these properties currently only apply in browsers on macOS (the property has been removed from the CSS spec, so we have to use browser prefixes to apply it).

As Block Canvas is being used more and more as a base, I think we should remove these from the theme so they are not included by default in every theme. We should consider their addition based on the fonts selected in the theme.

The main reason for advising against this is because it's bad for accessibility. The `antialiased` setting reduces the weight of the font and therefore reduces the contrast, so I don't think we should include it without careful consideration.

Here's a comparison of `subpixel-antialiased` (the default) vs `antialiased` / grayscale on macOS (from [Tailwind](https://tailwindcss.com/docs/font-smoothing)):

<img width="766" alt="image" src="https://user-images.githubusercontent.com/1645628/211058210-349a0455-bd04-4c7a-80ed-d4f9d6b054de.png">
