### PR TITLE
Remove auto-loading-homepage tag.

### DIFF
--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -11,7 +11,7 @@ Version: 0.0.28
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: block-canvas
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 Block Canvas WordPress Theme, (C) 2022 Automattic, Inc.
 Block Canvas is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
Removes the tag since it is no longer required by wpcom. This PR may grow if it's useful to remove the tag from block themes that do not require it. 

pbxlJb-4hQ-p2#comment-2864