### PR TITLE
Assembler: Hide jetpack and core patterns in editor inserter

### DIFF
--- a/assembler/functions.php
+++ b/assembler/functions.php
@@ -10,6 +10,40 @@
 
 declare( strict_types = 1 );
 
+if ( ! function_exists( 'assembler_unregister_patterns' ) ) :
+	/**
+	 * Unregister Jetpack patterns and core patterns bundled in WordPress.
+	 */
+	function assembler_unregister_patterns() {
+		$pattern_names = array(
+			// Jetpack form patterns.
+			'contact-form',
+			'newsletter-form',
+			'rsvp-form',
+			'registration-form',
+			'appointment-form',
+			'feedback-form',
+			// Patterns bundled in WordPress core.
+			// These would be removed by remove_theme_support( 'core-block-patterns' )
+			// if it's called on the init action with priority 9 from a plugin, not from a theme.
+			'core/query-standard-posts',
+			'core/query-medium-posts',
+			'core/query-small-posts',
+			'core/query-grid-posts',
+			'core/query-large-title-posts',
+			'core/query-offset-posts',
+			'core/social-links-shared-background-color',
+		);
+		foreach ( $pattern_names as $pattern_name ) {
+			$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
+			if ( $pattern ) {
+				unregister_block_pattern( $pattern_name );
+			}
+		}
+	}
+
+endif;
+
 if ( ! function_exists( 'assembler_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
@@ -22,7 +56,10 @@ if ( ! function_exists( 'assembler_setup' ) ) :
 
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
-
+		// Unregister Jetpack form patterns and core patterns bundled in WordPress.
+		assembler_unregister_patterns();
+		// Remove theme support for the core and featured patterns coming from the Dotorg pattern directory.
+		remove_theme_support( 'core-block-patterns' );
 	}
 
 endif;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
- Unregister Jetpack form patterns and core patterns bundled in WordPress.
- Remove theme support for the core and featured patterns from the Dotorg pattern directory.


|BEFORE|AFTER|
|-|-|
|<img width="314" alt="Screenshot 2567-02-01 at 15 37 35" src="https://github.com/Automattic/themes/assets/1881481/40e78320-e252-4b7a-91a5-0b2de3e94060">|<img width="315" alt="Screenshot 2567-02-01 at 15 38 16" src="https://github.com/Automattic/themes/assets/1881481/e58e2abf-1c8a-4f6f-ade3-2948c99fb8af">|


#### Related issue(s):
https://github.com/Automattic/jetpack/pull/35374

#### Testing instructions
- Sandbox a site and public API

  - Make sure your site has the Assembler theme active 
  - Apply the changes in this PR on your sandbox
  - Visit the editor `/wp-admin/site-editor.php` 
  - Verify you don't see the Forms, Banners, and Text categories on the inserter.
  - Verify you only see v2 patterns from Dotcompatterns (146) and three theme patterns that are not shown in the inserter (`inserter: false`)

![image](https://github.com/Automattic/themes/assets/1881481/37e8623b-4de7-4e62-8e10-41e0f79733d0)

  <img width="505" alt="Screenshot 2567-02-01 at 15 31 42" src="https://github.com/Automattic/themes/assets/1881481/81e2687c-6f3d-49d4-aa74-63c9263feca9">
<img width="126" alt="Screenshot 2567-02-01 at 16 00 51" src="https://github.com/Automattic/themes/assets/1881481/67a2be92-2bc4-4997-8dce-a9a69f6e3f55">

- Stop sandboxing and verify that Jetpack and core patterns are there
