### PR TITLE
Revert "Varia: Include Jetpack Content Options (#7518)"

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -225,17 +225,7 @@ if ( ! function_exists( 'varia_setup' ) ) :
 				'enable_theme_default' => true,
 			)
 		);
-		
-		// Add support for Content Options.
-		add_theme_support( 'jetpack-content-options', array(
-			'blog-display' => 'content',
-			'featured-images' => array(
-				'archive'         => true,
-				'archive-default' => true,
-				'post'            => true,
-				'page'            => true,
-			),
-		) );
+
 	}
 endif;
 add_action( 'after_setup_theme', 'varia_setup' );
@@ -488,6 +478,47 @@ function varia_customize_header_footer( $wp_customize ) {
 	);
 }
 add_action( 'customize_register', 'varia_customize_header_footer' );
+
+
+/**
+ * Add ability to show or hide featured images on pages
+ */
+function varia_customize_content_options( $wp_customize ) {
+
+	// Add Content section.
+	$wp_customize->add_section(
+		'jetpack_content_options',
+		array(
+			'title'    => esc_html__( 'Content Options', 'varia' ),
+			'priority' => 100,
+		)
+	);
+
+	// Add visibility setting for featured images on pages
+	$wp_customize->add_setting(
+		'show_featured_image_on_pages',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
+
+	// Add control for the visibility of featured images on pages
+	$wp_customize->add_control(
+		'show_featured_image_on_pages',
+		array(
+			'label'       => esc_html__( 'Show the featured image on pages', 'varia' ),
+			'description' => esc_html__( 'Check to display a featured image at the top of your pages when they have one.', 'varia' ),
+			'section'     => 'jetpack_content_options',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'show_featured_image_on_pages',
+		)
+	);
+}
+add_action( 'customize_register', 'varia_customize_content_options' );
 
 /**
  * SVG Icons class.

--- a/varia/template-parts/content/content-page.php
+++ b/varia/template-parts/content/content-page.php
@@ -17,7 +17,9 @@
 		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
 
-	<?php varia_post_thumbnail(); ?>
+	<?php if ( true === get_theme_mod( 'show_featured_image_on_pages', false ) ) : ?>
+		<?php varia_post_thumbnail(); ?>
+	<?php endif; ?>
 
 	<div class="entry-content">
 		<?php


### PR DESCRIPTION
This reverts commit 448a2ecbaa0c4e7567a6b3d65084f2ba4f00b5ff.

This fixes the bug reported here: https://github.com/Automattic/wp-calypso/issues/85369

Which was caused by using Jetpack to control varia (and children) Featured Image setting rather than Varia doing so.  #7518