### PR TITLE
Verso: Update headings font family

### DIFF
--- a/verso/theme.json
+++ b/verso/theme.json
@@ -520,7 +520,7 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
+					"fontFamily": "var:preset|font-family|crimson-text",
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Quick fix to set 'Crimson Text' as heading font family in Verso.
