### PR TITLE
Spearhead: remove excess JS from the frontend

### DIFF
--- a/spearhead/functions.php
+++ b/spearhead/functions.php
@@ -162,7 +162,7 @@ function spearhead_block_extends() {
 		array( 'wp-blocks', 'wp-edit-post' ) // wp-edit-post is added to avoid a race condition when trying to unregister a style variation
 	);
 }
-add_action( 'enqueue_block_assets', 'spearhead_block_extends' );
+add_action( 'enqueue_block_editor_assets', 'spearhead_block_extends' );
 
 /**
  * Add Google webfonts


### PR DESCRIPTION
Spearhead currently loads Gutenberg JS on the frontend, resulting in significantly reduced loading performance. This appears to be due to the wrong hook being used.

#### Changes proposed in this Pull Request:

- Change block extends to happen on `enqueue_block_editor_assets` instead of `enqueue_block_assets`

#### Related issue(s):

Fixes #7848