### PR TITLE
Fix navigation blocks - Remove ref attribute to avoid error message

### DIFF
--- a/awburn/parts/header.html
+++ b/awburn/parts/header.html
@@ -7,7 +7,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"40px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":6,"overlayBackgroundColor":"secondary","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+<div class="wp-block-group"><!-- wp:navigation {"overlayBackgroundColor":"secondary","overlayTextColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 <!-- wp:social-links {"iconColor":"secondary","iconColorValue":"#005ae1","size":"has-small-icon-size","style":{"spacing":{"blockGap":{"top":"16px","left":"16px"}}},"className":"is-style-logos-only"} -->
 <ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"/","service":"linkedin"} /-->

--- a/awburn/patterns/footer-home.php
+++ b/awburn/patterns/footer-home.php
@@ -56,7 +56,7 @@
 
 <!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":6,"overlayMenu":"never"} /--></div>
+<div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}}} -->

--- a/awburn/patterns/footer.php
+++ b/awburn/patterns/footer.php
@@ -9,7 +9,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"40px","left":"40px","top":"80px","bottom":"80px"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:80px;padding-right:40px;padding-bottom:80px;padding-left:40px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":6,"overlayMenu":"never"} /--></div>
+<div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}}} -->

--- a/bibliophile/parts/header.html
+++ b/bibliophile/parts/header.html
@@ -4,7 +4,7 @@
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":13,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"20px"}}} /-->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"20px"}}} /-->
 
 <!-- wp:spacer {"height":"60px"} -->
 <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/calyx/parts/header.html
+++ b/calyx/parts/header.html
@@ -10,7 +10,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":1047,"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between","orientation":"horizontal","flexWrap":"nowrap"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between","orientation":"horizontal","flexWrap":"nowrap"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/common/parts/header.html
+++ b/common/parts/header.html
@@ -12,6 +12,6 @@
 <div style="height:60px;width:72px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":112,"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/cortado/parts/header-inverted.html
+++ b/cortado/parts/header-inverted.html
@@ -8,7 +8,7 @@
 <div class="wp-block-group gapless-group" style="text-transform:uppercase"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--vertical)","top":"var(--wp--custom--gap--vertical)"}}},"className":"site-header","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull site-header" style="padding-top:var(--wp--custom--gap--vertical);padding-bottom:var(--wp--custom--gap--vertical)"><!-- wp:site-title {"style":{"typography":{"letterSpacing":"0.1rem","fontStyle":"normal","fontWeight":"400"}}} /-->
 
-<!-- wp:navigation {"ref":11,"overlayMenu":"never","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"},"typography":{"letterSpacing":"0.1rem"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"},"typography":{"letterSpacing":"0.1rem"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/cortado/parts/header.html
+++ b/cortado/parts/header.html
@@ -7,7 +7,7 @@
 <div class="wp-block-group gapless-group" style="text-transform:uppercase"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--gap--vertical)","top":"var(--wp--custom--gap--vertical)"}}},"className":"site-header","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull site-header" style="padding-top:var(--wp--custom--gap--vertical);padding-bottom:var(--wp--custom--gap--vertical)"><!-- wp:site-title {"style":{"typography":{"letterSpacing":"0.1rem","fontStyle":"normal","fontWeight":"400"}}} /-->
 
-<!-- wp:navigation {"ref":11,"overlayMenu":"never","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"3rem"},"typography":{"letterSpacing":"0.1rem"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","__unstableLocation":"primary","className":"social-links","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"3rem"},"typography":{"letterSpacing":"0.1rem"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/covr/parts/header.html
+++ b/covr/parts/header.html
@@ -4,7 +4,7 @@
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"20px"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
 <div class="wp-block-group"><!-- wp:site-title /-->
 
-<!-- wp:navigation {"ref":91,"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/ctlg/templates/page.html
+++ b/ctlg/templates/page.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"style":{"dimensions":{"minHeight":"65vw"},"spacing":[]},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="min-height:65vw"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns alignfull" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"var:preset|spacing|40","left":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:navigation {"ref":95,"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} /--></div>
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->

--- a/ctlg/templates/single.html
+++ b/ctlg/templates/single.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"dimensions":{"minHeight":"65vw"},"spacing":[]},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="min-height:65vw"><!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns alignfull" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"var:preset|spacing|40","left":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:navigation {"ref":95,"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} /--></div>
+<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:var(--wp--preset--spacing--40);padding-left:0"><!-- wp:navigation {"overlayMenu":"never","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->

--- a/erma/parts/header.html
+++ b/erma/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":6,"overlayMenu":"always","overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/fewer/parts/header.html
+++ b/fewer/parts/header.html
@@ -5,7 +5,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"66.66%","style":{"spacing":{"padding":{"left":"0","right":"0"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-right:0;padding-left:0;flex-basis:66.66%"><!-- wp:navigation {"ref":58,"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between","orientation":"horizontal","flexWrap":"wrap"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0"}}} /--></div>
+<div class="wp-block-column is-vertically-aligned-center" style="padding-right:0;padding-left:0;flex-basis:66.66%"><!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between","orientation":"horizontal","flexWrap":"wrap"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0"}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"0%"} -->

--- a/jaida/parts/header.html
+++ b/jaida/parts/header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--70);padding-right:0;padding-bottom:var(--wp--preset--spacing--70);padding-left:0"><!-- wp:site-title {"textAlign":"left","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background"} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":18,"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/jaida/parts/secondary-header.html
+++ b/jaida/parts/secondary-header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--70);padding-right:0;padding-bottom:var(--wp--preset--spacing--70);padding-left:0"><!-- wp:site-title {"textAlign":"left"} /-->
 
 <!-- wp:group {"style":{"border":{"width":"0px","style":"none","radius":"2px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="border-style:none;border-width:0px;border-radius:2px"><!-- wp:navigation {"ref":18,"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"blockGap":"var:preset|spacing|50"}}} /--></div>
+<div class="wp-block-group" style="border-style:none;border-width:0px;border-radius:2px"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"blockGap":"var:preset|spacing|50"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/organizer/parts/header.html
+++ b/organizer/parts/header.html
@@ -6,7 +6,7 @@
 <div class="wp-block-group alignwide"><!-- wp:site-title {"align":"wide"} /-->
 
 <!-- wp:group {"style":{"layout":{"selfStretch":"fixed","flexSize":"33.3%"},"spacing":{"padding":{"right":"1rem"}},"border":{"right":{"width":"1px"},"top":[],"bottom":[],"left":[]}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-<div class="wp-block-group" style="border-right-width:1px;padding-right:1rem"><!-- wp:navigation {"ref":4,"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}},"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
+<div class="wp-block-group" style="border-right-width:1px;padding-right:1rem"><!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}},"layout":{"selfStretch":"fit","flexSize":null}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/404.html
+++ b/pieria/templates/404.html
@@ -12,7 +12,7 @@
 <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/archive.html
+++ b/pieria/templates/archive.html
@@ -12,7 +12,7 @@
 <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/index.html
+++ b/pieria/templates/index.html
@@ -12,7 +12,7 @@
 <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/page.html
+++ b/pieria/templates/page.html
@@ -12,7 +12,7 @@
 <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/search.html
+++ b/pieria/templates/search.html
@@ -12,7 +12,7 @@
 <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/pieria/templates/single.html
+++ b/pieria/templates/single.html
@@ -12,7 +12,7 @@
   <div style="margin-top:0px;margin-bottom:0px;height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
   
-  <!-- wp:navigation {"ref":40,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
+  <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"}}} /--></div>
   <!-- /wp:group --></div>
   <!-- /wp:group --></div>
   <!-- /wp:column -->

--- a/poesis/patterns/header.php
+++ b/poesis/patterns/header.php
@@ -16,5 +16,5 @@
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:navigation {"ref":67,"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} /--></div>
+<!-- wp:navigation {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} /--></div>
 <!-- /wp:group -->

--- a/ron/templates/archive.html
+++ b/ron/templates/archive.html
@@ -19,5 +19,5 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|tertiary","width":"1px"}},"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"ref":40,"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
 <!-- /wp:group -->

--- a/ron/templates/page.html
+++ b/ron/templates/page.html
@@ -7,5 +7,5 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|tertiary","width":"1px"}},"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"ref":40,"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
 <!-- /wp:group -->

--- a/ron/templates/search.html
+++ b/ron/templates/search.html
@@ -23,5 +23,5 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|tertiary","width":"1px"}},"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"ref":40,"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--tertiary);border-top-width:1px;padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:navigation {"overlayMenu":"never","align":"wide","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
 <!-- /wp:group -->

--- a/ron/templates/single.html
+++ b/ron/templates/single.html
@@ -6,7 +6,7 @@
 <!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":40,"overlayMenu":"never","hasIcon":false,"layout":{"type":"flex","justifyContent":"right"}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","hasIcon":false,"layout":{"type":"flex","justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/sten/parts/header.html
+++ b/sten/parts/header.html
@@ -5,7 +5,7 @@
 <div class="wp-block-group"><!-- wp:site-title /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":6,"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","justifyContent":"right"}} /--></div>
+<!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","justifyContent":"right"}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0","top":"0","right":"0","left":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","verticalAlignment":"center"}} -->

--- a/ueno/parts/header.html
+++ b/ueno/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":11,"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0px"},"typography":{"textTransform":"uppercase"}}} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0px"},"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Might be related to https://github.com/WordPress/create-block-theme/issues/162 https://github.com/WordPress/gutenberg/issues/42730 https://github.com/WordPress/wordpress-develop/pull/3899

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Remove the `ref` attribute from navigation blocks to avoid the error message `Navigation menu has been deleted or is unavailable. Create a new menu?`.
- The affected themes are Awburn, Bibliophile, Calyx, Common, Cortado, Covr, Ctlg, Erma, Fewer, Jaida, Organizer, Pieria, Poesis, Ron, Sten, and Ueno.


|BEFORE|AFTER|
|--|--|
|<img width="1423" alt="Screenshot 2566-09-05 at 12 31 25" src="https://github.com/Automattic/themes/assets/1881481/49c727a1-8b99-4d63-b5db-4642b2a7ca47">|<img width="1422" alt="Screenshot 2566-09-05 at 12 31 57" src="https://github.com/Automattic/themes/assets/1881481/e8075e33-617e-49c0-ad03-ae0361b24dca">|

**Note:** When the navigation has no `ref` and no inner blocks the editor will use a fallback like the latest navigation menu on the site.


