### PR TITLE
Add navigation block markup provided by CBT

### DIFF
--- a/iotix/parts/header.html
+++ b/iotix/parts/header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--70);padding-right:0;padding-bottom:var(--wp--preset--spacing--60);padding-left:0"><!-- wp:site-title /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:navigation {5} /-->
+<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"}} /-->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"fontSize":"small"} -->


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79622

Missing properties on the Navigation block for the header template part were causing sites with PHP@8 or higher to break.

#### Testing
0. Make sure you're using PHP version 8 or higher, which is where the error happens.
1. Activate Iotix.
2. Go to Settings > Reading, set a to Static Page, and choose any existing page.
3. Visit site; it should not break.
4. Click on a few other pages for good measure — it was breaking for me even when skipping the Reading settings instruction, but the problem was reported using the steps above.