### PR TITLE
Pendant: Underline links by default and remove on hover / focus

### DIFF
--- a/pendant/style.css
+++ b/pendant/style.css
@@ -35,7 +35,6 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
  */
 a {
 	cursor: pointer;
-	text-decoration-line: none;
 }
 :is(h1, h2, h3, h4, h5, h6) a:is(:hover, :focus) {
 	text-underline-offset: 0.15em;

--- a/pendant/theme.json
+++ b/pendant/theme.json
@@ -375,19 +375,19 @@
 			},
 			"link": {
 				"typography": {
-					"textDecoration": "none"
+					"textDecoration": "underline"
 				},
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				},
 				":hover": {
 					"typography": {
-						"textDecoration": "underline"
+						"textDecoration": "none"
 					}
 				},
 				":focus": {
 					"typography": {
-						"textDecoration": "underline"
+						"textDecoration": "none"
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Fixes #7505.

#### Changes proposed in this Pull Request:
Underline links by default and remove on hover / focus.

![Screenshot 2024-10-10 at 2 54 07 PM](https://github.com/user-attachments/assets/4219181d-20fa-4de9-99a6-6e5e879d5b56)