### PR TITLE
Add body class for the theme variation

### DIFF
--- a/course/functions.php
+++ b/course/functions.php
@@ -128,22 +128,6 @@ function course_save_global_styles( $post_id, $post, $update ) {
 add_action( 'save_post', 'course_save_global_styles', 10, 3 );
 
 /**
- * Delete the theme variation option when the global styles post is deleted.
- *
- * @param int     $post_id Post ID.
- * @param WP_Post $post    Post object.
- */
-function course_delete_global_styles( $post_id, $post ) {
-	if ( 'wp_global_styles' !== $post->post_type ) {
-		return;
-	}
-
-	delete_option( 'course_theme_variation' );
-}
-
-add_action( 'delete_post', 'course_delete_global_styles', 10, 2 );
-
-/**
  * Add the theme variation to the body class.
  *
  * @param array $classes Array of body classes.

--- a/course/functions.php
+++ b/course/functions.php
@@ -154,7 +154,7 @@ function course_add_variation_body_class( $classes ) {
 		return $classes;
 	}
 
-	$classes[] = 'course-variation-' . $current_variation;
+	$classes[] = 'is-' . $current_variation;
 
 	return $classes;
 }

--- a/course/functions.php
+++ b/course/functions.php
@@ -119,7 +119,7 @@ function course_save_global_styles( $post_id, $post, $update ) {
 	$current_variation  = 'default';
 	foreach ( $variations as $variation ) {
 		if ( $variation['settings'] === $global['settings'] && $variation['styles'] === $global['styles'] ) {
-			$current_variation = strtolower( $variation['title'] );
+			$current_variation = sanitize_title( $variation['title'] );
 		}
 	}
 	update_option( 'course_theme_variation', $current_variation );

--- a/course/functions.php
+++ b/course/functions.php
@@ -102,6 +102,10 @@ add_action( 'init', 'course_register_block_patterns_category' );
 
 /**
  * Determine the theme variation and save in option.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an existing post being updated or not.
  */
 function course_save_global_styles( $post_id, $post, $update ) {
 	if ( 'wp_global_styles' !== $post->post_type ) {
@@ -125,6 +129,9 @@ add_action( 'save_post', 'course_save_global_styles', 10, 3 );
 
 /**
  * Delete the theme variation option when the global styles post is deleted.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
  */
 function course_delete_global_styles( $post_id, $post ) {
 	if ( 'wp_global_styles' !== $post->post_type ) {
@@ -138,6 +145,8 @@ add_action( 'delete_post', 'course_delete_global_styles', 10, 2 );
 
 /**
  * Add the theme variation to the body class.
+ *
+ * @param array $classes Array of body classes.
  */
 function course_add_variation_body_class( $classes ) {
 	$current_variation = get_option( 'course_theme_variation' );


### PR DESCRIPTION
As there is no reliable way to determine the variation on backend, we save the variation in an option at the moment it the global styles are saved.

#### Changes proposed in this Pull Request:
- Save theme variation on global styles update.
- Add body class for the theme variation.

#### Testing instructions:
- Go to `Appearance -> Themes` and activate the Course theme.
- Go to `Appearance -> Editor -> Templates -> Lesson (Learning Mode - Default)` (Not really important which template to select).
- Click `Styles -> Browse Styles`, select one, click `Save`.
- Go to front end and check the `<body>` tag has a class with the name `is-{lowercased-variation-title}`.
- Go to the Editor and change variation to another one. Save.
- Go to the front end and check that the body tag variation class has updated.
- Go to the Editor and reset global styles to defaults.
- Check the body tag has `is-default` CSS class.

#### Related Issues:
- https://github.com/Automattic/themes/issues/7123