### PR TITLE
Preview Workflow: Make sure workflow runs on PR base branch

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -10,12 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieved Theme Changes
         id: check-for-changes
         run: |
           # Retrieve list of all changed files
-          git fetch origin trunk:trunk
+          git fetch origin
           changed_files=$(git diff --name-only HEAD origin/trunk)
           
           # Loop through changed files and identify parent directories


### PR DESCRIPTION
Fix the fetch part of the action, which broke when switching from pull_request to pull_request_target, as they run in different contexts.