### PR TITLE
Podbase: Update version number

### DIFF
--- a/podbase/style.css
+++ b/podbase/style.css
@@ -7,7 +7,7 @@ Description: Sometimes, your podcast episode cover arts deserve more attention t
 Requires at least: 6.1
 Tested up to: 6.6
 Requires PHP: 5.7
-Version: 1.0.2
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: podbase


### PR DESCRIPTION
This PR bumps the version to have the same version at the Dotorg showcase and the repo.
The difference is due to a manual update on style.css during the theme submission.
I now understand we are not supposed to do it, and I won't repeat the process in future themes.

More themes on the same situation will be updates:
- Podbase
- Fixture
- Fixmate
- Happening
- Message
- MyMenu
- Retrato
- Promoter