### PR TITLE
Creatio - Remove blockGap between first-level patterns

### DIFF
--- a/creatio/style.css
+++ b/creatio/style.css
@@ -56,20 +56,3 @@ a {
 	text-decoration-thickness: .0625em !important;
 	text-underline-offset: .15em;
 }
-
-/**
- * Remove blockGap between header/sections/footer for Pattern Assembler.
- * See https://github.com/Automattic/wp-calypso/issues/78097 for reference. 
- */
-
-/* Remove the gap from the editor. */
-.editor-styles-wrapper :where(.wp-site-blocks) > * {
-    margin-block-start: 0;
-    margin-block-end: 0;
-}
-
-/* Remove the gap from the front-end. */
-:where(.wp-site-blocks) > * {
-    margin-block-start: 0;
-    margin-block-end: 0;
-}

--- a/creatio/theme.json
+++ b/creatio/theme.json
@@ -247,7 +247,7 @@
 		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
-		"css": "\/* Remove block gap between header and footer patterns *\/ :where(.wp-site-blocks) > * { margin-block-start: 0; margin-block-end: 0; }",
+		"css": "\/* Remove block gap between first-level blocks *\/ :where(.wp-site-blocks) > * { margin-block-start: 0; margin-block-end: 0; }",
 		"blocks": {
 			"core/button": {
 				"border": {

--- a/creatio/theme.json
+++ b/creatio/theme.json
@@ -247,6 +247,7 @@
 		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
+		"css": "\/* Remove block gap between header and footer patterns *\/ :where(.wp-site-blocks) > * { margin-block-start: 0; margin-block-end: 0; }",
 		"blocks": {
 			"core/button": {
 				"border": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
- Remove the global block gap between first-level patterns

### In the editor

|BEFORE|AFTER|
|---|---|
|<img width="1728" alt="Screenshot 2566-08-04 at 14 50 54" src="https://github.com/Automattic/themes/assets/1881481/a6ed989a-2bbb-4d7d-b8ec-977f96798fbe">|<img width="1728" alt="Screenshot 2566-08-04 at 14 53 18" src="https://github.com/Automattic/themes/assets/1881481/901249da-27fd-4389-8a3c-33eb9d86def7">|

### In the front-end

|BEFORE|AFTER|
|---|---|
|<img width="1728" alt="Screenshot 2566-08-04 at 14 51 41" src="https://github.com/Automattic/themes/assets/1881481/8817f174-0c68-4b5e-86c9-200f077ade0a">|<img width="1728" alt="Screenshot 2566-08-04 at 14 51 41" src="https://github.com/Automattic/themes/assets/1881481/8817f174-0c68-4b5e-86c9-200f077ade0a">|


### Notes

**First-level patterns**

These are patterns like the header, the footer, and the group in the next example:

<img width="351" alt="Screenshot 2566-08-04 at 14 34 10" src="https://github.com/Automattic/themes/assets/1881481/eeb533d8-0ba6-40dd-8811-5811e7bb600d">


**User Customization**

Users can still use the editor UI to add margins to their first-level patterns.


https://github.com/Automattic/themes/assets/1881481/1c83efa6-3220-4e55-a9bb-8178e12ddd91

These styles can also be edited by users in the option **Additional CSS** in the Global Styles sidebar.

<img width="284" alt="Screenshot 2566-08-04 at 14 40 49" src="https://github.com/Automattic/themes/assets/1881481/b6d57c2d-b78c-4974-8b7d-0c20f4b1ca7a">

These styles are automatically added to the editor and the front-end:

<img width="442" alt="Screenshot 2566-08-04 at 14 37 49" src="https://github.com/Automattic/themes/assets/1881481/95ad6b26-6ae7-4e77-9d3e-9954af5ee2da">

Read more about [site-wide custom CSS in theme.json](https://href.li/?https://fullsiteediting.com/lessons/how-to-use-custom-css-in-theme-json/)


#### Related issue(s):
https://github.com/Automattic/wp-calypso/pull/80212