### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report issues with one of our products.
 labels: [ 'Needs triage', '[Type] Bug' ]
+type: 'Bug'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This was added as an option as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/



#### Related issue(s):
