### PR TITLE
Update size of lesson progress meta and Exit Course link in Learning Mode default template

### DIFF
--- a/course/theme.json
+++ b/course/theme.json
@@ -665,7 +665,7 @@
 			"sensei-lms/course-theme-course-progress-counter": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system)",
-					"fontSize": "var(--wp--preset--font-size--x-small)",
+					"fontSize": "1rem",
 					"letterSpacing": "0.02em"
 				}
 			},
@@ -679,7 +679,7 @@
 			"sensei-lms/exit-course": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system)",
-					"fontSize": "1.125rem",
+					"fontSize": "1rem",
 					"letterSpacing": "0.02em",
 					"lineHeight": "1"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

### Changes proposed in this Pull Request:
Adjust the font size of the lesson progress meta and Exit Course link for the default variation and default LM template to `16px` on desktop.

### Testing Steps
- Using the default theme variation and default LM template, view a lesson.
- Check that the lesson progress meta and Exit Course link are `16px` on desktop.