### PR TITLE
Pieria: update heading font family

### DIFF
--- a/pieria/theme.json
+++ b/pieria/theme.json
@@ -398,7 +398,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontStyle": "normal",
 					"fontWeight": "600",
 					"lineHeight": "1.4"

--- a/pieria/theme.json
+++ b/pieria/theme.json
@@ -361,7 +361,7 @@
 					"fontSize": "16px",
 					"fontStyle": "normal",
 					"fontWeight": "600",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			},
 			"h3": {
@@ -369,7 +369,7 @@
 					"fontSize": "16px",
 					"fontStyle": "normal",
 					"fontWeight": "600",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			},
 			"h4": {
@@ -377,7 +377,7 @@
 					"fontSize": "16px",
 					"fontStyle": "normal",
 					"fontWeight": "600",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			},
 			"h5": {
@@ -385,7 +385,7 @@
 					"fontSize": "16px",
 					"fontStyle": "normal",
 					"fontWeight": "600",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			},
 			"h6": {
@@ -393,7 +393,7 @@
 					"fontSize": "16px",
 					"fontStyle": "normal",
 					"fontWeight": "600",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			},
 			"heading": {
@@ -415,7 +415,7 @@
 				"typography": {
 					"fontStyle": "normal",
 					"fontWeight": "400",
-					"lineHeight": 1.4
+					"lineHeight": "1.4"
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Quick PR to remove Rubik from the Pieria heading typography definition. Also made some of the `lineHeight` definitions strings instead of numbers, as this is what the schema expects.