### PR TITLE
Assembler: Fix background color not showing for headings

### DIFF
--- a/assembler/theme.json
+++ b/assembler/theme.json
@@ -65,13 +65,6 @@
             "contentSize": "620px",
             "wideSize": "1440px"
         },
-        "blocks": {
-            "core/heading": {
-                "color": {
-                    "background": false
-                }
-            }
-        },
         "spacing": {
             "defaultSpacingSizes": false,
             "spacingScale": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Fixes #8238.

#### Changes proposed in this Pull Request:
Adds the background color setting back to headings for the Assembler theme. However, it seems that this change may have been made intentionally as part of https://github.com/Automattic/themes/pull/8027? Adding the author of that PR as reviewer for this one.