### PR TITLE
Do not add padding in carusel block

### DIFF
--- a/rebalance/style.css
+++ b/rebalance/style.css
@@ -2154,7 +2154,7 @@ a:active {
 /* Large Screens */
 @media screen and (min-width: 881px) {
 
-	.page .page {
+	.page .page:not(.wp-block-newspack-blocks-carousel .page) {
 		padding: 50px 15%;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/56910

#### Changes proposed in this Pull Request:
In wp.com, there is an issue with the carousel block on pages, where the pages appear broken, see linked issue. This PR fixes this issue

#### Related issue(s):
Raised initially in: https://github.com/Automattic/wp-calypso/issues/56910

#### How to reproduce and test:
- In an installation that has the [carousel block](https://github.com/Automattic/newspack-blocks/releases) installed, activate the Rebalance theme.
- Create a couple of pages and add a featured image to them.
- On another page add the carousel block
- Observe that the pages appear broken.
- Switch to this branch and try again.
- Observe that the carousel is correct.

#### Before
![Screenshot 2024-09-11 at 14 16 02](https://github.com/user-attachments/assets/c5604990-66bc-4571-8d1e-e52d1de1b57e)

#### After
![Screenshot 2024-09-11 at 14 36 49](https://github.com/user-attachments/assets/43db862d-d217-44e4-9065-eba3ac89c28b)
