### PR TITLE
Remove table CSS from block canvas theme as it has been addressed in Gutenberg

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -38,29 +38,6 @@ GNU General Public License for more details.
 	border-color: var(--wp--preset--color--secondary);
 }
 
-/**
- * Currently table styles are only available with 'wp-block-styles' 
- * theme support (block css) thus the following needs to be included
- * since 'wp-block-styles' aren't used for this theme.
- * https://github.com/WordPress/gutenberg/issues/45065
- */
-.wp-block-table thead {
-	border-bottom: 3px solid;
-}
-.wp-block-table tfoot {
-	border-top: 3px solid;
-}
-.wp-block-table td,
-.wp-block-table th {
-	padding: var(--wp--preset--spacing--30);
-	border: 1px solid;
-	word-break: normal;
-}
-.wp-block-table figcaption {
-	font-size: var(--wp--preset--font-size--small);
-	text-align: center;
-}
-
 /*
  * Link styles
  * https://github.com/WordPress/gutenberg/issues/42319


### PR DESCRIPTION
Fixed here: https://github.com/WordPress/gutenberg/pull/45069


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
