### PR TITLE
Tenaz: Make sure header top always has side paddings

### DIFF
--- a/tenaz/patterns/header.php
+++ b/tenaz/patterns/header.php
@@ -8,37 +8,41 @@
 ?>
 <!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"padding":{"top":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40)">
-	<!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-	<div class="wp-block-columns alignfull are-vertically-aligned-center">
-		<!-- wp:column {"verticalAlignment":"center","width":"164px"} -->
-		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:164px">
-			<!-- wp:social-links {"iconColor":"base","iconColorValue":"#ffffff","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->
-			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
-				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+	<!-- wp:group {"align":"full","layout":{"type":"default"}} -->
+	<div class="wp-block-group alignfull">
+		<!-- wp:columns {"verticalAlignment":"center","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+		<div class="wp-block-columns are-vertically-aligned-center">
+			<!-- wp:column {"verticalAlignment":"center","width":"164px"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:164px">
+				<!-- wp:social-links {"iconColor":"base","iconColorValue":"#ffffff","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->
+				<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+					<!-- wp:social-link {"url":"#","service":"facebook"} /-->
 
-				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+					<!-- wp:social-link {"url":"#","service":"twitter"} /-->
 
-				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+					<!-- wp:social-link {"url":"#","service":"instagram"} /-->
 
-				<!-- wp:social-link {"url":"#","service":"tiktok"} /-->
+					<!-- wp:social-link {"url":"#","service":"tiktok"} /-->
 
-				<!-- wp:social-link {"url":"#","service":"youtube"} /-->
-			</ul>
-			<!-- /wp:social-links -->
+					<!-- wp:social-link {"url":"#","service":"youtube"} /-->
+				</ul>
+				<!-- /wp:social-links -->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":""} -->
+			<div class="wp-block-column is-vertically-aligned-center"></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"300px"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:300px">
+				<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"border":{"top":{"color":"#4a4a4a","style":"solid","width":"1px"},"right":{"color":"#4a4a4a","style":"solid","width":"1px"},"bottom":{"color":"#4a4a4a","style":"solid","width":"1px"},"left":{"color":"#4a4a4a","style":"solid","width":"1px"},"radius":"0px"}},"backgroundColor":"contrast","textColor":"base"} /-->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"verticalAlignment":"center","width":""} -->
-		<div class="wp-block-column is-vertically-aligned-center"></div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"verticalAlignment":"center","width":"300px"} -->
-		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:300px">
-			<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"border":{"top":{"color":"#4a4a4a","style":"solid","width":"1px"},"right":{"color":"#4a4a4a","style":"solid","width":"1px"},"bottom":{"color":"#4a4a4a","style":"solid","width":"1px"},"left":{"color":"#4a4a4a","style":"solid","width":"1px"},"radius":"0px"}},"backgroundColor":"contrast","textColor":"base"} /-->
-		</div>
-		<!-- /wp:column -->
+		<!-- /wp:columns -->
 	</div>
-	<!-- /wp:columns -->
+	<!-- /wp:group -->
 
 	<!-- wp:site-logo {"width":64,"align":"center"} /-->
 


### PR DESCRIPTION
I realised the social links and the search field bump the edge of the screen.

#### Changes proposed in this Pull Request:
Add a non-constrained group block wrapping the column blocks.

**Before**
![localhost local_ (12)](https://github.com/Automattic/themes/assets/908665/48e76267-6cb6-46b1-95fa-73d84aef2451)

**After**
![localhost local_ (11)](https://github.com/Automattic/themes/assets/908665/c7a285c4-3597-4c57-8b35-f614fe22096b)
