### PR TITLE
Remove Rubik from Ueno and Dawson

### DIFF
--- a/dawson/theme.json
+++ b/dawson/theme.json
@@ -536,7 +536,7 @@
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"lineHeight": 0.7
+					"lineHeight": "0.7"
 				}
 			},
 			"core/paragraph": {
@@ -563,7 +563,7 @@
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontStyle": "normal",
 					"fontWeight": "300",
-					"lineHeight": 1.7
+					"lineHeight": "1.7"
 				}
 			},
 			"core/post-date": {
@@ -820,7 +820,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}

--- a/ueno/theme.json
+++ b/ueno/theme.json
@@ -558,11 +558,10 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontStyle": "normal",
 					"fontWeight": "700",
 					"letterSpacing": "0.05em",
-					"lineHeight": 1.2,
+					"lineHeight": "1.2",
 					"textTransform": "uppercase"
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
PR to remove Rubik as the default font for headings in Ueno and Dawson.
