### PR TITLE
Fix heading font size for default variation

### DIFF
--- a/course/theme.json
+++ b/course/theme.json
@@ -323,7 +323,7 @@
 					"size": "4.5rem",
 					"fluid": {
 						"min": "3rem",
-						"max": "6rem"
+						"max": "5rem"
 					},
 					"slug": "xx-large"
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fix h1 font size for Single post, Single Page, Archive and sensei Learning Mode default variation

Design:
![Screen Shot 2023-05-17 at 3 46 49 PM](https://github.com/Automattic/themes/assets/6820724/ba0439a4-e9b3-40db-b424-c6fd7b0b90f2)
![Screen Shot 2023-05-17 at 3 47 09 PM](https://github.com/Automattic/themes/assets/6820724/c02a6546-a0a9-4f25-9edb-d2bb0b919468)
![Screen Shot 2023-05-17 at 3 47 41 PM](https://github.com/Automattic/themes/assets/6820724/208dc63a-6242-46e3-a4ac-7195019f3a4f)

Learning mode:
![image](https://github.com/Automattic/themes/assets/6820724/e5d88c07-222e-466e-928e-d318903fafc2)