### PR TITLE
Bump node version for theme version workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 19
+          node-version: 20
           
       - name: Install node dependencies
         run: npm install


### PR DESCRIPTION
The minimum version required by the project is not compatible with what we were currently using.
