### PR TITLE
Assembler: Unregister Jetpack form patterns on atomic sites

### DIFF
--- a/assembler/functions.php
+++ b/assembler/functions.php
@@ -57,7 +57,12 @@ if ( ! function_exists( 'assembler_setup' ) ) :
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
 		// Unregister Jetpack form patterns and core patterns bundled in WordPress.
+		// Simple sites
 		assembler_unregister_patterns();
+		add_filter( 'wp_loaded', function () {
+			// Atomic sites
+			assembler_unregister_patterns();
+		} );
 		// Remove theme support for the core and featured patterns coming from the Dotorg pattern directory.
 		remove_theme_support( 'core-block-patterns' );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
- Unregister Jetpack form patterns on atomic sites using the `wp_loaded` hook
- Leave the other call to `assembler_unregister_patterns()` because it's required for simple sites

#### Related issue(s):
https://github.com/Automattic/themes/pull/7633