### PR TITLE
Craftfully: Fix for missing "contrast" preset color

### DIFF
--- a/craftfully/patterns/header.php
+++ b/craftfully/patterns/header.php
@@ -10,7 +10,7 @@ declare( strict_types = 1 );
 <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"backgroundColor":"accent-3","textColor":"foreground","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-foreground-color has-accent-3-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group alignwide"><!-- wp:navigation {"overlayMenu":"never","overlayBackgroundColor":"accent-5","overlayTextColor":"contrast","style":{"typography":{"letterSpacing":"0px","fontSize":"14px"},"spacing":{"blockGap":"var:preset|spacing|40"}},"fontFamily":"system-font"} /--></div>
+<div class="wp-block-group alignwide"><!-- wp:navigation {"overlayMenu":"never","overlayBackgroundColor":"accent-5","overlayTextColor":"foreground","style":{"typography":{"letterSpacing":"0px","fontSize":"14px"},"spacing":{"blockGap":"var:preset|spacing|40"}},"fontFamily":"system-font"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/craftfully/patterns/sidebar.php
+++ b/craftfully/patterns/sidebar.php
@@ -65,7 +65,7 @@ declare( strict_types = 1 );
 <p class="has-small-font-size"><?php echo esc_html__( 'Stay updated with our latest tutorials and ideas by joining my newsletter.', 'craftfully' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"contrast","padding":12} /--></div>
+<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"foreground","padding":12} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->

--- a/craftfully/theme.json
+++ b/craftfully/theme.json
@@ -24,8 +24,8 @@
 				},
 				{
 					"color": "#404040",
-					"name": "Contrast",
-					"slug": "contrast"
+					"name": "Foreground",
+					"slug": "foreground"
 				},
 				{
 					"color": "#ffffff",
@@ -289,35 +289,35 @@
 			"core/button": {
 				"border": {
 					"bottom": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": "var(--wp--preset--color--foreground)",
 						"style": "solid",
 						"width": "1px"
 					},
 					"left": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": "var(--wp--preset--color--foreground)",
 						"style": "solid",
 						"width": "1px"
 					},
 					"radius": "50px",
 					"right": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": "var(--wp--preset--color--foreground)",
 						"style": "solid",
 						"width": "1px"
 					},
 					"top": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": "var(--wp--preset--color--foreground)",
 						"style": "solid",
 						"width": "1px"
 					}
 				},
 				"color": {
 					"background": "var(--wp--preset--color--accent-2)",
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": "var(--wp--preset--color--foreground)"
 						}
 					}
 				},
@@ -334,11 +334,11 @@
 				"variations": {
 					"outline": {
 						"border": {
-							"color": "var(--wp--preset--color--contrast)",
+							"color": "var(--wp--preset--color--foreground)",
 							"width": "1px"
 						},
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": "var(--wp--preset--color--foreground)"
 						},
 						"spacing": {
 							"padding": {
@@ -356,7 +356,7 @@
 			},
 			"core/code": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0.25rem",
 					"style": "solid",
 					"width": "2px"
@@ -402,12 +402,12 @@
 			},
 			"core/heading": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": "var(--wp--preset--color--foreground)"
 						}
 					}
 				}
@@ -505,7 +505,7 @@
 			},
 			"core/post-title": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"elements": {
 					"link": {
@@ -518,7 +518,7 @@
 							}
 						},
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": "var(--wp--preset--color--foreground)"
 						},
 						"typography": {
 							"textDecoration": "none"
@@ -533,7 +533,7 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": "var(--wp--preset--color--foreground)",
 					"style": "solid",
 					"width": "1px 0"
 				},
@@ -552,7 +552,7 @@
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": "var(--wp--preset--color--foreground)",
 					"style": "solid",
 					"width": "0 0 0 5px"
 				},
@@ -596,7 +596,7 @@
 					"width": "0 0 1px 0"
 				},
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-tagline": {
@@ -609,14 +609,14 @@
 					"link": {
 						":hover": {
 							"color": {
-								"text": "var(--wp--preset--color--contrast)"
+								"text": "var(--wp--preset--color--foreground)"
 							},
 							"typography": {
 								"textDecoration": "underline"
 							}
 						},
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": "var(--wp--preset--color--foreground)"
 						},
 						"typography": {
 							"textDecoration": "none"
@@ -632,24 +632,24 @@
 		},
 		"color": {
 			"background": "var(--wp--preset--color--base)",
-			"text": "var(--wp--preset--color--contrast)"
+			"text": "var(--wp--preset--color--foreground)"
 		},
 		"css": "/* Remove block gap between first-level blocks */ :where(.wp-site-blocks) > * { margin-block-start: 0; margin-block-end: 0; }\n\n.heading-bg {background: rgb(255,255,255);\nbackground: linear-gradient(180deg, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 50%, rgba(206,227,226,1) 50%, rgba(206,227,226,1) 100%);}",
 		"elements": {
 			"button": {
 				":active": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": "var(--wp--preset--color--foreground)",
 						"text": "var(--wp--preset--color--base)"
 					}
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": "var(--wp--preset--color--foreground)",
 						"text": "var(--wp--preset--color--base)"
 					},
 					"outline": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": "var(--wp--preset--color--foreground)",
 						"offset": "2px",
 						"style": "dotted",
 						"width": "1px"
@@ -658,7 +658,7 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--accent-5)",
-						"text": "var(--wp--preset--color--contrast)"
+						"text": "var(--wp--preset--color--foreground)"
 					}
 				},
 				"border": {
@@ -666,7 +666,7 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--accent-2)",
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--dm-mono)"
@@ -726,7 +726,7 @@
 					}
 				},
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
- Rename the color preset named `contrast` as `foreground` because `contrast` doesn't exist.

@alaczek I wasn't sure if you wanted to create a `contrast` preset or use `foreground` instead. 

#### Related issue(s):

<img width="1260" alt="Screenshot 2567-03-15 at 16 02 38" src="https://github.com/Automattic/themes/assets/1881481/6959a135-2f22-4ea7-8828-e69a116381a0">

