### PR TITLE
Happening: bumps the version number

### DIFF
--- a/happening/readme.txt
+++ b/happening/readme.txt
@@ -13,10 +13,10 @@ As its name states, Happening is a theme designed for events and ceremonies. It 
 == Changelog ==
 
 = 1.0.3 =
-* Updates version number to equal the showcase
+* Updates version number to equal the showcase (#8277)
 
 = 1.0.2 =
-* Updates version number to equal the showcase
+* Removes Holiday tag
 
 = 1.0.1 =
 * Multiple Themes: Fix broken template previews due to site-specific attributes in template/pattern markup (#7631)

--- a/happening/readme.txt
+++ b/happening/readme.txt
@@ -12,6 +12,12 @@ As its name states, Happening is a theme designed for events and ceremonies. It 
 
 == Changelog ==
 
+= 1.0.3 =
+* Updates version number to equal the showcase
+
+= 1.0.2 =
+* Updates version number to equal the showcase
+
 = 1.0.1 =
 * Multiple Themes: Fix broken template previews due to site-specific attributes in template/pattern markup (#7631)
 

--- a/happening/style.css
+++ b/happening/style.css
@@ -7,11 +7,11 @@ Description: As its name states Happening is a theme designed for events and cer
 Requires at least: 6.1
 Tested up to: 6.5
 Requires PHP: 5.7
-Version: 1.0.3
+Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: happening
-Tags: blog, food-and-drink, holiday, one-column, wide-blocks, block-patterns, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, flexible-header, full-site-editing, full-width-template, post-formats, rtl-language-support, theme-options, threaded-comments, translation-ready
+Tags: blog, food-and-drink, one-column, wide-blocks, block-patterns, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, flexible-header, full-site-editing, full-width-template, post-formats, rtl-language-support, theme-options, threaded-comments, translation-ready
 
 /* Progresive enhancement to reduce widows and orphans.
 /* https://github.com/WordPress/gutenberg/issues/55190


### PR DESCRIPTION
This PR updates the version to have the same theme at the Dotorg showcase and the repo.
The difference is related to a manual update during the theme submission that won't be repeated in future themes.

Related themes to be updated:
- Feature
- Fixmate
- Message
- MyMenu
- Retrato
- Promoter
