### PR TITLE
Update the minimum required WordPress version

### DIFF
--- a/course/readme.txt
+++ b/course/readme.txt
@@ -1,7 +1,7 @@
 === Course ===
 Contributors: Automattic
-Requires at least: 6.1
-Tested up to: 6.1
+Requires at least: 6.2
+Tested up to: 6.2
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/course/style.css
+++ b/course/style.css
@@ -4,8 +4,8 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Course is a flexible and modern theme for anyone wanting to share their knowledge. The theme is built with integration with Sensei LMS and is ideal for Sensei users that are creating or selling courses. Style variations with multiple font and color combinations help you craft the perfect look and feel to show off courses and content. The theme can be used without Sensei too.
 Version: 1.2.3
-Requires at least: 6.1
-Tested up to: 6.1
+Requires at least: 6.2
+Tested up to: 6.2
 Requires PHP: 7.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/course/theme.json
+++ b/course/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/wp/6.1/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.2/theme.json",
 	"version": 2,
 	"customTemplates": [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

I'm bumping the min WordPress version because we've started using the [custom CSS in theme.json](https://fullsiteediting.com/lessons/how-to-use-custom-css-in-theme-json/) feature that was introduced in WordPress 6.2.

#### Related issue(s):

https://github.com/Automattic/themes/pull/7046, https://github.com/Automattic/themes/pull/7047
