### PR TITLE
Perenne: remove period from version

### DIFF
--- a/perenne/style.css
+++ b/perenne/style.css
@@ -7,7 +7,7 @@ Description: Exegi monumentum aere perennius.
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 5.7
-Version: 1.0.0.
+Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: perenne


### PR DESCRIPTION
Extra period causes deploy script to fail when comparing versions.