### PR TITLE
Lettre: Fix styling issues for top nav menu

### DIFF
--- a/lettre/parts/header-archive.html
+++ b/lettre/parts/header-archive.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"align":"full","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
-<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"typography":{"fontStyle":"normal"}},"fontSize":"x-large"} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"background","overlayTextColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"typography":{"fontStyle":"normal"}},"fontSize":"large"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":"100px"} -->

--- a/lettre/style.css
+++ b/lettre/style.css
@@ -49,7 +49,7 @@ a {
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
-	opacity: 0.90;
+	opacity: 0.9;
 }
 
 /*
@@ -128,7 +128,7 @@ input:not([type="submit"]):not([type="button"]):focus {
  * Comment form refinements.
  */
 .comment-form .comment-subscription-form,
-.comment-form .post-subscription-form{
+.comment-form .post-subscription-form {
 	margin: 0;
 }
 
@@ -138,10 +138,29 @@ input:not([type="submit"]):not([type="button"]):focus {
  * https://github.com/Automattic/jetpack/milestone/295
  */
 
-.wp-block-jetpack-subscriptions__container .wp-element-button:not(.block-editor-rich-text__editable), 
+.wp-block-jetpack-subscriptions__container .wp-element-button:not(.block-editor-rich-text__editable),
 .wp-block-jetpack-subscriptions__container .wp-block-button__link:not(.block-editor-rich-text__editable) {
 	font-size: inherit;
 	margin-top: 10px;
 	padding: 24px 36px 24px 36px;
 	width: 100%;
+}
+
+/*
+ * Refine mobile navigation styling.
+ */
+.wp-block-navigation a:where(:not(.wp-element-button)):focus,
+.wp-block-pages-list__item:focus.wp-block-navigation a:where(:not(.wp-element-button)):focus {
+	text-decoration: none;
+}
+
+.wp-block-pages-list__item.current-menu-item a:where(:not(.wp-element-button)) {
+	text-decoration: underline;
+}
+
+@media screen and (max-width: 37.5em) {
+
+	.wp-block-pages-list__item {
+		text-align: right;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Reduces the font size of items in the nave menu. Among other things this fixes an issue with text for medium-to-longer page titles wrapping on small screens.
* Ensure wrapping text doesn't align left. 
* Remove underline from :focus items. This was producing a situation where the first item in the menu was always underlined, even when it was not current. 
* Add underline to current item. The current item in the menu will now be underlined. 

**Before**
<img width="751" alt="lettre nav before" src="https://github.com/Automattic/themes/assets/21228350/c0f225e4-1524-4bb9-af01-282c55846cb3">

**After**
<img width="386" alt="lettre-nav-after" src="https://github.com/Automattic/themes/assets/21228350/b7d56ab9-474d-4d1b-ae91-12d8c14fcaf3">

#### Related issue(s):
https://github.com/Automattic/themes/issues/7071
https://github.com/Automattic/themes/issues/7072

#### Testing instructions
1) Checkout this branch to your local WordPress instance.
2) Ensure you have multiple items on your menu, including one page with a long page title.
3) Confirm: 
   - First item isn't always underlined by default
   - Current page is underlined
   - Font size is smaller
   - If longer item does wrap, it is still aligned right.