### PR TITLE
Startfit: Remove CSS solution that is no longer necessary for the avatar block

### DIFF
--- a/startfit/style.css
+++ b/startfit/style.css
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: StartFit is a business theme perfect for a personal fitness training service.
 Requires at least: 6.0
-Tested up to: 6.2.2
+Tested up to: 6.3
 Requires PHP: 5.7
 Version: 1.0.1
 License: GNU General Public License v2 or later
@@ -32,15 +32,6 @@ Tags: one-column, wide-blocks, block-patterns, block-styles, featured-images, fu
 a {
 	text-decoration-thickness: 1px !important;
 	text-underline-offset: 2px;
-}
-
-/*
- * Avatar Block
- * Fix border radius setting for the avatar block
- */
-.wp-block-avatar a,
-.wp-block-avatar img {
-	border-radius: inherit;
 }
 
 /*


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Since the block was fixed in https://github.com/WordPress/gutenberg/pull/53007, the css solution is no longer needed, and in fact, it gets in the way of Global Styles.

**Before**
![Screenshot 2023-08-15 at 16 09 56](https://github.com/Automattic/themes/assets/908665/0b70a174-13b7-4e24-9ea3-4a3afcae96e1)

**After**
![Screenshot 2023-08-15 at 16 09 41](https://github.com/Automattic/themes/assets/908665/1a4b76b6-f1f5-4997-a087-71ff408e7c5e)

This also changes `Tested up to` to 6.3.
