### PR TITLE
Hey: fix avatar radius

### DIFF
--- a/hey/style.css
+++ b/hey/style.css
@@ -93,7 +93,8 @@ a {
  * Styles for Author blocks
  * https://github.com/WordPress/gutenberg/issues/24952
  */
-.wp-block-post-author__avatar img {
+.wp-block-post-author__avatar img,
+.wp-block-avatar img {
 	border-radius: 999px;
 	line-height: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Fixes border radius of avatar via CSS in hey theme.

Before:
<img width="306" alt="image" src="https://user-images.githubusercontent.com/1935113/229493817-08a7f3af-415a-4e08-a3ec-72c2cbaabac2.png">

After:
<img width="304" alt="image" src="https://user-images.githubusercontent.com/1935113/229493703-f885de5d-a895-4442-8842-a34c5626597f.png">

