### PR TITLE
Remove comma that breaks BC3 theme.json

### DIFF
--- a/blank-canvas-3/theme.json
+++ b/blank-canvas-3/theme.json
@@ -277,7 +277,7 @@
 			"blockGap": "1.5rem",
 			"padding": {
 				"left": "var(--wp--preset--spacing--40)",
-				"right": "var(--wp--preset--spacing--40)",
+				"right": "var(--wp--preset--spacing--40)"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- The json file is broken because of the trailing comma

#### Related issue(s):

- Settings and styles are missing 