### PR TITLE
Assembler: Remove unneeded ref

### DIFF
--- a/assembler/parts/header.html
+++ b/assembler/parts/header.html
@@ -11,7 +11,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":6,"className":"order-1 md:order-0"} /-->
+<div class="wp-block-group"><!-- wp:navigation {"className":"order-1 md:order-0"} /-->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Navigation blocks in themes shouldn't have a ref, so let's remove this one.

#### Related issue(s):
