### PR TITLE
Gardening action: enable new board automation task

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -42,4 +42,6 @@ jobs:
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
-         tasks: 'cleanLabels,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder'
+         triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+         project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
+         tasks: 'cleanLabels,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder,updateBoard'


### PR DESCRIPTION
> **Warning**
> This is on hold until https://github.com/Automattic/jetpack/pull/33469 gets merged

#### Changes proposed in this Pull Request:

This task was created in https://github.com/Automattic/jetpack/pull/33469

By enabling it, we'll be able to automate some of the column updates in "The One Board" when labels are updated in issues in this repo.

> **Note**
> The necessary secrets have already been added to this repo.

Related discussion: pciE2j-2u3-p2#comment-2359

#### Related issue(s):
