### PR TITLE
Lettre: Remove not necessary CSS fix

### DIFF
--- a/lettre/style.css
+++ b/lettre/style.css
@@ -137,20 +137,6 @@ input:not([type="submit"]):not([type="button"]):focus {
 }
 
 /*
- * Fixes an issue with Jetpack Subscribe block.
- * Necessary until Jetpack 11.7 is released:
- * https://github.com/Automattic/jetpack/milestone/295
- */
-
-.wp-block-jetpack-subscriptions__container .wp-element-button:not(.block-editor-rich-text__editable),
-.wp-block-jetpack-subscriptions__container .wp-block-button__link:not(.block-editor-rich-text__editable) {
-	font-size: inherit;
-	margin-top: 10px;
-	padding: 24px 36px 24px 36px;
-	width: 100%;
-}
-
-/*
  * Refine mobile navigation styling.
  */
 .wp-block-navigation li:not(.current-menu-item) a:where(:not(.wp-element-button)):focus:not(:hover),


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

It removes the CSS fix which is not needed anymore and in fact, it causes some issues with the Subscribe block rendered in the Site Editor.

### Before

<img width="1250" alt="Screenshot 2024-05-09 at 09 55 26" src="https://github.com/Automattic/themes/assets/4068554/141164da-3c7e-4854-a514-6c315126acdf">

### After

<img width="1250" alt="Screenshot 2024-05-09 at 09 54 36" src="https://github.com/Automattic/themes/assets/4068554/b16a8e0c-a891-4f1d-a0b3-622683e17796">

#### Related issue(s):

p1715169003179229-slack-C052XEUUBL4