### PR TITLE
Varia: Remove Jetpack Dependency For Featured Images

### DIFF
--- a/varia/functions.php
+++ b/varia/functions.php
@@ -227,17 +227,9 @@ if ( ! function_exists( 'varia_setup' ) ) :
 		);
 
 		// Add support for Content Options.
+		// We handled Featured Images within Varia directly.
 		add_theme_support( 'jetpack-content-options', array(
 			'blog-display' => 'content',
-			'featured-images' => array(
-				'archive'         => true,
-				'archive-default' => true,
-				'post'            => true,
-				'post-default'    => true,
-				'page'            => true,
-				//featured images on pages boolean was previously managed by Varia rather than jetpack.  If that value has been set default to that.
-				'page-default'    => get_theme_mod( 'show_featured_image_on_pages', false ),
-			),
 		) );
 	}
 endif;
@@ -491,6 +483,92 @@ function varia_customize_header_footer( $wp_customize ) {
 	);
 }
 add_action( 'customize_register', 'varia_customize_header_footer' );
+
+/**
+ * Add ability to show or hide Featured Images.
+ */
+function varia_customize_featured_images( $wp_customize ) {
+	// Add Content section.
+	$wp_customize->add_section(
+		'varia_featured_images',
+		array(
+			'title'    => esc_html__( 'Featured Images', 'varia' ),
+			'priority' => 100,
+			'description' => esc_html__( 'Customize the visibility of Featured Images.', 'varia' ),
+		)
+	);
+
+	// Add visibility setting for Featured Images on the homepage.
+	$wp_customize->add_setting(
+		'show_featured_image_on_archive',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
+
+	// Add control for the visibility of Featured Images on the homepage.
+	$wp_customize->add_control(
+		'show_featured_image_on_archive',
+		array(
+			'label'       => esc_html__( 'Display on blog and archives', 'varia' ),
+			'section'     => 'varia_featured_images',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'show_featured_image_on_archive',
+		)
+	);
+
+	// Add visibility setting for Featured Images on posts
+	$wp_customize->add_setting(
+		'show_featured_image_on_posts',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
+
+	// Add control for the visibility of Featured Images on posts
+	$wp_customize->add_control(
+		'show_featured_image_on_posts',
+		array(
+			'label'       => esc_html__( 'Display on posts', 'varia' ),
+			'section'     => 'varia_featured_images',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'show_featured_image_on_posts',
+		)
+	);
+
+	// Add visibility setting for Featured Images on pages
+	$wp_customize->add_setting(
+		'show_featured_image_on_pages',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'varia_sanitize_checkbox',
+		)
+	);
+
+	// Add control for the visibility of Featured Images on pages
+	$wp_customize->add_control(
+		'show_featured_image_on_pages',
+		array(
+			'label'       => esc_html__( 'Display on pages', 'varia' ),
+			'section'     => 'varia_featured_images',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'show_featured_image_on_pages',
+		)
+	);
+}
+add_action( 'customize_register', 'varia_customize_featured_images' );
+
 
 /**
  * SVG Icons class.

--- a/varia/inc/template-tags.php
+++ b/varia/inc/template-tags.php
@@ -207,6 +207,18 @@ if ( ! function_exists( 'varia_post_thumbnail' ) ) :
 		if ( ! varia_can_show_post_thumbnail() ) {
 			return;
 		}
+		
+		if ( ( is_home() || is_archive() ) && ( false === get_theme_mod( 'show_featured_image_on_archive', false ) ) ) {
+			return;
+		}
+
+		if ( is_single() && ( false === get_theme_mod( 'show_featured_image_on_posts', false ) ) ) {
+			return;
+		}
+
+		if ( is_page() && ( false === get_theme_mod( 'show_featured_image_on_pages', false ) ) ) {
+			return;
+		}
 
 		if ( is_singular() ) :
 			?>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
@pbking - this is how I'd go about #7566 :) Up to you if you'd prefer it to #7567, but here's the advantages. 

**Pros:**
A lot of the reports in Automattic/wp-calypso#85369 were about the fact that Content Options automatically hides the Featured Images set in the Latest Posts block. There is an open issue in Jetpack about this - Automattic/jetpack#29286 - but I tried fixing it, and it seems super tricky to do. This would at least remove Varia from the list of themes affected by that bug.

Also doesn't require Jetpack anymore, but I don't think that's a problem - can't imagine many self-hosted sites without Jetpack using Varia, to be honest. 

**Cons:**
User who have made changes in the last two weeks for the Posts and Blog settings will need to do so again. 

Feel free to close if, in your judgement, the cons outweigh the pros here. 

#### Related issue(s):
Closes Automattic/wp-calypso#85369