### PR TITLE
Add a script that inserts strict type declarations

### DIFF
--- a/add-strict-types.sh
+++ b/add-strict-types.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Verify an argument is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <directory>"
+    echo "Error: Directory argument missing."
+    exit 1
+fi
+
+# Directory containing PHP files, passed as an argument
+DIRECTORY="$1"
+
+# Loop over each PHP file in the specified directory
+find "$DIRECTORY" -type f -name "*.php" | while read -r file; do
+    echo "Processing file: $file"
+    # Check if the file contains the strict_types declaration
+    if ! grep -qE 'declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;' "$file"; then
+        echo "Declaration not found in: $file"
+        # If not, prepend the strict_types declaration
+        {
+            echo '<?php declare( strict_types = 1 ); ?>'
+            cat "$file"
+        } > "$file.tmp" && mv "$file.tmp" "$file"
+    else
+        echo "Declaration found in: $file"
+    fi
+done

--- a/add-strict-types.sh
+++ b/add-strict-types.sh
@@ -12,16 +12,16 @@ DIRECTORY="$1"
 
 # Loop over each PHP file in the specified directory
 find "$DIRECTORY" -type f -name "*.php" | while read -r file; do
-    echo "Processing file: $file"
+    [ -n "$DEBUG" ] && echo "Processing file: $file"
     # Check if the file contains the strict_types declaration
     if ! grep -qE 'declare\s*\(\s*strict_types\s*=\s*1\s*\)\s*;' "$file"; then
-        echo "Declaration not found in: $file"
+        [ -n "$DEBUG" ] && echo "Declaration not found in: $file"
         # If not, prepend the strict_types declaration
         {
             echo '<?php declare( strict_types = 1 ); ?>'
             cat "$file"
         } > "$file.tmp" && mv "$file.tmp" "$file"
     else
-        echo "Declaration found in: $file"
+       [ -n "$DEBUG" ] && echo "Declaration found in: $file"
     fi
 done

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"deploy:theme": "node ./theme-utils.mjs deploy-theme",
 		"deploy:zip": "node ./theme-utils.mjs build-com-zip",
 		"deploy:land": "node ./theme-utils.mjs land-diff",
+		"deploy:add-strict-typing": "node ./theme-utils.mjs add-strict-typing",
 		"pull:all": "node ./theme-utils.mjs pull-all-themes",
 		"core:pull": "node ./theme-utils.mjs pull-core-themes",
 		"core:push": "node ./theme-utils.mjs push-core-themes",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -215,8 +215,11 @@ async function addStrictTypesToChangedThemes() {
 
 	for (let theme of changedThemes) {
 		await executeCommand(`
-			bash -c "add-strict-types-to-theme ${theme}"
-		`, true);
+			bash -c "./add-strict-types.sh ${theme}"
+		`, true)
+		.catch((err) => {
+			console.log(`Error adding strict types to ${theme}: ${err}`);
+		});
 	}
 }
 

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -205,6 +205,16 @@ async function deployPreview() {
 	console.log(`\n\nCommit log of changes to be deployed:\n\n${logs}\n\n`);
 }
 
+async function addStrictTypesToChangedThemes() {
+	const changedThemes = await getChangedThemes();
+
+	for (let theme of changedThemes) {
+		await executeCommand(`
+			bash -c add-strict-types-to-theme ${theme}
+		`, true);
+	}
+}
+
 /*
  Execute the first phase of a deployment.
 	* Gets the last deployed hash from the sandbox
@@ -240,8 +250,9 @@ async function pushButtonDeploy() {
 	try {
 		await cleanSandbox();
 
-		let hash = await getLastDeployedHash();
-		let thingsWentBump = await versionBumpThemes();
+		const hash = await getLastDeployedHash();
+		await addStrictTypesToChangedThemes();
+		const thingsWentBump = await versionBumpThemes();
 
 		if (thingsWentBump) {
 			prompt = await inquirer.prompt([{
@@ -257,7 +268,7 @@ async function pushButtonDeploy() {
 			}
 		}
 
-		let changedThemes = await getChangedThemes(hash);
+		const changedThemes = await getChangedThemes(hash);
 
 		if (!changedThemes.length) {
 			console.log(`\n\nEverything is upto date. Nothing new to deploy.\n\n`);

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -65,6 +65,10 @@ const commands = {
 		additionalArgs: '<array of theme slugs>',
 		run: (args) => deployThemes(args?.[1].split(/[ ,]+/))
 	},
+	"add-strict-typing": {
+		helpText: 'Adds strict typing to any changed themes.',
+		run: () => addStrictTypesToChangedThemes()
+	},
 	"build-com-zip": {
 		helpText: 'Build the production zip file for the specified theme.',
 		additionalArgs: '<theme-slug>',
@@ -206,7 +210,8 @@ async function deployPreview() {
 }
 
 async function addStrictTypesToChangedThemes() {
-	const changedThemes = await getChangedThemes();
+	let hash = await getLastDeployedHash();
+	const changedThemes = await getChangedThemes(hash);
 
 	for (let theme of changedThemes) {
 		await executeCommand(`

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -210,7 +210,7 @@ async function addStrictTypesToChangedThemes() {
 
 	for (let theme of changedThemes) {
 		await executeCommand(`
-			bash -c add-strict-types-to-theme ${theme}
+			bash -c "add-strict-types-to-theme ${theme}"
 		`, true);
 	}
 }


### PR DESCRIPTION
Checks all php files in a given directory for existing strict type declartions, and if it doesn't find one, adds it.

Tasks:

- [x] Run the script as a part of the deployment script.