### PR TITLE
Add strict types declaration to latest themes

### DIFF
--- a/beep/functions.php
+++ b/beep/functions.php
@@ -7,7 +7,7 @@
  * @package Beep
  * @since Beep 1.0
  */
-
+declare( strict_types = 1 );
 
 if ( ! function_exists( 'beep_support' ) ) :
 

--- a/ici/functions.php
+++ b/ici/functions.php
@@ -7,7 +7,7 @@
  * @package Ici
  * @since Ici 1.0
  */
-
+declare( strict_types = 1 );
 
 if ( ! function_exists( 'ici_support' ) ) :
 

--- a/indice/functions.php
+++ b/indice/functions.php
@@ -8,6 +8,8 @@
  * @since indice 1.0
  */
 
+declare( strict_types = 1 );
+
 if ( ! function_exists( 'indice_support' ) ) :
 
 	/**

--- a/spiel/functions.php
+++ b/spiel/functions.php
@@ -7,7 +7,7 @@
  * @package Spiel
  * @since Spiel 1.0
  */
-
+declare( strict_types = 1 );
 
 if ( ! function_exists( 'spiel_support' ) ) :
 

--- a/xanadu/functions.php
+++ b/xanadu/functions.php
@@ -7,7 +7,7 @@
  * @package Xanadu
  * @since Xanadu 1.0
  */
-
+declare( strict_types = 1 );
 
 if ( ! function_exists( 'xanadu_support' ) ) :
 


### PR DESCRIPTION
Deploy script won't allow themes to be commited without strict types declaration.
Recent previous case: https://github.com/Automattic/themes/pull/7529


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->