### PR TITLE
Bedrock: add missing strict types declaration

### DIFF
--- a/bedrock/patterns/post-meta.php
+++ b/bedrock/patterns/post-meta.php
@@ -4,6 +4,7 @@
  * Slug: bedrock/post-meta
  * Inserter: no
  */
+declare( strict_types = 1 );
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"},"typography":{"lineHeight":"1"}},"textColor":"secondary","layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group has-secondary-color has-text-color" style="line-height:1">


### PR DESCRIPTION
Quick fix: add missing strict types declaration on post meta pattern.