### PR TITLE
Assembler: Fix php warnings

### DIFF
--- a/assembler/functions.php
+++ b/assembler/functions.php
@@ -8,6 +8,7 @@
  * @since Assembler 1.0
  */
 
+declare( strict_types = 1 );
 
 if ( ! function_exists( 'assembler_support' ) ) :
 

--- a/assembler/patterns/byline-date.php
+++ b/assembler/patterns/byline-date.php
@@ -4,6 +4,8 @@
  * Slug: assembler/byline-date
  * Inserter: no
  */
+
+declare( strict_types = 1 );
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.26rem","padding":{"bottom":"20px"}},"typography":{"fontSize":"x-small"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center","justifyContent":"center"}} -->
 <div class="wp-block-group" style="padding-bottom:20px;font-size:x-small"><!-- wp:paragraph {"fontSize":"x-small"} -->

--- a/assembler/patterns/footer.php
+++ b/assembler/patterns/footer.php
@@ -5,6 +5,8 @@
  * Categories: footer
  * Block Types: core/template-part/footer
  */
+
+declare( strict_types = 1 );
 ?>
 
 

--- a/assembler/patterns/header.php
+++ b/assembler/patterns/header.php
@@ -5,6 +5,8 @@
  * Categories: featured, header
  * Block Types: core/template-part/header
  */
+
+declare( strict_types = 1 );
 ?>
 
 

--- a/assembler/patterns/post-meta.php
+++ b/assembler/patterns/post-meta.php
@@ -5,6 +5,8 @@
  * Categories: post meta
  * Block Types: core/post-date, core/post-terms
  */
+
+declare( strict_types = 1 );
 ?>
 
 


### PR DESCRIPTION
Without these `declare( strict_types = 1 );` statement, our system won't let us commit the changes.