### PR TITLE
Update theme otis

### DIFF
--- a/otis/readme.txt
+++ b/otis/readme.txt
@@ -12,6 +12,12 @@ Otis is a WordPress block theme that is well-suited for personal blogging. It is
 
 == Changelog ==
 
+= 1.0.2 =
+* Lossless image optimization (#7671)
+
+= 1.0.2 =
+* Optimize images (#7671)
+
 = 1.0.1 =
 * Otis: remove theme attribute from template parts (#7246)
 
@@ -33,3 +39,13 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
+This theme bundles the following third-party resources:
+
+Open Sauce Sans Font
+Copyright (c) 2020 The Open Sauce Sans Authors (https://github.com/marcologous/Open-Sauce-Fonts)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+License URL: http://scripts.sil.org/OFL 
+-- End of Open Sauce Sans Font credits --

--- a/otis/style.css
+++ b/otis/style.css
@@ -7,7 +7,7 @@ Description: Otis is a WordPress block theme that is well-suited for personal bl
 Requires at least: 5.8
 Tested up to: 5.9
 Requires PHP: 5.7
-Version: 1.0.1
+Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: otis
@@ -29,6 +29,6 @@ Tags: blog, news, portfolio, one-column, wide-blocks, block-patterns, block-styl
  * https://github.com/WordPress/gutenberg/issues/42319
  */
 a {
-	text-decoration-thickness: .0625em !important;
-	text-underline-offset: .15em;
+	text-decoration-thickness: 0.5px !important;
+	text-underline-offset: .1em;
 }

--- a/otis/theme.json
+++ b/otis/theme.json
@@ -110,11 +110,11 @@
 			"fontSizes": [
 				{
 					"fluid": {
-						"max": "1.0625rem",
-						"min": "0.825rem"
+						"max": "1rem",
+						"min": "0.8rem"
 					},
 					"name": "Small",
-					"size": "1rem",
+					"size": "0.8rem",
 					"slug": "small"
 				},
 				{
@@ -129,10 +129,10 @@
 				{
 					"fluid": {
 						"max": "2rem",
-						"min": "1.75rem"
+						"min": "1.6rem"
 					},
 					"name": "Large",
-					"size": "1.75rem",
+					"size": "1.7rem",
 					"slug": "large"
 				},
 				{
@@ -143,6 +143,15 @@
 					"name": "Extra Large",
 					"size": "3rem",
 					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"max": "6.5rem",
+						"min": "5.5rem"
+					},
+					"name": "Huge",
+					"size": "6rem",
+					"slug": "huge"
 				}
 			]
 		},


### PR DESCRIPTION
Changes from WordPress Playground, to improve the theme and prepare for Dotorg submission:

- Set templates to use font size presets instead of local customizations
- Added font license
- Fixed some spacings that weren't optimized before