### PR TITLE
Block Canvas: Remove default underline for post-terms

### DIFF
--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -192,6 +192,20 @@
 					}
 				}
 			},
+			"core/post-terms": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/post-title": {
 				"spacing": {
 					"margin": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the default underline from post categories and tags in Block Canvas.

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/7048.