### PR TITLE
Revert to using `pull_request` as the event trigger

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,7 +1,7 @@
 name: Preview Theme Changes
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 permissions:
   pull-requests: write


### PR DESCRIPTION
Reverts event trigger change to avoid security concerns.