### PR TITLE
Update Navigation Alignment for popular themes

### DIFF
--- a/adventurer/patterns/header.php
+++ b/adventurer/patterns/header.php
@@ -15,7 +15,7 @@
 
         <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
         <div class="wp-block-group">
-            <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+            <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
             <!-- wp:buttons -->
             <div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","textColor":"background"} -->

--- a/assembler/parts/header.html
+++ b/assembler/parts/header.html
@@ -11,7 +11,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":6,"className":"order-1 md:order-0"} /-->
+<div class="wp-block-group"><!-- wp:navigation {"className":"order-1 md:order-0"} /-->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->

--- a/bibimbap/parts/header.html
+++ b/bibimbap/parts/header.html
@@ -8,6 +8,6 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayBackgroundColor":"secondary","overlayTextColor":"background","textColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayBackgroundColor":"secondary","overlayTextColor":"background","textColor":"foreground","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/erma/parts/header.html
+++ b/erma/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/foam/parts/header.html
+++ b/foam/parts/header.html
@@ -6,6 +6,6 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"customOverlayBackgroundColor":"#2544e3","overlayTextColor":"white","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<!-- wp:navigation {"customOverlayBackgroundColor":"#2544e3","overlayTextColor":"white","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/jaida/parts/header.html
+++ b/jaida/parts/header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--70);padding-right:0;padding-bottom:var(--wp--preset--spacing--70);padding-left:0"><!-- wp:site-title {"textAlign":"left","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background"} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/lativ/parts/header.html
+++ b/lativ/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"20px"},"layout":{"selfStretch":"fit"}}} /-->
+<!-- wp:navigation {"overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"20px"},"layout":{"selfStretch":"fit"}}} /-->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->

--- a/startfit/patterns/header-home.php
+++ b/startfit/patterns/header-home.php
@@ -21,7 +21,7 @@
 				</div>
 				<!-- /wp:group -->
 
-				<!-- wp:navigation {"textColor":"base","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"}}} /-->
+				<!-- wp:navigation {"textColor":"base","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"}}} /-->
 			</div>
 			<!-- /wp:group -->
 

--- a/startfit/patterns/header.php
+++ b/startfit/patterns/header.php
@@ -16,6 +16,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"textColor":"base","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"}}} /-->
+	<!-- wp:navigation {"textColor":"base","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"2rem"}}} /-->
 </div>
 <!-- /wp:group -->

--- a/ueno/parts/header.html
+++ b/ueno/parts/header.html
@@ -8,7 +8,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0px"},"typography":{"textTransform":"uppercase"}}} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","overlayBackgroundColor":"background","overlayTextColor":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"0px"},"typography":{"textTransform":"uppercase"}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
The following themes have right aligned navigation in their overlay which is probably not the intended design. This PR switches them to be left aligned.

- Foam
- Adventurer
- Lativ
- Bibimbap
- Startfit
- Erma
- Jaida

## Screenshots
Before
<img width="591" alt="Screenshot 2023-12-21 at 13 45 04" src="https://github.com/Automattic/themes/assets/275961/303689fd-e5f1-44cb-96b4-47db9bb059ba">
After
<img width="536" alt="Screenshot 2023-12-21 at 13 45 17" src="https://github.com/Automattic/themes/assets/275961/b0a46a1b-1d5d-40a3-b970-b6460778f7d2">
Before
<img width="594" alt="Screenshot 2023-12-21 at 13 43 27" src="https://github.com/Automattic/themes/assets/275961/918052a1-e4cb-45e8-a1c6-5239fe53513a">
After
<img width="594" alt="Screenshot 2023-12-21 at 13 43 38" src="https://github.com/Automattic/themes/assets/275961/4877ce8e-2c8e-4f13-b3d4-b101a1017690">
Before
<img width="551" alt="Screenshot 2023-12-21 at 13 47 59" 
src="https://github.com/Automattic/themes/assets/275961/100c4510-5cce-431b-87b3-8fb0ea9e87ea">
After
<img width="455" alt="Screenshot 2023-12-21 at 13 37 43" src="https://github.com/Automattic/themes/assets/275961/c825d552-4ea0-4d19-bffb-54ba9a9e44f8">
Before
<img width="487" alt="Screenshot 2023-12-21 at 13 35 06" src="https://github.com/Automattic/themes/assets/275961/5193be60-93f5-433d-aa8b-8cf69f2bcbdb">
After
<img width="485" alt="Screenshot 2023-12-21 at 13 34 55" src="https://github.com/Automattic/themes/assets/275961/23b9528e-cfd0-40b7-94b9-ab38d9dcb4ff">
Before
<img width="515" alt="Screenshot 2023-12-21 at 13 29 39" src="https://github.com/Automattic/themes/assets/275961/7de3f5ec-ea38-406b-b600-a84c706d0d0c">
After
<img width="520" alt="Screenshot 2023-12-21 at 13 29 28" src="https://github.com/Automattic/themes/assets/275961/d946e285-b5ae-4d2c-89c9-ea24f4854fa7">
Before
<img width="453" alt="Screenshot 2023-12-21 at 13 37 50" 
src="https://github.com/Automattic/themes/assets/275961/408a181c-6ba2-42cc-b33e-b10690230cea">
After
<img width="549" alt="Screenshot 2023-12-21 at 13 48 21" src="https://github.com/Automattic/themes/assets/275961/99f22702-afce-47df-a5b2-3d8aa3ae94fe">
Before
<img width="550" alt="Screenshot 2023-12-21 at 13 46 18" 
src="https://github.com/Automattic/themes/assets/275961/674bfd05-5676-498a-b5d3-8481257c3ca8">
After
<img width="551" alt="Screenshot 2023-12-21 at 13 46 59" 
src="https://github.com/Automattic/themes/assets/275961/b7366bc4-68f9-4ae5-a066-b7a7012a678c">
Before
<img width="582" alt="Screenshot 2023-12-21 at 13 19 18" src="https://github.com/Automattic/themes/assets/275961/004a424a-51b5-4789-9f7f-12413438a701">
After
<img width="586" alt="Screenshot 2023-12-21 at 13 18 46" src="https://github.com/Automattic/themes/assets/275961/22d055c0-6e91-4bda-8890-9f76e221dc2a">
Before
<img width="561" alt="Screenshot 2023-12-21 at 13 50 40" src="https://github.com/Automattic/themes/assets/275961/b61f782b-928c-41ec-b105-be659f38a924">
After
<img width="563" alt="Screenshot 2023-12-21 at 13 50 58" src="https://github.com/Automattic/themes/assets/275961/db2f2bd8-7ab6-4181-9263-efb7cc960e49">
