### PR TITLE
Fix error: Template part has been deleted or is unavailable in Erma, Poesis, and Meraki  

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -33,6 +33,10 @@
 		{
 			"name": "footer",
 			"area": "footer"
+		},
+		{
+			"name": "post-meta-icons",
+			"area": "uncategorized"
 		}
 	],
 	"customTemplates": [

--- a/erma/templates/archive.html
+++ b/erma/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:query {"queryId":31,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","displayLayout":{"type":"flex","columns":5},"align":"wide","layout":{"type":"default"}} -->
@@ -24,4 +24,4 @@
 <!-- /wp:query --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/templates/home.html
+++ b/erma/templates/home.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:columns {"align":"wide"} -->
@@ -152,4 +152,4 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/templates/index.html
+++ b/erma/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:query {"queryId":15,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"tagName":"main","displayLayout":{"type":"flex","columns":5},"align":"wide","layout":{"type":"default"}} -->
@@ -22,4 +22,4 @@
 <!-- /wp:query-pagination --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/templates/page.html
+++ b/erma/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|80","left":"var:preset|spacing|80"}}}} -->
@@ -14,4 +14,4 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/templates/search.html
+++ b/erma/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:query {"queryId":31,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","displayLayout":{"type":"flex","columns":5},"align":"wide","layout":{"type":"default"}} -->
@@ -34,4 +34,4 @@
 <!-- /wp:query --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/templates/single.html
+++ b/erma/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"erma","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"default"}} -->
@@ -22,7 +22,7 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"default"}} /-->
 
-<!-- wp:template-part {"slug":"post-meta","theme":"erma"} /--></div>
+<!-- wp:template-part {"slug":"post-meta"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
@@ -38,4 +38,4 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"erma","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/erma/theme.json
+++ b/erma/theme.json
@@ -640,6 +640,10 @@
 		{
 			"area": "footer",
 			"name": "footer"
+		},
+		{
+			"area": "uncategorized",
+			"name": "post-meta"
 		}
 	],
 	"version": 2,

--- a/poesis/templates/single.html
+++ b/poesis/templates/single.html
@@ -32,7 +32,7 @@
 <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"post-meta","theme":"poesis","area":"uncategorized"} /--></div>
+<!-- wp:template-part {"slug":"post-meta","area":"uncategorized"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"10%"} -->

--- a/poesis/theme.json
+++ b/poesis/theme.json
@@ -539,6 +539,10 @@
 		{
 			"area": "footer",
 			"name": "footer"
+		},
+		{
+			"area": "uncategorized",
+			"name": "post-meta"
 		}
 	],
 	"version": 2,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Remove theme attribute from template parts in **Erma** and **Poesis** themes
- Add post meta template part in the theme.json of **Erma**, **Poesis** and **Blockbase** themes

#### Testing instructions

- Sandbox a site
- Apply the changes to your sandbox
- Switch to the theme and go to the editor Templates to verify there aren't errors `Template part has been deleted or is unavailable` in the templates


**Meraki** 

The change in Blockbase theme.json fixes the `post-meta-icons` template part error in the search template in Meraki (its child theme).

|BEFORE|AFTER|
|--|--|
|![image](https://github.com/Automattic/themes/assets/1881481/04e12d16-3cae-48b6-af0d-2b33d4e4abfb)|![image](https://github.com/Automattic/themes/assets/1881481/4b48fdf7-a1c9-42f4-8bce-c4dce8fe2e62)|

**Poesis**

|BEFORE|AFTER|
|--|--|
|<img width="1276" alt="Screenshot 2566-09-07 at 19 39 13" src="https://github.com/Automattic/themes/assets/1881481/ce44825f-d5ff-405e-8c5e-5614e99e252e">|<img width="1277" alt="Screenshot 2566-09-07 at 19 41 40" src="https://github.com/Automattic/themes/assets/1881481/c3414e00-c608-47cf-844f-e794903eb424">|

**Erma**

Fixes the templates home, index, single, page, archive, and search.

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/themes/assets/1881481/89bbb7ed-b8e6-42ff-86e7-7a85b068f23b">|<video src="https://github.com/Automattic/themes/assets/1881481/c2100139-90c8-4f99-8b3e-2e35fa211e72">|



#### Related issue(s):

https://github.com/WordPress/gutenberg/issues/44243
