### PR TITLE
Bute: Update navigation so they are vertically centre to avoid wpcom banners overlapping

### DIFF
--- a/bute/patterns/header.php
+++ b/bute/patterns/header.php
@@ -24,7 +24,7 @@
 			</ul>
 			<!-- /wp:social-links -->
 
-			<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"right"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"xx-large"} /-->
+			<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"center","orientation":"vertical"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"xx-large"} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/bute/patterns/header.php
+++ b/bute/patterns/header.php
@@ -24,7 +24,7 @@
 			</ul>
 			<!-- /wp:social-links -->
 
-			<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"center","orientation":"vertical"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"xx-large"} /-->
+			<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"right"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"xx-large"} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/bute/theme.json
+++ b/bute/theme.json
@@ -724,7 +724,7 @@
 				}
 			},
 			"core/navigation": {
-				"css": " .wp-block-navigation__responsive-container.is-menu-open{justify-content:center; .wp-block-navigation__responsive-container-close{right:50%;transform:translate(50%, 0%)}}",
+				"css": " .wp-block-navigation__responsive-container.is-menu-open{justify-content:center;}}",
 				"elements": {
 					"link": {
 						"typography": {

--- a/bute/theme.json
+++ b/bute/theme.json
@@ -724,7 +724,7 @@
 				}
 			},
 			"core/navigation": {
-				"css": " .wp-block-navigation__responsive-container.is-menu-open{justify-content:center;}}",
+				"css": " .wp-block-navigation__responsive-container.is-menu-open{justify-content:center;}",
 				"elements": {
 					"link": {
 						"typography": {

--- a/bute/theme.json
+++ b/bute/theme.json
@@ -724,6 +724,7 @@
 				}
 			},
 			"core/navigation": {
+				"css": " .wp-block-navigation__responsive-container.is-menu-open{justify-content:center; .wp-block-navigation__responsive-container-close{right:50%;transform:translate(50%, 0%)}}",
 				"elements": {
 					"link": {
 						"typography": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This theme suggests having an "always-icon" navigation. 
![butedemo wordpress com_(MacBook Pro 14_) (1)](https://github.com/Automattic/themes/assets/908665/b7b5ebec-9b00-4bfd-b2fc-d47b87083202)

When you open the navigation, the demo or the marketing bars overlap the navigation, and the close button gets hidden.
![butedemo wordpress com_(MacBook Pro 14_) (2)](https://github.com/Automattic/themes/assets/908665/609f707e-0bea-4344-8ec2-954a3d068d7d)

Usually, this is not a problem because of the z-index of `100000` while the banners are `99998` and `99998`. However, when a header is inside a cover block, I don't think the z-index is actually `100000`, thus, it goes underneath the banners :/

I thought it'd be best to make the navigation vertically centre to avoid that. There is no option to modify the layout inside the modal, so I needed to use css though.

![localhost local_(MacBook Pro 14_) (2)](https://github.com/Automattic/themes/assets/908665/e912296b-a276-4a17-a2ed-8ff0cf7a3c14)

What do you think? Any other solution that we don't need to hold up the launch? 