### PR TITLE
Reverie: fix style variations

### DIFF
--- a/reverie/styles/fall.json
+++ b/reverie/styles/fall.json
@@ -19,7 +19,7 @@
 					"slug": "foreground"
 				},
 				{
-					"color": "#674019",
+					"color": "#a27f5b",
 					"name": "Background",
 					"slug": "background"
 				},

--- a/reverie/styles/summer.json
+++ b/reverie/styles/summer.json
@@ -9,11 +9,6 @@
 					"slug": "primary"
 				},
 				{
-					"color": "#F2874C",
-					"name": "Secondary",
-					"slug": "secondary"
-				},
-				{
 					"color": "#252525",
 					"name": "Foreground",
 					"slug": "foreground"
@@ -27,6 +22,11 @@
 					"color": "#E9E0B1",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#F2874C",
+					"name": "Secondary",
+					"slug": "secondary"
 				}
 			]
 		}

--- a/reverie/styles/winter.json
+++ b/reverie/styles/winter.json
@@ -9,11 +9,6 @@
 					"slug": "primary"
 				},
 				{
-					"color": "#3998AC",
-					"name": "Secondary",
-					"slug": "secondary"
-				},
-				{
 					"color": "#11202E",
 					"name": "Foreground",
 					"slug": "foreground"
@@ -27,6 +22,11 @@
 					"color": "#D8EBF3",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#3998AC",
+					"name": "Secondary",
+					"slug": "secondary"
 				}
 			]
 		}

--- a/reverie/theme.json
+++ b/reverie/theme.json
@@ -18,11 +18,6 @@
 					"slug": "primary"
 				},
 				{
-					"color": "#1E9AAE",
-					"name": "Secondary",
-					"slug": "secondary"
-				},
-				{
 					"color": "#11202E",
 					"name": "Foreground",
 					"slug": "foreground"
@@ -36,6 +31,11 @@
 					"color": "#B4CC91",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#1E9AAE",
+					"name": "Secondary",
+					"slug": "secondary"
 				}
 			],
 			"text": true


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Some minor palette updates to the style variations: 

Before | After
--- | ---
<img width="317" alt="Screenshot 2023-07-26 at 2 56 29 PM" src="https://github.com/Automattic/themes/assets/5375500/099138ce-4c1e-4285-8b6b-251e7ca637e0"> | <img width="312" alt="Screenshot 2023-07-26 at 2 55 34 PM" src="https://github.com/Automattic/themes/assets/5375500/64dac7a0-d4a4-4d4b-9c41-63e705ff5edb">

#### Related issue(s):
