### PR TITLE
Update new theme links to point to WPCOM instead of GitHub

### DIFF
--- a/adventurer/style.css
+++ b/adventurer/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Adventurer
-Theme URI: https://github.com/Automattic/themes/tree/trunk/adventurer
+Theme URI: https://wordpress.com/theme/adventurer/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: A theme for travelers, writers and photographers.

--- a/bibimbap/style.css
+++ b/bibimbap/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Bibimbap
-Theme URI: https://github.com/automattic/themes/tree/trunk/bibimbap
+Theme URI: https://wordpress.com/theme/bibimbap/
 Author: Automattic
 Author URI: https://automattic.com
 Description: A simple and fun restaurant theme.

--- a/blank-canvas-3/style.css
+++ b/blank-canvas-3/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Blank Canvas
-Theme URI: https://github.com/automattic/themes/tree/trunk/blank-canvas-3
+Theme URI: https://wordpress.com/theme/blank-canvas-3/
 Author: Automattic
 Author URI: https://automattic.com
 Description:Blank Canvas is a barebones starter theme, stripped off of content templates but only a footer and a header. With its minimal styling, Blank Canvas is a great theme starting fresh with your website.

--- a/disco/style.css
+++ b/disco/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Disco
-Theme URI: https://github.com/Automattic/themes/tree/trunk/disco
+Theme URI: https://wordpress.com/theme/disco/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Disco is a funky, vibrant, opinionated theme with a monospaced font. Both its styles and spacing form an edgy aesthetic perfect for those looking to build a quirky website.

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Loudness
-Theme URI: https://github.com/Automattic/themes/tree/trunk/loudness
+Theme URI: https://wordpress.com/theme/loudness/
 Author: Automattic
 Author URI: https://automattic.com
 Description: A bold opinionated theme for music and learning 

--- a/muscat/style.css
+++ b/muscat/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Muscat
-Theme URI: https://github.com/Automattic/themes/tree/trunk/muscat
+Theme URI: https://wordpress.com/theme/muscat/
 Author: Automattic
 Author URI: https://automattic.com
 Description: Muscat is a simple blogging WordPress theme with grid post templates and a centered post layout. Its geometric sans-serif typography contributes to a delightful, comfortable and modern reading experience. With a light style variation, Muscat lets your content shine, whether it is text or media.

--- a/paimio/style.css
+++ b/paimio/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Paimio
-Theme URI: https://github.com/Automattic/themes/tree/trunk/paimio
+Theme URI: https://wordpress.com/theme/paimio/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Paimio is a minimal blogging theme inspired by architects and designers Alvar, Aino and Elissa Aalto.

--- a/pixl/style.css
+++ b/pixl/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Pixl
-Theme URI: https://github.com/Automattic/themes/tree/trunk/pixl
+Theme URI: https://wordpress.com/theme/pixl/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Pixl is a simple yet opinionated blogging theme inspired by websites of the nineties.

--- a/rainfall/style.css
+++ b/rainfall/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Rainfall
-Theme URI: https://github.com/Automattic/themes/tree/trunk/rainfall
+Theme URI:https://wordpress.com/theme/rainfall/
 Author: Automattic
 Author URI: https://automattic.com
 Description: Rainfall is a clean, objective blogging theme strongly inspired by Swiss Design. Its minimalist functionality is balanced by a strong accent color, beautiful photography and post templates with sidebars.

--- a/spearhead-blocks/style.css
+++ b/spearhead-blocks/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Spearhead Blocks
-Theme URI: https://github.com/automattic/themes/tree/trunk/spearhead-blocks
+Theme URI: https://wordpress.com/theme/spearhead-blocks/
 Author: Automattic
 Author URI: https://automattic.com
 Description: Spearhead Blocks is the block based version of the original Spearhead theme.

--- a/upsidedown/style.css
+++ b/upsidedown/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Upsidedown
-Theme URI: https://github.com/Automattic/themes/tree/trunk/upsidedown
+Theme URI: https://wordpress.com/theme/upsidedown/
 Author: Automattic
 Author URI: https://automattic.com/
 Description: Upsidedown is a blog theme designed in the WordPress Site Editor. With its neat visuals, it introduces a direct experience on post reading: noticeable post titles listed on a text-only page, with an original swap of header and footer blocks.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Update all /pub themes so the theme-uri points to https://wordpress.com/theme/<slug>

Previously, they were linking to GitHub.

#### Related issue(s):

https://github.com/Automattic/wp-calypso/issues/62954