### PR TITLE
Dara: move away from deprecated class

### DIFF
--- a/dara/inc/jetpack.php
+++ b/dara/inc/jetpack.php
@@ -70,10 +70,10 @@ add_action( 'after_setup_theme', 'dara_jetpack_setup' );
 /**
  * Footer widgets Callback for Infinite Scroll
  */
-if ( function_exists( 'jetpack_is_mobile' ) && class_exists( 'Jetpack_User_Agent_Info' ) ) {
+if ( function_exists( 'jetpack_is_mobile' ) && class_exists( 'User_Agent_Info' ) ) {
 	function dara_has_footer_widgets() {
 
-		if ( ( Jetpack_User_Agent_Info::is_ipad() && is_active_sidebar( 'sidebar-1' ) ) || ( jetpack_is_mobile( '', true ) && is_active_sidebar( 'sidebar-1' ) ) ) {
+		if ( ( User_Agent_Info::is_ipad() && is_active_sidebar( 'sidebar-1' ) ) || ( jetpack_is_mobile( '', true ) && is_active_sidebar( 'sidebar-1' ) ) ) {
 			return true;
 		}
 		elseif ( is_active_sidebar( 'sidebar-2' ) || is_active_sidebar( 'sidebar-3' ) || is_active_sidebar( 'sidebar-4' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Jetpack's `Jetpack_User_Agent_Info` class was deprecated 4 years ago in https://github.com/Automattic/jetpack/pull/16129. It is now recommended to use its replacement, `User_Agent_Info`, also shipping with the Jetpack plugin.

This PR makes the change to avoid deprecation notices in the logs:

```
PHP Deprecated:  Function Jetpack_User_Agent_Info::is_ipad is deprecated since version Jetpack 8.7! Use \Automattic\Jetpack\Device_Detection\User_Agent_Info::is_ipad from the `automattic/jetpack-device-detection` package instead. in /srv/htdocs/__wp__/wp-includes/functions.php on line 6078
```

#### Related issue(s):
