### PR TITLE
Fix changedPublicThemes variable name

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -328,7 +328,7 @@ async function pushButtonDeploy() {
 			}
 		}
 
-		await buildComZips(changedPublicThemes);
+		await buildComZips(changedThemes);
 
 		console.log(`The following themes have changed:\n${changedThemes.join('\n')}`)
 		console.log('\n\nAll Done!!\n\n');


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I just ran our deploy script and noticed an error during the build-com-zips step (it worked great otherwise!). It looks like one of the variable names was missed as part of https://github.com/Automattic/themes/pull/7007. This PR replaces `changedPublicThemes` with `changedThemes`.
