### PR TITLE
Aligned the package files version of Spearhead and Quadrat 

### DIFF
--- a/quadrat/package.json
+++ b/quadrat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadrat",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "description": "",
   "main": "index.php",
   "devDependencies": {

--- a/spearhead/package.json
+++ b/spearhead/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spearhead",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"description": "a podcast theme",
 	"keywords": [
 		"gutenberg",


### PR DESCRIPTION
Aligned the package files version of Spearhead and Quadrat to the correct versions

I noticed that with the most recent deployments that the package version numbers are out of alignment with what is on wpcom and what is represented in those theme's `style.css` metadata.

This change just brings those versions to correct version and do not need to be deployed.
