### PR TITLE
Fix core theme deploy utility

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -375,10 +375,10 @@ return;
 		return;
 	}
 
+	await landChanges(diffId);
+	await deployThemes([theme]);
+	await buildComZips([theme]);
 	return;
-	// await landChanges(diffId);
-	// await deployThemes([theme]);
-	// await buildComZips([theme]);
 }
 
 


### PR DESCRIPTION
The part of the core deploy process that lands the change, deploys the theme and builds the zip was commented out.  It works fine so it was probably comment for historical debugging purposes and shouldn't have been comitted.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
