### PR TITLE
Theme Pixl - Footer - Use the standard credit line

### DIFF
--- a/pixl/patterns/footer.php
+++ b/pixl/patterns/footer.php
@@ -15,16 +15,13 @@
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size">
     <?php
-        /* Translators: Theme name. */
-        $theme_name = '<strong>' . esc_html__( 'Pixl Theme', 'pixl' ) . '</strong>';
-        /* Translators: WordPress link. */
-        $wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'pixl' ) ) . '" rel="nofollow">WordPress</a>';
-        echo sprintf(
-            esc_html__( '%1$s, Proudly Powered by %2$s', 'pixl' ),
-            $theme_name,
-            $wordpress_link
-        );
-    ?>
+	/* Translators: WordPress link. */
+	$wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'pixl' ) ) . '" rel="nofollow">WordPress</a>';
+	echo sprintf(
+		esc_html__( 'Designed with %1$s', 'pixl' ),
+		$wordpress_link
+	);
+?>
 </p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Use the standard credit line in Pixl footer to fix the preview in WordPress.com

See the [standard credit line in the footer in other themes](https://github.com/search?q=repo%3AAutomattic%2Fthemes+Designed+with+%251+language%3APHP&type=code).

|BEFORE|AFTER|
|--|--|
|![image](https://github.com/Automattic/themes/assets/1881481/c73e0ac2-8e88-48c1-b015-0597ee9974e0)|<img width="661" alt="Screenshot 2566-10-24 at 17 31 04" src="https://github.com/Automattic/themes/assets/1881481/0b6c83a3-25ce-4d9f-b961-780a80a05e59">|

#### Related issue(s):

https://github.com/Automattic/wp-calypso/issues/82438
