### PR TITLE
Fix/allow jetpack to register fonts (take 2)

### DIFF
--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -207,10 +207,20 @@ function enqueue_block_fonts( $content, $parsed_block ) {
 
 /**
  * Jetpack may attempt to register fonts for the Google Font Provider.
- * If that happens on a child theme then ONLY Jetpack fonts are registered.
- * This 'filter' filters out all of the fonts Jetpack should register
- * so that we depend exclusively on those provided by Blockbase.
+ * This filters out all of the fonts Blockbase has already registered.
  */
 function blockbase_filter_jetpack_google_fonts_list( $list_to_filter ) {
-	return array();
+	$font_families = array();
+	$filtered_list = array();
+	$fonts         = collect_fonts_from_blockbase();
+	foreach ( $fonts as $font ) {
+		$font_families[] = $font['name'];
+	}
+	foreach ( $list_to_filter as $jetpack_font_family ) {
+		if ( ! in_array( $jetpack_font_family, $font_families, true ) ) {
+			$filtered_list[] = $jetpack_font_family;
+		}
+	}
+	return $filtered_list;
 }
+

--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -209,18 +209,16 @@ function enqueue_block_fonts( $content, $parsed_block ) {
  * Jetpack may attempt to register fonts for the Google Font Provider.
  * This filters out all of the fonts Blockbase has already registered.
  */
-function blockbase_filter_jetpack_google_fonts_list( $list_to_filter ) {
-	$font_families = array();
-	$filtered_list = array();
-	$fonts         = collect_fonts_from_blockbase();
-	foreach ( $fonts as $font ) {
-		$font_families[] = $font['name'];
-	}
-	foreach ( $list_to_filter as $jetpack_font_family ) {
-		if ( ! in_array( $jetpack_font_family, $font_families, true ) ) {
+function blockbase_filter_jetpack_google_fonts_list( $jetpack_fonts ) {
+	$theme_fonts         = collect_fonts_from_blockbase();
+	$theme_font_families = array_column( $theme_fonts, 'name' );
+	$filtered_list       = array();
+
+	// If the Jetpack font isn't in theme already, let Jetpack register it
+	foreach ( $jetpack_fonts as $jetpack_font_family ) {
+		if ( ! in_array( $jetpack_font_family, $theme_font_families, true ) ) {
 			$filtered_list[] = $jetpack_font_family;
 		}
 	}
 	return $filtered_list;
 }
-


### PR DESCRIPTION
This is the same change originally made (and reverted) in #6777.  It was refactored [per suggestion](https://github.com/Automattic/themes/pull/6777#discussion_r1053380947).

This change requires [this gutenberg fix](https://github.com/WordPress/gutenberg/pull/47290) to be included before it works as expected with child themes.

To test ensure that you are in an environment where Jetpack is supplying additional Fonts (such as wpcom) and the Gutenberg change noted has been applied.  Activate a Blockbase Child theme and note the available Fonts.  All of the fonts offered by BOTH Blockbase and Jetpack should be available in the Site Editor and rendered as expected in the view.
