### PR TITLE
Blockbase Children: remove conflicting `core/navigation-link` styles

### DIFF
--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -199,12 +199,6 @@
 					"lineHeight": "1.6"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontSize": "min(max(3rem, 7vw), 4rem)",

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -210,12 +210,6 @@
 					"fontSize": "var(--wp--custom--font-size--normal)"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontSize": "min(max(3rem, 7vw), 5rem)",

--- a/videomaker/theme.json
+++ b/videomaker/theme.json
@@ -96,12 +96,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/navigation-link": {
-				"color": {
-					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
 			"core/post-date": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -204,12 +204,6 @@
 					"fontSize": "var(--wp--custom--font-size--normal)"
 				}
 			},
-			"core/navigation-link": {
-				"color": {
-					"background": "transparent",
-					"text": "var(--wp--custom--color--foreground)"
-				}
-			},
 			"core/post-title": {
 				"spacing": {
 					"margin": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Remove `core/navigation-link` styles in Blockbase children so that they properly inherit from the parent nav block. I dug for a while but was unable to figure out why the styles were present in the first place.

Prior to this, `core/navigation-link` styles would always override the parent nav block's color. I couldn't see any reason for those styles, perhaps somebody will be able to figure it out.

Note that in my testing you could only access the Navigation Link block when loading a "Classic" menu for the nav menu block. The page list menu doesn't use `core/navigation-link` it seemed. 

#### Related issue(s):

Fixes https://github.com/Automattic/wp-calypso/issues/74984
