### PR TITLE
Lettre: Update spacer in archive header

### DIFF
--- a/lettre/parts/header-archive.html
+++ b/lettre/parts/header-archive.html
@@ -6,8 +6,8 @@
 <!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"typography":{"fontStyle":"normal"}},"fontSize":"x-large"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":"200px"} -->
-<div style="height:200px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"100px"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR reduces the spacer height from 200px to 100px on the achive header template part.

Note: This issue started with a desire to reduce spacing above the post title on single posts. Not obviously that a single post template would be using a header called 'archive header'. 

#### Related issue(s):

Resolves https://github.com/Automattic/themes/issues/7069

#### Testing Instructions:

1) Load the Lettre theme.
2) Pull up a single post on the frontend and confirm the post loads without issue and the space above the post title is reduced as expected.
3) Go to Site Editor > Templates > Header Archive template part and confirm the title block now shows and there are no other issues. 