### PR TITLE
Remove tags blog-homepage and auto-loading-homepage

### DIFF
--- a/archeo/style.css
+++ b/archeo/style.css
@@ -11,7 +11,7 @@ Version: 1.0.19
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: archeo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 Archeo WordPress Theme, (C) 2022 Automattic, Inc.
 Archeo is distributed under the terms of the GNU GPL.

--- a/artly/style.css
+++ b/artly/style.css
@@ -11,7 +11,7 @@ Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: artly
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/bibimbap/style.css
+++ b/bibimbap/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: bibimbap
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, auto-loading-homepage, wide-blocks, food-and-drink
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, food-and-drink
 */
 
 /*

--- a/blank-canvas-blocks/style.css
+++ b/blank-canvas-blocks/style.css
@@ -12,5 +12,5 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: blockbase
 Text Domain: blank-canvas-blocks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -13,7 +13,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Status: inactive
 Template: seedlet
 Text Domain: blank-canvas
-Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready, auto-loading-homepage
+Tags: one-column, accessibility-ready, custom-colors, editor-style, featured-images, rtl-language-support, sticky-post, translation-ready
 
 Blank Canvas WordPress Theme, (C) 2021 Automattic, Inc.
 Blank Canvas is distributed under the terms of the GNU GPL.

--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -11,7 +11,7 @@ Version: 3.1.13
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: blockbase
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 
 Blockbase WordPress Theme, (C) 2021 Automattic, Inc.
 Blockbase is distributed under the terms of the GNU GPL.

--- a/brompton/sass/style-child-theme.scss
+++ b/brompton/sass/style-child-theme.scss
@@ -11,7 +11,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: brompton
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -12,7 +12,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: brompton
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -12,7 +12,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: brompton
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/common/style.css
+++ b/common/style.css
@@ -11,7 +11,7 @@ Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: common
-Tags: blog, photography, portfolio, grid-layout, one-column, three-columns, four-columns, wide-blocks, block-patterns, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, template-editing, theme-options, threaded-comments, translation-ready, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: blog, photography, portfolio, grid-layout, one-column, three-columns, four-columns, wide-blocks, block-patterns, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, template-editing, theme-options, threaded-comments, translation-ready, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/didone/style.css
+++ b/didone/style.css
@@ -11,7 +11,7 @@ Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: didone
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/disco/style.css
+++ b/disco/style.css
@@ -11,7 +11,7 @@ Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: disco
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 Disco WordPress Theme, (C) 2021 Automattic, Inc.
 Disco is distributed under the terms of the GNU GPL.

--- a/dyad-2/style.css
+++ b/dyad-2/style.css
@@ -7,7 +7,7 @@ Description: Dyad pairs your written content and images together in perfect bala
 Version: 2.0.10-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: art, artwork, blog, blog-homepage, blue, classic-menu, custom-colors, custom-header, custom-menu, dark, design, editor-style, featured-images, food, grid-layout, infinite-scroll, photoblogging, photography, post-slider, responsive-layout, rtl-language-support, site-logo, social-menu, sticky-post, threaded-comments, translation-ready, yellow
+Tags: art, artwork, blog, blue, classic-menu, custom-colors, custom-header, custom-menu, dark, design, editor-style, featured-images, food, grid-layout, infinite-scroll, photoblogging, photography, post-slider, responsive-layout, rtl-language-support, site-logo, social-menu, sticky-post, threaded-comments, translation-ready, yellow
 Text Domain: dyad-2
 
 This theme, like WordPress, is licensed under the GPL.

--- a/erma/style.css
+++ b/erma/style.css
@@ -11,7 +11,7 @@ Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: erma
-Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: geologist
-Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/hey/style.css
+++ b/hey/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: hey
-Tags: blog, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: blog, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/independent-publisher-2/style.css
+++ b/independent-publisher-2/style.css
@@ -8,7 +8,7 @@ Author URI: http://raamdev.com/
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Text Domain: independent-publisher-2
-Tags: accessibility-ready, author-bio, auto-loading-homepage, classic-menu, custom-background, custom-colors, custom-header, custom-menu, featured-image-header, featured-images, flexible-header, blue, right-sidebar, light, one-column, responsive-layout, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, white, minimal, modern, conservative, blog, journal, blog-homepage
+Tags: accessibility-ready, author-bio, classic-menu, custom-background, custom-colors, custom-header, custom-menu, featured-image-header, featured-images, flexible-header, blue, right-sidebar, light, one-column, responsive-layout, sticky-post, theme-options, threaded-comments, translation-ready, two-columns, white, minimal, modern, conservative, blog, journal
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/livro/style.css
+++ b/livro/style.css
@@ -12,7 +12,7 @@ Version: 1.0.21
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: livro
-Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage, style-variations
+Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, sticky-post, threaded-comments, style-variations
 
 Livro WordPress Theme, (C) 2022 Automattic, Inc.
 Livro is distributed under the terms of the GNU GPL.

--- a/lois/style.css
+++ b/lois/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: lois
-Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/lynx/style.css
+++ b/lynx/style.css
@@ -11,7 +11,7 @@ Version: 1.0.26
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: lynx
-Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, style-variations
+Tags: block-patterns, one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 
 Lynx WordPress Theme, (C) 2022 Automattic, Inc.
 Lynx is distributed under the terms of the GNU GPL.

--- a/masu/style.css
+++ b/masu/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: masu
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/mpho/style.css
+++ b/mpho/style.css
@@ -11,7 +11,7 @@ Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: mpho
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/paimio/style.css
+++ b/paimio/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: 
 Text Domain: paimio
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, blog
 */
 
 /*

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -13,7 +13,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template: 
 Text Domain: pendant
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/rainfall/style.css
+++ b/rainfall/style.css
@@ -11,7 +11,7 @@ Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: rainfall
-Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, auto-loading-homepage, blog-homepage, blog, news
+Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, blog, news
 */
 
 /**

--- a/redhill/sass/style-child-theme.scss
+++ b/redhill/sass/style-child-theme.scss
@@ -11,7 +11,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: redhill
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, a8c-globals-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -12,7 +12,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: redhill
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, a8c-globals-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -12,7 +12,7 @@ License URI: LICENSE
 Status: inactive
 Template: varia
 Text Domain: redhill
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, a8c-globals-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, a8c-globals-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/remote/style.css
+++ b/remote/style.css
@@ -11,7 +11,7 @@ Version: 1.1.2
 License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Text Domain: remote
-Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: one-column, block-patterns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks, style-variations
 */
 
 /*

--- a/reverie/style.css
+++ b/reverie/style.css
@@ -11,7 +11,7 @@ Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: reverie
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, blog
 */
 
 /*

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -11,7 +11,7 @@ Version: 1.0.50
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: skatepark
-Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage
+Tags: one-column, block-styles, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/spearhead/assets/sass/style.scss
+++ b/spearhead/assets/sass/style.scss
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 */
 
 @import "../../../seedlet/assets/sass/abstracts/mixins";

--- a/spearhead/style-rtl.css
+++ b/spearhead/style-rtl.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 */
 /**
  * Required Variables

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: seedlet
 Text Domain: spearhead
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, jetpack-global-styles, blog-homepage
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 */
 /**
  * Required Variables

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -11,7 +11,7 @@ Version: 1.15
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: stewart
-Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: two-columns, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Stewart WordPress Theme, (C) 2022 Automattic, Inc.
 Stewart is distributed under the terms of the GNU GPL.

--- a/the-menu/style.css
+++ b/the-menu/style.css
@@ -11,7 +11,7 @@ Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: the-menu
-Tags: food-and-drink, three-columns, wide-blocks, block-patterns, block-styles, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, flexible-header, full-site-editing, auto-loading-homepage, post-formats, rtl-language-support, style-variations, theme-options, threaded-comments, translation-ready, restaurants, menu, cuisine, food, lacarte, static, dujour, fixedmenu, bar, cafeteria, coffeeshop
+Tags: food-and-drink, three-columns, wide-blocks, block-patterns, block-styles, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, flexible-header, full-site-editing, post-formats, rtl-language-support, style-variations, theme-options, threaded-comments, translation-ready, restaurants, menu, cuisine, food, lacarte, static, dujour, fixedmenu, bar, cafeteria, coffeeshop
 */
 
 /*

--- a/twentytwentytwo-blue/style.css
+++ b/twentytwentytwo-blue/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-blue
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Twenty Twenty-Two (Blue) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Blue) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-mint/style.css
+++ b/twentytwentytwo-mint/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-mint
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Twenty Twenty-Two (Mint) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Mint) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-pink/style.css
+++ b/twentytwentytwo-pink/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-pink
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Twenty Twenty-Two (Pink) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Pink) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-red/style.css
+++ b/twentytwentytwo-red/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-yellow
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Twenty Twenty-Two (Red) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Red) is distributed under the terms of the GNU GPL.

--- a/twentytwentytwo-swiss/style.css
+++ b/twentytwentytwo-swiss/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo-swiss
 Template: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 Twenty Twenty-Two (Swiss) WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two (Swiss) is distributed under the terms of the GNU GPL.

--- a/varia/sass/child-theme/style-child-theme.scss
+++ b/varia/sass/child-theme/style-child-theme.scss
@@ -10,7 +10,7 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: varia
 Text Domain: varia-child-theme
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, wpcom-fse, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, wpcom-fse, jetpack-global-styles
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -10,7 +10,7 @@ Version: 1.6.25
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, wpcom-fse, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, wpcom-fse, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/varia/style.css
+++ b/varia/style.css
@@ -10,7 +10,7 @@ Version: 1.6.25
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, wpcom-fse, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, wpcom-fse, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/varia/style.scss
+++ b/varia/style.scss
@@ -9,7 +9,7 @@ Version: 1.6.25
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: varia
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, auto-loading-homepage, wpcom-fse, jetpack-global-styles
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, wpcom-fse, jetpack-global-styles
 AMP: true
 
 This theme, like WordPress, is licensed under the GPL.

--- a/vivre/style.css
+++ b/vivre/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: https://raw.githubusercontent.com/Automattic/themes/trunk/LICENSE
 Template:
 Text Domain: vivre
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
 */
 
 /*

--- a/zoologist/style.css
+++ b/zoologist/style.css
@@ -12,7 +12,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: blockbase
 Text Domain: zoologist
-Tags: custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, one-column, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, auto-loading-homepage, blog-homepage, style-variations
+Tags: custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, one-column, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks, style-variations
 
 Zoologist WordPress Theme, (C) 2021 Automattic, Inc.
 Zoologist is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Update tags `blog-homepage` and `auto-loading-homepage` according to their correct usages. See pbxlJb-4hQ-p2 for more context.
