### PR TITLE
Penscratch 2: remove jQuery

### DIFF
--- a/penscratch-2/functions.php
+++ b/penscratch-2/functions.php
@@ -230,7 +230,7 @@ function penscratch_2_scripts() {
 
 	wp_enqueue_script( 'penscratch-2-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true );
 
-	wp_enqueue_script( 'penscratch-2-scripts', get_template_directory_uri() . '/js/penscratch-2.js', array( 'jquery' ), '20170608', true );
+	wp_enqueue_script( 'penscratch-2-scripts', get_template_directory_uri() . '/js/penscratch-2.js', array(), '20230518', true );
 
 	wp_enqueue_script( 'penscratch-2-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20130115', true );
 

--- a/penscratch-2/js/penscratch-2.js
+++ b/penscratch-2/js/penscratch-2.js
@@ -1,11 +1,10 @@
-/*
- * Triggers resize event to make sure video widgets in the footer maintain the correct aspect ratio
- */
-( function( $ ) {
+( function () {
+	'use strict';
 
-	$( window ).on( 'load', function() {
-		setTimeout( function(){
-			if ( typeof( Event ) === 'function' ) {
+	function onPageLoad() {
+		// Trigger resize event to make sure video widgets in the footer maintain the correct aspect ratio
+		setTimeout( function () {
+			if ( typeof Event === 'function' ) {
 				window.dispatchEvent( new Event( 'resize' ) );
 			} else {
 				var event = window.document.createEvent( 'UIEvents' );
@@ -13,6 +12,11 @@
 				window.dispatchEvent( event );
 			}
 		} );
-	} );
+	}
 
-} )( jQuery );
+	if ( document.readyState === 'complete' ) {
+		onPageLoad();
+	} else {
+		window.addEventListener( 'load', onPageLoad );
+	}
+} )();


### PR DESCRIPTION
This PR reimplements the small theme script in Penscratch 2 to use vanilla JS, dropping the `jQuery` dependency.

#### Changes proposed in this Pull Request:
- Reimplement Penscratch 2 script in vanilla JS
- Remove `jQuery` dependency when enqueuing

#### Related issue(s):
See D111284-code