### PR TITLE
Indice: Fix a wrong tag

### DIFF
--- a/indice/readme.txt
+++ b/indice/readme.txt
@@ -1,7 +1,7 @@
 === Indice ===
 Contributors: 
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.6
 Requires PHP: 5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/indice/style.css
+++ b/indice/style.css
@@ -5,13 +5,13 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Indice is a tribute to the iconic indicehibit, an archetypal open source CMS that was heavily used by a generation of designers in the early web due to its simplicity and charm.
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.6
 Requires PHP: 5.7
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: indice
-Tags: blog, portfolio, two-column, wide-blocks, block-styles, full-site-editing, rtl-language-support, style-variations, threaded-comments, translation-ready
+Tags: blog, portfolio, two-columns, wide-blocks, block-styles, full-site-editing, rtl-language-support, style-variations, threaded-comments, translation-ready
 */
 
 /*


### PR DESCRIPTION
`two-column` -> `two-columns`