### PR TITLE
Remove copyright statement

### DIFF
--- a/bitacora/patterns/footer.php
+++ b/bitacora/patterns/footer.php
@@ -61,22 +61,8 @@
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><?php _e( '©', 'bitacora' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:site-title {"style":{"typography":{"letterSpacing":"0px","textTransform":"none"}},"fontSize":"small"} /-->
-
-			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><?php _e( '2022, All Rights Reserved.', 'bitacora' ); ?></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:group -->
-
 		<!-- wp:paragraph {"align":"left","className":"has-small-font-size","fontSize":"small"} -->
 		<p class="has-text-align-left has-small-font-size">
 			<?php

--- a/fontaine/patterns/footer-dark.php
+++ b/fontaine/patterns/footer-dark.php
@@ -52,11 +52,6 @@ declare( strict_types = 1 );
 	<div class="wp-block-group">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:paragraph -->
-			<p><?php echo esc_html__( '© 2023', 'fontaine' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:site-title {"level":0} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/fontaine/patterns/footer.php
+++ b/fontaine/patterns/footer.php
@@ -52,11 +52,6 @@ declare( strict_types = 1 );
 	<div class="wp-block-group">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:paragraph -->
-			<p><?php echo esc_html__( '© 2023', 'fontaine' ); ?></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:site-title {"level":0} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/jaida/patterns/footer.php
+++ b/jaida/patterns/footer.php
@@ -34,7 +34,7 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"0","left":"0","top":"var:preset|spacing|80","bottom":"var:preset|spacing|70"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-right:0;padding-bottom:var(--wp--preset--spacing--70);padding-left:0"><!-- wp:paragraph {"style":{"typography":{"fontSize":"0.8rem"}}} -->
-<p style="font-size:0.8rem"><?php echo esc_html__( 'Jaida Theme', 'jaida' ); ?> © 2023</p>
+<p style="font-size:0.8rem"></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"right","style":{"typography":{"fontSize":"0.8rem"}}} -->

--- a/pendant/patterns/footer.php
+++ b/pendant/patterns/footer.php
@@ -10,7 +10,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}},"layout":{"inherit":true}} -->
 <div class="wp-block-group" style="padding-top:40px;padding-bottom:40px"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull"><!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left"><?php echo esc_html__( '2021 Pendant © All Rights Reserved', 'pendant' ); ?></p>
+<p class="has-text-align-left"></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"align":"right"} -->

--- a/vitrum/patterns/footer.php
+++ b/vitrum/patterns/footer.php
@@ -9,15 +9,7 @@
 ?>
 <!-- wp:group {"style":{"border":{"top":{"width":"1px"},"right":[],"bottom":[],"left":[]}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="border-top-width:1px"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"3vh","bottom":"60px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:3vh;padding-bottom:60px"><!-- wp:group {"style":{"spacing":{"blockGap":"5px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p><?php echo __('©', 'vitrum');?></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:site-title {"fontSize":"small"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:paragraph {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-group alignwide" style="padding-top:3vh;padding-bottom:60px"><!-- wp:paragraph {"lock":{"move":false,"remove":true}} -->
 <p><?php echo __('Designed with <a rel="noreferrer noopener" href="http://wordpress.org" data-type="URL" data-id="wordpress.org" target="_blank">WordPress.</a>', 'vitrum');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove copyright statement from the following themes:
 * Vitrum
 * Fontaine (x2)
 * Pendant
 * Bitacora
 * Jaida

The standard for a while has been to use "Designed with WordPress" (or something similar) in the footer, rather than a copyright statement. Additionally the copyright line is often incorrect - where it hardcodes the year, this is obviously not accurate and where it credits the name of the blog, or states "All Rights Reserved", this may not be accurate either. We should leave it to users to set their own copyright statements appropriately.

Theme | Before | After
-------|------|-----
Vitrum | <img width="1461" alt="Screenshot 2024-07-30 at 18 30 22" src="https://github.com/user-attachments/assets/548586b6-1cb0-4c9e-a1f5-1d160b185819"> | <img width="1461" alt="image" src="https://github.com/user-attachments/assets/96c7d0d9-c09f-4700-9a89-08da9b0ef2c2">
Fontaine | <img width="731" alt="Screenshot 2024-07-30 at 18 33 13" src="https://github.com/user-attachments/assets/525ef6f3-1848-44d0-b50b-d4fbb04a86f3"> | <img width="731" alt="image" src="https://github.com/user-attachments/assets/d1ffc1a4-8f22-4ebf-a6d8-57869998b848">
Fontaine (dark) | <img width="731" alt="image" src="https://github.com/user-attachments/assets/a6f0df6a-72e8-45b9-9ff9-0fdd42911e87"> | <img width="731" alt="image" src="https://github.com/user-attachments/assets/c34fc93e-016b-4be1-8d31-54677b81b943">
Pendant | <img width="731" alt="Screenshot 2024-07-30 at 18 56 32" src="https://github.com/user-attachments/assets/6c999acf-2dcc-41ea-be94-dd2a3d4882d3"> | <img width="731" alt="image" src="https://github.com/user-attachments/assets/f1f332b1-7b0f-4daa-9bf0-d8bd33a7cb4c">
Bitacora | <img width="731" alt="Screenshot 2024-07-30 at 18 57 10" src="https://github.com/user-attachments/assets/4ca84b3a-bc07-4f80-8e04-416930459ac8"> | <img width="731" alt="image" src="https://github.com/user-attachments/assets/c2728b46-4e23-45ba-981f-a751f7af1f85">
Jaida | <img width="1461" alt="Screenshot 2024-07-30 at 18 31 34" src="https://github.com/user-attachments/assets/4ce19faf-7ffe-4892-861a-a28e317ca43e"> | <img width="1461" alt="image" src="https://github.com/user-attachments/assets/d3bcc580-b972-4dee-994b-f079b6a75cae">


#### Related issue(s):
#7970