### PR TITLE
Karuna: Add block CSS to the editor so that colors work as expected

### DIFF
--- a/karuna/functions.php
+++ b/karuna/functions.php
@@ -347,6 +347,7 @@ add_action( 'wp_enqueue_scripts', 'karuna_scripts' );
  * Gutenberg Editor Styles
  */
 function karuna_editor_styles() {
+	wp_enqueue_style( 'karuna-block-style', get_template_directory_uri() . '/blocks.css' );
 	wp_enqueue_style( 'karuna-editor-block-style', get_template_directory_uri() . '/editor-blocks.css' );
 	wp_enqueue_style( 'karuna-fonts', karuna_fonts_url(), array(), null );
 }


### PR DESCRIPTION
Add block CSS to the editor so that colors work as expected. This is the same issue as reported for Rebalance in https://github.com/Automattic/wp-calypso/issues/54990, and the fix is the same as #4756 .