### PR TITLE
Barnsbury23: Remove all wp-image class names

### DIFF
--- a/barnsbury23/patterns/front-page.php
+++ b/barnsbury23/patterns/front-page.php
@@ -157,7 +157,7 @@
 
 <!-- wp:column {"width":"66.6%","layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-column" style="flex-basis:66.6%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png","dimRatio":0,"minHeight":520,"minHeightUnit":"px"} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-463" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->

--- a/barnsbury23/patterns/hero-green.php
+++ b/barnsbury23/patterns/hero-green.php
@@ -40,8 +40,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520,"style":{"color":[]}} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-621" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520,"style":{"color":[]}} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover --></div>

--- a/barnsbury23/patterns/hero-green.php
+++ b/barnsbury23/patterns/hero-green.php
@@ -40,7 +40,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520,"style":{"color":[]}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520,"style":{"color":[]}} -->
 <div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>

--- a/barnsbury23/patterns/hero-green.php
+++ b/barnsbury23/patterns/hero-green.php
@@ -41,7 +41,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520,"style":{"color":[]}} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover --></div>

--- a/barnsbury23/patterns/home-clean.php
+++ b/barnsbury23/patterns/home-clean.php
@@ -42,7 +42,7 @@
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg","dimRatio":0,"minHeight":520} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-621" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_hero.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover --></div>

--- a/barnsbury23/patterns/home.php
+++ b/barnsbury23/patterns/home.php
@@ -157,7 +157,7 @@
 
 <!-- wp:column {"width":"66.6%","layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-column" style="flex-basis:66.6%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png","dimRatio":0,"minHeight":520,"minHeightUnit":"px"} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-463" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->

--- a/barnsbury23/patterns/numbers-clean.php
+++ b/barnsbury23/patterns/numbers-clean.php
@@ -89,7 +89,7 @@
 
 <!-- wp:column {"width":"66.6%","layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-column" style="flex-basis:66.6%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png","dimRatio":0,"minHeight":520,"minHeightUnit":"px"} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-463" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/barnsbury_the-farm.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->

--- a/barnsbury23/patterns/numbers-green.php
+++ b/barnsbury23/patterns/numbers-green.php
@@ -89,7 +89,7 @@
 
 <!-- wp:column {"width":"66.6%","layout":{"type":"constrained","justifyContent":"left"}} -->
 <div class="wp-block-column" style="flex-basis:66.6%"><!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_farm.jpg","dimRatio":0,"minHeight":520,"minHeightUnit":"px"} -->
-<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-620" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_farm.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
+<div class="wp-block-cover" style="min-height:520px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/b-original_farm.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"<?php echo esc_attr__( 'Write title…', 'barnsbury23' ); ?>","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->

--- a/barnsbury23/patterns/post-meta.php
+++ b/barnsbury23/patterns/post-meta.php
@@ -14,7 +14,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"1.5rem"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"0.5rem"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"bottom"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"24px"}}} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/ic_date.png" alt="" class="wp-image-334"/></figure>
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/ic_date.png" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:post-date {"format":"F j, Y","isLink":true,"style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400","fontSize":"0.9rem","letterSpacing":"5%","lineHeight":"1.7"}},"fontFamily":"rubik"} /--></div>
@@ -22,7 +22,7 @@
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"},"blockGap":"0.5rem"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"bottom"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"24px"}}} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/ic_category.png" alt="" class="wp-image-333"/></figure>
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/ic_category.png" alt=""/></figure>
 <!-- /wp:image -->
 
 <!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400","fontSize":"0.9rem","letterSpacing":"5%","lineHeight":"1.7"}},"fontFamily":"rubik"} /--></div>

--- a/barnsbury23/patterns/testimonials-alt.php
+++ b/barnsbury23/patterns/testimonials-alt.php
@@ -17,23 +17,23 @@
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.6%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"120px"},"blockGap":"2rem"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group" style="padding-right:120px"><!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -48,7 +48,7 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem","padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:image {"width":64,"height":64,"sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
-<figure class="wp-block-image size-full is-resized is-style-rounded"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/avatar-user.jpg" alt="" class="wp-image-206" width="64" height="64"/></figure>
+<figure class="wp-block-image size-full is-resized is-style-rounded"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/avatar-user.jpg" alt="" width="64" height="64"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontStyle":"italic","fontWeight":"300","fontSize":"1.4rem","letterSpacing":"5%","lineHeight":"1"}},"fontFamily":"rubik"} -->

--- a/barnsbury23/patterns/testimonials.php
+++ b/barnsbury23/patterns/testimonials.php
@@ -17,23 +17,23 @@
 <div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -56,23 +56,23 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 
@@ -96,23 +96,23 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"width":24,"height":24,"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" class="wp-image-59" width="24" height="24"/></figure>
+<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/basic-icon-star.png" alt="" width="24" height="24"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->
 

--- a/barnsbury23/theme.json
+++ b/barnsbury23/theme.json
@@ -614,6 +614,14 @@
 		{
 			"area": "footer",
 			"name": "footer"
+		},
+		{
+			"name": "testimonials",
+			"area": "uncategorized"
+		},
+		{
+			"name": "testimonials-alt",
+			"area": "uncategorized"
 		}
 	],
 	"version": 2,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Removes any `wp-image` class names from image blocks in Barnsbury23, which fixes block validation errors in the editor.

Before:
![image](https://github.com/Automattic/themes/assets/1645628/0ebb1e73-f0b8-4b06-8445-9677c2500f44)

After:
![image](https://github.com/Automattic/themes/assets/1645628/6702986c-5d13-4f6d-a952-dd10af4064a9)

