### PR TITLE
Fixmate: bumps the version number

### DIFF
--- a/fixmate/readme.txt
+++ b/fixmate/readme.txt
@@ -14,6 +14,9 @@ Fixmate is a blog theme designed for individuals focusing on users who are into 
 
 == Changelog ==
 
+= 1.0.1 =
+* Updates version number to equal the showcase
+
 = 1.0.0 =
 * Initial release
 

--- a/fixmate/style.css
+++ b/fixmate/style.css
@@ -7,7 +7,7 @@ Description: Fixmate is a blog theme designed for individuals focusing on users 
 Requires at least: 6.0
 Tested up to: 6.6
 Requires PHP: 5.7
-Version: 1.0
+Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: fixmate


### PR DESCRIPTION
This PR updates the version to have the same theme at the Dotorg showcase and the repo.
The difference is related to a manual update during the theme submission that won't be repeated in future themes.

Related themes to be updated:

- Feature
- Happening
- Message
- MyMenu
- Retrato
- Promoter
