### PR TITLE
Kawaii-chan: fixes heading font issue

### DIFF
--- a/kawaii-chan/theme.json
+++ b/kawaii-chan/theme.json
@@ -167,7 +167,7 @@
 							"fontFamily": "Modak",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": "file:./assets/fonts/modak/modak_regular_400.woff2"
+							"src": "file:./assets/fonts/modak/modak_normal_400.ttf"
 						}
 					],
 					"fontFamily": "Modak, system-ui",

--- a/kawaii-chan/theme.json
+++ b/kawaii-chan/theme.json
@@ -167,7 +167,7 @@
 							"fontFamily": "Modak",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": "file:./assets/fonts/modak/modak_normal_400.ttf"
+							"src": "file:./assets/fonts/modak/modak_normal_400.woff2"
 						}
 					],
 					"fontFamily": "Modak, system-ui",


### PR DESCRIPTION
This PR fixes the failing heading font, Modak. There was a typo on the theme.json.