### PR TITLE
Exmoor: Fix footer credit so it will be replaced correctly for WP.com

### DIFF
--- a/exmoor/patterns/footer.php
+++ b/exmoor/patterns/footer.php
@@ -47,7 +47,7 @@
 					/* Translators: WordPress link. */
 					$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'exmoor' ) ) . '" rel="nofollow">WordPress</a>';
 					echo sprintf(
-						wp_kses_post( __( 'Designed with<br>%1$s', 'exmoor' ) ),
+						esc_html__( 'Designed with %1$s', 'exmoor' ),
 						$wordpress_link
 					);?></p>
 			<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Initially, I wanted to make the footer credit span two lines, but that prevented it from being replaced correctly for the WP.com-specific credit.

**before**
![Screenshot 2023-07-04 at 15 20 06](https://github.com/Automattic/themes/assets/908665/10ddd740-ccb7-43c2-bae0-ecc115d7c2fd)

**after**
![Screenshot 2023-07-04 at 15 22 01](https://github.com/Automattic/themes/assets/908665/edf2870a-e2eb-4a25-a468-1d3883630749)

