### PR TITLE
Lock chalk dependency at 4.1.2 to avoid node ESM import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@wordpress/stylelint-config": "^22.6.0",
 		"ajv": "^8.17.1",
 		"ajv-draft-04": "^1.0.0",
-		"chalk": "^5.3.0",
+		"chalk": "4.1.2",
 		"chokidar-cli": "^3.0.0",
 		"fast-glob": "^3.3.2",
 		"fs-extra": "^11.2.0",


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

- Downgrade `chalk` package dependency from `v5.3.0` to `v4.1.2` to avoid a commit error when requiring dependencies in [pre-commit-hook.js](https://github.com/Automattic/themes/blob/522a37b70c224eefeaca5f6594e74d585bdcbe3f/pre-commit-hook.js) with `require()` because Chalk v5 is an ES module.


#### Related issue(s):

```
const chalk = require( 'chalk' );
              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/Ola/Web/themes/node_modules/chalk/source/index.js from /Users//Web/themes/pre-commit-hook.js not supported.
Instead change the require of index.js in /Users/Ola/Web/themes/pre-commit-hook.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/Ola/Web/themes/pre-commit-hook.js:7:15) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v19.9.0
husky - pre-commit script failed (code 1)
```
