### PR TITLE
StartFit: Remove css font size from Latest Posts block

### DIFF
--- a/startfit/theme.json
+++ b/startfit/theme.json
@@ -407,7 +407,7 @@
 				}
 			},
 			"core/latest-posts": {
-				"css": " .wp-block-latest-posts__post-author,.wp-block-latest-posts__post-date {font-size: var(--wp--preset--font-size--x-small);}.wp-block-latest-posts__post-excerpt{margin:var(--wp--preset--spacing--30) 0 var(--wp--preset--spacing--50)}"
+				"css": " .wp-block-latest-posts__post-author,.wp-block-latest-posts__post-date {font-size: inherit;}.wp-block-latest-posts__post-excerpt{margin:0 0 var(--wp--style--block-gap)}"
 			},
 			"core/list": {
 				"spacing": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Similar to #7314, this removes css font sizes so that the value in the Global Styles is respected. Also adjust the vertical spacing to use the block gap.

**Before**
![Screenshot 2023-08-15 at 15 52 12](https://github.com/Automattic/themes/assets/908665/f0c6ca5c-1453-4c0d-af1e-321a9a96a42f)

**After**
![Screenshot 2023-08-15 at 15 51 56](https://github.com/Automattic/themes/assets/908665/73fcd5ed-0d21-4f99-83ff-70fd67cd6327)


#### Related issue(s):
