### PR TITLE
Refactor pre commit hook to be an ESM Module

### DIFF
--- a/pre-commit-hook.mjs
+++ b/pre-commit-hook.mjs
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { execSync } from 'child_process';
-import { spawnSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import chalk from 'chalk';
 import path from 'path';
@@ -10,8 +9,8 @@ import _ from 'lodash';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __filename = fileURLToPath( import.meta.url );
+const __dirname = dirname( __filename );
 
 /*
  * A lot of this code has been liberally borrowed from the wp-calypso pre-commit script


### PR DESCRIPTION
While reviewing themes using node@^20.14, I started running into this issue when trying to commit:

```sh
➜  themes git:(trunk) ✗ git commit
→ No staged files found.
/Users/vcanales/dev/themes/pre-commit-hook.js:7
const chalk = require( 'chalk' );
              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/vcanales/dev/themes/node_modules/chalk/source/index.js from /Users/vcanales/dev/themes/pre-commit-hook.js not supported.
Instead change the require of index.js in /Users/vcanales/dev/themes/pre-commit-hook.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/vcanales/dev/themes/pre-commit-hook.js:7:15) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.14.0
husky - pre-commit script failed (code 1)
```

The error suggests using a dynamic import as a solution, but the error itself is caused by the fact that `chalk` is an ESM Module that cannot be imported using CommonJS `require()`. This means that a more robust solution that ensures this will not happen if other dependencies are ESM Modules is to turn this pre-commit hook into an ESM Module.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->
