### PR TITLE
Workflow security issue

### DIFF
--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -39,23 +39,28 @@ function createBlueprint(themeSlug, branch) {
  * @param {string} changedThemeSlugs - A space-separated string of theme slugs that have changed.
  */
 async function createPreviewLinksComment(github, context, changedThemeSlugs) {
-	const changedThemes = changedThemeSlugs.split(' ');
+	const changedThemes = changedThemeSlugs.split(',');
 	const previewLinks = changedThemes
 		.map((theme) => {
 			const [themeName, themeDir] = theme.split(':');
 			const themeSlug = themeDir.split('/')[0];
-			return `- [Preview changes for **${themeName}**](https://playground.wordpress.net/#${createBlueprint(
+			const parentThemeSlug = themeName.split('_childof_')[1];
+			return `- [Preview changes for **${
+				themeName.split('_childof_')[0]
+			}**](https://playground.wordpress.net/#${createBlueprint(
 				themeSlug,
 				context.payload.pull_request.head.ref
-			)})`;
+			)})${parentThemeSlug ? ` (child of **${parentThemeSlug}**)` : ''}`;
 		})
 		.join('\n');
 
-	const includesChildThemes = previewLinks.includes('Child of');
+	const includesChildThemes = previewLinks.includes('child of');
 
 	const comment = `
 I've detected changes to the following themes in this PR: ${changedThemes
-		.map((changedThemes) => changedThemes.split(':')[0])
+		.map(
+			(changedThemes) => changedThemes.split(':')[0].split('_childof_')[0]
+		)
 		.join(', ')}.
 
 You can preview these changes by following the links below:

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,12 +1,17 @@
 name: Preview Theme Changes
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
+permissions:
+  pull-requests: write
 
 jobs:
   check-for-changes-to-themes:
     runs-on: ubuntu-latest
+    outputs:
+      HAS_THEME_CHANGES: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES }}
+      CHANGED_THEMES: ${{ steps.check-for-changes.outputs.CHANGED_THEMES }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,9 +30,14 @@ jobs:
           for file in $changed_files; do
             dir_name=$(dirname "$file")
             while [[ "$dir_name" != "." ]]; do
-              if [[ -f "$dir_name/style.css" ]]; then  # Check if the parent directory contains a theme
-                # Save only the basename
-                unique_dirs[$dir_name]=$(basename $dir_name)
+              if [[ -f "$dir_name/style.css" ]]; then 
+                # Get theme name from style.css
+                theme_name=$(grep -m 1 "Theme Name:" "$dir_name/style.css" | sed 's/Theme Name: //')
+                parent_theme=$(grep -m 1 "Template:" "${unique_dirs[$theme]}/style.css" | sed 's/Template: //')
+                # Append parent theme to the theme name if it exists
+                [ -n "$parent_theme" ] && theme_name="$theme (Child of $parent_theme)"
+                # Store theme name and directory in associative array
+                unique_dirs["$theme_name"]=$dir_name
                 break
               fi
               dir_name=$(dirname "$dir_name")
@@ -41,13 +51,36 @@ jobs:
           fi
           # Output list of theme slugs with changes
           echo "HAS_THEME_CHANGES=true" >> $GITHUB_OUTPUT
-          echo "CHANGED_THEMES=$(echo ${unique_dirs[@]})" >> $GITHUB_ENV
+
+          # Serialize associative array of theme dirs to a string
+          declare -A CHANGED_THEMES
+          for theme in "${!unique_dirs[@]}"; do
+              # Append each entry as key:value,
+              CHANGED_THEMES+="$theme:${unique_dirs[$theme]},"
+          done
+          # Remove the last comma for correct JSON formatting
+          CHANGED_THEMES=${CHANGED_THEMES%,}
+          echo "CHANGED_THEMES=$CHANGED_THEMES" >> $GITHUB_OUTPUT
+
           echo "Theme directories with changes: $CHANGED_THEMES"
+  
+  handle-pr-comment:
+    runs-on: ubuntu-latest
+    needs: check-for-changes-to-themes
+    steps:
+      - name: Checkout create-preview-links script from trunk
+        uses: actions/checkout@v3
+        with:
+          repository: Automattic/themes
+          sparse-checkout: .github/scripts/create-preview-links
+          ref: workflow-security-issue
 
       - name: Add Preview Links comment
         id: comment-on-pr
-        if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'true' }}
+        if: ${{ needs.check-for-changes-to-themes.outputs.HAS_THEME_CHANGES == 'true' }}
         uses: actions/github-script@v7
+        env:
+          CHANGED_THEMES: ${{ needs.check-for-changes-to-themes.outputs.CHANGED_THEMES }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -55,7 +88,7 @@ jobs:
             createPreviewLinks(github, context, process.env.CHANGED_THEMES);
 
       - name: Remove comment if no changes are detected
-        if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'false' }}
+        if: ${{ needs.check-for-changes-to-themes.outputs.HAS_THEME_CHANGES == 'false' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,4 +108,4 @@ jobs:
                 repo: context.repo.repo
               });
             }
- 
+  

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -33,9 +33,9 @@ jobs:
               if [[ -f "$dir_name/style.css" ]]; then 
                 # Get theme name from style.css
                 theme_name=$(grep -m 1 "Theme Name:" "$dir_name/style.css" | sed 's/Theme Name: //')
-                parent_theme=$(grep -m 1 "Template:" "${unique_dirs[$theme]}/style.css" | sed 's/Template: //')
+                parent_theme=$(grep -m 1 "Template:" "$dir_name/style.css" | sed 's/Template: //')
                 # Append parent theme to the theme name if it exists
-                [ -n "$parent_theme" ] && theme_name="$theme (Child of $parent_theme)"
+                [ -n "$parent_theme" ] && theme_name="${theme_name}_childof_${parent_theme}"
                 # Store theme name and directory in associative array
                 unique_dirs["$theme_name"]=$dir_name
                 break

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,7 +1,7 @@
 name: Preview Theme Changes
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 permissions:
   pull-requests: write
@@ -73,7 +73,7 @@ jobs:
         with:
           repository: Automattic/themes
           sparse-checkout: .github/scripts/create-preview-links
-          ref: workflow-security-issue
+          ref: trunk
 
       - name: Add Preview Links comment
         id: comment-on-pr

--- a/adventurer/patterns/404.php
+++ b/adventurer/patterns/404.php
@@ -13,6 +13,7 @@
     <h1 class="wp-block-heading alignwide has-text-align-left" id="oops-that-page-can-t-be-found" style="font-size:4.4rem"><?php echo esc_html__( 'Oops! That page can&rsquo;t be found.', 'adventurer' ); ?></h1>
     <!-- /wp:heading -->
 
+    
     <!-- wp:paragraph -->
     <p><?php echo  esc_html__( 'It looks like nothing was found at this location. Maybe try a search?', 'adventurer' ); ?></p>
     <!-- /wp:paragraph -->


### PR DESCRIPTION
Calling create-preview-links from the branch is a possible security concern, where the script could be modified.

To avoid it, I've split the workflow in two which makes it so it's not possible to execute code that is modifiable, as a part of the Workflow, by checking out the script from trunk.