### PR TITLE
Assembler: Remove inherited color styling from linked headings

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -14,12 +14,6 @@ Text Domain: assembler
 Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, style-variations, template-editing, theme-options, threaded-comments, translation-ready
 */
 
-/* Make link colors match text colors. */
-
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-    color: inherit;
-}
-
 /* Remove auto-applied padding on headings when color is applied. */
 
 h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.has-background, h6.has-background {

--- a/assembler/style.css
+++ b/assembler/style.css
@@ -14,12 +14,6 @@ Text Domain: assembler
 Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, style-variations, template-editing, theme-options, threaded-comments, translation-ready
 */
 
-/* Make link colors match text colors. */
-
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-    color: inherit !important;
-}
-
 /* Remove auto-applied padding on headings when color is applied. */
 
 h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.has-background, h6.has-background {

--- a/assembler/style.css
+++ b/assembler/style.css
@@ -14,6 +14,12 @@ Text Domain: assembler
 Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, style-variations, template-editing, theme-options, threaded-comments, translation-ready
 */
 
+/* Make link colors match text colors. */
+
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    color: inherit;
+}
+
 /* Remove auto-applied padding on headings when color is applied. */
 
 h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.has-background, h6.has-background {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Fixes https://github.com/Automattic/themes/issues/8193.

#### Changes proposed in this Pull Request:

- Assembler: Remove inherited color styling from linked headings

There doesn't seem to be a need for the `!important` inherited color override that is causing small regression with the hover link color.

#### Testing instructions:

1. Add `Title` and `Heading` blocks to a page / post and make sure these titles are linked somewhere (`#` should be enough).
2. Try changing blocks' colors, including hover color through the editor sidebar.
3. Adjust link and text colors through the Global Styles.
4. There should be no regressions or unexpected color styling on the published page / post.
5. Try to reproduce https://github.com/Automattic/themes/issues/8193. It shouldn't be possible.

#### Related issue(s):

- https://github.com/Automattic/themes/issues/8193
- related comment: https://github.com/Automattic/themes/pull/8027#pullrequestreview-2328174006