### PR TITLE
Bute: Fix the side padding for the header

### DIFF
--- a/bute/patterns/header.php
+++ b/bute/patterns/header.php
@@ -8,8 +8,8 @@
 ?>
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"textColor":"contrast","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
-	<div class="wp-block-group alignfull has-contrast-color has-text-color" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"textColor":"contrast","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
+<div class="wp-block-group alignfull has-contrast-color has-text-color" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 		<!-- wp:site-title /-->
 
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
There must be some changes in Gutenberg, but the site title and the navigation in the header now bump to the screen edges. And this will fix it.

| Before | After |
| ----------- | ----------- |
| ![localhost local_(MacBook Pro 14_) (1)](https://github.com/Automattic/themes/assets/908665/b6650d38-f0ab-493f-8f3a-bfa1fd9f164a) | ![localhost local_(MacBook Pro 14_)](https://github.com/Automattic/themes/assets/908665/ab0be75f-e0e8-4d6a-a69d-3afc9f5fe823)|