### PR TITLE
Spearhead: fix wp editor colors import path

### DIFF
--- a/spearhead/inc/wpcom-editor-colors.php
+++ b/spearhead/inc/wpcom-editor-colors.php
@@ -1,2 +1,2 @@
 <?php
-	require_once __DIR__ . 'wpcom-colors.php';
+	require_once __DIR__ . '/wpcom-colors.php';


### PR DESCRIPTION
Typo in require path was causing this error on wp simple sites:

```php
 PHP Fatal error: Uncaught Error: Failed opening required '/home/wpcom/public_html/wp-content/themes/pub/spearhead/incwpcom-colors.php' (include_path='.')
```