### PR TITLE
Independent Pub 2: use get_avatar

### DIFF
--- a/independent-publisher-2/header.php
+++ b/independent-publisher-2/header.php
@@ -30,7 +30,15 @@
 
 					<?php if ( '' !== get_theme_mod( 'independent_publisher_2_gravatar_email', get_option( 'admin_email' ) ) && validate_gravatar( get_theme_mod( 'independent_publisher_2_gravatar_email', get_option( 'admin_email' ) ) ) ) : ?>
 						<a class="site-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>">
-							<img alt="" class="site-logo-image no-grav" width="80" height="80" src="<?php echo esc_url( get_avatar_url( get_theme_mod( 'independent_publisher_2_gravatar_email', get_option( 'admin_email' ) ), array( 'size' => 160 ) ) ); ?>" />
+							<?php
+								echo get_avatar(
+									get_theme_mod( 'independent_publisher_2_gravatar_email', get_option( 'admin_email' ) ),
+									80,
+									'',
+									'',
+									array( 'class' => array( 'site-logo-image' ), 'loading' => 'eager' )
+								);
+							?>
 						</a><!-- .site-logo-link -->
 						<?php endif;
 


### PR DESCRIPTION
Use `get_avatar` to get the full avatar `<img>` element, instead of manually composing it in the theme.

This gets us a `srcset`, so that we can pick a resolution-appropriate image size. I also took the opportunity to explicitly add `loading="eager"`, given that this avatar is a likely candidate for the LCP (Largest Contentful Paint) element, and should thus not wait until layout occurs to start being fetched.

#### Changes proposed in this Pull Request:

- Replace manual `<img>` tag generation with `get_avatar`.

#### Related issue(s):

For wpcom, this change was initially done in D114229-code, but it appears to have later been overwritten by the version of Independent Publisher 2 in this repo.