### PR TITLE
Texty: remove rubik font for headings

### DIFF
--- a/texty/theme.json
+++ b/texty/theme.json
@@ -539,7 +539,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontStyle": "normal",
 					"fontWeight": "500",
 					"lineHeight": "1"


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Remove font family definition for headings.

#### Related issue(s):

p1692870215116709/1692787095.392069-slack-C057THCBY2X