### PR TITLE
Remove fixed font-size from post title block on blockbase themes

### DIFF
--- a/arbutus/theme.json
+++ b/arbutus/theme.json
@@ -63,11 +63,6 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
-			},
-			"core/post-title": {
-				"typography": {
-					"fontSize": "48px"
-				}
 			}
 		},
 		"typography": {

--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -683,7 +683,6 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},

--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -201,7 +201,6 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(3rem, 7vw), 4rem)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "1.2"
 				}

--- a/mayland-blocks/theme.json
+++ b/mayland-blocks/theme.json
@@ -133,7 +133,6 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"lineHeight": "var(--wp--custom--heading--typography--line-height)"
 				}
 			},

--- a/meraki/theme.json
+++ b/meraki/theme.json
@@ -134,7 +134,6 @@
 			"core/post-title": {
 				"typography": {
 			        	"fontFamily": "var:preset|font-family|jost",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "500",
 					"lineHeight": "1.2"
 				},

--- a/quadrat/theme.json
+++ b/quadrat/theme.json
@@ -212,7 +212,6 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "min(max(3rem, 7vw), 5rem)",
 					"fontWeight": "var(--wp--custom--heading--typography--font-weight)",
 					"lineHeight": "1.2"
 				}

--- a/russell/theme.json
+++ b/russell/theme.json
@@ -76,8 +76,7 @@
             },
             "core/post-title": {
                 "typography": {
-			        "fontFamily": "var:preset|font-family|libre-baskerville",
-                    "fontSize": "var(--wp--preset--font-size--x-large)"
+			        "fontFamily": "var:preset|font-family|libre-baskerville"
                 }
             }
         },

--- a/seedlet-blocks/theme.json
+++ b/seedlet-blocks/theme.json
@@ -172,7 +172,6 @@
             		},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 			        	"fontFamily": "var:preset|font-family|playfair-display"
 				}
 			},

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -211,7 +211,6 @@
 					}
 				},
 				"typography": {
-					"fontSize": "min(max(3rem, 7vw), 4rem)",
 					"fontWeight": "700",
 					"lineHeight": 1.2
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

If we decide to go with this approach ([see this discussion in the issue](https://github.com/Automattic/themes/issues/8046)), it removes the fixed font-size from post title block on blockbase themes.

#### Related issue(s):

https://github.com/Automattic/themes/issues/8046

# Screenshots

With the screenshots, I also described if it was needed to change the child theme and the default tag of the post title in the page template.

## Blockbase

- Default heading tag: `h2`.

I took the screenshot from the "All Archives" template only for the Blockbase theme to save time.

#### Before

<img width="957" alt="_blockbase-current" src="https://github.com/user-attachments/assets/d3f97213-26e9-4963-a7ce-34d0210cc7fc">

<img width="959" alt="_blockbase-archive-current" src="https://github.com/user-attachments/assets/b1f02dcf-990a-434f-a5b0-6261470d151c">

#### After

<img width="957" alt="_blockbase-without-fontsize-h2" src="https://github.com/user-attachments/assets/7904a162-657e-469e-9acf-0390d65f1963">

<img width="966" alt="_blockbase-archive-without-fontsize-h2" src="https://github.com/user-attachments/assets/9461803c-c890-4309-b6c6-d5f04985b1f6">

## Ames

- Default heading tag: `h2`.

#### Before

<img width="959" alt="ames-current" src="https://github.com/user-attachments/assets/34cbaab8-0b85-4598-ae8a-1e38c325c21d">

#### After

<img width="962" alt="ames-without-fontsize-h2" src="https://github.com/user-attachments/assets/3386695d-c5b4-40fc-ac45-dcf2c7f75029">

## Antonia

- Default heading tag: `h2`.

#### Before

<img width="959" alt="antonia-current" src="https://github.com/user-attachments/assets/c5dac458-d9ed-4898-9534-d1a2a0cff5cf">

#### After

<img width="954" alt="antonia-without-fontsize-h2" src="https://github.com/user-attachments/assets/0f07ee69-1edb-45f9-b85d-ba0ae8405194">

## Appleton

- Default heading tag: `h2`.

#### Before

<img width="952" alt="appleton-current" src="https://github.com/user-attachments/assets/ca743f0a-73f7-4c25-818c-bc262b0ba9ab">

#### After

<img width="957" alt="appleton-without-fontsize-h2" src="https://github.com/user-attachments/assets/b1ec9131-746d-4e6f-81cb-40991faa981b">

## Arbustus

- Default heading tag: `h2`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="960" alt="arbutus-current" src="https://github.com/user-attachments/assets/d541edae-efd9-4812-b195-f1c44bed532b">

#### After

<img width="960" alt="arbutus-without-font-size-h2-needed-theme-change" src="https://github.com/user-attachments/assets/ee60f3b2-46a7-46ca-b616-42d6bfbf150c">

## Attar

- Default heading tag: `h2`.

#### Before

<img width="959" alt="attar-current" src="https://github.com/user-attachments/assets/92fc6781-bd85-482e-84f5-b1b45908d4cd">

#### After

<img width="956" alt="attar-without-fontsize-h2" src="https://github.com/user-attachments/assets/5eedb005-502a-44e3-8b16-1df682f9494d">

## Barnett

- Default heading tag: `h2`.

#### Before

<img width="955" alt="barnett-current" src="https://github.com/user-attachments/assets/34ff1e53-5447-405e-b3fd-aa95219a7760">

#### After

<img width="961" alt="barnett-without-fontsize-h2" src="https://github.com/user-attachments/assets/fb80c5ea-3c47-4b8d-b8bb-cf33ed3c33c9">

## Bennett

- Default heading tag: `h2`.

#### Before

<img width="954" alt="bennett-current" src="https://github.com/user-attachments/assets/5cf919f7-e5f8-4f15-9fd9-a69af999de31">

#### After

<img width="962" alt="bennett-without-fontsize-h2" src="https://github.com/user-attachments/assets/87d1d776-e898-457f-aa9b-ac8939167efa">

## Blank Canvas

- Default heading tag: `h2`.

#### Before

<img width="960" alt="blank-canvas-current" src="https://github.com/user-attachments/assets/27aa1dcf-b3e9-4150-8e23-45acac60429b">

#### After

<img width="957" alt="blank-canvas-without-fontsize-h2" src="https://github.com/user-attachments/assets/d08eac9c-4394-40f4-86bc-82ba0c939b7b">

## Calvin

- Default heading tag: `h2`.

#### Before

<img width="953" alt="calvin-current" src="https://github.com/user-attachments/assets/c0ccd5d0-e08b-4ba5-9034-dd7ed916da5f">

#### After

<img width="959" alt="calvin-without-fontsize-h2" src="https://github.com/user-attachments/assets/b2183966-96d9-47aa-b1af-03dd03044baa">

## Dorna

- Default heading tag: `h2`.

#### Before

<img width="959" alt="dorna-current" src="https://github.com/user-attachments/assets/28118c36-8238-42c3-a3e4-03e777472427">

#### After

<img width="959" alt="dorna-without-fontsize-h2" src="https://github.com/user-attachments/assets/441be189-4af1-413c-9df3-d154ffd07fef">

## Farrow

- Default heading tag: `h2`.

#### Before

<img width="958" alt="farrow-current" src="https://github.com/user-attachments/assets/88b25744-f0c1-49ae-8ced-e36350b35d6d">

#### After

<img width="957" alt="farrow-without-fontsize-h2" src="https://github.com/user-attachments/assets/581992cb-0f61-47a7-9a38-8a6a32fc21b5">

## Geologist

- Default heading tag: `h1`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="961" alt="geologist-current" src="https://github.com/user-attachments/assets/fa11431c-a2c7-4c28-8a48-58e26c98c18a">

#### After

<img width="927" alt="geologist-without-fontsize-h1-needed-theme-change" src="https://github.com/user-attachments/assets/94ee7c39-e5a6-4c59-98f2-6d04102009e4">

## Hari

- Default heading tag: `h2`.

#### Before

<img width="930" alt="hari-current" src="https://github.com/user-attachments/assets/c21356b2-2f98-4acb-af95-3e0b40148205">

#### After

<img width="928" alt="hari-without-fontsize-h2" src="https://github.com/user-attachments/assets/cfe00d81-e1a8-46c4-a065-00eb125705f0">

## Heiwa

- Default heading tag: `h2`.

#### Before

<img width="891" alt="heiwa-current" src="https://github.com/user-attachments/assets/5cb135da-b0b1-4a0c-85ad-66df73ea6abd">

#### After

<img width="892" alt="heiwa-without-fontsize-h2" src="https://github.com/user-attachments/assets/52f557c7-e33e-4be4-864a-d9c364c62588">

## Jackson

- Default heading tag: `h2`.

#### Before

<img width="927" alt="jackson-current" src="https://github.com/user-attachments/assets/54472728-b29c-42dc-be10-f81f7a1107da">

#### After

<img width="928" alt="jackson-without-fontsize-h2" src="https://github.com/user-attachments/assets/ab47bfad-4377-4413-89ed-fc4b13904229">

## Kingsley

- Default heading tag: `h2`.

#### Before

<img width="923" alt="kingsley-current" src="https://github.com/user-attachments/assets/46ca9b54-4668-4ae1-91f1-b90ea45cf384">

#### After

<img width="922" alt="kingsley-without-fontsize-h2" src="https://github.com/user-attachments/assets/a9eb4217-ff9b-4fb1-9862-94fce5f2762f">

## Marl

- Default heading tag: `h2`.

#### Before

<img width="924" alt="marl-current" src="https://github.com/user-attachments/assets/fd4f6faf-9e8e-450a-bc2d-611e9bf1fce7">

#### After

<img width="927" alt="marl-without-fontsize-h2" src="https://github.com/user-attachments/assets/1f1ac79f-ed83-4db9-81d6-0ea392003a4d">

## Mayland (Blocks)

- Default heading tag: `h1`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="921" alt="mayland-blocks-current" src="https://github.com/user-attachments/assets/4631958a-27e0-4457-b66c-6ccea7dd4a4b">

#### After

<img width="922" alt="mayland-blocks-without-fontsize-h1" src="https://github.com/user-attachments/assets/81a63ad2-7ca2-4d32-adc7-ca60dead1cc0">

## Meraki

- Default heading tag: `h2`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="928" alt="meraki-current" src="https://github.com/user-attachments/assets/78111202-ab3d-4728-9d2a-3251ed245c9b">

#### After

<img width="929" alt="meraki-without-font-size-h2-needed-theme-change" src="https://github.com/user-attachments/assets/a8d1c437-c8ba-432d-8061-f5bd1c8a55ed">

## Quadrat

- Default heading tag: `h1`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="922" alt="quadrat-current" src="https://github.com/user-attachments/assets/20833922-12c0-4a0c-b1e7-3b56068144b4">

#### After

<img width="923" alt="quadrat-without-font-size-h1-needed-theme-change" src="https://github.com/user-attachments/assets/0f1a681b-c4df-4639-bd00-038e2e73749a">

## Russell

- Default heading tag: `h2`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="924" alt="russell-current" src="https://github.com/user-attachments/assets/25f08e57-693d-44c2-8b25-03731c82bfb9">

#### After

<img width="931" alt="russell-without-fontsize-h2-needed-theme-change" src="https://github.com/user-attachments/assets/3d5159ad-dcab-432f-9120-166d04919416">

## Seedlet (Blocks)

- Default heading tag: `h1`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="654" alt="seedlet-blocks-current" src="https://github.com/user-attachments/assets/465994eb-ed41-488b-9a7f-10e940e423ec">

#### After

<img width="639" alt="seedlet-blocks-without-font-size-h1-needed-theme-change" src="https://github.com/user-attachments/assets/bc9a1e3f-6b92-4550-857f-22c200595edd">

## Winkel

- Default heading tag: `h2`.

#### Before

<img width="925" alt="winkel-current" src="https://github.com/user-attachments/assets/e8a362b8-2628-42a6-ac66-8fd86cde4f6b">

#### After

<img width="923" alt="winkel-without-fontsize-h2" src="https://github.com/user-attachments/assets/f4ff619b-30c2-4d30-9d01-8ed4fd54dfe7">

## Zoologist

- Default heading tag: `h1`.
- Also needed a change in the child `theme.json`.

#### Before

<img width="930" alt="zoologist-current" src="https://github.com/user-attachments/assets/9ebd03e7-4af9-4f17-8872-ad37e99b3244">

#### After

<img width="930" alt="zoologist-without-font-size-h1-needed-theme-change" src="https://github.com/user-attachments/assets/945ce46d-8f48-41ef-afa2-2950f9cfce11">


