### PR TITLE
Canard: Fix display of dotted separator

### DIFF
--- a/canard/blocks.css
+++ b/canard/blocks.css
@@ -272,9 +272,12 @@ hr.wp-block-separator {
 .wp-block-separator {
 	background-color: #ddd;
 	border: 0;
-	height: 1px;
 	margin-bottom: 30px;
 	max-width: 66%;
+}
+
+.wp-block-separator:not(.is-style-dots) {
+	height: 1px;
 }
 
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {

--- a/canard/editor-blocks.css
+++ b/canard/editor-blocks.css
@@ -1,4 +1,4 @@
-
+`
 /*
  * Theme Name: Canard
  * Description: Gutenberg Block Editor Styles
@@ -747,12 +747,16 @@
 }
 
 /* Separator */
+
 .wp-block-separator {
 	background-color: #ddd;
 	border: 0;
-	height: 1px;
 	margin-bottom: 30px;
 	max-width: 66%;
+}
+
+.wp-block-separator:not(.is-style-dots) {
+	height: 1px;
 }
 
 .wp-block-separator.is-wide {


### PR DESCRIPTION
The dotted separator wasn't displaying because the height of the separator was too small.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change overrides the height for the dotted separator only.


Location | Before | After
-|------|------
Front-end | <img width="1145" alt="Screenshot 2024-07-30 at 17 35 14" src="https://github.com/user-attachments/assets/a6079854-efa8-4403-a2e4-fc65fb8c4331">|<img width="1145" alt="Screenshot 2024-07-30 at 17 34 26" src="https://github.com/user-attachments/assets/a81887b4-18fd-4b70-9e6d-4255cfc1b2dc">
Editor | <img width="1145" alt="Screenshot 2024-07-30 at 17 35 39" src="https://github.com/user-attachments/assets/2463382f-023b-4f1c-87be-b7e84670cb5f"> | <img width="1145" alt="Screenshot 2024-07-30 at 17 34 44" src="https://github.com/user-attachments/assets/ceb36271-a351-4c5a-8b65-074af9cb8114">


#### Related issue(s): 
#7978
