### PR TITLE
Update course theme variation button spacing

### DIFF
--- a/course/style.css
+++ b/course/style.css
@@ -263,10 +263,12 @@ a {
 	border-color: currentcolor;
 	border-width: 1px;
 	color: currentcolor;
-	padding: 0.5856em 1.5238em;
 	text-decoration: none;
 }
 
+.wp-block-button {
+	text-align: center;
+}
 /*
  * Pagination styles
  */

--- a/course/styles/blue.json
+++ b/course/styles/blue.json
@@ -286,6 +286,9 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--body)",
 					"letterSpacing": "-0.04em"
+				},
+				"spacing": {
+					"padding": "0.9em 1.75em"
 				}
 			},
 			"heading": {

--- a/course/styles/dark.json
+++ b/course/styles/dark.json
@@ -255,6 +255,9 @@
 				"typography": {
 					"fontWeight": "500",
 					"letterSpacing": "-0.01em"
+				},
+				"spacing": {
+					"padding": "0.9em 1.6em"
 				}
 			},
 			"heading": {

--- a/course/styles/gold.json
+++ b/course/styles/gold.json
@@ -303,6 +303,9 @@
 					"fontWeight": "700",
 					"letterSpacing": "0.001em",
 					"fontSize": "var(--wp--preset--font-size--x-small)"
+				},
+				"spacing": {
+					"padding": "1em 1.3em"
 				}
 			}
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes the padding inside the button on different variations of Course theme to make them uniform

**Gold**
Before:
![Gold-button-before](https://github.com/Automattic/themes/assets/6820724/896f2cbc-d1bc-47b7-a094-22de9f2c6731)

After (Compared with design using PixelParallel)
![Button-gold-after](https://github.com/Automattic/themes/assets/6820724/eaa2b99d-5405-48a4-982f-1663ffb4836e)


**Dark**
Before:
![Dark-button-before](https://github.com/Automattic/themes/assets/6820724/6860f168-c209-4518-b879-5b99bcae60c7)

After (Compared with design using PixelParallel)
![Dark-button-after](https://github.com/Automattic/themes/assets/6820724/e6d2d3d4-7a6e-4bdf-9a90-a56ddf7e0472)


**Blue**
Before:
![Button-blue-before](https://github.com/Automattic/themes/assets/6820724/08e64186-e372-4d3f-b0b3-248f8e936355)

After (Compared with design using PixelParallel)
![Button-blue-after](https://github.com/Automattic/themes/assets/6820724/2485637d-4b33-4d77-8528-0833be856b05)

#### Related issue(s):

https://github.com/Automattic/themes/issues/7110
