### PR TITLE
Block Canvas: Remove Rubik font from heading definition

### DIFF
--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -339,7 +339,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Block Canvas is currently setting Rubik as the heading font in its theme.json file, however, this font isn't included with the theme and I believe the theme is meant to default to the system font.

This theme is generally used as a starting point for many other block themes and we have seen Rubik accidentally included in other themes, so I think it should be removed to prevent this from happening.
