### PR TITLE
Startorg: Remove Rubik font from heading definition

### DIFF
--- a/startorg/theme.json
+++ b/startorg/theme.json
@@ -620,7 +620,6 @@
 					"text": "var(--wp--preset--color--contrast)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--rubik)",
 					"fontStyle": "normal",
 					"fontWeight": "600",
 					"lineHeight": "1.125"


### PR DESCRIPTION
Remove Rubik font from heading definition