### PR TITLE
Assembler: Remove Instrument serif bold variant from theme.json

### DIFF
--- a/assembler/theme.json
+++ b/assembler/theme.json
@@ -539,14 +539,6 @@
                             "src": [
                                 "file:./assets/fonts/instrument-serif/InstrumentSerif-Italic.ttf"
                             ]
-                        },
-                        {
-                            "fontFamily": "Instrument Serif",
-                            "fontStyle": "bold",
-                            "fontWeight": "600 800",
-                            "src": [
-                                "file:./assets/fonts/instrument-serif/InstrumentSerif-Bold.ttf"
-                            ]
                         }
                     ],
                     "fontFamily": "\"Instrument Serif\", serif",


### PR DESCRIPTION
Removing Instrument Serif from the font families, as there is not a bold variant. https://fonts.google.com/specimen/Instrument+Serif