### PR TITLE
Radcliffe 2: Removes logo resize reset testing code

### DIFF
--- a/radcliffe-2/inc/logo-resizer.php
+++ b/radcliffe-2/inc/logo-resizer.php
@@ -136,13 +136,3 @@ function logo_awesomeness_customize_css() {
 	wp_add_inline_style( 'customize-controls', '#customize-control-logo_size input[type=range] { width: 100%; }' );
 }
 add_action( 'customize_controls_enqueue_scripts', 'logo_awesomeness_customize_css' );
-
-/**
- * Testing function to remove logo_size theme mod
- */
-function logo_awesomeness_remove_theme_mod() {
-	if ( isset( $_GET['remove_logo_size'] ) && 'true' == $_GET['remove_logo_size'] ){
-		set_theme_mod( 'logo_size', '' );
-	}
-}
-add_action( 'wp_loaded', 'logo_awesomeness_remove_theme_mod' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes testing code that deletes the `logo_size` theme mod with a query param, as it's not needed any longer.

There's no other references to the `remove_logo_size` param I can find, and the theme and related customizer features are not being actively developed, so this code shouldn't be missed.

See p3btAN-2Id-p2 for more context.