### PR TITLE
Lettre: Add avatars to post comments

### DIFF
--- a/lettre/templates/single.html
+++ b/lettre/templates/single.html
@@ -35,7 +35,11 @@
 
   <!-- wp:comment-template -->
   <!-- wp:columns -->
-  <div class="wp-block-columns"><!-- wp:column -->
+  <div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
+    <div class="wp-block-column" style="flex-basis:40px"><!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /--></div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
     <div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
 
       <!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR updates the single post template to add avatars to post comments. 

<img width="1094" alt="lettre avatar" src="https://github.com/Automattic/themes/assets/21228350/aed377fc-1bdf-488d-a65d-b2d096529b9e">

#### Related issue(s):

https://github.com/Automattic/themes/issues/7087

#### Testing instructions

1) Checkout this branch to a local WordPress install and activate Lettre theme.
2) Ensure you're logged into the site with a user that has an avatar associated. 
3) Go to a single post, add a comment, and confirm the avatar loads as expected above. 
4) For safety, from the dashboard/admin, go to Appearance > Editor > Templates > Single, and confirm the updated Single template loads without issues. 
 