### PR TITLE
CTLG: Bump WP version to 6.0

### DIFF
--- a/ctlg/readme.txt
+++ b/ctlg/readme.txt
@@ -1,7 +1,7 @@
 === CTLG ===
 Contributors: Automattic
-Requires at least: 5.8
-Tested up to: 5.9
+Requires at least: 6.0
+Tested up to: 6.0
 Requires PHP: 5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ctlg/style.css
+++ b/ctlg/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.com/theme/ctlg
 Author: Automattic
 Author URI: https://automattic.com
 Description: CTLG is a free WordPress block theme that is specifically designed for creating lists, directories, and catalogs. It comes with a variety of pre-designed block templates and style variations.
-Requires at least: 5.8
-Tested up to: 5.9
+Requires at least: 6.0
+Tested up to: 6.0
 Requires PHP: 5.7
 Version: 1.0.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This is a small change to bump the WP version for CTLG's "Tested up to:" and "Requires at least:" fields. I'm testing if this will allow the `style-variations` tag to show in the .org directory.