### PR TITLE
Assembler: Lint styles

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -135,21 +135,18 @@ footer {
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
-    font-size: inherit;
+	font-size: inherit;
+	width: auto;
+	padding: 0 4px;
+	transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1), top 0.15s cubic-bezier(0.4, 0, 0.2, 1), font-size 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
-    width: auto;
-    padding: 0 4px;
-    transition: transform 0.15s cubic-bezier(.4,0,.2,1), top 0.15s cubic-bezier(.4,0,.2,1), font-size 0.15s cubic-bezier(.4,0,.2,1);
-}
-
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder~.animated-label__label, 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus~.animated-label__label, 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.animated-label__label, 
-.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label {
-    background-color: var(--wp--custom--input--color--background) !important;
-    transform: translateY(-11px) translateX(-4px); /* Moves the label out of the field. */
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label {
+	background-color: var(--wp--custom--input--color--background) !important;
+	transform: translateY(-11px) translateX(-4px); /* Moves the label out of the field. */
 }
 
 .contact-form label,

--- a/assembler/style.css
+++ b/assembler/style.css
@@ -15,123 +15,130 @@ Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-color
 */
 
 /* Progresive enhancement to reduce widows and orphans. */
-h1, h2, h3, h4, h5, h6, blockquote {
-    text-wrap: balance;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+blockquote {
+	text-wrap: balance;
 }
 
 p {
-    text-wrap: pretty;
+	text-wrap: pretty;
 }
 
 /* Tiny tweak to make sure footers are properly spaced. */
 footer {
-    margin-top: 0 !important;
+	margin-top: 0 !important;
 }
 
 /* Provide better default color for social links */
 .wp-block-social-links.is-style-logos-only li.wp-social-link {
-    color: currentColor;
+	color: currentcolor;
 }
 
 .wp-block-social-links.is-style-logos-only .wp-social-link svg {
-    height: 1em;
-    width: 1em;
+	height: 1em;
+	width: 1em;
 }
 
 .wp-block-social-links.has-small-icon-size {
-    font-size: 20px;
+	font-size: 20px;
 }
 
 /* Set default line height for font size presets. */
 .has-xx-large-font-size {
-   line-height: 1;
+	line-height: 1;
 }
 
 /* Add space between the header and first element, if its a paragraph. */
 .entry-content > p:first-child {
-    margin-top: var(--wp--style--root--padding-left); 
+	margin-top: var(--wp--style--root--padding-left);
 }
 
 /* Move header core/navigation to the right on mobile. */
 .order-0 {
-    order: 0;
+	order: 0;
 }
 
 .order-1 {
-    order: 1;
+	order: 1;
 }
 
 .grow-0 {
-    flex-grow: 0;
+	flex-grow: 0;
 }
 
 .grow {
-    flex-grow: 1;
+	flex-grow: 1;
 }
-  
+
 @media (min-width: 600px) {
-    .md\:order-0 {
-        order: 0;
-    }
 
-    .md\:order-1 {
-      order: 1;
-    }
+	.md\:order-0 {
+		order: 0;
+	}
 
-    .md\:grow-0 {
-        flex-grow: 0;
-    }
-    
-    .md\:grow {
-        flex-grow: 1;
-    }
+	.md\:order-1 {
+		order: 1;
+	}
+
+	.md\:grow-0 {
+		flex-grow: 0;
+	}
+
+	.md\:grow {
+		flex-grow: 1;
+	}
 
 }
 
 .overflow-hidden {
-    overflow: hidden;
+	overflow: hidden;
 }
 
 /* Style Jetpack forms */
 .wp-block-jetpack-contact-form-container {
-    --jetpack--contact-form--input-padding-left: 16px !important;
+	--jetpack--contact-form--input-padding-left: 16px !important;
 }
 
 .wp-block-jetpack-contact-form input,
 .wp-block-jetpack-contact-form textarea {
-    backdrop-filter: saturate(1.1);
-    background-color: transparent;
-    border-color: var(--wp--custom--input--border--color);
-    border-radius: var(--wp--custom--input--border--radius) !important; /* Requires !important to override local variables with theme variables. */
-    border-width: var(--wp--custom--input--border--width) !important;  /* Requires !important to override local variables with theme variables. */
-    filter: brightness(0.975);
-    font-size: inherit;
-    color: inherit;
-    transition: border-color 0.15s cubic-bezier(.4,0,.2,1);
+	backdrop-filter: saturate(1.1);
+	background-color: transparent;
+	border-color: var(--wp--custom--input--border--color);
+	border-radius: var(--wp--custom--input--border--radius) !important; /* Requires !important to override local variables with theme variables. */
+	border-width: var(--wp--custom--input--border--width) !important;  /* Requires !important to override local variables with theme variables. */
+	filter: brightness(0.975);
+	font-size: inherit;
+	color: inherit;
+	transition: border-color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.jetpack-contact-form .jetpack-field .jetpack-field__input, 
+.jetpack-contact-form .jetpack-field .jetpack-field__input,
 .jetpack-contact-form .jetpack-field .jetpack-field__textarea {
-    border-color: var(--wp--custom--input--border--color);
+	border-color: var(--wp--custom--input--border--color);
 }
 
 .wp-block-jetpack-contact-form input:not(:placeholder-shown),
 .wp-block-jetpack-contact-form textarea:not(:placeholder-shown),
 .wp-block-jetpack-contact-form input:focus,
 .wp-block-jetpack-contact-form textarea:focus {
-    filter: brightness(1);
-    backdrop-filter: saturate(1);
+	filter: brightness(1);
+	backdrop-filter: saturate(1);
 }
 
 .wp-block-jetpack-contact-form input:focus,
 .wp-block-jetpack-contact-form textarea:focus {
-    border-color: var(--wp--custom--input--focus--border--color);
+	border-color: var(--wp--custom--input--focus--border--color);
 }
 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select, 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>input, 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>textarea {
-    padding-top: var(--field-padding); /* Remove unnecessary padding adjustment from Jetpack. */
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea {
+	padding-top: var(--field-padding); /* Remove unnecessary padding adjustment from Jetpack. */
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
@@ -152,9 +159,9 @@ footer {
 .contact-form label,
 .wp-block-jetpack-contact-form label,
 .jetpack-field-label .rich-text.jetpack-field-label__input {
-    font-weight: 500;
+	font-weight: 500;
 }
 
 .contact-form__input-error {
-    font-size: var(--wp--preset--font-size--small);
+	font-size: var(--wp--preset--font-size--small);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Linting CSS based on [`wp-scripts lint-style`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-style), which uses [stylelint](https://github.com/stylelint/stylelint) with the [@wordpress/stylelint-config](https://www.npmjs.com/package/@wordpress/stylelint-config) configuration per the [WordPress CSS Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/). 

Ensures consistency in style linting for when the theme is used within other environments. 

There are no actual changes to the styles, simply formatting. 