### PR TITLE
Independent Publisher 2: Fix Gravatar Not Appearing

### DIFF
--- a/independent-publisher-2/inc/extras.php
+++ b/independent-publisher-2/inc/extras.php
@@ -105,7 +105,7 @@ function validate_gravatar( $id_or_email ) {
 	}
 
 	$hashkey = md5( strtolower( trim( $email ) ) );
-	$uri     = 'http://www.gravatar.com/avatar/' . $hashkey . '?d=404';
+	$uri     = 'https://www.gravatar.com/avatar/' . $hashkey . '?d=404';
 	$data    = wp_cache_get( $hashkey );
 	$expire  = 60 * 5;
 	$group   = '';


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This is actually a pretty simple fix - Gravatar just requires checking against the SSL domain now. :) You should be able to find this setting under "Theme Options". It should appear when enabled again! 

<img width="656" alt="Screenshot 2023-11-25 at 15 21 32" src="https://github.com/Automattic/themes/assets/43215253/dc6e7b92-3c7b-41f5-adc1-15458253d896">

#### Related issue(s):
Fixes #7433