### PR TITLE
Removed unnecessary and unexpected styles from heading element

### DIFF
--- a/effigy/theme.json
+++ b/effigy/theme.json
@@ -616,16 +616,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"heading": {
-				"color": {
-					"text": "#004de5"
-				},
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
-					"fontWeight": "400",
-					"lineHeight": "1.125"
-				}
-			},
 			"link": {
 				":hover": {
 					"typography": {


### PR DESCRIPTION
The font 'rubik' is not installed by the font and not expected to be used.  The color defined is the default and unneeded to be set.

This change removes those settings completely.

There are no visual changes unless Rubik font is available (for example via Jetpack fonts, etc)