### PR TITLE
Cottage: Update CSS classes

### DIFF
--- a/cottage/patterns/header-with-sticky-post.php
+++ b/cottage/patterns/header-with-sticky-post.php
@@ -18,8 +18,8 @@
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|40"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group alignwide has-base-color has-text-color has-link-color"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","letterSpacing":"0px"}},"fontSize":"small","fontFamily":"source-sans-3"} -->
-<p class="has-source-sans-3-font-family has-small-font-size" style="font-style:normal;font-weight:400;letter-spacing:0px"><?php esc_html_e('Featured', 'cottage');?></p>
+<div class="wp-block-group alignwide has-base-color has-text-color has-link-color"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","letterSpacing":"0px"}},"fontSize":"small"} -->
+<p class="has-small-font-size" style="font-style:normal;font-weight:400;letter-spacing:0px"><?php esc_html_e('Featured', 'cottage');?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"lineHeight":"1.3"}},"fontSize":"xxx-large"} /--></div>

--- a/cottage/patterns/latest-post-heading.php
+++ b/cottage/patterns/latest-post-heading.php
@@ -10,8 +10,8 @@ declare( strict_types = 1 );
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0.5rem","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","letterSpacing":"0px"}},"fontSize":"small","fontFamily":"source-sans-3"} -->
-	<h2 class="wp-block-heading has-source-sans-3-font-family has-small-font-size" style="font-style:normal;font-weight:600;letter-spacing:0px"><?php echo esc_html__( 'Latest Posts', 'cottage' ); ?></h2>
+	<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","letterSpacing":"0px"}},"fontSize":"small"} -->
+	<h2 class="wp-block-heading has-small-font-size" style="font-style:normal;font-weight:600;letter-spacing:0px"><?php echo esc_html__( 'Latest Posts', 'cottage' ); ?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:separator -->

--- a/cottage/patterns/post-author.php
+++ b/cottage/patterns/post-author.php
@@ -14,8 +14,8 @@ declare( strict_types = 1 );
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 	<div class="wp-block-group">
-		<!-- wp:paragraph {"fontSize":"small","fontFamily":"source-sans-3"} -->
-		<p class="has-source-sans-3-font-family has-small-font-size"><?php esc_html_e('Published by', 'cottage');?></p>
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size"><?php esc_html_e('Published by', 'cottage');?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:post-author-name {"isLink":true} /-->

--- a/cottage/patterns/single.php
+++ b/cottage/patterns/single.php
@@ -17,8 +17,8 @@
 <div class="wp-block-group" style="border-top-color:var(--wp--preset--color--secondary);border-top-width:1px;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:avatar {"size":56} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"small","fontFamily":"source-sans-3"} -->
-<p class="has-source-sans-3-font-family has-small-font-size"><?php esc_html_e('Published by', 'cottage');?></p>
+<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php esc_html_e('Published by', 'cottage');?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-author-name {"isLink":true} /-->

--- a/cottage/theme.json
+++ b/cottage/theme.json
@@ -441,19 +441,13 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--source-sans-3)",
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"letterSpacing": "normal",
-					"lineHeight": "1.590909091"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-content": {
 				"css": "& p{margin:0;}& p+p{margin-top:1.75rem;}",
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--source-sans-3)",
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"letterSpacing": "normal",
-					"lineHeight": "1.590909091"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-date": {
@@ -470,10 +464,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--source-sans-3)",
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"letterSpacing": "normal",
-					"lineHeight": "1.590909091"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-edit-link": {
@@ -490,10 +481,7 @@
 					}
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--source-sans-3)",
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"letterSpacing": "normal",
-					"lineHeight": "1.590909091"
+					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
 			"core/comment-reply-link": {


### PR DESCRIPTION
While testing Cottage on .com I noticed some strings were rendered in Source Sans font, which I believe is a mistake, since this font is not included with the theme. This PR removes those references from CSS classes and theme.json.