### PR TITLE
Low Fi: Remove the space in the theme display name

### DIFF
--- a/lowfi/readme.txt
+++ b/lowfi/readme.txt
@@ -1,4 +1,4 @@
-=== Low Fi ===
+=== LowFi ===
 Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.4
@@ -8,12 +8,12 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Low Fi is a simple blog theme inspired by Lo-fi aesthetics and beats.
+LowFi is a simple blog theme inspired by Lo-fi aesthetics and beats.
 
 == Changelog ==
 
 = 1.0.2 =
-* Low Fi: Remove the patch version for submission (#7691)
+* LowFi: Remove the patch version for submission (#7691)
 
 = 1.0.1 =
 * Lossless image optimization (#7671)
@@ -26,8 +26,8 @@ Low Fi is a simple blog theme inspired by Lo-fi aesthetics and beats.
 
 == Copyright ==
 
-Low Fi WordPress Theme (C) 2023 Automattic
-Low Fi is distributed under the terms of the GNU GPL.
+LowFi WordPress Theme (C) 2023 Automattic
+LowFi is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lowfi/style.css
+++ b/lowfi/style.css
@@ -1,9 +1,9 @@
 /*
-Theme Name: Low Fi
+Theme Name: LowFi
 Theme URI: https://wordpress.com/theme/lowfi/
 Author: Automattic
 Author URI: https://automattic.com/
-Description: Low Fi is a simple blog theme with Lo-fi aesthetics.
+Description: LowFi is a simple blog theme with Lo-fi aesthetics.
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 5.7


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the space in the theme display name, but there is no change in the slug and the text domain.

The display name was `Low Fi`, and Dotorg wants the theme slug and the text domain to be `low-fi` with that name. Since naming changes in an already launched theme is a nightmare, I'm changing the display name to `LowFi` (removing the space between `Low` and `Fi`) so the current slug and text domain, `lowfi`, makes better sense.