### PR TITLE
Course, UpsideDown: Remove copyright symbol

### DIFF
--- a/course/patterns/footer.php
+++ b/course/patterns/footer.php
@@ -135,7 +135,7 @@
         <?php
           $wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'course' ) ) . '" rel="nofollow">WordPress</a>';
             echo sprintf(
-                esc_html__( '© Designed with %1$s', 'course' ),
+                esc_html__( 'Designed with %1$s', 'course' ),
                 $wordpress_link
             );
         ?>

--- a/upsidedown/patterns/footer.php
+++ b/upsidedown/patterns/footer.php
@@ -56,7 +56,7 @@
                     /* Translators: WordPress link. */
                     $wordpress_link = '<a href="' . esc_url( __( 'https://wordpress.org', 'upsidedown' ) ) . '" rel="nofollow">WordPress</a>';
                     echo sprintf(
-                        esc_html__( '© Designed with %1$s', 'upsidedown' ),
+                        esc_html__( 'Designed with %1$s', 'upsidedown' ),
                         $wordpress_link
                     );
                 ?>


### PR DESCRIPTION

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The copyright symbol in these themes was just positioned infront of 'Designed with...' which didn't make sense. Removing completely - users would've needed to customise the pattern for the copyright to have made sense anyway.

Theme | Before | After
---|----|------
Course | <img width="1145" alt="Screenshot 2024-07-30 at 18 03 21" src="https://github.com/user-attachments/assets/bbd700d1-45a2-482f-bc1f-2bb2619723b7"> | <img width="1145" alt="Screenshot 2024-07-30 at 18 02 57" src="https://github.com/user-attachments/assets/f3b7cd99-84dd-448c-adad-cd8345880580">
Upside down | <img width="1145" alt="Screenshot 2024-07-30 at 18 13 10" src="https://github.com/user-attachments/assets/18ebee9e-8f63-425d-8cf3-ea24935162f5"> | <img width="1145" alt="Screenshot 2024-07-30 at 18 13 20" src="https://github.com/user-attachments/assets/87cc7e0d-e0b8-4d51-b2ae-fb096e5557e7">


#### Related issue(s):
https://github.com/Automattic/themes/issues/7970