### PR TITLE
Arbutus: Remove bottom margin inherited from heading element

### DIFF
--- a/arbutus/theme.json
+++ b/arbutus/theme.json
@@ -55,6 +55,11 @@
 				}
 			},
 			"core/site-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "0"
+					}
+				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)"
 				}


### PR DESCRIPTION
Reported in Slack, p1692196374866429-slack-C029FM1EH by @Nyiriland

#### Changes proposed in this Pull Request:
Remove the bottom margin inherited from the heading element.

**Before**
![Screenshot 2023-08-18 at 14 02 45](https://github.com/Automattic/themes/assets/908665/941e6121-f451-46c1-bc63-9f4ab4a65968)

**After**
![Screenshot 2023-08-18 at 14 02 03](https://github.com/Automattic/themes/assets/908665/eca225ae-8dd3-4da2-acfb-0cb68f2f15e3)

