### PR TITLE
Small tweaks to force update following `style-variations` tag fix

### DIFF
--- a/archivo/style.css
+++ b/archivo/style.css
@@ -16,6 +16,15 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 */
 
 /*
+ * Font smoothing
+ * https://github.com/WordPress/gutenberg/issues/35934
+ */
+body {
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+}
+
+/*
  * Control the hover stylings of outline block style.
  * Unnecessary once block styles are configurable via theme.json
  * https://github.com/WordPress/gutenberg/issues/42794

--- a/archivo/style.css
+++ b/archivo/style.css
@@ -16,15 +16,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 */
 
 /*
- * Font smoothing
- * https://github.com/WordPress/gutenberg/issues/35934
- */
-body {
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-font-smoothing: antialiased;
-}
-
-/*
  * Control the hover stylings of outline block style.
  * Unnecessary once block styles are configurable via theme.json
  * https://github.com/WordPress/gutenberg/issues/42794
@@ -33,30 +24,6 @@ body {
 	background-color: var(--wp--preset--color--secondary);
 	color: var(--wp--preset--color--background);
 	border-color: var(--wp--preset--color--secondary);
-}
-
-/**
- * Currently table styles are only available with 'wp-block-styles' 
- * theme support (block css) thus the following needs to be included
- * since 'wp-block-styles' aren't used for this theme.
- * https://github.com/WordPress/gutenberg/issues/45065
- */
-.wp-block-table thead {
-	border-bottom: 3px solid;
-}
-.wp-block-table tfoot {
-	border-top: 3px solid;
-}
-.wp-block-table td,
-.wp-block-table th {
-	padding: var(--wp--preset--spacing--30);
-	border: 1px solid;
-	word-break: normal;
-}
-.wp-block-table figcaption {
-	font-size: var(--wp--preset--font-size--small);
-	margin-top: calc( var(--wp--preset--spacing--50) / 4 );
-	text-align: center;
 }
 
 /*

--- a/bitacora/readme.txt
+++ b/bitacora/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Bitácora is a simple old-school blog theme
+Bitácora is a simple old-school blog theme.
 
 == Changelog ==
 

--- a/bitacora/style.css
+++ b/bitacora/style.css
@@ -3,7 +3,7 @@ Theme Name: Bitácora
 Theme URI: https://wordpress.com/theme/bitacora
 Author: Automattic
 Author URI: https://automattic.com/
-Description: Bitácora is a simple old-school blog theme
+Description: Bitácora is a simple old-school blog theme.
 Requires at least: 6.0
 Tested up to: 6.1.1
 Requires PHP: 5.7

--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -25,5 +25,4 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
-
 */

--- a/deploy-dotorg.sh
+++ b/deploy-dotorg.sh
@@ -21,6 +21,7 @@ declare -a THEMES_TO_DEPLOY=(
 	"bibimbap"
 	"bitacora"
 	"blockbase"
+	"course"
 	"ctlg"
 	"disco"
 	"geologist"

--- a/erma/style.css
+++ b/erma/style.css
@@ -11,7 +11,7 @@ Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: erma
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
 */
 
 /*

--- a/exmoor/style.css
+++ b/exmoor/style.css
@@ -11,7 +11,7 @@ Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: exmoor
-Tags: blog, holiday, one-column, wide-blocks, block-patterns, custom-background, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, template-editing, threaded-comments, translation-ready, two-columns, style-variations
+Tags: blog, holiday, one-column, two-columns, wide-blocks, block-patterns, custom-background, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, template-editing, threaded-comments, translation-ready, style-variations
 */
 
 /*

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: geologist
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/hey/style.css
+++ b/hey/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: hey
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog, style-variations
+Tags: blog, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
 */
 
 /*

--- a/iotix/style.css
+++ b/iotix/style.css
@@ -12,13 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: iotix
 Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
-*//*
- * Font smoothing
- */
- body {
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-font-smoothing: antialiased;
-}
+*/
 
 /*
  * Link styles

--- a/iotix/style.css
+++ b/iotix/style.css
@@ -15,6 +15,14 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 */
 
 /*
+ * Font smoothing
+ */
+body {
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+}
+
+/*
  * Link styles
  * https://github.com/WordPress/gutenberg/issues/42319
  */

--- a/lettre/style.css
+++ b/lettre/style.css
@@ -11,7 +11,7 @@ Version: 1.1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: lettre
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, news, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, sticky-post, threaded-comments, news, style-variations
 
 Lettre WordPress Theme, (C) 2022 Automattic, Inc.
 Lettre is distributed under the terms of the GNU GPL.

--- a/livro/style.css
+++ b/livro/style.css
@@ -12,7 +12,7 @@ Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: livro
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, style-variations
+Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, style-variations
 
 Livro WordPress Theme, (C) 2022 Automattic, Inc.
 Livro is distributed under the terms of the GNU GPL.

--- a/lynx/style.css
+++ b/lynx/style.css
@@ -11,7 +11,7 @@ Version: 1.0.25
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: lynx
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
 
 Lynx WordPress Theme, (C) 2022 Automattic, Inc.
 Lynx is distributed under the terms of the GNU GPL.

--- a/pendant/readme.txt
+++ b/pendant/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-An elegant product-focused theme
+An elegant product-focused theme.
 
 == Changelog ==
 

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -3,7 +3,7 @@ Theme Name: Pendant
 Theme URI: https://wordpress.com/theme/pendant
 Author: Automattic
 Author URI: https://automattic.com
-Description: An elegant product-focused theme
+Description: An elegant product-focused theme.
 Requires at least: 6.1
 Tested up to: 6.1
 Requires PHP: 5.7

--- a/pixl/style.css
+++ b/pixl/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template:
 Text Domain: pixl
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
+Tags: custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, one-column, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: quadrat
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: one-column, block-patterns, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/remote/readme.txt
+++ b/remote/readme.txt
@@ -1,5 +1,5 @@
 === Remote ===
-Contributors: 
+Contributors: Automattic
 Requires at least: 6.1
 Tested up to: 6.1
 Requires PHP: 5.7

--- a/storia/style.css
+++ b/storia/style.css
@@ -11,7 +11,7 @@ Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: storia
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, blog, style-variations
+Tags: blog, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/upsidedown/style.css
+++ b/upsidedown/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: upsidedown
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, blog, style-variations
+Tags: blog, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/vetro/style.css
+++ b/vetro/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: vetro
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
+Tags: custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, one-column, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/zoologist/style.css
+++ b/zoologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: zoologist
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, one-column, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
 
 Zoologist WordPress Theme, (C) 2021 Automattic, Inc.
 Zoologist is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
We [recently added](https://github.com/Automattic/themes/pull/7199/) the `style-variations` tag to some themes, but the tag wasn't yet activated in the .org theme directory. This has since been fixed, and in order for this update to be picked up for each theme, these themes need a version bump. More info here: https://wordpress.slack.com/archives/C02RP4VMP/p1688660056424209?thread_ts=1688581180.844569&cid=C02RP4VMP.

I've updated the relevant themes with small changes like updating the order of the theme tags in the style.css files, in order to bump the theme versions. These are the affected themes:

archivo
bitacora
blockbase
course
erma
exmoor
geologist
george-lois
hey
iotix
lettre
livro
lynx
pendant
pixl
quadrat
remote
storia
upsidedown
vetro
zoologist