### PR TITLE
Use theme-check plugin master branch instead of a particular PR

### DIFF
--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install and activate Theme Check plugin
       run: |
-        wp-env run cli wp plugin install https://github.com/WordPress/theme-check/archive/refs/pull/458/head.zip --activate
+        wp-env run cli wp plugin install https://github.com/WordPress/theme-check/archive/refs/heads/master.zip --activate
 
     - name: Get changed root folders
       uses: actions/github-script@v6


### PR DESCRIPTION
## What?
Use theme-check plugin master branch instead of a particular PR


## Why?
We were using a particular PR that included the wp-cli integration to run the theme-check plugin in the CI environment. That branch is merged now, so we can use master. 