### PR TITLE
Dara: Fix Table of Contents Block

### DIFF
--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -191,6 +191,12 @@ blockquote cite {
 	color: #fff;
 }
 
+/* Table of Contents */
+
+.wp-block-table-of-contents__entry:before {
+	display: none;
+}
+
 /*--------------------------------------------------------------
 3.0 Blocks - Formatting Blocks
 --------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The Table of Contents block in Dara is broken because of the styles the theme applies to `[class*=content]:before`. These needs to be overriden for this block. In future, it may be worth reviewing those broad selectors, but that's probably out of scope of this PR.

**Before:**
<img width="675" alt="Screenshot 2023-11-26 at 11 28 07" src="https://github.com/Automattic/themes/assets/43215253/06f23f3e-3363-4230-9e58-72d79d7eebc2">

**After:**
<img width="682" alt="Screenshot 2023-11-26 at 11 29 35" src="https://github.com/Automattic/themes/assets/43215253/7f1a8413-d4b3-4def-a234-fbc6b9e7bfaa">

#### Related issue(s):
User in 7323036-zen was very frustrated by this; they don't have Custom CSS, so I'm filing a fix here. 