### PR TITLE
Nested: Fix the excerpt colour

### DIFF
--- a/nested/templates/home.html
+++ b/nested/templates/home.html
@@ -7,7 +7,7 @@
 <div class="wp-block-cover is-light has-parallax has-border-color" style="border-color:#ffffff;border-radius:4px;padding-top:2rem;padding-right:2.5rem;padding-bottom:2.5rem;padding-left:2.5rem"><span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"}},"dimensions":{"minHeight":"45vh"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between","justifyContent":"stretch"}} -->
 <div class="wp-block-group" style="min-height:45vh;margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:group {"layout":{"type":"constrained","justifyContent":"right","contentSize":"40%"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:post-excerpt {"textAlign":"left","showMoreOnNewLine":false,"excerptLength":45,"style":{"layout":{"selfStretch":"fit","flexSize":null},"typography":{"fontSize":"1.25rem"}}} /-->
+<div class="wp-block-group"><!-- wp:post-excerpt {"textAlign":"left","showMoreOnNewLine":false,"excerptLength":45,"style":{"layout":{"selfStretch":"fit","flexSize":null},"typography":{"fontSize":"1.25rem"}},"textColor":"base"} /-->
 
 <!-- wp:read-more {"content":"+","style":{"typography":{"lineHeight":"1","fontSize":"1.5rem"}},"textColor":"base"} /--></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
I've noticed the excerpt colour is left not styled as default. That should be white as default, like the heading below.

Before
![localhost local_ (17)](https://github.com/Automattic/themes/assets/908665/f36ece2d-1f7e-4e88-9f6b-65866ce4f5b8)

After
![localhost local_ (16)](https://github.com/Automattic/themes/assets/908665/8dae2e06-9afe-4ca3-9e6f-3c1f42706ebb)
