### PR TITLE
Fix/6829 lettre archive query inherit

### DIFF
--- a/lettre/patterns/query-sidebar.php
+++ b/lettre/patterns/query-sidebar.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: List of posts with sidebar
- * Slug: lettre/query-related-post
+ * Slug: lettre/query-sidebar
  * Categories: featured, query, columns
  */
 ?>

--- a/lettre/templates/archive.html
+++ b/lettre/templates/archive.html
@@ -9,7 +9,7 @@
 <div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
   <!-- wp:columns -->
   <div class="wp-block-columns"><!-- wp:column {"width":"33.33%"} -->

--- a/lettre/templates/index.html
+++ b/lettre/templates/index.html
@@ -10,7 +10,7 @@
 <div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
   <!-- wp:columns -->
   <div class="wp-block-columns"><!-- wp:column {"width":"33.33%"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Set `archive.html` template to inherit query params
Set `index.html` template to inherit query params
gave `query-sidebar` a unique slug (it was sharing a slug with `query-related-posts`)

#### Related issue(s):

Fixes: 6829