### PR TITLE
Lettre: Add title to page template

### DIFF
--- a/lettre/templates/page.html
+++ b/lettre/templates/page.html
@@ -4,6 +4,8 @@
 <main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 
+<!-- wp:post-title {"level":1} /-->
+
 <!-- wp:spacer {"height":"1px"} -->
 <div style="height:1px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR adds a title to the theme's single Page template.

#### Related issue(s):

Resolves https://github.com/Automattic/themes/issues/7070

#### Testing Instructions:

1) Load the Lettre theme.
2) Pull up a single page on the frontend and confirm it loads as expected, but now shows a page title. 
3) Go to Site Editor > Templates > Page and confirm the title block now shows and there are no other issues. 