### PR TITLE
Livro: Fix XXL Font Size

### DIFF
--- a/livro/theme.json
+++ b/livro/theme.json
@@ -100,6 +100,10 @@
 				{
 					"size": "clamp(2.25rem, 6vw, 2.75rem)",
 					"slug": "x-large"
+				},
+				{
+					"size": "clamp(3.25rem, 8vw, 6.25rem)",
+					"slug": "xx-large"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Livro is forked on the Twenty Twenty Two theme, which means that the XXL font from it has been registered. It therefore displays in the Editor, but the font size hasn't been added to `theme.json`.

This change should fix it. Like the rest of the font sizes, I've used the value from Twenty Twenty Two. 

| Before   | After |
|----------|--------|
| <img width="454" alt="Screenshot 2023-11-06 at 09 46 09" src="https://github.com/Automattic/themes/assets/43215253/81a0459e-b86c-4a0a-80dd-a2f08c7e627b">  | <img width="565" alt="Screenshot 2023-11-06 at 09 46 02" src="https://github.com/Automattic/themes/assets/43215253/00738987-0092-4fe5-962e-35c58e524332">|

#### Related issue(s):
Fixes #7456 

Sorry - it's been a while for me to know who to ping for theme fixes. @jffng - would you mind taking a look? Thanks! 