### PR TITLE
Theme preview: use pull_request_target

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,7 +1,7 @@
 name: Preview Theme Changes
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 permissions:
   pull-requests: write


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The new action has to be used as `pull_request_target` to be able to post comments when PRs are created from a fork.
