### PR TITLE
Multiple Themes: Fix Details (Accordion) Block 

### DIFF
--- a/affinity/assets/stylesheets/shared/_normalize.scss
+++ b/affinity/assets/stylesheets/shared/_normalize.scss
@@ -18,8 +18,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/affinity/style.css
+++ b/affinity/style.css
@@ -67,8 +67,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 

--- a/altofocus/assets/stylesheets/shared/_normalize.scss
+++ b/altofocus/assets/stylesheets/shared/_normalize.scss
@@ -18,8 +18,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/altofocus/style.css
+++ b/altofocus/style.css
@@ -741,8 +741,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 

--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -154,8 +154,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/button-2/style.css
+++ b/button-2/style.css
@@ -66,8 +66,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/canard/style.css
+++ b/canard/style.css
@@ -92,8 +92,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 audio,

--- a/dyad-2/editor-style.css
+++ b/dyad-2/editor-style.css
@@ -22,8 +22,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/dyad-2/style.css
+++ b/dyad-2/style.css
@@ -71,8 +71,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/gazette/style.css
+++ b/gazette/style.css
@@ -89,8 +89,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 audio,

--- a/ixion/style.css
+++ b/ixion/style.css
@@ -67,8 +67,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/karuna/assets/stylesheets/shared/_normalize.scss
+++ b/karuna/assets/stylesheets/shared/_normalize.scss
@@ -18,8 +18,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/karuna/style.css
+++ b/karuna/style.css
@@ -67,8 +67,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/libre-2/style.css
+++ b/libre-2/style.css
@@ -67,8 +67,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/lodestar/style.css
+++ b/lodestar/style.css
@@ -69,8 +69,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/pique/style.css
+++ b/pique/style.css
@@ -68,8 +68,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/publication/style.css
+++ b/publication/style.css
@@ -90,8 +90,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 audio,

--- a/radcliffe-2/style.css
+++ b/radcliffe-2/style.css
@@ -69,8 +69,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/rebalance/style.css
+++ b/rebalance/style.css
@@ -90,8 +90,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/scratchpad/style.css
+++ b/scratchpad/style.css
@@ -89,8 +89,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/shoreditch/style.css
+++ b/shoreditch/style.css
@@ -94,8 +94,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 

--- a/textbook/style.css
+++ b/textbook/style.css
@@ -67,8 +67,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 

--- a/toujours/style.css
+++ b/toujours/style.css
@@ -84,8 +84,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
 	display: block;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Almost all Automattic themes use `normalize.css` to start its file. However, annoyingly, there was a bug in `normalize.css` a few years ago which broke the `summary` element. This was fixed in 2016, but it looks like the themes have continued using an outdated version, meaning that lots of themes have been affected. You can learn more about that here: https://css-tricks.com/careful-when-changing-the-display-of-summary/

This PR updates the styles of several themes with the corrected changes to `normalize.css` from 2016. This is admittedly a pain because it affects so many themes; I did consider a change in Core, and I might one file later, but the problem is that won't work for any accordions inserted with HTML, which is supported on WordPress.com. There's also no guarantee that Core would accept a fix for a bug caused by themes.

As a result, we need to remove `display: block` from `summary` to fix the Details block in Gutenberg, and also any accordions inserted with HTML.

**Before:**
<img width="267" alt="Screenshot 2023-11-26 at 15 01 51" src="https://github.com/Automattic/themes/assets/43215253/82bfeb30-d64e-4828-9e0a-a5ee75947ba6">

**After:**
<img width="290" alt="Screenshot 2023-11-26 at 15 03 38" src="https://github.com/Automattic/themes/assets/43215253/76fede3d-7f0f-4d8a-900b-fa69dce16bfd">

#### Related issue(s):
Fixes #7041