### PR TITLE
Blockbase: Remove hardcoded styling for navigation block

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -355,16 +355,7 @@ input[type=checkbox] + label {
   color: var(--wp--custom--latest-posts--meta--color--text);
 }
 
-.wp-block-navigation .has-child .wp-block-navigation__submenu-container {
-  background-color: var(--wp--custom--navigation--submenu--color--background);
-  border: var(--wp--custom--navigation--submenu--border--width) var(--wp--custom--navigation--submenu--border--style) var(--wp--custom--navigation--submenu--border--color);
-}
-.wp-block-navigation .has-child .wp-block-navigation__submenu-container a {
-  color: var(--wp--custom--navigation--submenu--color--text);
-}
-.wp-block-navigation.is-responsive:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
-  background-color: var(--wp--custom--color--background);
-  color: var(--wp--custom--color--foreground);
+.wp-block-navigation.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
   padding-left: var(--wp--custom--gap--horizontal);
   padding-right: var(--wp--custom--gap--horizontal);
 }
@@ -435,26 +426,15 @@ input[type=checkbox] + label {
 }
 
 /* Additional Styling for header-linear */
-.wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-navigation-link a:hover {
-  background: transparent;
-}
-.wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-pages-list__item .wp-block-pages-list__item__link,
-.wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-navigation-link__content {
-  color: var(--wp--custom--color--foreground);
-}
 .wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-pages-list__item .wp-block-pages-list__item__link:hover,
 .wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-navigation-link__content:hover {
   text-decoration: underline;
 }
-.wp-block-navigation.blockbase-responsive-navigation-linear:not(.has-background) .wp-block-navigation__submenu-container {
-  background-color: var(--wp--custom--color--background);
-  border-color: var(--wp--custom--color--tertiary);
-}
-.wp-block-navigation.blockbase-responsive-navigation-linear .wp-block-navigation__mobile-menu-open-button {
-  color: var(--wp--custom--color--primary);
-}
-.wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
-  background-color: var(--wp--custom--color--tertiary);
+.wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-item a {
+  font-size: var(--wp--custom--font-sizes--normal);
+  line-height: 50px;
+  margin: 0;
+  align-items: flex-end;
 }
 .wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item,
 .wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-item {
@@ -473,7 +453,6 @@ input[type=checkbox] + label {
 .wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-navigation-item.has-child .wp-block-navigation__submenu-container {
   gap: 0;
   padding: 0 19px 0 0;
-  border-right: 1px solid var(--wp--custom--color--foreground);
 }
 .wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-pages-list__item__link,
 .wp-block-navigation.blockbase-responsive-navigation-linear.is-responsive .wp-block-navigation__responsive-container.is-menu-open.has-modal-open .wp-block-pages-list__item.has-child .wp-block-navigation__submenu-container .wp-block-navigation-item__content,

--- a/blockbase/sass/blocks/_navigation.scss
+++ b/blockbase/sass/blocks/_navigation.scss
@@ -1,20 +1,9 @@
 // See https://github.com/WordPress/gutenberg/issues/39052
 .wp-block-navigation {
-	// See https://github.com/WordPress/gutenberg/issues/34648
-	.has-child .wp-block-navigation__submenu-container {
-		background-color: var(--wp--custom--navigation--submenu--color--background);
-		border: var(--wp--custom--navigation--submenu--border--width) var(--wp--custom--navigation--submenu--border--style) var(--wp--custom--navigation--submenu--border--color);
-
-		a {
-			color: var(--wp--custom--navigation--submenu--color--text);
-		}
-	}
 
 	&.is-responsive {
 
-		&:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
-			background-color: var(--wp--custom--color--background);
-			color: var(--wp--custom--color--foreground);
+		.wp-block-navigation__responsive-container.is-menu-open {
 			padding-left: var(--wp--custom--gap--horizontal);
 			padding-right: var(--wp--custom--gap--horizontal);
 		}
@@ -111,35 +100,24 @@
 /* Additional Styling for header-linear */
 .wp-block-navigation.blockbase-responsive-navigation-linear {
 
-	.wp-block-navigation-link a:hover {
-		background: transparent;
-	}
-
 	.wp-block-pages-list__item .wp-block-pages-list__item__link,
 	.wp-block-navigation-link__content {
-		color: var(--wp--custom--color--foreground);
 
 		&:hover {
 			text-decoration: underline;
 		}
 	}
 
-	&:not(.has-background) {
-
-		.wp-block-navigation__submenu-container {
-			background-color: var(--wp--custom--color--background);
-			border-color: var(--wp--custom--color--tertiary);
-		}
-	}
-
-	.wp-block-navigation__mobile-menu-open-button {
-		color: var(--wp--custom--color--primary);
-	}
-
 	&.is-responsive .wp-block-navigation__responsive-container.is-menu-open {
-		background-color: var(--wp--custom--color--tertiary);
 
 		&.has-modal-open {
+
+			.wp-block-navigation-item a {
+				font-size: var(--wp--custom--font-sizes--normal);
+				line-height: 50px;
+				margin: 0;
+				align-items: flex-end;
+			}
 
 			.wp-block-pages-list__item,
 			.wp-block-navigation-item {
@@ -158,7 +136,6 @@
 					.wp-block-navigation__submenu-container {
 						gap: 0;
 						padding: 0 19px 0 0;
-						border-right: 1px solid var(--wp--custom--color--foreground);
 
 						.wp-block-pages-list__item__link,
 						.wp-block-navigation-item__content {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove the hardcoded styling for the navigation block for Blockbase and its child themes. 

- Install the theme (or use the playground from the comment below - you can also use a child theme like meraki)
- Go to the Site Editor
- Edit the navigation by adding submenus
- Apply a background to the navigation
- Notice in the site editor that the background also applies to the submenus
- Save the changes and visit the front-end
- Notice that the dropdown submenu contains the background (just like in the SE)
- Try various style combinations (submenus with background, etc)

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/65419

**Before**

![Screenshot 2024-10-14 at 11 07 38](https://github.com/user-attachments/assets/af8dd59a-b875-4828-995b-6df1f1d3652c)
![Screenshot 2024-10-14 at 11 08 50](https://github.com/user-attachments/assets/94d80ef6-72bd-4a8f-bbcd-42a6c2cced01)


**After**
![Screenshot 2024-10-14 at 11 12 04](https://github.com/user-attachments/assets/48be248c-edee-4756-a227-8adc5ea48a89)
![Screenshot 2024-10-14 at 11 12 50](https://github.com/user-attachments/assets/8f3e055a-7003-46cb-9421-29d1966b1268)

