### PR TITLE
Blockbase: Remove inherited style variations from child themes

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -103,6 +103,7 @@ if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
 }
 
 require get_template_directory() . '/inc/fonts/custom-fonts.php';
+require get_template_directory() . '/inc/rest-api.php';
 
 
 // Force menus to reload

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -15,24 +15,18 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 
 	$handler_class  = isset( $handler['callback'][0] ) ? $handler['callback'][0] : null;
 	$handler_method = isset( $handler['callback'][1] ) ? $handler['callback'][1] : null;
+	$opt_out        = wp_get_global_settings( array( 'custom', 'optOutOfParentStyleVariations' ) );
 
 	/*
 	 * Prevents Blockbase child themes from being considered child themes in the
 	 * `wp/v2/global-styles/themes/:theme/variations` API endpoint, so they don't
 	 * inherit the style variations from the parent theme.
 	 */
-	if ( is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) && 'get_theme_items' === $handler_method ) {
+	if ( $opt_out && is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) && 'get_theme_items' === $handler_method ) {
 		add_filter( 'template_directory', 'get_stylesheet_directory' );
 	}
 
 	return $response;
 }
 
-function blockbase_check_for_opt_out_parent_variations() {
-	$opt_out = wp_get_global_settings( array( 'custom', 'optOutOfParentStyleVariations' ) );
-	if ( $opt_out ) {
-		add_filter( 'rest_request_before_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );
-	}
-}
-
-add_action( 'init', 'blockbase_check_for_opt_out_parent_variations', 99 );
+add_filter( 'rest_request_before_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -4,62 +4,27 @@
  * Removes the style variations of Blockbase child themes inherited by the parent theme.
  *
  * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
- *                                                                   Usually a WP_REST_Response or WP_Error.
- * @param array                                            $handler  Route handler used for the request.
+ * @param array $handler Route handler used for the request.
  *
- * @return WP_REST_Response Filtered response without the inherited style variations.
+ * @return WP_REST_Response|WP_HTTP_Response|WP_Error|mixed Result to send to the client.
  */
 function blockbase_remove_style_variations_from_child_themes( $response, $handler ) {
-	if ( ! $response instanceof WP_REST_Response ) {
-		return $response;
-	}
-
 	if ( ! isset( $handler['callback'] ) || ! is_array( $handler['callback'] ) ) {
 		return $response;
 	}
 
 	$handler_class  = isset( $handler['callback'][0] ) ? $handler['callback'][0] : null;
 	$handler_method = isset( $handler['callback'][1] ) ? $handler['callback'][1] : null;
-	if ( ! is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) || 'get_theme_items' !== $handler_method ) {
-		return $response;
+
+	/*
+	 * Prevents Blockbase child themes from being considered child themes in the
+	 * `wp/v2/global-styles/themes/:theme/variations` API endpoint, so they don't
+	 * inherit the style variations from the parent theme.
+	 */
+	if ( is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) && 'get_theme_items' === $handler_method ) {
+		add_filter( 'template_directory', 'get_stylesheet_directory' );
 	}
 
-	$base_directory     = get_stylesheet_directory() . '/styles';
-	$template_directory = get_template_directory() . '/styles';
-	if ( ! is_dir( $template_directory ) || $template_directory === $base_directory ) {
-		return $response;
-	}
-
-	$variations = $response->get_data();
-	if ( ! is_array( $variations ) ) {
-		return $response;
-	}
-
-	$variation_titles_parent = array();
-	$files_parent            = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $template_directory ) );
-	$variation_files_parent  = iterator_to_array( new RegexIterator( $files_parent, '/^.+\.json$/i', RecursiveRegexIterator::GET_MATCH ) );
-	foreach ( $variation_files_parent as $path => $file ) {
-		$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
-		if ( ! is_array( $decoded_file ) ) {
-			continue;
-		}
-
-		if ( empty( $decoded_file['title'] ) ) {
-			$variation_title_parent = basename( $path, '.json' );
-		} else {
-			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
-			$variation_title_parent = translate_with_gettext_context( $decoded_file['title'], 'Style variation name', wp_get_theme()->get( 'TextDomain' ) );
-		}
-		$variation_titles_parent[] = $variation_title_parent;
-	}
-
-	$variations = array_filter(
-		$variations,
-		function( $variation ) use ( $variation_titles_parent ) {
-			return ! in_array( $variation['title'], $variation_titles_parent, true );
-		}
-	);
-	$response->set_data( $variations );
 	return $response;
 }
-add_filter( 'rest_request_after_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );
+add_filter( 'rest_request_before_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -24,17 +24,14 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 		return $response;
 	}
 
-	if ( ! is_child_theme() ) {
+	$base_directory     = get_stylesheet_directory() . '/styles';
+	$template_directory = get_template_directory() . '/styles';
+	if ( ! is_dir( $template_directory ) || $template_directory === $base_directory ) {
 		return $response;
 	}
 
 	$variations = $response->get_data();
 	if ( ! is_array( $variations ) ) {
-		return $response;
-	}
-
-	$template_directory = get_template_directory() . '/styles';
-	if ( ! is_dir( $template_directory ) ) {
 		return $response;
 	}
 
@@ -55,9 +52,13 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 		$variation_titles_parent[] = $variation_title_parent;
 	}
 
-	$response->set_data( array_filter( $variations, function( $variation ) use ( $variation_titles_parent ) {
-		return ! in_array( $variation['title'], $variation_titles_parent, true );
-	} ) );
+	$variations = array_filter(
+		$variations,
+		function( $variation ) use ( $variation_titles_parent ) {
+			return ! in_array( $variation['title'], $variation_titles_parent, true );
+		}
+	);
+	$response->set_data( $variations );
 	return $response;
 }
 add_filter( 'rest_request_after_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -47,6 +47,7 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 		if ( empty( $decoded_file['title'] ) ) {
 			$variation_title_parent = basename( $path, '.json' );
 		} else {
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 			$variation_title_parent = translate_with_gettext_context( $decoded_file['title'], 'Style variation name', wp_get_theme()->get( 'TextDomain' ) );
 		}
 		$variation_titles_parent[] = $variation_title_parent;

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Removes the style variations of Blockbase child themes inherited by the parent theme.
+ *
+ * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
+ *                                                                   Usually a WP_REST_Response or WP_Error.
+ * @param array                                            $handler  Route handler used for the request.
+ *
+ * @return WP_REST_Response Filtered response without the inherited style variations.
+ */
+function blockbase_remove_style_variations_from_child_themes( $response, $handler ) {
+	if ( ! $response instanceof WP_REST_Response ) {
+		return $response;
+	}
+
+	if ( ! isset( $handler['callback'] ) || ! is_array( $handler['callback'] ) ) {
+		return $response;
+	}
+
+	$handler_class  = isset( $handler['callback'][0] ) ? $handler['callback'][0] : null;
+	$handler_method = isset( $handler['callback'][1] ) ? $handler['callback'][1] : null;
+	if ( ! is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) || 'get_theme_items' !== $handler_method ) {
+		return $response;
+	}
+
+	if ( ! is_child_theme() ) {
+		return $response;
+	}
+
+	$variations = $response->get_data();
+	if ( ! is_array( $variations ) ) {
+		return $response;
+	}
+
+	$template_directory = get_template_directory() . '/styles';
+	if ( ! is_dir( $template_directory ) ) {
+		return $response;
+	}
+
+	$variation_titles_parent = array();
+	$files_parent            = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $template_directory ) );
+	$variation_files_parent  = iterator_to_array( new RegexIterator( $files_parent, '/^.+\.json$/i', RecursiveRegexIterator::GET_MATCH ) );
+	foreach ( $variation_files_parent as $path => $file ) {
+		$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
+		if ( ! is_array( $decoded_file ) ) {
+			continue;
+		}
+
+		if ( empty( $decoded_file['title'] ) ) {
+			$variation_title_parent = basename( $path, '.json' );
+		} else {
+			$variation_title_parent = translate_with_gettext_context( $decoded_file['title'], 'Style variation name', wp_get_theme()->get( 'TextDomain' ) );
+		}
+		$variation_titles_parent[] = $variation_title_parent;
+	}
+
+	$response->set_data( array_filter( $variations, function( $variation ) use ( $variation_titles_parent ) {
+		return ! in_array( $variation['title'], $variation_titles_parent, true );
+	} ) );
+	return $response;
+}
+add_filter( 'rest_request_after_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );

--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -27,4 +27,12 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 
 	return $response;
 }
-add_filter( 'rest_request_before_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );
+
+function blockbase_check_for_opt_out_parent_variations() {
+	$opt_out = wp_get_global_settings( array( 'custom', 'optOutOfParentStyleVariations' ) );
+	if ( $opt_out ) {
+		add_filter( 'rest_request_before_callbacks', 'blockbase_remove_style_variations_from_child_themes', 10, 2 );
+	}
+}
+
+add_action( 'init', 'blockbase_check_for_opt_out_parent_variations', 99 );

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -93,6 +93,7 @@
 			]
 		},
 		"custom": {
+			"optOutOfParentStyleVariations": false,
 			"alignment": {
 				"alignedMaxWidth": "50%"
 			},

--- a/jackson/theme.json
+++ b/jackson/theme.json
@@ -24,7 +24,8 @@
 				"primary": "var(--wp--preset--color--foreground)",
 				"secondary": "var(--wp--preset--color--foreground)",
 				"tertiary": "var(--wp--preset--color--background)"
-			}
+			},
+            "optOutOfParentStyleVariations": true
         }
     },
     "styles": {

--- a/kingsley/theme.json
+++ b/kingsley/theme.json
@@ -24,7 +24,8 @@
 				"primary": "var(--wp--preset--color--foreground)",
 				"secondary": "var(--wp--preset--color--foreground)",
 				"tertiary": "var(--wp--preset--color--background)"
-			}
+			},
+            "optOutOfParentStyleVariations": true
         }
     },
     "styles": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As of [Gutenberg 15.1](https://github.com/WordPress/gutenberg/pull/46554)/[WordPress 6.2](https://github.com/WordPress/wordpress-develop/pull/3901), child themes inherit the style variations of the parent theme.

This is causing issues to some Blockbase child themes like Jackson or Kingsley, because the headstart content for a child theme is only created for the default style variation. When a different style variation is applied, the styles from the headstart content are incompatible with the new variation:

https://user-images.githubusercontent.com/1233880/230398566-f5abd9a1-c558-4016-9734-201c430d81d3.mov

<br>

To mitigate that, this PR introduces a new `optOutOfParentStyleVariations` setting to the Global Styles, so child themes can opt out of inheriting style variations from the parent theme. The net setting has a `false` value by default and has only been enabled on the Jackson and Kingsley themes.

#### Testing instructions:

- Apply these changes:
  - To a local/self-hosted site
  - To your WP.com sandbox (`npm run deploy:push:changes` and sandbox the API)
  - To a WoA dev site (p9o2xV-1r2-p2)
- Go to Appearance > Themes
- Activate the Jackson or the Kingsley theme
- Go to Appearance > Editor
- Open the Styles sidebar
- Make sure there are no style variations
- Go to Appearance > Themes
- Activate any other Blockbase child theme (e.g. Attar)
- Go to Appearance > Editor
- Open the Styles sidebar
- Make sure style variations are available

You can also follow instructions from D107265-code to ensure that style variations are not displayed in the WP.com design picker nor in the WP.com theme showcase.

#### Related issue(s):

https://github.com/Automattic/themes/issues/6941