### PR TITLE
Corrected version numbers that should have already been at 1.x or higher

### DIFF
--- a/antonia/style.css
+++ b/antonia/style.css
@@ -7,7 +7,7 @@ Description: Antonia is a theme for selling products with the help of payments b
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.5
+Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/appleton/style.css
+++ b/appleton/style.css
@@ -7,7 +7,7 @@ Description: Appleton is a theme for creative professionals, such as photographe
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.7
+Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/arbutus/style.css
+++ b/arbutus/style.css
@@ -7,7 +7,7 @@ Description: Arbutus is a simple blogging theme that supports full-site editing.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.7
-Version: 0.0.16
+Version: 1.0.16
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/archivo/style.css
+++ b/archivo/style.css
@@ -7,7 +7,7 @@ Description: Archivo is a blog and portfolio theme that shows your featured imag
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.1
+Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 

--- a/attar/style.css
+++ b/attar/style.css
@@ -7,7 +7,7 @@ Description: Attar is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.4
+Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/blank-canvas-3/style.css
+++ b/blank-canvas-3/style.css
@@ -7,7 +7,7 @@ Description:Blank Canvas is a barebones starter theme, stripped off of content t
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.10
+Version: 1.0.10
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: blank-canvas

--- a/calyx/style.css
+++ b/calyx/style.css
@@ -7,7 +7,7 @@ Description: Calyx is a simple theme that supports full-site editing.
 Requires at least: 5.7
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.12
+Version: 1.0.12
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: calyx

--- a/dorna/style.css
+++ b/dorna/style.css
@@ -7,7 +7,7 @@ Description: Dorna is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.3
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/hari/style.css
+++ b/hari/style.css
@@ -7,7 +7,7 @@ Description: Hari is a minimalist, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.3
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/lynx/style.css
+++ b/lynx/style.css
@@ -7,7 +7,7 @@ Description: A theme for anyone who wants to create a collection of links to the
 Requires at least: 5.7
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.24
+Version: 1.0.24
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: lynx

--- a/marl/style.css
+++ b/marl/style.css
@@ -7,7 +7,7 @@ Description: Marl is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.4
+Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/meraki/style.css
+++ b/meraki/style.css
@@ -7,7 +7,7 @@ Description: Meraki is a blogging theme that supports full-site editing.
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.9
+Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/muscat/style.css
+++ b/muscat/style.css
@@ -7,7 +7,7 @@ Description: Muscat is a simple blogging WordPress theme with grid post template
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.4
+Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 

--- a/russell/style.css
+++ b/russell/style.css
@@ -7,7 +7,7 @@ Description: Russell is a simple blogging theme that supports full-site editing.
 Requires at least: 5.7
 Tested up to: 5.7
 Requires PHP: 5.7
-Version: 0.0.26
+Version: 1.0.26
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase

--- a/spearhead-blocks/style.css
+++ b/spearhead-blocks/style.css
@@ -7,7 +7,7 @@ Description: Spearhead Blocks is the block based version of the original Spearhe
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.3
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template:

--- a/twentytwentytwo-blue/style.css
+++ b/twentytwentytwo-blue/style.css
@@ -7,7 +7,7 @@ Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.6
-Version: 0.8
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-blue

--- a/twentytwentytwo-mint/style.css
+++ b/twentytwentytwo-mint/style.css
@@ -7,7 +7,7 @@ Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.6
-Version: 0.8
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-mint

--- a/twentytwentytwo-pink/style.css
+++ b/twentytwentytwo-pink/style.css
@@ -7,7 +7,7 @@ Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.6
-Version: 0.8
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-pink

--- a/twentytwentytwo-red/style.css
+++ b/twentytwentytwo-red/style.css
@@ -7,7 +7,7 @@ Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.6
-Version: 0.8
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-yellow

--- a/twentytwentytwo-swiss/style.css
+++ b/twentytwentytwo-swiss/style.css
@@ -7,7 +7,7 @@ Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
 Requires PHP: 5.6
-Version: 0.8
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-swiss

--- a/winkel/style.css
+++ b/winkel/style.css
@@ -7,7 +7,7 @@ Description: Winkel is a minimal, product-oriented theme.
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 0.0.3
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase


### PR DESCRIPTION
There are a number of themes that are already in production that don't have versions of 1.x or higher.  None of these are considered "in development" or "experimental" and should have been bumped upon release.

Rather than setting all of these versions to "1.0" I have instead set the versions to reflect the changes since the beginning; thus only changing the major versions from 0 -> 1.

There were a few themes I did NOT change:

Blank Canvas Blocks (I think that's only used for development, I don't believe this is in production)
Block Canvas (Only used as a base for other themes.  Isn't in production and I don't believe should have a 1.0 version)
Gramming (Not yet in production)
Verso (Not yet in production)
