### PR TITLE
Layover: fixing after Dotorg review

### DIFF
--- a/layover/patterns/404.php
+++ b/layover/patterns/404.php
@@ -6,7 +6,8 @@
  * Inserter: no
  */
 ?>
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem","top":"4rem"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:group -->
@@ -28,4 +29,5 @@
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /--></div>
+<!-- /wp:group -->

--- a/layover/patterns/404.php
+++ b/layover/patterns/404.php
@@ -8,8 +8,8 @@
 ?>
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4rem","top":"4rem"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:group -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem","top":"4rem"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:group -->
 <div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"align":"wide"} -->
 <h1 class="wp-block-heading alignwide has-text-align-center" id="oops-that-page-can-t-be-found"><?php echo __('Oops!', 'layover');?></h1>
@@ -25,7 +25,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:search {"showLabel":false,"placeholder":"SEARCH","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"border":{"width":"0px","style":"none"}}} /--></div>
-<!-- /wp:group --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/layover/patterns/footer.php
+++ b/layover/patterns/footer.php
@@ -7,7 +7,7 @@
  */
 ?>
 <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4rem","top":"4rem"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center"><?php echo __('Designed with <a href="https://wordpress.org" rel="nofollow">WordPress</a>.', 'layover');?></p>
+<div class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground"} -->
+<p class="has-text-align-center has-foreground-color has-text-color has-link-color"><?php echo __('Designed with <a href="https://wordpress.org" rel="nofollow">WordPress</a>.', 'layover');?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->

--- a/layover/patterns/header.php
+++ b/layover/patterns/header.php
@@ -14,8 +14,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"dimensions":{"minHeight":""}},"layout":{"type":"constrained","contentSize":"40px"}} -->
-<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","padding":{"top":"2px","right":"2px","bottom":"2px","left":"2px"}},"border":{"top":{"width":"1px"},"bottom":{"width":"1px"}},"dimensions":{"minHeight":""}},"layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-group" style="border-top-width:1px;border-bottom-width:1px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px"></div>
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5rem","padding":{"top":"2px","right":"2px","bottom":"2px","left":"2px"}},"border":{"top":{"color":"var:preset|color|foreground","width":"1px"},"bottom":{"color":"var:preset|color|foreground","width":"1px"},"right":[],"left":[]},"dimensions":{"minHeight":""}},"layout":{"type":"constrained","contentSize":""}} -->
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--foreground);border-top-width:1px;border-bottom-color:var(--wp--preset--color--foreground);border-bottom-width:1px;padding-top:2px;padding-right:2px;padding-bottom:2px;padding-left:2px"></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/layover/style.css
+++ b/layover/style.css
@@ -7,7 +7,7 @@ Description: Layover displays large titles and excerpts that scroll over an imag
 Requires at least: 5.8
 Tested up to: 6.5
 Requires PHP: 5.7
-Version: 1.0.1
+Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: layover

--- a/layover/style.css
+++ b/layover/style.css
@@ -2,12 +2,12 @@
 Theme Name: Layover
 Theme URI: 
 Author: Automattic
-Author URI: https://wordpress.org
+Author URI: https://automattic.com
 Description: Layover displays large titles and excerpts that scroll over an image on the Homepage and neat single pages for users who want their blogging to be simple.
 Requires at least: 5.8
 Tested up to: 6.5
 Requires PHP: 5.7
-Version: 1.0
+Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: layover

--- a/layover/templates/archive.html
+++ b/layover/templates/archive.html
@@ -1,4 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
@@ -17,7 +18,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-pagination {"fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:query-pagination {"style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"PREV"} /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -28,4 +29,5 @@
 <!-- /wp:query --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /--></div>
+<!-- /wp:group -->

--- a/layover/templates/archive.html
+++ b/layover/templates/archive.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
 <main class="wp-block-query alignwide"><!-- wp:query-title {"type":"archive","textAlign":"center","align":"wide"} /-->
 
 <!-- wp:post-template {"align":"wide","style":{"spacing":{"blockGap":"8rem"}}} -->
@@ -17,7 +17,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"fontSize":"large"} -->
+<div class="wp-block-group"><!-- wp:query-pagination {"fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"PREV"} /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -25,7 +25,7 @@
 <!-- wp:query-pagination-next {"label":"NEX"} /-->
 <!-- /wp:query-pagination --></div>
 <!-- /wp:group --></main>
-<!-- /wp:query --></div>
+<!-- /wp:query --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/layover/templates/index.html
+++ b/layover/templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
 <main class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide","style":{"spacing":{"blockGap":"8rem"}}} -->
 <!-- wp:group {"style":{"spacing":{"blockGap":"2rem"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"1","width":"40%"} /-->
@@ -15,7 +15,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"fontSize":"large"} -->
+<div class="wp-block-group"><!-- wp:query-pagination {"fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"PREV"} /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -23,7 +23,7 @@
 <!-- wp:query-pagination-next {"label":"NEX"} /-->
 <!-- /wp:query-pagination --></div>
 <!-- /wp:group --></main>
-<!-- /wp:query --></div>
+<!-- /wp:query --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/layover/templates/index.html
+++ b/layover/templates/index.html
@@ -1,4 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:query {"queryId":5,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","align":"wide","layout":{"type":"constrained"}} -->
@@ -15,7 +16,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-pagination {"fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:query-pagination {"style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"PREV"} /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -26,4 +27,5 @@
 <!-- /wp:query --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /--></div>
+<!-- /wp:group -->

--- a/layover/templates/page.html
+++ b/layover/templates/page.html
@@ -1,7 +1,9 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<!-- wp:group {"align":"wide","style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:group {"tagName":"main","align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem","top":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-top:4rem;padding-bottom:4rem"><!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"wide","layout":{"type":"constrained"}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /--></div>
+<!-- /wp:group -->

--- a/layover/templates/page.html
+++ b/layover/templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
-<!-- wp:group {"align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem","top":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-top:4rem;padding-bottom:4rem"><!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"wide","layout":{"type":"default"}} /--></div>
+<!-- wp:group {"tagName":"main","align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem","top":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-top:4rem;padding-bottom:4rem"><!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"wide","layout":{"type":"constrained"}} /--></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /-->

--- a/layover/templates/search.html
+++ b/layover/templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"},"blockGap":"4rem"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"},"blockGap":"4rem"}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:search {"showLabel":false,"placeholder":"SEARCH","width":100,"widthUnit":"%","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"border":{"width":"0px","style":"none"}}} /--></div>
 <!-- /wp:group -->
 
@@ -21,7 +21,7 @@
 <!-- /wp:post-template -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"fontSize":"large"} -->
+<div class="wp-block-group"><!-- wp:query-pagination {"fontSize":"large","layout":{"type":"flex","justifyContent":"center"}} -->
 <!-- wp:query-pagination-previous {"label":"PREV"} /-->
 
 <!-- wp:query-pagination-numbers /-->
@@ -29,7 +29,7 @@
 <!-- wp:query-pagination-next {"label":"NEX"} /-->
 <!-- /wp:query-pagination --></div>
 <!-- /wp:group --></main>
-<!-- /wp:query --></div>
+<!-- /wp:query --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/layover/templates/search.html
+++ b/layover/templates/search.html
@@ -1,4 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem"},"blockGap":"4rem"}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:4rem;padding-bottom:4rem"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
@@ -32,4 +33,5 @@
 <!-- /wp:query --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /--></div>
+<!-- /wp:group -->

--- a/layover/templates/single.html
+++ b/layover/templates/single.html
@@ -1,4 +1,5 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<!-- wp:group {"align":"wide","style":{"dimensions":{"minHeight":"100vh"}},"backgroundColor":"primary","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide has-primary-background-color has-background" style="min-height:100vh"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:group {"tagName":"main","align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
 <main class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-bottom:4rem"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"4rem","padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"},"margin":{"top":"0rem","bottom":"0rem"}}},"layout":{"type":"default"}} -->
@@ -46,4 +47,5 @@
 <!-- /wp:comments --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /--></div>
+<!-- /wp:group -->

--- a/layover/templates/single.html
+++ b/layover/templates/single.html
@@ -1,10 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
-<!-- wp:group {"align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-bottom:4rem"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"4rem","padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"},"margin":{"top":"0rem","bottom":"0rem"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide" style="margin-top:0rem;margin-bottom:0rem;padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:0rem"><!-- wp:post-featured-image /-->
+<!-- wp:group {"tagName":"main","align":"wide","style":{"border":{"top":[],"right":{"width":"1rem","style":"solid"},"bottom":[],"left":{"width":"1rem","style":"solid"}},"spacing":{"padding":{"bottom":"4rem"},"margin":{"top":"4rem","bottom":"0rem"}}},"backgroundColor":"foreground","textColor":"primary","layout":{"type":"constrained"}} -->
+<main class="wp-block-group alignwide has-primary-color has-foreground-background-color has-text-color has-background" style="border-right-style:solid;border-right-width:1rem;border-left-style:solid;border-left-width:1rem;margin-top:4rem;margin-bottom:0rem;padding-bottom:4rem"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"4rem","padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"},"margin":{"top":"0rem","bottom":"0rem"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="margin-top:0rem;margin-bottom:0rem;padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:0rem"><!-- wp:post-featured-image {"height":"50vh"} /-->
 
-<!-- wp:post-title {"textAlign":"center","level":1,"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary"} /-->
+<!-- wp:post-title {"textAlign":"center","level":1,"isLink":true,"align":"wide","style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary"} /-->
 
 <!-- wp:post-content {"lock":{"move":false,"remove":false},"align":"wide","layout":{"type":"default"}} /--></div>
 <!-- /wp:group -->
@@ -43,7 +43,7 @@
 <!-- /wp:comments-pagination -->
 
 <!-- wp:post-comments-form {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary"} /--></div>
-<!-- /wp:comments --></div>
+<!-- /wp:comments --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","align":"wide"} /-->

--- a/layover/theme.json
+++ b/layover/theme.json
@@ -639,8 +639,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--preset--color--primary)",
-			"text": "var(--wp--preset--color--foreground)"
+			"background": "var(--wp--preset--color--foreground)",
+			"text": "var(--wp--preset--color--primary)"
 		},
 		"elements": {
 			"button": {

--- a/layover/theme.json
+++ b/layover/theme.json
@@ -102,7 +102,7 @@
 			"text": true
 		},
 		"layout": {
-			"contentSize": "600px",
+			"contentSize": "640px",
 			"wideSize": "900px"
 		},
 		"shadow": {

--- a/layover/theme.json
+++ b/layover/theme.json
@@ -443,6 +443,16 @@
 				}
 			},
 			"core/post-content": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--primary)"
+						}
+					}
+				},
 				"spacing": {
 					"blockGap": "1.5rem"
 				},


### PR DESCRIPTION
This update fixes the following issues:

- https://wordpress.org is not the valid author URI for your theme. This URI is reserved only for core themes like twenty twenty-four, twenty twenty-five.....
- Headings like H1, H2 and text with the link is not visible in the content area, https://i.rankmath.com/i/PksdjD Check by adding content in post and page and see it.
- Skip link is not working in the single page, post. Fix this.