### PR TITLE
Radcliffe 2: Fix Scroll on Table Block

### DIFF
--- a/radcliffe-2/assets/css/blocks.css
+++ b/radcliffe-2/assets/css/blocks.css
@@ -330,10 +330,6 @@ ul.wp-block-gallery li {
 
 /* Tables */
 
-.wp-block-table {
-	display: table;
-}
-
 .wp-block-table td,
 .wp-block-table th {
 	border: none;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Radcliffe 2 seems to assign `display: table` to `wp-block-table` for some reason. However, this class is the table wrapper; it's not the actual table itself - that's already set within the theme. This prevents the Table Block from scrolling on mobile devices, and it also prevents the table from being full width.

**Before:**
<img width="288" alt="Screenshot 2023-11-12 at 15 06 56" src="https://github.com/Automattic/themes/assets/43215253/f822e4a4-0d7b-425e-9633-2e69afe9e4cd">

**After:**
<img width="309" alt="Screenshot 2023-11-12 at 15 06 27" src="https://github.com/Automattic/themes/assets/43215253/739ae85b-98f8-43f6-b8a8-484a5d973717">

Note the ability to scroll. 

#### Related issue(s):
Fixes #7439