### PR TITLE
Update blockbase to better ensure type safety

### DIFF
--- a/blockbase/inc/fonts/custom-font-migration.php
+++ b/blockbase/inc/fonts/custom-font-migration.php
@@ -30,10 +30,14 @@ function migrate_blockbase_custom_fonts() {
 	// Look first for fonts customized via Customizer, then for fonts configured in the child theme.json "the old way"
 	// Also count fonts registerd to the blockbase font provider
 	foreach ( $font_families as $font_family ) {
-		if ( strpos( $font_family['slug'], 'heading' ) !== false && array_key_exists( 'fontSlug', $font_family ) ) {
+		if ( isset( $font_family['slug'] )
+			&& strpos( $font_family['slug'], 'heading' ) !== false
+			&& array_key_exists( 'fontSlug', $font_family ) ) {
 			$heading_font_slug = $font_family['fontSlug'];
 		}
-		if ( strpos( $font_family['slug'], 'body' ) !== false && array_key_exists( 'fontSlug', $font_family ) ) {
+		if ( isset( $font_family['slug'] )
+			&& strpos( $font_family['slug'], 'body' ) !== false
+			&& array_key_exists( 'fontSlug', $font_family ) ) {
 			$body_font_slug = $font_family['fontSlug'];
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The Blockbase custom font migration doesn't deal well with bad data. This increases the ability to deal with it a bit, by checking that some array keys exist before using them.

The error was `Warning: Undefined array key "slug"`, and now strict type checking is enabled for this file on wpcom, this is a fatal type error rather than a warning.

#### Related issue(s):

See p1728779070911429-slack-C4N88L95W


#### How to test

 1. Checkout this file locally
 2. Add `<?php declare( strict_types=1 );?>` as the new first line, to replicate what happens on wpcom
 3. scp to your sandbox
 4. Sandbox the site mentioned in the slack thread linked above
 5. access it via `curl --insecure <url> > test.html`
 6. Check your sandboxes error log, and see there are no errors.
 7. Unsandbox the site
 8. Open test.html in your browser
 9. See that the site is legible.