### PR TITLE
Block Canvas: Add standard spacing presets

### DIFF
--- a/block-canvas/theme.json
+++ b/block-canvas/theme.json
@@ -38,6 +38,33 @@
 			"wideSize": "1000px"
 		},
 		"spacing": {
+			"spacingSizes": [
+				{
+					"name": "Step 1",
+					"size": "0.25rem",
+					"slug": "10"
+				},
+				{
+					"name": "Step 2",
+					"size": "0.5rem",
+					"slug": "20"
+				},
+				{
+					"name": "Step 3",
+					"size": "0.75rem",
+					"slug": "30"
+				},
+				{
+					"name": "Step 4",
+					"size": "1rem",
+					"slug": "40"
+				},
+				{
+					"name": "Step 5",
+					"size": "1.25rem",
+					"slug": "50"
+				}
+			],
 			"units": ["%", "px", "em", "rem", "vh", "vw"]
 		},
 		"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds some standard spacing presets to Block Canvas. As Block Canvas is often used as a base theme, this ensures that some standards are used for spacing across more themes.

It's worth noting that Block Canvas was using the default spacing presets before, which are:

- --wp--preset--spacing--20: 0.44rem;
- --wp--preset--spacing--30: 0.67rem;
- --wp--preset--spacing--40: 1rem;
- --wp--preset--spacing--50: 1.5rem;
- --wp--preset--spacing--60: 2.25rem;
- --wp--preset--spacing--70: 3.38rem;
- --wp--preset--spacing--80: 5.06rem;

But the new sizes aren't too dissimilar, and I think this change is fine as this theme is used as a base theme; no existing themes will see this change until a new theme is made using these new presets.

#### Related issue(s):
pNEWy-ieA-p2