### PR TITLE
Update George Lois theme default styles to dark

### DIFF
--- a/george-lois/theme.json
+++ b/george-lois/theme.json
@@ -6,27 +6,27 @@
 			"customGradient": true,
 			"palette": [
 				{
-					"color": "#131020",
+					"color": "#f4f4f3",
 					"name": "Primary",
 					"slug": "primary"
 				},
 				{
-					"color": "#f4f4f3",
+					"color": "#131020",
 					"name": "Secondary",
 					"slug": "secondary"
 				},
 				{
-					"color": "#131020",
+					"color": "#f4f4f3",
 					"name": "Foreground",
 					"slug": "foreground"
 				},
 				{
-					"color": "#f4f4f3",
+					"color": "#131020",
 					"name": "Background",
 					"slug": "background"
 				},
 				{
-					"color": "#f4f4f3",
+					"color": "#131020",
 					"name": "Tertiary",
 					"slug": "tertiary"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Update George Lois default styles to dark. Light version is offered through style variation.

<img width="355" alt="image" src="https://github.com/Automattic/themes/assets/1935113/8c4e9800-4d69-4940-b58e-f044b74bd795">

#### Related issue(s):

Fixes: https://github.com/Automattic/wp-calypso/issues/78104