### PR TITLE
Tronar: Remove theme attribute from comments template part

### DIFF
--- a/tronar/templates/page.html
+++ b/tronar/templates/page.html
@@ -4,7 +4,7 @@
 <main class="wp-block-group" style="margin-top:0px;margin-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:post-content {"layout":{"type":"constrained","justifyContent":"center"}} /-->
 
-	<!-- wp:template-part {"slug":"comments","theme":"tronar"} /-->
+	<!-- wp:template-part {"slug":"comments"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/tronar/templates/single.html
+++ b/tronar/templates/single.html
@@ -18,7 +18,7 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:template-part {"slug":"comments","theme":"tronar"} /-->
+	<!-- wp:template-part {"slug":"comments"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Removes theme attribute from comments template part in Page and Single templates. Fixes the missing template part error - missed on my initial review.

#### Related issue(s):
