### PR TITLE
Added a utility to pull changes to all themes from sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"deploy:theme": "node ./theme-utils.mjs deploy-theme",
 		"deploy:zip": "node ./theme-utils.mjs build-com-zip",
 		"deploy:land": "node ./theme-utils.mjs land-diff",
+		"pull:all": "node ./theme-utils.mjs pull-all-themes", 
 		"core:pull": "node ./theme-utils.mjs pull-core-themes",
 		"core:push": "node ./theme-utils.mjs push-core-themes",
 		"core:sync": "node ./theme-utils.mjs sync-core-theme",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -75,6 +75,10 @@ const commands = {
 		additionalArgs: '<theme-slug>',
 		run: (args) => checkoutCoreTheme(args?.[1])
 	},
+	"pull-all-themes": {
+		helpText: 'Use rsync to copy all public theme files from your sandbox to your local machine.',
+		run: pullAllThemes
+	},
 	"pull-core-themes": {
 		helpText: 'Use rsync to copy all public CORE theme files from your sandbox to your local machine. CORE themes are any of the Twenty<whatever> themes.',
 		run: pullCoreThemes
@@ -908,6 +912,21 @@ async function checkoutCoreTheme(theme) {
 		rm -rf ./${theme}
 		svn checkout https://wpcom-themes.svn.automattic.com/${theme} ./${theme}
 	`);
+}
+
+async function pullAllThemes() {
+	console.log("Pulling ALL themes from sandbox.");
+	let allThemes = await getActionableThemes();
+	for (let theme of allThemes) {
+		try {
+		await executeCommand(`
+			rsync -avr --no-p --no-times --delete -m --exclude-from='.sandbox-ignore' wpcom-sandbox:${sandboxPublicThemesFolder}/${theme}/ ./${theme}/ 
+		`, true);
+		}
+		catch (err) {
+			console.log('Error pulling:', err);
+		}
+	}
 }
 
 async function pullCoreThemes() {


### PR DESCRIPTION
To use run `npm run pull:all`

This will pull the resources from the sandbox to your local environment.  A useful utility if changes have been made to the private repo and need to be synced to the public repo.