### PR TITLE
Pique: Enqueue WooCommerce font

### DIFF
--- a/pique/inc/woocommerce.php
+++ b/pique/inc/woocommerce.php
@@ -68,6 +68,21 @@ function pique_woocommerce_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'pique_woocommerce_scripts' );
 
+function pique_woocommerce_editor_styles() {
+	$font_path   = WC()->plugin_url() . '/assets/fonts/';
+	$inline_font = '@font-face {
+			font-family: "WooCommerce";
+			src: url("' . $font_path . 'WooCommerce.woff2") format("woff2"),
+			     url("' . $font_path . 'WooCommerce.woff") format("woff"),
+			     url("' . $font_path . 'WooCommerce.ttf") format("truetype");
+			font-weight: normal;
+			font-style: normal;
+		}';
+
+	wp_add_inline_style( 'pique-block-editor-style', $inline_font );
+}
+add_action('enqueue_block_editor_assets', 'pique_woocommerce_editor_styles');
+
 /**
  * WooCommerce specific scripts & stylesheets.
  *

--- a/pique/inc/woocommerce.php
+++ b/pique/inc/woocommerce.php
@@ -53,6 +53,14 @@ function pique_woocommerce_scripts() {
 				 url("' . $font_path . 'star.svg#star") format("svg");
 			font-weight: normal;
 			font-style: normal;
+		}
+		@font-face {
+			font-family: "WooCommerce";
+			src: url("' . $font_path . 'WooCommerce.woff2") format("woff2"),
+			     url("' . $font_path . 'WooCommerce.woff") format("woff"),
+			     url("' . $font_path . 'WooCommerce.ttf") format("truetype");
+			font-weight: normal;
+			font-style: normal;
 		}';
 
 	wp_add_inline_style( 'pique-woocommerce-style', $inline_font );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR enqueues the `WooCommerce` font alongside `star`. That's because WooCommerce is moving away from `star` (see https://github.com/woocommerce/woocommerce/pull/31670) and some blocks rely on the `WooCommerce` font being present.

#### Steps to test

1. Enable the Pique theme.
2. Create a post or page with the All Products block or the Product Collection block (in that one, you will need to manually add the Product Rating inner block). Verify rating stars are rendered correctly.
3. View the post or page in the frontend. Verify rating stars are rendered correctly.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/9fb27ed2-099c-4342-895d-5b70755fd774) | ![imatge](https://github.com/user-attachments/assets/383af7dd-03bf-4cb7-8fbc-45281de9baeb)
#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/7994.