### PR TITLE
Lativ: Remove Rubik from heading definition

### DIFF
--- a/lativ/theme.json
+++ b/lativ/theme.json
@@ -701,7 +701,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}


### PR DESCRIPTION
Removes the Rubik font from the heading definition in Lativ.