### PR TITLE
theme-utils: Fix for fish shell

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1099,7 +1099,17 @@ export async function executeCommand(command, logResponse) {
 				detached: true,
 			})
 		} else {
-			child = spawn(process.env.SHELL, ['-c', command], {
+			/*
+			* Determines the shell to execute the command.
+			* - Prioritizes using the user's default shell unless it's fish, a known problematic shell.
+			* - In this case, falls back to `/bin/bash` for better syntax compatibility.
+			*/
+			let shellPath = process.env.SHELL || '/bin/bash';
+			if (shellPath.includes('fish') && fs.existsSync('/bin/bash')) {
+				shellPath = '/bin/bash';
+			}
+
+			child = spawn(shellPath, ['-c', command], {
 				stdio: [process.stdin, 'pipe', 'pipe'],
 				detached: true,
 			});


### PR DESCRIPTION
The deploy commands don't work at all on my system (fish). Making this change fixed it:

```diff
diff --git a/theme-utils.mjs b/theme-utils.mjs                                                                              index 233354b26..f0e55f3a5 100644                                                                                           --- a/theme-utils.mjs                                                                                                       
+++ b/theme-utils.mjs                                                                                                       
@@ -1099,7 +1099,7 @@ export async function executeCommand(command, logResponse) {                                          
                                detached: true,                                                                             
                        })                                                                                                  
                } else {                                                                                                    
-                       child = spawn(process.env.SHELL, ['-c', command], {                                                 
+                       child = spawn('/bin/bash', ['-c', command], {                                                       
                                stdio: [process.stdin, 'pipe', 'pipe'],                                                     
                                detached: true,                                                                             
                        });                                                                                                 
```

But I wanted to make a change that's a little more flexible, I guess. How's this?