### PR TITLE
Replace `experimental-link-color` theme supports with `link-color`

### DIFF
--- a/blockbase/functions.php
+++ b/blockbase/functions.php
@@ -10,8 +10,8 @@ if ( ! function_exists( 'blockbase_support' ) ) :
 		// Alignwide and alignfull classes in the block editor.
 		add_theme_support( 'align-wide' );
 
-		// Add support for experimental link color control.
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 
 		// Add support for responsive embedded content.
 		// https://github.com/WordPress/gutenberg/issues/26901

--- a/hever/functions.php
+++ b/hever/functions.php
@@ -70,8 +70,8 @@ if ( ! function_exists( 'hever_setup' ) ) :
 			varia_mobile_nav_on_side_setup();
 		}
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'hever_setup', 12 );
@@ -113,7 +113,7 @@ function hever_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/morden/functions.php
+++ b/morden/functions.php
@@ -69,8 +69,8 @@ if ( ! function_exists( 'morden_setup' ) ) :
 			varia_mobile_nav_on_side_setup();
 		}
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'morden_setup', 12 );
@@ -112,7 +112,7 @@ function morden_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/rockfield/functions.php
+++ b/rockfield/functions.php
@@ -64,8 +64,8 @@ if ( ! function_exists( 'rockfield_setup' ) ) :
 			)
 		);
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'rockfield_setup', 12 );
@@ -112,7 +112,7 @@ function rockfield_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/seedlet/functions.php
+++ b/seedlet/functions.php
@@ -253,8 +253,8 @@ if ( ! function_exists( 'seedlet_setup' ) ) :
 		// Add support for custom line height controls.
 		add_theme_support( 'custom-line-height' );
 
-		// Add support for experimental link color control.
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 
 		// Add support for experimental cover block spacing.
 		add_theme_support( 'custom-spacing' );
@@ -307,7 +307,7 @@ function seedlet_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/shawburn/functions.php
+++ b/shawburn/functions.php
@@ -67,8 +67,8 @@ if ( ! function_exists( 'shawburn_setup' ) ) :
 		// Enable Full Site Editing
 		add_theme_support( 'full-site-editing' );
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'shawburn_setup', 12 );
@@ -113,7 +113,7 @@ function shawburn_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/stow/functions.php
+++ b/stow/functions.php
@@ -64,8 +64,8 @@ if ( ! function_exists( 'stow_setup' ) ) :
 			)
 		);
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'stow_setup', 12 );
@@ -124,7 +124,7 @@ function stow_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );

--- a/stratford/functions.php
+++ b/stratford/functions.php
@@ -67,8 +67,8 @@ if ( ! function_exists( 'stratford_setup' ) ) :
 		// Remove footer menu
 		unregister_nav_menu( 'menu-2' );
 
-		// Add support for experimental link color via Gutenberg: https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-support.md
-		add_theme_support( 'experimental-link-color' );
+		// Add support for link color control.
+		add_theme_support( 'link-color' );
 	}
 endif;
 add_action( 'after_setup_theme', 'stratford_setup', 12 );
@@ -125,7 +125,7 @@ function stratford_fonts_url() {
 
 		/**
 		 * A filter to enable child themes to add/change/omit font families.
-		 * 
+		 *
 		 * @param array $font_families An array of font families to be imploded for the Google Font API
 		 */
 		$font_families = apply_filters( 'included_google_font_families', $font_families );


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This replaces `add_theme_support( 'experimental-link-color' );` with `add_theme_support( 'link-color' );`, as from Gutenberg 16.2, `experimental-link-color` will trigger a "doing it wrong" message. Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/51775

**This should only be merged once Gutenberg 16.2 is released, scheduled for July 12.**

The following themes are affected:

- Blockbase
- Hever
- Morden
- Rockfield
- Seedlet
- Shawburn
- Stow
- Stratford

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/7178