### PR TITLE
Remove block-level duotone from skatepark patterns and templates

### DIFF
--- a/skatepark/block-templates/page.html
+++ b/skatepark/block-templates/page.html
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"align":"full"} -->
 <div class="wp-block-group">
-<!-- wp:post-featured-image {"align":"full","style":{"color":{"duotone":["#000","#B9FB9C"]}}} /--></div>
+<!-- wp:post-featured-image {"align":"full"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"layout":{"inherit":true},"lock":{"move":false,"remove":true}} /-->

--- a/skatepark/patterns/blog-posts.php
+++ b/skatepark/patterns/blog-posts.php
@@ -17,7 +17,7 @@
 <!-- /wp:separator --></div>
 <!-- /wp:group -->
 
-<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":["#000","#B9FB9C"]}}} /-->
+<!-- wp:post-featured-image {"isLink":true} /-->
 
 <!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"var(--wp--custom--font-sizes--normal)"},"spacing":{"margin":{"bottom":"calc( 0.5 * var(--wp--custom--gap--vertical) )"}}}} /-->
 

--- a/skatepark/patterns/columns-in-container.php
+++ b/skatepark/patterns/columns-in-container.php
@@ -37,7 +37,7 @@
 <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:image {"align":"wide","id":26,"sizeSlug":"large","linkDestination":"none","style":{"color":{"duotone":["#000","#B9FB9C"]}}} -->
+<!-- wp:image {"align":"wide","id":26,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image alignwide size-large"><img src="<?php echo get_stylesheet_directory_uri() . '/assets/images/riding-skateboard.jpeg'; ?>" alt="<?php echo esc_html__( 'Close-up of a person riding a skateboard, focusing on their feet and the board. One foot is on the board, while the other foot is up, in motion. A skatepark is blurred in the background.', 'skatepark' ); ?>" class="wp-image-26"/></figure>
 <!-- /wp:image -->
 

--- a/skatepark/patterns/mixed-media-in-container.php
+++ b/skatepark/patterns/mixed-media-in-container.php
@@ -27,7 +27,7 @@
 <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:image {"sizeSlug":"large","style":{"color":{"duotone":["#000","#BFF5A5"]}}} -->
+<!-- wp:image {"sizeSlug":"large"} -->
 <figure class="wp-block-image size-large"><img src="<?php echo get_stylesheet_directory_uri() . '/assets/images/skateboard-sideways.jpg'; ?>" alt="<?php echo esc_attr__( 'A skateboard laying on its side on top of concrete.', 'skatepark' ); ?>"/></figure>
 <!-- /wp:image -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Remove unnecessary block-level duotone filters in skatepark—these filters are already applied globally.

Additionally, it will be easier to use these patterns in other themes since the custom duotone won't be attached.
