### PR TITLE
Blissed: Separate strings from HTML.

### DIFF
--- a/blissed/patterns/footer.php
+++ b/blissed/patterns/footer.php
@@ -13,17 +13,17 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left"} -->
-<p class="has-text-align-left"><?php esc_html_e('September 15, 2024 — 4:00 PM<br>Whispering Pines, Lake Tahoe, CA<br>Reception to follow ceremony', 'blissed');?></p>
+<p class="has-text-align-left"><?php esc_html_e('September 15, 2024 — 4:00 PM', 'blissed');?><br /><?php esc_html_e('Whispering Pines, Lake Tahoe, CA', 'blissed');?><br /><?php esc_html_e('Reception to follow ceremony', 'blissed');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"blockGap":"var:preset|spacing|20","margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":1,"className":"no-underline","fontSize":"large"} -->
-<h1 class="wp-block-heading no-underline has-large-font-size"><?php esc_html_e('<a href="#" data-type="page" data-id="391">Our story</a>', 'blissed');?></h1>
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":2,"className":"no-underline","fontSize":"large"} -->
+<h2 class="wp-block-heading no-underline has-large-font-size"><a href="#" alt=""><?php esc_html_e('Our story', 'blissed');?></a></h2>
 <!-- /wp:heading -->
 
-<!-- wp:heading {"level":1,"className":"no-underline","fontSize":"large"} -->
-<h1 class="wp-block-heading no-underline has-large-font-size"><?php esc_html_e('<a href="#" data-type="page" data-id="391">RSVP</a>', 'blissed');?></h1>
+<!-- wp:heading {"level":2,"className":"no-underline","fontSize":"large"} -->
+<h2 class="wp-block-heading no-underline has-large-font-size"><a href="#" alt=""><?php esc_html_e('RSVP', 'blissed');?></a></h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/blissed/patterns/header.php
+++ b/blissed/patterns/header.php
@@ -12,23 +12,21 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"className":"no-underline"} -->
-<p class="no-underline"><?php echo __('<a href="#ceremony" data-type="internal" data-id="#ceremony">Ceremony</a>', 'blissed');?></p>
+<p class="no-underline"><a href="#ceremony" data-type="internal" data-id="#ceremony"><?php esc_html_e('Ceremony', 'blissed');?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"className":"no-underline"} -->
-<p class="no-underline"><?php echo __('<a href="#ceremony" data-type="internal" data-id="#ceremony">Reception</a>', 'blissed');?></p>
+<p class="no-underline"><a href="#ceremony" data-type="internal" data-id="#ceremony"><?php esc_html_e('Reception', 'blissed');?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"className":"no-underline"} -->
-<p class="no-underline"><?php echo __('<a href="#ceremony" data-type="internal" data-id="#ceremony">Accommodations</a>', 'blissed');?></p>
+<p class="no-underline"><a href="#ceremony" data-type="internal" data-id="#ceremony"><?php esc_html_e('Accommodations', 'blissed');?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"className":"no-underline"} -->
-<p class="no-underline"><?php echo __('<a href="#ceremony" data-type="internal" data-id="#ceremony">Wedding Registry</a>', 'blissed');?></p>
+<p class="no-underline"><a href="#ceremony" data-type="internal" data-id="#ceremony"><?php esc_html_e('Wedding Registry', 'blissed');?></a></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"className":"no-underline"} -->
-<p class="no-underline"><?php echo __('<a href="/blog" data-type="internal" data-id="#ceremony">Blog</a>', 'blissed');?></p>
-<!-- /wp:paragraph --></div>
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Separate strings from HTML in header and footer patterns to fix this issue:

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/673024cf-5f34-4312-a2f6-2de4b660ccb8">

