### PR TITLE
Spearhead: don't use a relative requires

### DIFF
--- a/spearhead/inc/wpcom-editor-colors.php
+++ b/spearhead/inc/wpcom-editor-colors.php
@@ -1,2 +1,2 @@
 <?php
-	require_once 'wpcom-colors.php';
+	require_once __DIR__ . 'wpcom-colors.php';


### PR DESCRIPTION
Ran into deployment issues, this fixes the problem.

```sh
remote: ***********************************
remote: Syntax Error in: spearhead/inc/wpcom-editor-colors.php:
remote: Relative path includes are not allowed. Please fix this relative include before committing the file:
remote:         require_once 'wpcom-colors.php';
remote: 
remote: You can use the __DIR__ or ABSPATH constants for this. For example:
remote: 
remote: require( __DIR__ . '/myfile.php' );
remote: or
remote: require( ABSPATH . 'wp-content/mu-plugins/myfile.php' );
remote: ***********************************
```