### PR TITLE
Preview Workflow: Use pull_request_target to avoid token restriction

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,7 +1,8 @@
 name: Preview Theme Changes
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
   check-for-changes-to-themes:


### PR DESCRIPTION
Due to restrictions imposed to the `GH_TOKEN` when forks are created from forks when workflows are triggered by the `pull_request` event, I'm switching the execution to be done on `pull_request_trigger`, which lifts said restrictions.

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

> This event runs in the context of the base of the pull request, rather
than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

