### PR TITLE
Bedrock: Make sure page navigation button has no underline on hover and focus states

### DIFF
--- a/bedrock/theme.json
+++ b/bedrock/theme.json
@@ -544,12 +544,18 @@
 							"color": {
 								"background": "var(--wp--preset--color--accent-two)",
 								"text": "var(--wp--preset--color--accent-three)"
+							},
+							"typography": {
+								"textDecoration": "none"
 							}
 						},
 						":hover": {
 							"color": {
 								"background": "var(--wp--preset--color--accent-two)",
 								"text": "var(--wp--preset--color--accent-three)"
+							},
+							"typography": {
+								"textDecoration": "none"
 							}
 						},
 						"border": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Remove the underline from the page navigation button on hover and focus state.

| Before | After |
| ----------- | ----------- |
| ![Screenshot 2024-01-19 at 19 42 01](https://github.com/Automattic/themes/assets/908665/3ba43c66-22a7-4ac6-8178-1a1adb3dc766) | ![Screenshot 2024-01-19 at 19 41 40](https://github.com/Automattic/themes/assets/908665/afaa902a-5931-422c-9174-a65c1d34601a) |



