### PR TITLE
Add course theme single lesson template

### DIFF
--- a/course/functions.php
+++ b/course/functions.php
@@ -92,6 +92,17 @@ add_filter(
 	3
 );
 
+/**
+ * Filter the list of templates for the single lesson page.
+ *
+ * @param array   $page_templates Array of page templates.
+ * @param string  $theme          The current theme.
+ * @param WP_Post $post           The post being edited, provided for context, or null.
+ *
+ * @since Course 1.3.1
+ *
+ * @return array Array of page templates.
+ */
 function course_theme_filter_single_lesson_template_for_sensei_learning_mode( $page_templates, $theme, $post ) {
 	// In case some other plugin has a post type called lesson.
 	if ( ! $post || ! class_exists( 'Sensei_Main' ) ) {

--- a/course/functions.php
+++ b/course/functions.php
@@ -87,23 +87,24 @@ add_action( 'init', 'course_register_block_patterns_category' );
 
 add_filter(
 	'theme_lesson_templates',
-	function( $page_templates, $theme, $post ) {
-
-		// In case some other plugin has a post type called lesson.
-		if ( ! $post || ! class_exists( 'Sensei_Main' ) ) {
-			return $page_templates;
-		}
-
-		$course_id                = Sensei()->lesson->get_course_id( $post->ID );
-		$is_learning_mode_enabled = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
-
-		if ( $is_learning_mode_enabled ) {
-			unset( $page_templates['single-lesson'] );
-		}
-
-		return $page_templates;
-	},
+	'course_theme_filter_single_lesson_template_for_sensei_learning_mode',
 	11,
 	3
 );
+
+function course_theme_filter_single_lesson_template_for_sensei_learning_mode( $page_templates, $theme, $post ) {
+	// In case some other plugin has a post type called lesson.
+	if ( ! $post || ! class_exists( 'Sensei_Main' ) ) {
+		return $page_templates;
+	}
+
+	$course_id                = Sensei()->lesson->get_course_id( $post->ID );
+	$is_learning_mode_enabled = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+
+	if ( $is_learning_mode_enabled ) {
+		unset( $page_templates['single-lesson'] );
+	}
+
+	return $page_templates;
+}
 

--- a/course/functions.php
+++ b/course/functions.php
@@ -49,8 +49,8 @@ if ( ! function_exists( 'course_scripts' ) ) :
 		 * It is only used to continue loading the deprecated styles if a old sensei version is installed.
 		 */
 		$use_deprecated_style = apply_filters( 'course_learning_mode_load_styles', true );
-		
-		if ( class_exists( 'Sensei_Main' ) && $use_deprecated_style  ) {
+
+		if ( class_exists( 'Sensei_Main' ) && $use_deprecated_style ) {
 			wp_register_style( 'course-sensei-learning-mode', get_stylesheet_directory_uri() . '/learning-mode.css', array(), wp_get_theme()->get( 'Version' ) );
 			wp_enqueue_style( 'course-sensei-learning-mode' );
 		}
@@ -84,4 +84,26 @@ function course_register_block_patterns_category() {
 }
 
 add_action( 'init', 'course_register_block_patterns_category' );
+
+add_filter(
+	'theme_lesson_templates',
+	function( $page_templates, $theme, $post ) {
+
+		// In case some other plugin has a post type called lesson.
+		if ( ! $post || ! class_exists( 'Sensei_Main' ) ) {
+			return $page_templates;
+		}
+
+		$course_id                = Sensei()->lesson->get_course_id( $post->ID );
+		$is_learning_mode_enabled = Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id );
+
+		if ( $is_learning_mode_enabled ) {
+			unset( $page_templates['single-lesson'] );
+		}
+
+		return $page_templates;
+	},
+	11,
+	3
+);
 

--- a/course/templates/single-lesson.html
+++ b/course/templates/single-lesson.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"bottom":"80px"}}},"layout":{"type":"constrained","contentSize":"1000px"}} -->
+<main class="wp-block-group" style="margin-bottom:80px">
+    <!-- wp:group {"layout":{"inherit":true,"type":"constrained","contentSize":"1000px"}} -->
+    <div class="wp-block-group">
+        <!-- wp:post-title {"level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"2.5rem"}}}} /-->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:post-content {"layout":{"inherit":true,"contentSize":"1000px"}} /-->
+
+    <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+    <div class="wp-block-group">
+        <!-- wp:group {"layout":{"type":"constrained"}} -->
+        <div class="wp-block-group">
+            <!-- wp:pattern {"slug":"course/comments"} /-->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/course/theme.json
+++ b/course/theme.json
@@ -85,7 +85,7 @@
 		},
 		{
 			"name": "single-lesson",
-			"title": "Single Lesson",
+			"title": "Lesson",
 			"postTypes": [
 				"lesson"
 			]

--- a/course/theme.json
+++ b/course/theme.json
@@ -82,6 +82,13 @@
 				"post",
 				"course"
 			]
+		},
+		{
+			"name": "single-lesson",
+			"title": "Single Lesson",
+			"postTypes": [
+				"lesson"
+			]
 		}
 	],
 	"settings": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Lesson is a Custom Post Type in sensei. So, the lessons were supposed to use the `Single` template. But as Sensei forced lessons to be rendered using the `Page` template instead, though it showed in the editor that Lesson is using the Single template, in reality, it was using the Page template of Course theme.

Now that we've fixed the issue for FSE themes in sensei https://github.com/Automattic/sensei/pull/7045, it'll no longer force the Page template and it'll start using the Single template.

But the Single template for post in Course theme is a two column design, so we'll get only less than 60% of the page's real estate for the lesson content to show, which doesn't look very good, and also it'll be a sudden unintended side effect.

To solve that, we're adding a template only for the lesson post type which is an exact copy of the page template. So, now even after the change in core sensei, lessons in Course theme will still look as they were before. With the ability for the user to edit the template as they wish unlike before.

#### Related issue(s):
https://github.com/Automattic/sensei/pull/7045