### PR TITLE
StartFit: Remove css font size from Latest Comments block

### DIFF
--- a/startfit/theme.json
+++ b/startfit/theme.json
@@ -399,7 +399,7 @@
 				"css": " .wp-element-caption{text-align:center;}"
 			},
 			"core/latest-comments": {
-				"css": " .wp-block-latest-comments__comment-meta {font-size: var(--wp--preset--font-size--small);}.wp-block-latest-comments__comment-excerpt p{font-size: var(--wp--preset--font-size--small);}.wp-block-latest-comments__comment-excerpt p{margin:0 0 var(--wp--preset--spacing--50)}",
+				"css": " .wp-block-latest-comments__comment-date,.wp-block-latest-comments__comment-excerpt p{font-size: inherit;}.wp-block-latest-comments__comment-excerpt p{margin:0 0 var(--wp--style--block-gap)}",
 				"spacing": {
 					"padding": {
 						"left": "0px"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Remove css font sizes for the latest comments block. Currently, changing the font size in the Global Styles is not respected. 

For example, let's say you want to change the size to the extra small.
![Screenshot 2023-08-14 at 22 25 58](https://github.com/Automattic/themes/assets/908665/da19cc99-30af-4202-892e-6e42a2358915)

**Before**
![Screenshot 2023-08-14 at 22 25 31](https://github.com/Automattic/themes/assets/908665/97e98e89-5c0f-4ad3-92b5-758b474ffbce)

**After**
![Screenshot 2023-08-14 at 22 24 54](https://github.com/Automattic/themes/assets/908665/d41953f6-36d9-447e-9d6f-d6198435704f)

This also changes the bottom margin to `blockGap`.