### PR TITLE
Multiple Block Themes: Fix Cursor When Hovering Links 

### DIFF
--- a/artly/styles/space-cadet.json
+++ b/artly/styles/space-cadet.json
@@ -195,7 +195,7 @@
 				}
 			}
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				"color": {

--- a/covr/theme.json
+++ b/covr/theme.json
@@ -565,7 +565,7 @@
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/didone/theme.json
+++ b/didone/theme.json
@@ -557,7 +557,7 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: 0.07em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: 0.07em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/foam/theme.json
+++ b/foam/theme.json
@@ -1138,7 +1138,7 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/loic/theme.json
+++ b/loic/theme.json
@@ -653,7 +653,7 @@
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/mpho/theme.json
+++ b/mpho/theme.json
@@ -490,7 +490,7 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
-		"css": " a[rel=\"tag\"]:before{\ncontent:\"#\";\n}\n\n a[rel=\"tag\"] + span{\ndisplay:none;\n}\n\n a[rel=\"tag\"]:after{\ncontent:\" \";\n}\n\na:any-link {\ncursor: auto;\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": " a[rel=\"tag\"]:before{\ncontent:\"#\";\n}\n\n a[rel=\"tag\"] + span{\ndisplay:none;\n}\n\n a[rel=\"tag\"]:after{\ncontent:\" \";\n}\n\na:any-link {\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/poesis/theme.json
+++ b/poesis/theme.json
@@ -433,7 +433,7 @@
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
-		"css": "a:any-link {\n    cursor: auto;\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/strand/theme.json
+++ b/strand/theme.json
@@ -598,7 +598,7 @@
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"
 		},
-		"css": "a:any-link {\n    cursor: auto;\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .02em !important;\n    text-underline-offset: .20em;\n}",
 		"elements": {
 			"button": {
 				":active": {

--- a/sunderland/theme.json
+++ b/sunderland/theme.json
@@ -1161,7 +1161,7 @@
 			"background": "var(--wp--preset--color--base)",
 			"text": "var(--wp--preset--color--contrast)"
 		},
-		"css": "a:any-link {\ncursor: auto;\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
+		"css": "a:any-link {\n    text-decoration-thickness: .01em !important;\n    text-underline-offset: .20em;\n}\na:where(:not(.wp-element-button)):hover {\n    text-decoration: none;\n}",
 		"elements": {
 			"button": {
 				":active": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
For some reason, a lot of block themes set this styling: 

```css
a:any-link {
   cursor: auto;
}
```
It seems unnecessary; instead, it just prevents browsers from activating their usual cursor when hovering over links. I reckon that it was added by mistake, so this PR proposes removing it. 

#### Related issue(s):
Fixes #7381
Fixes #7287