### PR TITLE
MyMenu: bumps the version number

### DIFF
--- a/mymenu/patterns/404.php
+++ b/mymenu/patterns/404.php
@@ -1,4 +1,3 @@
-<?php declare( strict_types = 1 ); ?>
 <?php
 /**
  * Title: 404

--- a/mymenu/patterns/archive.php
+++ b/mymenu/patterns/archive.php
@@ -1,4 +1,3 @@
-<?php declare( strict_types = 1 ); ?>
 <?php
 /**
  * Title: archive

--- a/mymenu/patterns/front-page.php
+++ b/mymenu/patterns/front-page.php
@@ -1,4 +1,3 @@
-<?php declare( strict_types = 1 ); ?>
 <?php
 /**
  * Title: front-page

--- a/mymenu/patterns/index.php
+++ b/mymenu/patterns/index.php
@@ -1,4 +1,3 @@
-<?php declare( strict_types = 1 ); ?>
 <?php
 /**
  * Title: index

--- a/mymenu/patterns/search.php
+++ b/mymenu/patterns/search.php
@@ -1,4 +1,3 @@
-<?php declare( strict_types = 1 ); ?>
 <?php
 /**
  * Title: search

--- a/mymenu/readme.txt
+++ b/mymenu/readme.txt
@@ -10,13 +10,13 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-My Menu is a simple theme designed to facilitate restaurant owners’ site-building experiences. It is clean, direct, and customizable. Test the cool style variations that have been added to the theme.
+MyMenu is a simple theme designed to facilitate restaurant owners’ site-building experiences. It is clean, direct, and customizable. Test the cool style variations that have been added to the theme.
 
 
 == Changelog ==
 
 = 1.0.2 =
-* Updates version number to equal the showcase
+* Updates version number to equal the showcase (#8282)
 
 = 1.0.1 =
 * Hard-coded links removed from patterns/front-page.php

--- a/mymenu/readme.txt
+++ b/mymenu/readme.txt
@@ -16,7 +16,7 @@ My Menu is a simple theme designed to facilitate restaurant owners’ site-build
 == Changelog ==
 
 = 1.0.2 =
-* MyMenu: fixing after review (#7946)
+* Updates version number to equal the showcase
 
 = 1.0.1 =
 * Hard-coded links removed from patterns/front-page.php

--- a/mymenu/style.css
+++ b/mymenu/style.css
@@ -7,7 +7,7 @@ Description: My Menu is a simple theme designed to facilitate restaurant ownersâ
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 5.7
-Version: 1.0.2
+Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: mymenu


### PR DESCRIPTION
This PR updates the version to have the same theme at the Dotorg showcase and the repo.
The difference is related to a manual update during the theme submission that won't be repeated in future themes.

**Related themes to be updated:**
- Feature
- Fixmate
- Happening
- Message
- Retrato
- Promoter
