### PR TITLE
Renamed 'Spearhead' to 'Spearhead (Classic)' and 'Spearhead Blocks' to 'Spearhead'

### DIFF
--- a/spearhead-blocks/readme.txt
+++ b/spearhead-blocks/readme.txt
@@ -1,4 +1,4 @@
-=== Spearhead Blocks ===
+=== Spearhead ===
 Contributors: Automattic
 Requires at least: 5.8
 Tested up to: 5.9

--- a/spearhead-blocks/style.css
+++ b/spearhead-blocks/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: Spearhead Blocks
+Theme Name: Spearhead
 Theme URI: https://wordpress.com/theme/spearhead-blocks/
 Author: Automattic
 Author URI: https://automattic.com

--- a/spearhead/readme.txt
+++ b/spearhead/readme.txt
@@ -1,4 +1,4 @@
-=== Spearhead ===
+=== Spearhead (Classic) ===
 Contributors: Automattic, Babak Nivi, Cece Yu
 Requires at least: 5.0
 Tested up to: 5.5.1

--- a/spearhead/style-rtl.css
+++ b/spearhead/style-rtl.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: Spearhead
+Theme Name: Spearhead (Classic)
 Theme URI: https://wordpress.com/theme/spearhead
 Author: Automattic
 Author URI: https://automattic.com/

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: Spearhead
+Theme Name: Spearhead (Classic)
 Theme URI: https://wordpress.com/theme/spearhead
 Author: Automattic
 Author URI: https://automattic.com/


### PR DESCRIPTION
Only the NAME has changed.  The Theme URI, Text Domain, folder/slug and everything else remains as it was before.

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

<img width="862" alt="image" src="https://github.com/Automattic/themes/assets/146530/e742bf78-37ca-4957-8dfe-75407e3caa8b">

