### PR TITLE
Default featured images to false and leverage theme mod values that have already been set

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -225,15 +225,16 @@ if ( ! function_exists( 'varia_setup' ) ) :
 				'enable_theme_default' => true,
 			)
 		);
-		
+
 		// Add support for Content Options.
 		add_theme_support( 'jetpack-content-options', array(
 			'blog-display' => 'content',
 			'featured-images' => array(
-				'archive'         => true,
-				'archive-default' => true,
-				'post'            => true,
-				'page'            => true,
+				'archive'         => false,
+				'archive-default' => false,
+				'post'            => false,
+				//featured images on pages boolean was previously managed by Varia rather than jetpack.  If that value has been set default to that.
+				'page'            => get_theme_mod( 'show_featured_image_on_pages', false ),
 			),
 		) );
 	}

--- a/varia/functions.php
+++ b/varia/functions.php
@@ -230,11 +230,13 @@ if ( ! function_exists( 'varia_setup' ) ) :
 		add_theme_support( 'jetpack-content-options', array(
 			'blog-display' => 'content',
 			'featured-images' => array(
-				'archive'         => false,
-				'archive-default' => false,
-				'post'            => false,
+				'archive'         => true,
+				'archive-default' => true,
+				'post'            => true,
+				'post-default'    => true,
+				'page'            => true,
 				//featured images on pages boolean was previously managed by Varia rather than jetpack.  If that value has been set default to that.
-				'page'            => get_theme_mod( 'show_featured_image_on_pages', false ),
+				'page-default'    => get_theme_mod( 'show_featured_image_on_pages', false ),
 			),
 		) );
 	}


### PR DESCRIPTION
A possible alternative to #7566 

#### Changes proposed in this Pull Request:

Default Jetpack Content options to FALSE
Includes any previously set values as the default value for Jetpack Content Options

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/85369