### PR TITLE
Programme: Fix Century & Futury Style Colours

### DIFF
--- a/programme/styles/century.json
+++ b/programme/styles/century.json
@@ -13,7 +13,7 @@
 			"gradients": [],
 			"palette": [
 				{
-					"color": "#141414",
+					"color": "#d1ddc9",
 					"name": "Primary",
 					"slug": "primary"
 				},
@@ -23,44 +23,14 @@
 					"slug": "secondary"
 				},
 				{
-					"color": "#2f2e2c",
+					"color": "#dfdbc5",
 					"name": "Foreground",
 					"slug": "foreground"
 				},
 				{
-					"color": "#fafafa",
+					"color": "#0b412f",
 					"name": "Background",
 					"slug": "background"
-				},
-				{
-					"color": "#fafafa",
-					"name": "Tertiary",
-					"slug": "tertiary"
-				},
-				{
-					"color": "#010229",
-					"name": "Futura Background",
-					"slug": "custom-futura-background"
-				},
-				{
-					"color": "#d1ddc9",
-					"name": "Futura Accent",
-					"slug": "custom-futura-accent"
-				},
-				{
-					"color": "#f2fcf5",
-					"name": "Futura Foreground",
-					"slug": "custom-futura-foreground"
-				},
-				{
-					"color": "#0b412f",
-					"name": "Century Background",
-					"slug": "custom-century-background"
-				},
-				{
-					"color": "#dfdbc5",
-					"name": "Century Foreground",
-					"slug": "custom-century-foreground"
 				}
 			],
 			"text": true
@@ -414,12 +384,12 @@
 			},
 			"core/heading": {
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var:preset|color|custom-century-foreground"
+							"text": "var:preset|color|foreground"
 						}
 					}
 				}
@@ -447,12 +417,12 @@
 			},
 			"core/paragraph": {
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var:preset|color|custom-century-foreground"
+							"text": "var:preset|color|foreground"
 						}
 					}
 				},
@@ -480,7 +450,7 @@
 			},
 			"core/post-date": {
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
@@ -490,7 +460,7 @@
 							}
 						},
 						"color": {
-							"text": "var:preset|color|custom-century-foreground"
+							"text": "var:preset|color|foreground"
 						},
 						"typography": {
 							"textDecoration": "none"
@@ -593,7 +563,7 @@
 			},
 			"core/search": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
@@ -637,8 +607,8 @@
 			}
 		},
 		"color": {
-			"background": "var:preset|color|custom-century-background",
-			"text": "var:preset|color|custom-century-foreground"
+			"background": "var:preset|color|background",
+			"text": "var:preset|color|foreground"
 		},
 		"elements": {
 			"button": {
@@ -670,13 +640,13 @@
 					"radius": "0.25rem"
 				},
 				"color": {
-					"background": "var:preset|color|custom-century-foreground",
-					"text": "var:preset|color|custom-century-background"
+					"background": "var:preset|color|foreground",
+					"text": "var:preset|color|background"
 				}
 			},
 			"caption": {
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				}
 			},
 			"h1": {
@@ -719,7 +689,7 @@
 			},
 			"heading": {
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"typography": {
 					"fontFamily": "var:preset|font-family|libre-baskerville",
@@ -735,7 +705,7 @@
 					}
 				},
 				"color": {
-					"text": "var:preset|color|custom-century-foreground"
+					"text": "var:preset|color|foreground"
 				}
 			}
 		},

--- a/programme/styles/futura.json
+++ b/programme/styles/futura.json
@@ -13,7 +13,7 @@
 			"gradients": [],
 			"palette": [
 				{
-					"color": "#141414",
+					"color": "#fafafa",
 					"name": "Primary",
 					"slug": "primary"
 				},
@@ -23,12 +23,12 @@
 					"slug": "secondary"
 				},
 				{
-					"color": "#2f2e2c",
+					"color": "#f2fcf5",
 					"name": "Foreground",
 					"slug": "foreground"
 				},
 				{
-					"color": "#fafafa",
+					"color": "#010229",
 					"name": "Background",
 					"slug": "background"
 				}
@@ -384,12 +384,12 @@
 			},
 			"core/heading": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var:preset|color|custom-futura-foreground"
+							"text": "var:preset|color|foreground"
 						}
 					}
 				}
@@ -417,12 +417,12 @@
 			},
 			"core/paragraph": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var:preset|color|custom-futura-foreground"
+							"text": "var:preset|color|foreground"
 						}
 					}
 				},
@@ -450,7 +450,7 @@
 			},
 			"core/post-date": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"elements": {
 					"link": {
@@ -460,7 +460,7 @@
 							}
 						},
 						"color": {
-							"text": "var:preset|color|custom-futura-foreground"
+							"text": "var:preset|color|foreground"
 						},
 						"typography": {
 							"textDecoration": "none"
@@ -563,7 +563,7 @@
 			},
 			"core/search": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
@@ -607,8 +607,8 @@
 			}
 		},
 		"color": {
-			"background": "var:preset|color|custom-futura-background",
-			"text": "var:preset|color|custom-futura-foreground"
+			"background": "var:preset|color|background",
+			"text": "var:preset|color|foreground"
 		},
 		"elements": {
 			"button": {
@@ -640,13 +640,13 @@
 					"radius": "0.25rem"
 				},
 				"color": {
-					"background": "var:preset|color|custom-futura-foreground",
-					"text": "var:preset|color|custom-futura-background"
+					"background": "var:preset|color|foreground",
+					"text": "var:preset|color|background"
 				}
 			},
 			"caption": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				}
 			},
 			"h1": {
@@ -689,7 +689,7 @@
 			},
 			"heading": {
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				},
 				"typography": {
 					"fontFamily": "var:preset|font-family|evolventa",
@@ -705,7 +705,7 @@
 					}
 				},
 				"color": {
-					"text": "var:preset|color|custom-futura-foreground"
+					"text": "var:preset|color|foreground"
 				}
 			}
 		},

--- a/programme/styles/futura.json
+++ b/programme/styles/futura.json
@@ -31,36 +31,6 @@
 					"color": "#fafafa",
 					"name": "Background",
 					"slug": "background"
-				},
-				{
-					"color": "#fafafa",
-					"name": "Tertiary",
-					"slug": "tertiary"
-				},
-				{
-					"color": "#010229",
-					"name": "Futura Background",
-					"slug": "custom-futura-background"
-				},
-				{
-					"color": "#d1ddc9",
-					"name": "Futura Accent",
-					"slug": "custom-futura-accent"
-				},
-				{
-					"color": "#f2fcf5",
-					"name": "Futura Foreground",
-					"slug": "custom-futura-foreground"
-				},
-				{
-					"color": "#18303b",
-					"name": "Century Background",
-					"slug": "custom-century-background"
-				},
-				{
-					"color": "#dfdbc5",
-					"name": "Century Foreground",
-					"slug": "custom-century-foreground"
 				}
 			],
 			"text": true

--- a/programme/templates/archive.html
+++ b/programme/templates/archive.html
@@ -81,7 +81,7 @@
 			class="wp-block-group"
 			style="margin-top: 2.1rem; margin-bottom: 2.1rem"
 		>
-			<!-- wp:query-pagination {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"4rem"},"elements":{"link":{"color":{"text":"var:preset|color|custom-futura-foreground"}}}},"textColor":"custom-futura-foreground"} -->
+			<!-- wp:query-pagination {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"4rem"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground"} -->
 			<!-- wp:query-pagination-previous {"label":"Prev"} /-->
 
 			<!-- wp:query-pagination-numbers /-->

--- a/programme/templates/home.html
+++ b/programme/templates/home.html
@@ -109,7 +109,7 @@
 			class="wp-block-group"
 			style="margin-top: 2.1rem; margin-bottom: 2.1rem"
 		>
-			<!-- wp:query-pagination {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"4rem"},"elements":{"link":{"color":{"text":"var:preset|color|custom-futura-foreground"}}}},"textColor":"custom-futura-foreground"} -->
+			<!-- wp:query-pagination {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"4rem"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground"} -->
 			<!-- wp:query-pagination-previous {"label":"Prev"} /-->
 
 			<!-- wp:query-pagination-numbers /-->

--- a/programme/theme.json
+++ b/programme/theme.json
@@ -31,36 +31,6 @@
 					"color": "#fafafa",
 					"name": "Background",
 					"slug": "background"
-				},
-				{
-					"color": "#fafafa",
-					"name": "Tertiary",
-					"slug": "tertiary"
-				},
-				{
-					"color": "#010229",
-					"name": "Futura Background",
-					"slug": "custom-futura-background"
-				},
-				{
-					"color": "#d1ddc9",
-					"name": "Futura Accent",
-					"slug": "custom-futura-accent"
-				},
-				{
-					"color": "#f2fcf5",
-					"name": "Futura Foreground",
-					"slug": "custom-futura-foreground"
-				},
-				{
-					"color": "#18303b",
-					"name": "Century Background",
-					"slug": "custom-century-background"
-				},
-				{
-					"color": "#dfdbc5",
-					"name": "Century Foreground",
-					"slug": "custom-century-foreground"
 				}
 			],
 			"text": true


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
It seems that the styles for Century and Fury were added to the default colours rather than replacing them, so they had no effect. The colours already are listed, but this PR fixes this issue so that they are correctly used. 

| Before | After |
|--------|--------|
| <img width="1599" alt="Screenshot 2023-11-12 at 21 13 15" src="https://github.com/Automattic/themes/assets/43215253/9bf28461-0d81-4652-87d3-29432d937023"> | <img width="1612" alt="Screenshot 2023-11-12 at 21 03 44" src="https://github.com/Automattic/themes/assets/43215253/39f9d450-e324-44e3-923f-c0dbe6e3aa13"> |
| <img width="1585" alt="Screenshot 2023-11-12 at 21 13 20" src="https://github.com/Automattic/themes/assets/43215253/8db744f9-f2f6-4124-9902-441e6fc4a858"> | <img width="1606" alt="Screenshot 2023-11-12 at 21 03 50" src="https://github.com/Automattic/themes/assets/43215253/9d223ec5-8d75-480f-96c6-eccc1e3764eb">  |
| <img width="1587" alt="Screenshot 2023-11-12 at 21 13 25" src="https://github.com/Automattic/themes/assets/43215253/9c3bda94-a682-4f81-acf4-3f5c77698e92"> | <img width="1610" alt="Screenshot 2023-11-12 at 21 03 57" src="https://github.com/Automattic/themes/assets/43215253/79294dd4-897a-426a-a3b1-cb97dafe7d09"> | 

#### Related issue(s):
Fixes #7435