### PR TITLE
fixed reference to collection of themes to build zips for

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -328,7 +328,7 @@ async function pushButtonDeploy() {
 			}
 		}
 
-		await buildComZips(changedPublicThemes);
+		await buildComZips(changedThemes);
 
 		console.log(`The following themes have changed:\n${changedThemes.join('\n')}`)
 		console.log('\n\nAll Done!!\n\n');


### PR DESCRIPTION
I think when the premium themes were removed (and the deploy script changed to no longer consider them) this reference to `changedPublicThemes` remained.

This just makes it reference what it's supposed to reference so that zips are built again.