### PR TITLE
Bugfix: replaced bitacora with tu where needed.

### DIFF
--- a/bitacora/functions.php
+++ b/bitacora/functions.php
@@ -12,11 +12,11 @@
 if ( ! function_exists( 'bitacora_support' ) ) :
 
 	/**
-	 * Sets up theme defaults and registers support for various WordPress feabitacorares.
+	 * Sets up theme defaults and registers support for various WordPress features.
 	 *
 	 * @since Bitácora 1.0
 	 *
-	 * @rebitacorarn void
+	 * @return void
 	 */
 	function bitacora_support() {
 
@@ -29,7 +29,7 @@ if ( ! function_exists( 'bitacora_support' ) ) :
 
 endif;
 
-add_action( 'after_sebitacorap_theme', 'bitacora_support' );
+add_action( 'after_setup_theme', 'bitacora_support' );
 
 if ( ! function_exists( 'bitacora_styles' ) ) :
 
@@ -38,7 +38,7 @@ if ( ! function_exists( 'bitacora_styles' ) ) :
 	 *
 	 * @since Bitácora 1.0
 	 *
-	 * @rebitacorarn void
+	 * @return void
 	 */
 	function bitacora_styles() {
 


### PR DESCRIPTION
Due to typo bitacora_support was hooked to after_sebitacorap_theme.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Replacing instances of the string bitacora with tu in lines 15, 19, 32 & 41.
In the above mentioned lines the string tu was replaced with the theme's slug thus disabling the after_setup_theme action by turning it to after_sebitacorap_theme resulting in the editor style not being added and the theme's text domain not being loaded properly.

This PR replaces the string bitacora with tu where needed to mitigate the issue.

#### Related issue(s):
