### PR TITLE
Deploy script: Improve npm versioning step

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -781,9 +781,6 @@ async function versionBumpTheme(theme, addChanges) {
 		}
 		if (addChanges) {
 			await executeCommand(`git add ${file}`);
-			if (isPackageJson) {
-				await executeCommand(`git add package-lock.json`);
-			}
 		}
 	}
 }

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -775,7 +775,7 @@ async function versionBumpTheme(theme, addChanges) {
 		const isPackageJson = file === `${theme}/package.json`;
 		if (isPackageJson) {
 			// update theme/package.json and package-lock.json
-			await executeCommand(`npm version ${currentVersion.replace('-wpcom', '')} --workspace=${theme} --silent`);
+			await executeCommand(`npm version ${currentVersion.replace('-wpcom', '')} --workspace=${theme}`);
 		} else {
 			await executeCommand(`perl -pi -e 's/Version: (.*)$/"Version: '${currentVersion}'"/ge' ${file}`);
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Sometimes there can be issues with node modules which will cause the deploy script to fail. This PR removes the `--silent` parameter in the npm versioning step for each theme, so if there is an error, there should be a helpful error message printed to help debug the problem. Currently, it's difficult to see what's causing the script to fail.

I've also removed the step that adds the root package-lock.json file for each theme that has a package.json file, as the root package-lock.json file is added at the end of the updates on [line 642](https://github.com/Automattic/themes/blob/trunk/theme-utils.mjs#L642).

To test, ensure the deploy script runs successfully by running `npm run deploy`.

#### Related issues:
p1710970837782649-slack-C029FM1EH