### PR TITLE
Message: bumps the version number

### DIFF
--- a/message/readme.txt
+++ b/message/readme.txt
@@ -14,6 +14,9 @@ Message is a theme that brings the mobile messaging experience to your WordPress
 
 == Changelog ==
 
+= 1.0.1 =
+* Updates version number to equal the showcase
+
 = 1.0.0 =
 * Initial release
 

--- a/message/style.css
+++ b/message/style.css
@@ -7,7 +7,7 @@ Description: Message is a theme that brings the mobile messaging experience to y
 Requires at least: 6.0
 Tested up to: 6.6
 Requires PHP: 5.7
-Version: 1.0.1
+Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: message


### PR DESCRIPTION
This PR updates the version to have the same theme at the Dotorg showcase and the repo.
The difference is related to a manual update during the theme submission that won't be repeated in future themes.

Related themes to be updated:
- Feature
- Fixmate
- Happening
- MyMenu
- Retrato
- Promoter