### PR TITLE
Varia: Include Jetpack Content Options

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -225,7 +225,17 @@ if ( ! function_exists( 'varia_setup' ) ) :
 				'enable_theme_default' => true,
 			)
 		);
-
+		
+		// Add support for Content Options.
+		add_theme_support( 'jetpack-content-options', array(
+			'blog-display' => 'content',
+			'featured-images' => array(
+				'archive'         => true,
+				'archive-default' => true,
+				'post'            => true,
+				'page'            => true,
+			),
+		) );
 	}
 endif;
 add_action( 'after_setup_theme', 'varia_setup' );
@@ -478,47 +488,6 @@ function varia_customize_header_footer( $wp_customize ) {
 	);
 }
 add_action( 'customize_register', 'varia_customize_header_footer' );
-
-
-/**
- * Add ability to show or hide featured images on pages
- */
-function varia_customize_content_options( $wp_customize ) {
-
-	// Add Content section.
-	$wp_customize->add_section(
-		'jetpack_content_options',
-		array(
-			'title'    => esc_html__( 'Content Options', 'varia' ),
-			'priority' => 100,
-		)
-	);
-
-	// Add visibility setting for featured images on pages
-	$wp_customize->add_setting(
-		'show_featured_image_on_pages',
-		array(
-			'default'           => false,
-			'type'              => 'theme_mod',
-			'transport'         => 'refresh',
-			'sanitize_callback' => 'varia_sanitize_checkbox',
-		)
-	);
-
-	// Add control for the visibility of featured images on pages
-	$wp_customize->add_control(
-		'show_featured_image_on_pages',
-		array(
-			'label'       => esc_html__( 'Show the featured image on pages', 'varia' ),
-			'description' => esc_html__( 'Check to display a featured image at the top of your pages when they have one.', 'varia' ),
-			'section'     => 'jetpack_content_options',
-			'priority'    => 10,
-			'type'        => 'checkbox',
-			'settings'    => 'show_featured_image_on_pages',
-		)
-	);
-}
-add_action( 'customize_register', 'varia_customize_content_options' );
 
 /**
  * SVG Icons class.

--- a/varia/template-parts/content/content-page.php
+++ b/varia/template-parts/content/content-page.php
@@ -17,9 +17,7 @@
 		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
 
-	<?php if ( true === get_theme_mod( 'show_featured_image_on_pages', false ) ) : ?>
-		<?php varia_post_thumbnail(); ?>
-	<?php endif; ?>
+	<?php varia_post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This includes Jetpack Content Options to Varia and therefore its child themes. In #3220, an option was added to hide the Featured Images from pages. This was included in the section `jetpack_content_options`, but Jetpack Content Options weren't actually registered. 

cc @scruffian: I believe this was an oversight, and not intentional - would you mind confirming that? I'm reverting that change here in favour of adding Jetpack Content Options, which means that users can choose to hide Featured Images on posts and the homepage as well, rather than just pages. Thanks!

---

I've set the defaults based on how they are currently, so that sites using this theme right now won't be affected without changes being manually made in the Customizer. 

<img width="1760" alt="Screenshot 2023-11-26 at 16 03 24" src="https://github.com/Automattic/themes/assets/43215253/6b268f6d-1835-470c-bf21-1718f2892987">
<img width="1759" alt="Screenshot 2023-11-26 at 16 03 39" src="https://github.com/Automattic/themes/assets/43215253/94eb1131-c4c5-49a8-b03f-f9ccecd5f9a3">


#### Related issue(s):
Fixes #3637
Fixes #3544
Fixes #1754