### PR TITLE
Bute: Remove `comments` and `post-meta` template part refs from theme.json

### DIFF
--- a/bute/theme.json
+++ b/bute/theme.json
@@ -1298,20 +1298,12 @@
 	},
 	"templateParts": [
 		{
-			"area": "comments",
-			"name": "comments"
-		},
-		{
 			"area": "header",
 			"name": "header"
 		},
 		{
 			"area": "footer",
 			"name": "footer"
-		},
-		{
-			"area": "post-meta",
-			"name": "post-meta"
 		}
 	],
 	"version": 2,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This removes the `comments` and `post-meta` template part refs from the theme.json of Bute, as they cause the following notices:

```
Notice: "post-meta" is not a supported wp_template_part area value and has been added as "uncategorized". in /wp-includes/block-template-utils.php on line 219
```

```
Notice: "comments" is not a supported wp_template_part area value and has been added as "uncategorized". in /wp-includes/block-template-utils.php on line 219
```