### PR TITLE
Removed forced content wrapper styles

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -184,12 +184,6 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
   --wpadmin-bar--height: 46px;
 }
 
-.wp-site-blocks {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
 .site-footer-container {
   margin-top: auto;
 }

--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -54,9 +54,9 @@ pre {
  */
 @media (min-width: 480px) {
   .wp-block[data-align=left],
-.wp-block[data-align=right],
-.wp-site-blocks .alignleft,
-.wp-site-blocks .alignright {
+  .wp-block[data-align=right],
+  .wp-site-blocks .alignleft,
+  .wp-site-blocks .alignright {
     max-width: var(--wp--custom--alignment--aligned-max-width);
   }
 }
@@ -424,8 +424,7 @@ input[type=checkbox] + label {
   row-gap: 0;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item > a:hover {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
+  text-decoration-line: underline;
 }
 .wp-block-navigation.blockbase-responsive-navigation-minimal.is-responsive .is-menu-open.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content .wp-block-navigation-item.current-menu-item > a {
   text-decoration: underline;

--- a/blockbase/sass/base/_layout.scss
+++ b/blockbase/sass/base/_layout.scss
@@ -2,22 +2,17 @@
 	--wpadmin-bar--height: 46px;
 }
 
-.wp-site-blocks {
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
-}
-
 .site-footer-container {
 	margin-top: auto;
 }
 
 body.admin-bar {
+
 	@include break-small() {
 		--wpadmin-bar--height: 32px;
 	}
 
 	.wp-site-blocks {
-		min-height: calc( 100vh - var(--wpadmin-bar--height) );
+		min-height: calc(100vh - var(--wpadmin-bar--height));
 	}
 }


### PR DESCRIPTION
This removes [this fix](https://github.com/Automattic/themes/pull/4190) which was ultimately causing [this bug](https://github.com/Automattic/wp-calypso/issues/69859).

It returns the original issue of content not being "all the way at the bottom" when there isn't much content.  But that's a problem in all block themes.  

The problem it was causing was that the elements were forced to be in a 'flex' container when that wasn't expected.

Before:

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/146530/228667791-76b69455-ae73-4309-a485-4251ea174070.png">

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/146530/228668463-9e28e5e1-b4c2-4e3b-bac3-20912b31d5a8.png">

After:

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/146530/228667897-405aa0c9-c337-4cf4-ab9f-a8b713751524.png">

<img width="639" alt="image" src="https://user-images.githubusercontent.com/146530/228668330-1e35e1f1-9cb7-4241-abcc-558812779ae4.png">
