### PR TITLE
Retrato: bumps the version number

### DIFF
--- a/retrato/readme.txt
+++ b/retrato/readme.txt
@@ -10,12 +10,12 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Besides an appreciable snapshot of the author, the theme immediately offers large titles and post metadata displayed on a grid with no Featured Images.
+Besides an appreciable snapshot of the author, the theme immediately offers large titles and post meta data displayed on a grid with no Featured Images.
 
 == Changelog ==
 
 = 1.0.1 =
-* Hard-coded links removed from patterns/front-page.php
+* Updates version number to equal the showcase (#8283)
 
 = 1.0.0 =
 * Initial release

--- a/retrato/readme.txt
+++ b/retrato/readme.txt
@@ -10,9 +10,12 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Besides an appreciable snapshot of the author, the theme immediately offers large titles and post meta data displayed on a grid with no Featured Images.
+Besides an appreciable snapshot of the author, the theme immediately offers large titles and post metadata displayed on a grid with no Featured Images.
 
 == Changelog ==
+
+= 1.0.1 =
+* Hard-coded links removed from patterns/front-page.php
 
 = 1.0.0 =
 * Initial release

--- a/retrato/style.css
+++ b/retrato/style.css
@@ -7,7 +7,7 @@ Description: Besides an appreciable snapshot of the author, the theme immediatel
 Requires at least: 
 Tested up to: 6.5
 Requires PHP: 
-Version: 1.0.1
+Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: retrato


### PR DESCRIPTION
This PR updates the version to have the same theme at the Dotorg showcase and the repo.
The difference is related to a manual update during the theme submission that won't be repeated in future themes.

**Related themes to be updated:**
- Feature
- Fixmate
- Happening
- Message
- MyMenu
- Promoter
