### PR TITLE
Assembler: Add color and typography variations

### DIFF
--- a/assembler/.gitignore
+++ b/assembler/.gitignore
@@ -1,2 +1,2 @@
 #Ignoring style variations
-/styles/*
+/assembler-colors-typesets

--- a/assembler/styles/colors/01-blueberry.json
+++ b/assembler/styles/colors/01-blueberry.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Blueberry",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#c7d1ff",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#213fd4",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#1d35b4",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1e1e1e",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#c7d1ff"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#213fd4"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#1d35b4"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#1e1e1e"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#c7d1ff",
+                        "#213fd4"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#c7d1ff",
+                        "#1d35b4"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#c7d1ff",
+                        "#1e1e1e"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#213fd4",
+                        "#1d35b4"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#213fd4",
+                        "#1e1e1e"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#1d35b4",
+                        "#1e1e1e"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-3)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/02-pearl.json
+++ b/assembler/styles/colors/02-pearl.json
@@ -1,0 +1,224 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Pearl",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#DCDCDC",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#184690",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#123267",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#091B34",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#DCDCDC"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#184690"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#123267"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#091B34"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#DCDCDC",
+                        "#184690"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#DCDCDC",
+                        "#123267"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#DCDCDC",
+                        "#091B34"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#184690",
+                        "#123267"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#184690",
+                        "#091B34"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#123267",
+                        "#091B34"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/03-mauve.json
+++ b/assembler/styles/colors/03-mauve.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Mauve",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#E5CCC8",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#C28376",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#BD796B",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#311B16",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#E5CCC8"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#C28376"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#BD796B"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#311B16"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#E5CCC8",
+                        "#C28376"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#E5CCC8",
+                        "#BD796B"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#E5CCC8",
+                        "#311B16"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#C28376",
+                        "#BD796B"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#C28376",
+                        "#311B16"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#BD796B",
+                        "#311B16"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-3)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-5)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-5)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/04-gateau.json
+++ b/assembler/styles/colors/04-gateau.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Gateau",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FEF3ED",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#6A5D58",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#E4007E",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#D30978",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#FEF3ED"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#6A5D58"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#E4007E"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#D30978"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FEF3ED",
+                        "#6A5D58"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FEF3ED",
+                        "#E4007E"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FEF3ED",
+                        "#D30978"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#6A5D58",
+                        "#E4007E"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#6A5D58",
+                        "#D30978"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#E4007E",
+                        "#D30978"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/navigation": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-4)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/05-tangerine.json
+++ b/assembler/styles/colors/05-tangerine.json
@@ -1,0 +1,217 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Tangerine",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#EEE",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#CCC",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#FF4D00",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#EEE"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#CCC"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FF4D00"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#EEE",
+                        "#CCC"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#EEE",
+                        "#FF4D00"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#EEE",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#CCC",
+                        "#FF4D00"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#CCC",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#FF4D00",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/06-saffron.json
+++ b/assembler/styles/colors/06-saffron.json
@@ -1,0 +1,216 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Saffron",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FBFBF4",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F7BE25",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#F5A3AB",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#89DF89",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#00000A",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FBFBF4",
+                        "#F7BE25"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FBFBF4",
+                        "#F5A3AB"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FBFBF4",
+                        "#89DF89"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FBFBF4",
+                        "#00000A"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#F5A3AB"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#89DF89"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#00000A"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#F5A3AB",
+                        "#89DF89"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#F5A3AB",
+                        "#00000A"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#89DF89",
+                        "#00000A"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-2)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/07-regalia.json
+++ b/assembler/styles/colors/07-regalia.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Regalia",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#f4f6f3",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#b72831",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#1d4c53",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#2832B8",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1A1A1A",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#f4f6f3",
+                        "#b72831"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#f4f6f3",
+                        "#1d4c53"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#f4f6f3",
+                        "#2832B8"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#f4f6f3",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#b72831",
+                        "#1d4c53"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#b72831",
+                        "#2832B8"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#b72831",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#1d4c53",
+                        "#2832B8"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#1d4c53",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#2832B8",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/08-cinnabar.json
+++ b/assembler/styles/colors/08-cinnabar.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Cinnabar",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#EFEFEB",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#FFDFD3",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#D63D00",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1A1A1A",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#EFEFEB"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#FFDFD3"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#D63D00"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#EFEFEB",
+                        "#FFDFD3"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#EFEFEB",
+                        "#D63D00"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#EFEFEB",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#FFDFD3",
+                        "#D63D00"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#FFDFD3",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#D63D00",
+                        "#1A1A1A"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/09-hunter.json
+++ b/assembler/styles/colors/09-hunter.json
@@ -1,0 +1,216 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Hunter",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F6F4ED",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#002A32",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#281907",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#121313",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#F6F4ED"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#002A32"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#281907"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#121313"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F6F4ED",
+                        "#002A32"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F6F4ED",
+                        "#281907"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F6F4ED",
+                        "#121313"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#002A32",
+                        "#281907"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#002A32",
+                        "#121313"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#281907",
+                        "#121313"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-3)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/10-cornflower.json
+++ b/assembler/styles/colors/10-cornflower.json
@@ -1,0 +1,234 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Cornflower",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F2F2F2",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#989898",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#87A3BF",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#0F0F0F",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#F2F2F2"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#989898"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#87A3BF"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F2F2F2",
+                        "#989898"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F2F2F2",
+                        "#87A3BF"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F2F2F2",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#989898",
+                        "#87A3BF"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#989898",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#87A3BF",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-5)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/11-umber.json
+++ b/assembler/styles/colors/11-umber.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Umber",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#F4F3F1",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#DCD9D1",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#513E29",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#443322",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1B130E",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#F4F3F1",
+                        "#DCD9D1"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#F4F3F1",
+                        "#513E29"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#F4F3F1",
+                        "#443322"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#F4F3F1",
+                        "#1B130E"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#DCD9D1",
+                        "#513E29"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#DCD9D1",
+                        "#443322"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#DCD9D1",
+                        "#1B130E"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#513E29",
+                        "#443322"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#513E29",
+                        "#1B130E"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#443322",
+                        "#1B130E"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-3)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/12-chestnut.json
+++ b/assembler/styles/colors/12-chestnut.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Chestnut",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ECECE4",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#D7D7C6",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#BBBB9E",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#484036",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#3B332B",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ECECE4",
+                        "#D7D7C6"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ECECE4",
+                        "#BBBB9E"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ECECE4",
+                        "#484036"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ECECE4",
+                        "#3B332B"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#D7D7C6",
+                        "#BBBB9E"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#D7D7C6",
+                        "#484036"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#D7D7C6",
+                        "#3B332B"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#BBBB9E",
+                        "#484036"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#BBBB9E",
+                        "#3B332B"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#484036",
+                        "#3B332B"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/13-mist.json
+++ b/assembler/styles/colors/13-mist.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Mist",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#E4E9EB",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#193641",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#214522",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "rgba(0, 0, 0, 0.75)",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#E4E9EB",
+                        "#193641"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#E4E9EB",
+                        "#214522"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#E4E9EB",
+                        "rgba(0, 0, 0, 0.75)"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#E4E9EB",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#193641",
+                        "#214522"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#193641",
+                        "rgba(0, 0, 0, 0.75)"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#193641",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#214522",
+                        "rgba(0, 0, 0, 0.75)"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#214522",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "rgba(0, 0, 0, 0.75)",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-1)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-2)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-2)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/14-bisque.json
+++ b/assembler/styles/colors/14-bisque.json
@@ -1,0 +1,204 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Bisque",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#e9d7c9",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#7a7e5f",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#2b453c",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#062b23",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#e9d7c9"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#7a7e5f"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#2b453c"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#062b23"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#e9d7c9",
+                        "#7a7e5f"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#e9d7c9",
+                        "#2b453c"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#e9d7c9",
+                        "#062b23"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#7a7e5f",
+                        "#2b453c"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#7a7e5f",
+                        "#062b23"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#2b453c",
+                        "#062b23"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "elements": {
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/15-coral.json
+++ b/assembler/styles/colors/15-coral.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Coral",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F8D4D4",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#F2B1B7",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#EA4322",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#e53815",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#F8D4D4"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#F2B1B7"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#EA4322"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#e53815"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F8D4D4",
+                        "#F2B1B7"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F8D4D4",
+                        "#EA4322"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F8D4D4",
+                        "#e53815"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#F2B1B7",
+                        "#EA4322"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#F2B1B7",
+                        "#e53815"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#EA4322",
+                        "#e53815"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-3)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-4)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/16-salmon.json
+++ b/assembler/styles/colors/16-salmon.json
@@ -1,0 +1,217 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Salmon",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#fbfbfb",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFA6A6",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#00000038",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#000000C9",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#0F0F0F",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#fbfbfb",
+                        "#FFA6A6"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#fbfbfb",
+                        "#00000038"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#fbfbfb",
+                        "#000000C9"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#fbfbfb",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFA6A6",
+                        "#00000038"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFA6A6",
+                        "#000000C9"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFA6A6",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#00000038",
+                        "#000000C9"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#00000038",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#000000C9",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/17-maize.json
+++ b/assembler/styles/colors/17-maize.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Maize",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#E1D372",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#DBCE75",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#452D48",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1F201F",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#E1D372"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#DBCE75"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#452D48"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#1F201F"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#E1D372",
+                        "#DBCE75"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#E1D372",
+                        "#452D48"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#E1D372",
+                        "#1F201F"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#DBCE75",
+                        "#452D48"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#DBCE75",
+                        "#1F201F"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#452D48",
+                        "#1F201F"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-3)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-4)"
+                }
+            },
+            "button": {
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)"
+                    }
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/18-ash.json
+++ b/assembler/styles/colors/18-ash.json
@@ -1,0 +1,204 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Ash",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#f1f1f1",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#C7C7C7",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#858585",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#111111",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#f1f1f1",
+                        "#C7C7C7"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#f1f1f1",
+                        "#858585"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#f1f1f1",
+                        "#111111"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#f1f1f1",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#C7C7C7",
+                        "#858585"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#C7C7C7",
+                        "#111111"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#C7C7C7",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#858585",
+                        "#111111"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#858585",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#111111",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-4)"
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/19-rosewood.json
+++ b/assembler/styles/colors/19-rosewood.json
@@ -1,0 +1,221 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Rosewood",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFFFFF30",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#B69691",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#4b332f",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#201713",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FFFFFF30"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#B69691"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#4b332f"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#201713"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF30",
+                        "#B69691"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF30",
+                        "#4b332f"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF30",
+                        "#201713"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#B69691",
+                        "#4b332f"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#B69691",
+                        "#201713"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#4b332f",
+                        "#201713"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-3)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-5)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/20-taupe.json
+++ b/assembler/styles/colors/20-taupe.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Taupe",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F3EBDD",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#A6987C",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#171412D1",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#171412",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#F3EBDD"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#A6987C"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#171412D1"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#171412"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F3EBDD",
+                        "#A6987C"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F3EBDD",
+                        "#171412D1"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F3EBDD",
+                        "#171412"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#A6987C",
+                        "#171412D1"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#A6987C",
+                        "#171412"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#171412D1",
+                        "#171412"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-3)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/21-cherry.json
+++ b/assembler/styles/colors/21-cherry.json
@@ -1,0 +1,219 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Cherry",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#ff9c9c",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#DA1035",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#000000BF",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#ff9c9c"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#DA1035"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#000000BF"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#ff9c9c",
+                        "#DA1035"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#ff9c9c",
+                        "#000000BF"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#ff9c9c",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#DA1035",
+                        "#000000BF"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#DA1035",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#000000BF",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-3)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-5)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-5)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/22-peach.json
+++ b/assembler/styles/colors/22-peach.json
@@ -1,0 +1,217 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Peach",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#ffffff",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#F7BE25",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#ED4011E8",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#EC4010",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#171717",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#F7BE25"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#ED4011E8"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#EC4010"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#171717"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#ED4011E8"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#EC4010"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#F7BE25",
+                        "#171717"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#ED4011E8",
+                        "#EC4010"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#ED4011E8",
+                        "#171717"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#EC4010",
+                        "#171717"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-2)",
+            "text": "var(--wp--preset--color--theme-5)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-5)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-5)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/23-raspberry.json
+++ b/assembler/styles/colors/23-raspberry.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Raspberry",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFF0ED",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFDDD1",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#FF462C",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#AC250B",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFF0ED",
+                        "#FFDDD1"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFF0ED",
+                        "#FF462C"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFF0ED",
+                        "#AC250B"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFF0ED",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFDDD1",
+                        "#FF462C"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFDDD1",
+                        "#AC250B"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFDDD1",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#FF462C",
+                        "#AC250B"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#FF462C",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#AC250B",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-2)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-1)"
+                        }
+                    }
+                }
+            },
+            "core/site-title": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-1)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-2)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/24-sapphire.json
+++ b/assembler/styles/colors/24-sapphire.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Sapphire",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFFD1",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#ffffff",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#527CEB",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#2628DD",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFFD1",
+                        "#ffffff"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFD1",
+                        "#527CEB"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFD1",
+                        "#2628DD"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFD1",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#527CEB"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#2628DD"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#527CEB",
+                        "#2628DD"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#527CEB",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#2628DD",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-1)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/25-forest.json
+++ b/assembler/styles/colors/25-forest.json
@@ -1,0 +1,217 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Forest",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FCFCCCCF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FDFDCE",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#7D5912",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#127C1C",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FCFCCCCF",
+                        "#FDFDCE"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FCFCCCCF",
+                        "#7D5912"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FCFCCCCF",
+                        "#127C1C"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FCFCCCCF",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FDFDCE",
+                        "#7D5912"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FDFDCE",
+                        "#127C1C"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FDFDCE",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#7D5912",
+                        "#127C1C"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#7D5912",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#127C1C",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-1)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/26-plum.json
+++ b/assembler/styles/colors/26-plum.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Plum",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFFC7",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#ffffff",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#0092B0",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#DDAB77",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#622C69",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFFC7",
+                        "#ffffff"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFC7",
+                        "#0092B0"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFC7",
+                        "#DDAB77"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFC7",
+                        "#622C69"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#0092B0"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#DDAB77"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#ffffff",
+                        "#622C69"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#0092B0",
+                        "#DDAB77"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#0092B0",
+                        "#622C69"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#DDAB77",
+                        "#622C69"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        },
+        "elements": {
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-1)",
+                        "text": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/27-shale.json
+++ b/assembler/styles/colors/27-shale.json
@@ -1,0 +1,223 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Shale",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#F7F0FF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#EDDCFF",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#DBF9FF",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#3A333B",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1B181B",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#F7F0FF",
+                        "#EDDCFF"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#F7F0FF",
+                        "#DBF9FF"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#F7F0FF",
+                        "#3A333B"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#F7F0FF",
+                        "#1B181B"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#EDDCFF",
+                        "#DBF9FF"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#EDDCFF",
+                        "#3A333B"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#EDDCFF",
+                        "#1B181B"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#DBF9FF",
+                        "#3A333B"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#DBF9FF",
+                        "#1B181B"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#3A333B",
+                        "#1B181B"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-2)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-1)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/28-cafe.json
+++ b/assembler/styles/colors/28-cafe.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Cafe",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFDFFF",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#C9E2DB",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#4C230B",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#4C230B",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FFDFFF"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFDFFF",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFDFFF",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFDFFF",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#4C230B",
+                        "#4C230B"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/site-title": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            },
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-3)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/29-emerald.json
+++ b/assembler/styles/colors/29-emerald.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Emerald",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#fdffe6",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FBFFCF",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#C9E2DB",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#213414",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#122B07",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#fdffe6",
+                        "#FBFFCF"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#fdffe6",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#fdffe6",
+                        "#213414"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#fdffe6",
+                        "#122B07"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FBFFCF",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FBFFCF",
+                        "#213414"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FBFFCF",
+                        "#122B07"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#213414"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#122B07"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#213414",
+                        "#122B07"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/site-title": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            },
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-3)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/30-ink.json
+++ b/assembler/styles/colors/30-ink.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Ink",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#DAEDE770",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#DAECE6",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#C9E2DB",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#0F3039",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#08272F",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#DAEDE770",
+                        "#DAECE6"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#DAEDE770",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#DAEDE770",
+                        "#0F3039"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#DAEDE770",
+                        "#08272F"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#DAECE6",
+                        "#C9E2DB"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#DAECE6",
+                        "#0F3039"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#DAECE6",
+                        "#08272F"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#0F3039"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#C9E2DB",
+                        "#08272F"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#0F3039",
+                        "#08272F"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-4)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/site-title": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-3)"
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            },
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-3)"
+                        }
+                    }
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-3)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)",
+                    "text": "var(--wp--preset--color--theme-4)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-2)",
+                        "text": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/31-pine.json
+++ b/assembler/styles/colors/31-pine.json
@@ -1,0 +1,217 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Pine",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#E7E7E4",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#D1D1C5",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#113B3B",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#0B2323",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#E7E7E4"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#D1D1C5"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#113B3B"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#0B2323"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#E7E7E4",
+                        "#D1D1C5"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#E7E7E4",
+                        "#113B3B"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#E7E7E4",
+                        "#0B2323"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#D1D1C5",
+                        "#113B3B"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#D1D1C5",
+                        "#0B2323"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#113B3B",
+                        "#0B2323"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-1)",
+                        "text": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/32-lime.json
+++ b/assembler/styles/colors/32-lime.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Lime",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#A4C1C9",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#c8ff2dd1",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#C8FF2D",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#052335",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#A4C1C9"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#c8ff2dd1"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#C8FF2D"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#052335"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#A4C1C9",
+                        "#c8ff2dd1"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#A4C1C9",
+                        "#C8FF2D"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#A4C1C9",
+                        "#052335"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#c8ff2dd1",
+                        "#C8FF2D"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#c8ff2dd1",
+                        "#052335"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#C8FF2D",
+                        "#052335"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/33-mocha.json
+++ b/assembler/styles/colors/33-mocha.json
@@ -1,0 +1,231 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Mocha",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#EDE8CC3D",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#EEE9CC",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#825c30",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#674825",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#1E1914",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#EDE8CC3D",
+                        "#EEE9CC"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#EDE8CC3D",
+                        "#825c30"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#EDE8CC3D",
+                        "#674825"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#EDE8CC3D",
+                        "#1E1914"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#EEE9CC",
+                        "#825c30"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#EEE9CC",
+                        "#674825"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#EEE9CC",
+                        "#1E1914"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#825c30",
+                        "#674825"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#825c30",
+                        "#1E1914"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#674825",
+                        "#1E1914"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-1)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-3)",
+                        "text": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/34-galactic.json
+++ b/assembler/styles/colors/34-galactic.json
@@ -1,0 +1,244 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Galactic",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#E2E0FF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#CECBFF",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#87A8E3",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#273E41",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#001D21",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#E2E0FF",
+                        "#CECBFF"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#E2E0FF",
+                        "#87A8E3"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#E2E0FF",
+                        "#273E41"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#E2E0FF",
+                        "#001D21"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#CECBFF",
+                        "#87A8E3"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#CECBFF",
+                        "#273E41"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#CECBFF",
+                        "#001D21"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#87A8E3",
+                        "#273E41"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#87A8E3",
+                        "#001D21"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#273E41",
+                        "#001D21"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-2)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-2)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-2)"
+                        }
+                    }
+                }
+            },
+            "core/navigation": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/site-title": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-2)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-1)",
+                        "text": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/35-noir.json
+++ b/assembler/styles/colors/35-noir.json
@@ -1,0 +1,226 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Noir",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFFFFFDB",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#FFFFFFB3",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#FFFFFF24",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#0F0F0F",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFF",
+                        "#FFFFFFDB"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFF",
+                        "#FFFFFFB3"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFF",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFF",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#FFFFFFB3"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFB3",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFB3",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF24",
+                        "#0F0F0F"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-5)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-4)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-4)",
+                        "text": "var(--wp--preset--color--theme-1)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/36-eclipse.json
+++ b/assembler/styles/colors/36-eclipse.json
@@ -1,0 +1,304 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Eclipse",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#e6ecf76b",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#E7EDF8F7",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#C7D4EBE0",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#6a38ff",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#5126da",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                },
+                {
+                    "color": "#05060f",
+                    "name": "Color 6",
+                    "slug": "theme-6"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#e6ecf76b",
+                        "#E7EDF8F7"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#e6ecf76b",
+                        "#C7D4EBE0"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#e6ecf76b",
+                        "#6a38ff"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#e6ecf76b",
+                        "#5126da"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#e6ecf76b",
+                        "#05060f"
+                    ],
+                    "slug": "duotone-0-5",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#E7EDF8F7",
+                        "#C7D4EBE0"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#E7EDF8F7",
+                        "#6a38ff"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#E7EDF8F7",
+                        "#5126da"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#E7EDF8F7",
+                        "#05060f"
+                    ],
+                    "slug": "duotone-1-5",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#C7D4EBE0",
+                        "#6a38ff"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 10"
+                },
+                {
+                    "colors": [
+                        "#C7D4EBE0",
+                        "#5126da"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 11"
+                },
+                {
+                    "colors": [
+                        "#C7D4EBE0",
+                        "#05060f"
+                    ],
+                    "slug": "duotone-2-5",
+                    "name": "Duotone 12"
+                },
+                {
+                    "colors": [
+                        "#6a38ff",
+                        "#5126da"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 13"
+                },
+                {
+                    "colors": [
+                        "#6a38ff",
+                        "#05060f"
+                    ],
+                    "slug": "duotone-3-5",
+                    "name": "Duotone 14"
+                },
+                {
+                    "colors": [
+                        "#5126da",
+                        "#05060f"
+                    ],
+                    "slug": "duotone-4-5",
+                    "name": "Duotone 15"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-1-6",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-6) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-2-6",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-6) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 10"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 11"
+                },
+                {
+                    "slug": "gradient-3-6",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-6) 100%)",
+                    "name": "Gradient 12"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 13"
+                },
+                {
+                    "slug": "gradient-4-6",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-6) 100%)",
+                    "name": "Gradient 14"
+                },
+                {
+                    "slug": "gradient-5-6",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-5) 0%, var(--wp--preset--color--theme-6) 100%)",
+                    "name": "Gradient 15"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-6)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                },
+                ":focus": {
+                    "border": {
+                        "color": "var(--wp--preset--color--theme-4)"
+                    }
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-6)",
+            "text": "var(--wp--preset--color--theme-3)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-1)"
+                        },
+                        "color": {
+                            "text": "var(--wp--preset--color--theme-2)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-1)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-2)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-4)",
+                    "text": "var(--wp--preset--color--theme-2)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-5)",
+                        "text": "var(--wp--preset--color--theme-2)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/colors/37-onyx.json
+++ b/assembler/styles/colors/37-onyx.json
@@ -1,0 +1,226 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "title": "Onyx",
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "color": "#FFFFFF",
+                    "name": "Color 1",
+                    "slug": "theme-1"
+                },
+                {
+                    "color": "#FFFFFFDB",
+                    "name": "Color 2",
+                    "slug": "theme-2"
+                },
+                {
+                    "color": "#FFFFFF69",
+                    "name": "Color 3",
+                    "slug": "theme-3"
+                },
+                {
+                    "color": "#FFFFFF24",
+                    "name": "Color 4",
+                    "slug": "theme-4"
+                },
+                {
+                    "color": "#000000",
+                    "name": "Color 5",
+                    "slug": "theme-5"
+                }
+            ],
+            "duotone": [
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FFFFFFDB"
+                    ],
+                    "slug": "duotone-0-1",
+                    "name": "Duotone 1"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FFFFFF69"
+                    ],
+                    "slug": "duotone-0-2",
+                    "name": "Duotone 2"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-0-3",
+                    "name": "Duotone 3"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF",
+                        "#000000"
+                    ],
+                    "slug": "duotone-0-4",
+                    "name": "Duotone 4"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#FFFFFF69"
+                    ],
+                    "slug": "duotone-1-2",
+                    "name": "Duotone 5"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-1-3",
+                    "name": "Duotone 6"
+                },
+                {
+                    "colors": [
+                        "#FFFFFFDB",
+                        "#000000"
+                    ],
+                    "slug": "duotone-1-4",
+                    "name": "Duotone 7"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF69",
+                        "#FFFFFF24"
+                    ],
+                    "slug": "duotone-2-3",
+                    "name": "Duotone 8"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF69",
+                        "#000000"
+                    ],
+                    "slug": "duotone-2-4",
+                    "name": "Duotone 9"
+                },
+                {
+                    "colors": [
+                        "#FFFFFF24",
+                        "#000000"
+                    ],
+                    "slug": "duotone-3-4",
+                    "name": "Duotone 10"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "gradient-text-transparent",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) -50%, transparent 50%)",
+                    "name": "Text to Transparent"
+                },
+                {
+                    "slug": "gradient-1-2",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-2) 100%)",
+                    "name": "Gradient 1"
+                },
+                {
+                    "slug": "gradient-1-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 2"
+                },
+                {
+                    "slug": "gradient-1-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 3"
+                },
+                {
+                    "slug": "gradient-1-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-1) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 4"
+                },
+                {
+                    "slug": "gradient-2-3",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-3) 100%)",
+                    "name": "Gradient 5"
+                },
+                {
+                    "slug": "gradient-2-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 6"
+                },
+                {
+                    "slug": "gradient-2-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-2) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 7"
+                },
+                {
+                    "slug": "gradient-3-4",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-4) 100%)",
+                    "name": "Gradient 8"
+                },
+                {
+                    "slug": "gradient-3-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-3) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 9"
+                },
+                {
+                    "slug": "gradient-4-5",
+                    "gradient": "linear-gradient(to bottom, var(--wp--preset--color--theme-4) 0%, var(--wp--preset--color--theme-5) 100%)",
+                    "name": "Gradient 10"
+                }
+            ]
+        },
+        "custom": {
+            "input": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-3)"
+                },
+                "border": {
+                    "color": "var(--wp--preset--color--theme-3)"
+                }
+            }
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--theme-5)",
+            "text": "var(--wp--preset--color--theme-1)"
+        },
+        "blocks": {
+            "core/button": {
+                "variations": {
+                    "outline": {
+                        "border": {
+                            "color": "var(--wp--preset--color--theme-1)"
+                        }
+                    }
+                }
+            },
+            "core/separator": {
+                "border": {
+                    "color": "var(--wp--preset--color--theme-4)"
+                }
+            }
+        },
+        "elements": {
+            "heading": {
+                "color": {
+                    "text": "var(--wp--preset--color--theme-1)"
+                }
+            },
+            "button": {
+                "color": {
+                    "background": "var(--wp--preset--color--theme-1)",
+                    "text": "var(--wp--preset--color--theme-5)"
+                },
+                ":hover": {
+                    "color": {
+                        "background": "var(--wp--preset--color--theme-2)",
+                        "text": "var(--wp--preset--color--theme-5)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/assembler/styles/typography/01-bricolage.json
+++ b/assembler/styles/typography/01-bricolage.json
@@ -1,0 +1,105 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Bricolage",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "17px",
+					"slug": "small",
+					"fluid": {
+						"min": "16px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Medium",
+					"size": "18px",
+					"slug": "medium",
+					"fluid": {
+						"min": "17px",
+						"max": "18px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "70px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "104px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "14px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "450"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "450"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "6px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "14px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"left": "28px",
+						"right": "28px",
+						"top": "16px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--bricolage-grotesque)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "500"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--bricolage-grotesque)",
+					"fontWeight": "700",
+					"lineHeight": "0.9"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--bricolage-grotesque)",
+			"fontWeight": "300",
+			"lineHeight": "1.4",
+			"fontSize": "var(--wp--preset--font-size--medium)"
+		}
+	}
+}

--- a/assembler/styles/typography/02-dm.json
+++ b/assembler/styles/typography/02-dm.json
@@ -1,0 +1,75 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "DM Serif & DM Sans",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "20px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "32px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "60px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "98px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "500"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"spacing": {
+					"padding": {
+						"bottom": "1em",
+						"left": "1.25em",
+						"right": "1.25em",
+						"top": "1em"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-serif-display)",
+					"fontSize": "18px",
+					"letterSpacing": "0.05em"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-serif-display)",
+					"fontWeight": "normal"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
+			"fontWeight": "400",
+			"lineHeight": "1.65",
+			"fontSize": "18px"
+		}
+	}
+}

--- a/assembler/styles/typography/03-fahkwang.json
+++ b/assembler/styles/typography/03-fahkwang.json
@@ -1,0 +1,106 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Fahkwang & Roboto",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "14px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "26px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "52px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "86px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "8px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontWeight": "400",
+					"textTransform": "uppercase",
+					"fontFamily": "var(--wp--preset--font-family--fahkwang)",
+					"fontStyle": "italic",
+					"fontSize": "18px",
+					"letterSpacing": "0.0075em"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--roboto)",
+					"fontWeight": "400",
+					"letterSpacing": "0.0075em",
+					"textTransform": "uppercase",
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "100px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "8px",
+						"left": "18px",
+						"right": "18px",
+						"top": "8px"
+					}
+				},
+				"typography": {
+					"fontWeight": "400",
+					"textTransform": "uppercase",
+					"fontFamily": "var(--wp--preset--font-family--fahkwang)",
+					"fontStyle": "italic",
+					"fontSize": "16px",
+					"letterSpacing": "0.05em"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fahkwang)",
+					"fontWeight": "400",
+					"lineHeight": "0.75",
+					"letterSpacing": "0.005em",
+					"textTransform": "uppercase"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--roboto)",
+			"fontSize": "16px",
+			"fontStyle": "normal",
+			"fontWeight": "300",
+			"lineHeight": "1.8",
+			"letterSpacing": "0.0025em"
+		}
+	}
+}

--- a/assembler/styles/typography/04-figtree.json
+++ b/assembler/styles/typography/04-figtree.json
@@ -1,0 +1,115 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Figtree",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "17px",
+					"slug": "medium",
+					"fluid": {
+						"min": "15px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "60px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "86px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "16px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontSize": "22px",
+					"fontWeight": "800"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "16px",
+					"fontWeight": "900",
+					"fontStyle": "italic"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "4px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": {
+						"topLeft": "16px",
+						"bottomRight": "16px",
+						"topRight": "0",
+						"bottomLeft": "0"
+					}
+				},
+				"typography": {
+					"fontSize": "16px",
+					"fontWeight": "900",
+					"fontStyle": "italic"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"top": "16px"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--figtree)",
+					"fontWeight": "900",
+					"fontStyle": "italic"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			},
+			"h2": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--figtree)",
+			"fontWeight": "400",
+			"lineHeight": "1.5",
+			"fontSize": "var(--wp--preset--font-size--medium)"
+		}
+	}
+}

--- a/assembler/styles/typography/05-fjalla.json
+++ b/assembler/styles/typography/05-fjalla.json
@@ -1,0 +1,121 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Fjalla",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "24px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "48px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "52px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "86px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "32px"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "3px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"spacing": {
+					"padding": {
+						"bottom": "1.2em",
+						"left": "1.6em",
+						"right": "1.6em",
+						"top": "1.2em"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--libre-baskerville)",
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fjalla-one)",
+					"fontWeight": "600"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"textTransform": "uppercase",
+					"lineHeight": "0.95"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"textTransform": "uppercase"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"textTransform": "uppercase"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "700",
+					"fontFamily": "var(--wp--preset--font-family--inter)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontFamily": "var(--wp--preset--font-family--inter)"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontFamily": "var(--wp--preset--font-family--inter)"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--libre-baskerville)",
+			"fontWeight": "400",
+			"fontSize": "var(--wp--preset--font-size--small)",
+			"lineHeight": "1.7"
+		}
+	}
+}

--- a/assembler/styles/typography/06-fraunces.json
+++ b/assembler/styles/typography/06-fraunces.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Fraunces",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "17px",
+					"slug": "medium",
+					"fluid": {
+						"min": "16px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "60px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "86px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontSize": "20px",
+					"fontWeight": "300"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "13px",
+					"fontWeight": "400",
+					"textTransform": "uppercase",
+					"letterSpacing": "1px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"typography": {
+					"fontSize": "18px",
+					"fontWeight": "200"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"top": "16px"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fraunces)",
+					"fontWeight": "200"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "1"
+				}
+			},
+			"h2": {
+				"typography": {
+					"lineHeight": "1"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--inter)",
+			"fontWeight": "300",
+			"lineHeight": "1.6",
+			"fontSize": "var(--wp--preset--font-size--medium)"
+		}
+	}
+}

--- a/assembler/styles/typography/07-gabarito.json
+++ b/assembler/styles/typography/07-gabarito.json
@@ -1,0 +1,95 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Gabarito",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "14px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "20px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "30px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "60px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "98px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--gabarito)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "500",
+					"letterSpacing": "1px",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--gabarito)",
+					"fontSize": "17px",
+					"fontWeight": "500"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "4px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"spacing": {
+					"padding": {
+						"bottom": "14px",
+						"left": "24px",
+						"right": "24px",
+						"top": "14px"
+					}
+				},
+				"typography": {
+					"fontSize": "17px",
+					"fontWeight": "400"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--gabarito)",
+					"fontWeight": "600",
+					"lineHeight": "1",
+					"textTransform": "uppercase"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--noto-sans-mono)",
+			"fontSize": "13px",
+			"lineHeight": "2"
+		}
+	}
+}

--- a/assembler/styles/typography/08-ibarra.json
+++ b/assembler/styles/typography/08-ibarra.json
@@ -1,0 +1,94 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Ibarra & Inter",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "22px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "44px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "76px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "110px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "13px",
+					"fontWeight": "500",
+					"textTransform": "uppercase",
+					"letterSpacing": "2px"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "13px",
+					"fontWeight": "500",
+					"textTransform": "uppercase",
+					"letterSpacing": "2px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"spacing": {
+					"padding": {
+						"bottom": "18px",
+						"top": "18px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "13px",
+					"fontWeight": "500",
+					"textTransform": "uppercase",
+					"letterSpacing": "2px"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--ibarra-real-nova)",
+					"fontWeight": "100",
+					"lineHeight": "1"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--ibarra-real-nova)",
+			"fontSize": "19px",
+			"fontStyle": "normal",
+			"fontWeight": "400",
+			"lineHeight": "1.75"
+		}
+	}
+}

--- a/assembler/styles/typography/09-instrument-serif-mono.json
+++ b/assembler/styles/typography/09-instrument-serif-mono.json
@@ -1,0 +1,112 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Instrument Serif & Noto Sans Mono",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "12px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "22px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "42px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "72px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "120px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "8px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--noto-sans-mono)",
+					"fontWeight": "400",
+					"fontSize": "14px",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--noto-sans-mono)",
+					"fontWeight": "400",
+					"textTransform": "uppercase",
+					"fontSize": "14px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "100px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "14px",
+						"left": "32px",
+						"right": "32px",
+						"top": "14px"
+					}
+				},
+				"typography": {
+					"fontFamily": { "ref": "styles.typography.fontFamily" },
+					"fontSize": { "ref": "styles.typography.fontSize" },
+					"fontWeight": "400",
+					"textTransform": "uppercase"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--instrument-serif)",
+					"fontSize": "160px",
+					"lineHeight": "0.8"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--instrument-serif)"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--noto-sans-mono)",
+					"fontWeight": "400",
+					"lineHeight": "0.8",
+					"letterSpacing": "-0.005em"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--noto-sans-mono)",
+			"fontSize": "13px",
+			"fontStyle": "normal",
+			"textTransform": "uppercase",
+			"fontWeight": "400",
+			"lineHeight": "1.85"
+		}
+	}
+}

--- a/assembler/styles/typography/10-instrument-serif-urbanist.json
+++ b/assembler/styles/typography/10-instrument-serif-urbanist.json
@@ -1,0 +1,124 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Instrument Serif & Urbanist",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "14px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "17px",
+					"slug": "medium",
+					"fluid": {
+						"min": "15px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "42px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "72px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "124px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "3px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--urbanist)",
+					"fontWeight": "600",
+					"fontSize": "22px"
+				}
+			},
+			"core/navigation": {
+				"spacing": {
+					"blockGap": "16px"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--urbanist)",
+					"fontWeight": "600",
+					"fontSize": "22px"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "2px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "3px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "14px",
+						"left": "24px",
+						"right": "24px",
+						"top": "14px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--instrument-serif)",
+					"fontSize": "20px",
+					"fontWeight": "400",
+					"fontStyle": "italic"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--instrument-serif)",
+					"fontSize": "160px",
+					"lineHeight": "0.9",
+					"fontWeight": "400",
+					"letterSpacing": "-0.005em"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--instrument-serif)",
+					"letterSpacing": "-0.005em",
+					"fontWeight": "400",
+					"lineHeight": "0.9"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--urbanist)",
+					"fontWeight": "600",
+					"lineHeight": "1"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--urbanist)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"fontWeight": "400",
+			"lineHeight": "1.55"
+		}
+	}
+}

--- a/assembler/styles/typography/11-inter-ibarra.json
+++ b/assembler/styles/typography/11-inter-ibarra.json
@@ -1,0 +1,110 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Inter & Ibarra",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "17px",
+					"slug": "small",
+					"fluid": {
+						"min": "15px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Medium",
+					"size": "19px",
+					"slug": "medium",
+					"fluid": {
+						"min": "18px",
+						"max": "19px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "62px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "100px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "8px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "300"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "4px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "100px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "14px",
+						"top": "14px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontWeight": "500"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--ibarra-real-nova)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"fontStyle": "normal",
+			"fontWeight": "400",
+			"lineHeight": "1.7"
+		}
+	}
+}

--- a/assembler/styles/typography/12-rufina.json
+++ b/assembler/styles/typography/12-rufina.json
@@ -1,0 +1,115 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Rufina & PT Serif",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "14px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "17px",
+					"slug": "medium",
+					"fluid": {
+						"min": "15px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "60px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "86px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "8px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontSize": "20px",
+					"fontWeight": "300"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "13px",
+					"fontWeight": "400",
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"textTransform": "uppercase",
+					"letterSpacing": "1px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "100px"
+				},
+				"typography": {
+					"fontSize": "13px",
+					"fontWeight": "400",
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"textTransform": "uppercase",
+					"letterSpacing": "1px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"top": "16px",
+						"right": "24px",
+						"left": "24px"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--rufina)",
+					"fontWeight": "100"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "1"
+				}
+			},
+			"h2": {
+				"typography": {
+					"lineHeight": "1"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--pt-serif)",
+			"fontWeight": "200",
+			"lineHeight": "1.6",
+			"fontSize": "var(--wp--preset--font-size--medium)"
+		}
+	}
+}

--- a/assembler/styles/typography/13-sora.json
+++ b/assembler/styles/typography/13-sora.json
@@ -1,0 +1,101 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Sora",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "18px",
+					"slug": "small",
+					"fluid": {
+						"min": "16px",
+						"max": "17px"
+					}
+				},
+				{
+					"name": "Medium",
+					"size": "24px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "40px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "56px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "90px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "6px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"typography": {
+					"fontSize": "16px",
+					"fontWeight": "250"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "600"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "2px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "6px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"left": "24px",
+						"right": "24px",
+						"top": "16px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--sora)",
+					"fontSize": "16px",
+					"fontWeight": "300"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--sora)",
+					"fontWeight": "600",
+					"lineHeight": "0.9"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--sora)",
+			"fontWeight": "250",
+			"lineHeight": "1.6",
+			"fontSize": "var(--wp--preset--font-size--small)"
+		}
+	}
+}

--- a/assembler/styles/typography/14-syne.json
+++ b/assembler/styles/typography/14-syne.json
@@ -1,0 +1,95 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Syne",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "16px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "24px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "48px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "48px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "76px",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--syne)",
+					"fontSize": "14px",
+					"textTransform": "uppercase",
+					"fontWeight": "700"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "4px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"left": "30px",
+						"right": "30px",
+						"top": "16px"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--syne)",
+					"fontSize": "14px",
+					"textTransform": "uppercase",
+					"fontStyle": "italic",
+					"fontWeight": "700"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			},
+			"h2": {
+				"typography": {
+					"lineHeight": "0.95"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--syne)",
+					"fontWeight": "700",
+					"textTransform": "uppercase"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--syne)",
+			"fontWeight": "400",
+			"lineHeight": "1.5",
+			"fontSize": "17px"
+		}
+	}
+}

--- a/assembler/styles/typography/15-vina-sans.json
+++ b/assembler/styles/typography/15-vina-sans.json
@@ -1,0 +1,108 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"title": "Vina Sans & Rubik",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Small",
+					"size": "18px",
+					"slug": "small"
+				},
+				{
+					"name": "Medium",
+					"size": "24px",
+					"slug": "medium"
+				},
+				{
+					"name": "Large",
+					"size": "44px",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "80px",
+					"slug": "x-large"
+				},
+				{
+					"name": "2X Large",
+					"size": "130px",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"custom": {
+			"input": {
+				"border": {
+					"radius": "8px"
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"letterSpacing": "1px",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--vina-sans)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "400"
+				}
+			},
+			"core/separator": {
+				"border": {
+					"width": "8px"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "16px"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"top": "14px"
+					}
+				},
+				"typography": {
+					"fontSize": "22px",
+					"fontFamily": "var(--wp--preset--font-family--vina-sans)",
+					"fontWeight": "300",
+					"letterSpacing": "1px"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--vina-sans)",
+					"fontWeight": "600",
+					"lineHeight": "1"
+				}
+			},
+			"h1": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			},
+			"h2": {
+				"typography": {
+					"lineHeight": "0.9"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--rubik)",
+			"fontSize": "18px",
+			"lineHeight": "1.6",
+			"fontWeight": "350"
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This allows users who've onboarded on WordPress.com access to the same color sets and typesets provided by the onboarding experience. You can switch to any permutation of color and typography with Gutenberg active (and an upcoming WordPress release). 

- Adds color-only and typography-only style variations to Assembler. When Gutenberg is active, and with the next release of WordPress, these variations will be filtered as color and typography presets—as detailed [here](https://github.com/WordPress/gutenberg/pull/60031). 

- Note the "blank" typography variations showing up as colors. This will be resolved by [this PR](https://github.com/WordPress/gutenberg/pull/60220) (not a blocker). 

### Testing

#### With Gutenberg active: 

1. Open the Site Editor.
2. Select Global Styles at the top right.
3. Select "Colors", see changes.
4. Go back one level.
5. Select "Typography", see changes. 

#### Without Gutenberg: 

1. Open the Site Editor.
2. Select Global Styles at the top right.
3. Select "Browse styles".
4. See changes.

### Visuals

| Colors  | Typography |
| ------------- | ------------- |
|![CleanShot 2024-04-04 at 11 33 01](https://github.com/Automattic/themes/assets/1813435/b6751140-6f6c-4bc6-ad47-e9d3b3772156)|![CleanShot 2024-04-04 at 11 33 11](https://github.com/Automattic/themes/assets/1813435/a90a07ff-fa11-484d-9982-e9f9bdfe411e)|


![CleanShot 2024-04-04 at 11 48 26](https://github.com/Automattic/themes/assets/1813435/417a747e-a710-45ee-a55d-2f57c0fdb582)


