### PR TITLE
Seedlet: Fix a fatal error in Gutenberg

### DIFF
--- a/seedlet/inc/wpcom-editor-colors.php
+++ b/seedlet/inc/wpcom-editor-colors.php
@@ -1,3 +1,3 @@
 <?php declare( strict_types = 1 ); ?>
 <?php
-require_once __DIR__ . 'wpcom-colors.php';
+require_once __DIR__ . '/wpcom-colors.php';


### PR DESCRIPTION
4bf4fb9a introduced a bug when including `wpcom-colors.php` by using the editor. It was missing a directory separate and so  it fataled with an error message like:
`PHP Fatal error:  Uncaught Error: Failed opening required '/xxx/seedlet/incwpcom-colors.php' (include_path='.') in /xxx/seedlet/inc/wpcom-editor-colors.php:3


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):

https://github.com/Automattic/themes/issues/7937
