### PR TITLE
Remove top and bottom global paddings from blank-canvas-3 theme.json

### DIFF
--- a/blank-canvas-3/theme.json
+++ b/blank-canvas-3/theme.json
@@ -276,10 +276,8 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"bottom": "var(--wp--preset--spacing--40)",
 				"left": "var(--wp--preset--spacing--40)",
 				"right": "var(--wp--preset--spacing--40)",
-				"top": "var(--wp--preset--spacing--40)"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
- Remove vertical paddings from theme.json

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/72814