### PR TITLE
Manually bumping foam to 1.0.2

### DIFF
--- a/foam/readme.txt
+++ b/foam/readme.txt
@@ -12,6 +12,9 @@ Foam is a WordPress event theme with a vibrant, straightforward style. Entirely 
 
 == Changelog ==
 
+= 1.0.2 =
+* Bumping to rebuild theme zip for wpcom ms updater PHP8 support.
+
 = 1.0.1 =
 * Multiple Block Themes: Fix Cursor When Hovering Links  (#7479)
 

--- a/foam/style.css
+++ b/foam/style.css
@@ -7,7 +7,7 @@ Description: Foam is a simple theme that supports full-site editing. It comes wi
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 5.7
-Version: 1.0.1
+Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: foam


### PR DESCRIPTION
v1.0.1 bundles the old version of the wpcom theme updater which has PHP8 errors, bumping the version will allow a new zip to be generated which will bundle the new PHP8 compatible version of the wpcom theme updater.

See #7657 for more details.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
