### PR TITLE
Lineup: Make sure gap between posts are 0

### DIFF
--- a/lineup/style.css
+++ b/lineup/style.css
@@ -253,7 +253,3 @@ div[id^="contact-form-"] .contact-form-submission {
 	overflow: hidden;
 	white-space: nowrap;
 }
-/* This removes the gap between each posts in the query loop block */
-.wp-block-post-template li {
-	margin: 0;
-}

--- a/lineup/theme.json
+++ b/lineup/theme.json
@@ -472,6 +472,9 @@
 					}
 				}
 			},
+			"core/post-template": {
+				"css": ".wp-block-post-template > * + * { margin-top: 0;}"
+			},
 			"core/post-terms": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
[The demo site](https://lineupthemedemo.wordpress.com/?demo) appears as expected. but I've noticed the gap between posts isn't `0` when I preview the theme in WP.com onboarding.

![wordpress com_setup_site-setup_designSetup_siteSlug=iamtakashinuxtest20230703155039 wordpress com theme=lineup](https://github.com/Automattic/themes/assets/908665/d10b3ccd-3443-4a8c-9084-48ca29517966)

I assume this happens because I've adjusted the spacing in the `style.css` (I built this theme quite some time ago before we agreed on where to include custom CSS in a theme.) Other themes that I adjusted the same thing in the `theme.json` appear as expected in the wp.com onboarding.

With this PR, the posts keep appearing back-to-back like how they are seen in`screenshot.png`, but it should solve the problem in the onboarding.

![screenshot](https://github.com/Automattic/themes/assets/908665/c9c15094-710a-409e-8257-604b6a71a2cc)
