### PR TITLE
Dara: Fix TikTok Embed Block

### DIFF
--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -191,6 +191,16 @@ blockquote cite {
 	color: #fff;
 }
 
+/* Embed */
+
+.wp-block-embed blockquote {
+	padding: 0;
+}
+
+.wp-block-embed blockquote:before {
+	content: none;
+}
+
 /*--------------------------------------------------------------
 3.0 Blocks - Formatting Blocks
 --------------------------------------------------------------*/

--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -193,11 +193,11 @@ blockquote cite {
 
 /* Embed */
 
-.wp-block-embed blockquote {
+.wp-block-embed.is-type-video blockquote {
 	padding: 0;
 }
 
-.wp-block-embed blockquote:before {
+.wp-block-embed.is-type-video blockquote:before {
 	content: none;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Ideally, Core would change the oEmbed for TikTok so that the `<blockquote>` is replaced with a `<div>` - but it seems like they're not keen on that. Dara seems to be the only theme where significant styling is done to quotes which damages such embeds, so it's probably worth fixing here.

| Before | After |
|--------|--------|
| <img width="836" alt="Screenshot 2023-11-12 at 21 50 09" src="https://github.com/Automattic/themes/assets/43215253/f9838e31-a006-4118-997f-0102da035ba1"> | <img width="841" alt="Screenshot 2023-11-12 at 21 49 29" src="https://github.com/Automattic/themes/assets/43215253/2b33d7a2-a9d0-4f2e-b648-30b2e52f3346"> |

Edit: actually, I changed my mind on targeting all embeds - it probably makes more sense to only target videos instead. I can imagine there's some embeds where a quote might be useful (eg. a tweet which has subsequently been deleted).

#### Related issue(s):
Fixes #7341