### PR TITLE
Add main tag to Vitrum theme

### DIFF
--- a/vitrum/patterns/front-page.php
+++ b/vitrum/patterns/front-page.php
@@ -8,8 +8,8 @@
 ?>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"5vh","bottom":"5vh"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:5vh;padding-bottom:5vh"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"5vh","bottom":"5vh"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="padding-top:5vh;padding-bottom:5vh"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"90%"} -->
 <div class="wp-block-column" style="flex-basis:90%"><!-- wp:heading {"textAlign":"left","level":1,"className":"alignwide"} -->
@@ -79,7 +79,7 @@
 <!-- wp:post-terms {"term":"category","separator":" × "} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
-<!-- /wp:query --></div>
+<!-- /wp:query --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add `main` tag to Vitrum theme.

#### Why?
Vitrum is not printing a `<main>` tag, and that's needed for the[ skip link](https://make.wordpress.org/accessibility/handbook/markup/skip-links/) to be printed to the page.


Reference: https://github.com/WordPress/wordpress-develop/blob/b39f58ec3eab0f2b66dccebbf0fc97baaaaa9a15/src/wp-includes/theme-templates.php#L173-L212

#### Related issue(s):
https://themes.trac.wordpress.org/ticket/178552#no0