### PR TITLE
Bedrock: Move template parts from patterns to templates

### DIFF
--- a/bedrock/patterns/404.php
+++ b/bedrock/patterns/404.php
@@ -7,8 +7,6 @@
 declare( strict_types = 1 );
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-primary-background-color has-background" style="margin-top:0px;margin-bottom:0px">
 	<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/background.png","isRepeated":true,"dimRatio":0,"isUserOverlayColor":true,"align":"full","layout":{"type":"constrained"}} -->
@@ -48,11 +46,5 @@ declare( strict_types = 1 );
 		</div>
 	</div>
 	<!-- /wp:cover -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
 </div>
 <!-- /wp:group -->

--- a/bedrock/patterns/index.php
+++ b/bedrock/patterns/index.php
@@ -7,8 +7,6 @@
 declare( strict_types = 1 );
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-primary-background-color has-background" style="margin-top:0px;margin-bottom:0px">
 	<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/background.png","isRepeated":true,"dimRatio":0,"isUserOverlayColor":true,"align":"full","layout":{"type":"constrained"}} -->
@@ -42,11 +40,5 @@ declare( strict_types = 1 );
 		</div>
 	</div>
 	<!-- /wp:cover -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
 </div>
 <!-- /wp:group -->

--- a/bedrock/patterns/page.php
+++ b/bedrock/patterns/page.php
@@ -7,8 +7,6 @@
 declare( strict_types = 1 );
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-primary-background-color has-background" style="margin-top:0px;margin-bottom:0px">
 	<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/background.png","isRepeated":true,"dimRatio":0,"isUserOverlayColor":true,"align":"full","layout":{"type":"constrained"}} -->
@@ -48,11 +46,5 @@ declare( strict_types = 1 );
 		</div>
 	</div>
 	<!-- /wp:cover -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
 </div>
 <!-- /wp:group -->

--- a/bedrock/patterns/post-meta.php
+++ b/bedrock/patterns/post-meta.php
@@ -6,6 +6,7 @@
  */
 declare( strict_types = 1 );
 ?>
+
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"},"typography":{"lineHeight":"1"}},"textColor":"secondary","layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group has-secondary-color has-text-color" style="line-height:1">
 	<!-- wp:image {"width":"20px","height":"20px","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->

--- a/bedrock/patterns/search.php
+++ b/bedrock/patterns/search.php
@@ -7,8 +7,6 @@
 declare( strict_types = 1 );
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-primary-background-color has-background" style="margin-top:0px;margin-bottom:0px">
 	<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/background.png","isRepeated":true,"dimRatio":0,"isUserOverlayColor":true,"align":"full","layout":{"type":"constrained"}} -->
@@ -92,10 +90,3 @@ declare( strict_types = 1 );
 	<!-- /wp:cover -->
 </div>
 <!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
-</div>
-<!-- /wp:group -->
-

--- a/bedrock/patterns/single.php
+++ b/bedrock/patterns/single.php
@@ -7,8 +7,6 @@
 declare( strict_types = 1 );
 ?>
 
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
-
 <!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-primary-background-color has-background" style="margin-top:0px;margin-bottom:0px">
 	<!-- wp:cover {"url":"<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/background.png","isRepeated":true,"dimRatio":0,"isUserOverlayColor":true,"align":"full","layout":{"type":"constrained"}} -->
@@ -64,10 +62,3 @@ declare( strict_types = 1 );
 	<!-- /wp:cover -->
 </div>
 <!-- /wp:group -->
-
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
-	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
-</div>
-<!-- /wp:group -->
-

--- a/bedrock/templates/404.html
+++ b/bedrock/templates/404.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/404"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->

--- a/bedrock/templates/archive.html
+++ b/bedrock/templates/archive.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/archive"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->

--- a/bedrock/templates/index.html
+++ b/bedrock/templates/index.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/index"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->

--- a/bedrock/templates/page.html
+++ b/bedrock/templates/page.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/page"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->

--- a/bedrock/templates/search.html
+++ b/bedrock/templates/search.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/search"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->

--- a/bedrock/templates/single.html
+++ b/bedrock/templates/single.html
@@ -1,1 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"full"} /-->
+
 <!-- wp:pattern {"slug":"bedrock/single"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px">
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"full"} /-->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I'm not sure when, but with a recent change in the Gutenberg plugin, having a template part in a pattern seems to break the editor. Therefore, I moved all the template parts from the patterns and added to the templates directly.

#### Related issue(s):
This should fix https://github.com/Automattic/wp-calypso/issues/88219