### PR TITLE
Theme validation: Reintroduce missing variables

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1768,13 +1768,12 @@ async function validateThemes( themes, { format, color, tableWidth } ) {
 			? `${ themeRequires }.0`.split( '.', 2 ).join( '.' )
 			: undefined;
 		const isSupportedWpVersion =
-			wpVersion && semver.gte( `${ wpVersion }.0`, '5.9.0' );
-
-		const hasThemeJson = fs.existsSync( themeJsonPath );
-		const hasThemeJsonSupport =
 			wpVersion &&
 			semver.valid( `${ wpVersion }.0` ) &&
-			isSupportedWpVersion;
+			semver.gte( `${ wpVersion }.0`, '5.9.0' );
+
+		const hasThemeJson = fs.existsSync( themeJsonPath );
+		const hasThemeJsonSupport = wpVersion && isSupportedWpVersion;
 
 		if ( hasThemeJson && ! hasThemeJsonSupport ) {
 			problems.push(

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1774,7 +1774,7 @@ async function validateThemes( themes, { format, color, tableWidth } ) {
 		const hasThemeJsonSupport =
 			wpVersion &&
 			semver.valid( `${ wpVersion }.0` ) &&
-			semver.gte( `${ wpVersion }.0`, '5.9.0' );
+			isSupportedWpVersion;
 
 		if ( hasThemeJson && ! hasThemeJsonSupport ) {
 			problems.push(

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1770,6 +1770,12 @@ async function validateThemes( themes, { format, color, tableWidth } ) {
 		const isSupportedWpVersion =
 			wpVersion && semver.gte( `${ wpVersion }.0`, '5.9.0' );
 
+		const hasThemeJson = fs.existsSync( themeJsonPath );
+		const hasThemeJsonSupport =
+			wpVersion &&
+			semver.valid( `${ wpVersion }.0` ) &&
+			semver.gte( `${ wpVersion }.0`, '5.9.0' );
+
 		if ( hasThemeJson && ! hasThemeJsonSupport ) {
 			problems.push(
 				createProblem( {


### PR DESCRIPTION
### Description

Running the theme validation script is failing in trunk, because of missing variables. This PR reintroduces these variables.


`trunk`:
```sh
➜  themes git:(trunk) node theme-utils.mjs validate-theme --format=json $(find . -name 'style.css' | awk -F/ '{print $2}' | uniq | sort | paste -s -d, -) | jq '.[].data[].message' | sort | uniq -c | sort -bgr

file:///Users/vcanales/dev/themes/theme-utils.mjs:1773
                if ( hasThemeJson && ! hasThemeJsonSupport ) {
                ^

ReferenceError: hasThemeJson is not defined
    at validateThemes (file:///Users/vcanales/dev/themes/theme-utils.mjs:1773:3)
    at async Object.run (file:///Users/vcanales/dev/themes/theme-utils.mjs:192:4)
    at async start (file:///Users/vcanales/dev/themes/theme-utils.mjs:210:2)

Node.js v20.14.0
```




#### Related issue(s):

Fix for https://github.com/Automattic/themes/pull/8068#issuecomment-2356115802
