### PR TITLE
Pierian: fixing esc_html_e pointed by Theme Check plugin

### DIFF
--- a/pierian/patterns/sidebar-right.php
+++ b/pierian/patterns/sidebar-right.php
@@ -19,7 +19,7 @@
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group"><!-- wp:image {"aspectRatio":"3/4","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"color":[]}} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/sappho_marble-profile.jpg" alt="<?php esc_html_e('Marble statue of Sappho on side profile.', 'pierian');?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/sappho_marble-profile.jpg" alt="<?php esc_attr_e('Marble statue of Sappho on side profile.', 'pierian');?>" style="aspect-ratio:3/4;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"align":"left"} -->


### PR DESCRIPTION
After all changes, Theme Check replied with the message below. It is now fixed.

```
WARNING: Found ="<?php esc_html_e in patterns/sidebar-right.php. Use esc_attr_e() inside HTML attributes, and esc_url() for link attributes. A manual review is needed.
Line 22: <figure class='wp-block-image size-full'><img src='<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/assets/images/sappho_marble-profile.jpg' alt='<?php esc_html_e('Marble statue of Sappho on side profile.', 'pierian');?
```
