### PR TITLE
Dara: Fix display of dotted separator

### DIFF
--- a/dara/blocks.css
+++ b/dara/blocks.css
@@ -333,9 +333,12 @@ hr.wp-block-separator {
 	border: 0;
 }
 
+.wp-block-separator:not(.is-style-dots) {
+	height: 1px;
+}
+
 .wp-block-separator {
 	border: 0;
-	height: 1px;
 	margin: 1.6em auto;
 	background-color: #e6e6e6;
 	max-width: 66%;

--- a/dara/editor-blocks.css
+++ b/dara/editor-blocks.css
@@ -805,9 +805,12 @@
 
 /* Separator */
 
+.wp-block-separator:not(.is-style-dots) {
+    height:1px;
+}
+
 .wp-block-separator {
 	border: 0;
-	height: 1px;
 	margin: 1.6em auto;
 	background-color: #e6e6e6;
 	max-width: 66%;


### PR DESCRIPTION
The dotted separator wasn't displaying because the height of the separator was too small.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change overrides the height for the dotted separator only.


Location | Before | After
-|------|------
Front-end | <img width="1145" alt="Screenshot 2024-07-30 at 16 34 44" src="https://github.com/user-attachments/assets/0cfa82f0-1235-4413-b158-d9f7ffa99e03"> | <img width="1145" alt="Screenshot 2024-07-30 at 16 35 29" src="https://github.com/user-attachments/assets/a1199a3e-0a52-472d-b698-da065b2950ba">
Editor | <img width="1145" alt="Screenshot 2024-07-30 at 16 33 06" src="https://github.com/user-attachments/assets/4504979b-69b2-4fc2-9713-a30e574600d3"> | <img width="1145" alt="Screenshot 2024-07-30 at 16 36 09" src="https://github.com/user-attachments/assets/ab61ae6f-fb4a-4d42-b05d-3e2b3d634993">


#### Related issue(s): 
#7978
