### PR TITLE
Blockbase: Fix font collection logic and add error handling

### DIFF
--- a/blockbase/inc/fonts/custom-fonts.php
+++ b/blockbase/inc/fonts/custom-fonts.php
@@ -118,14 +118,26 @@ function extract_font_slug_from_setting( $setting ) {
  * @return array Collection of all font slugs defined in the theme.json file
  */
 function collect_fonts_from_blockbase() {
-	$fonts                  = array();
-	$parent_theme_json_data = json_decode( file_get_contents( get_template_directory() . '/theme.json' ), true );
-	$font_families          = $parent_theme_json_data['settings']['typography']['fontFamilies'];
+	$fonts           = array();
+	$theme_json_path = get_template_directory() . '/theme.json';
 
-	foreach ( $font_families as $font ) {
-		// Only pick it up if we're claiming it as ours to manage
-		if ( array_key_exists( 'provider', $font ) && 'blockbase-fonts' === $font['provider'] ) {
-			$fonts[] = $font;
+	// Check if the file exists and is readable
+	if ( file_exists( $theme_json_path ) && is_readable( $theme_json_path ) ) {
+		$theme_json = file_get_contents( $theme_json_path );
+		if ( is_string( $theme_json ) ) {
+			$parent_theme_json_data = json_decode( $theme_json, true );
+
+			// Check if the file content was decoded properly
+			if ( is_array( $parent_theme_json_data ) && isset( $parent_theme_json_data['settings']['typography']['fontFamilies'] ) ) {
+				$font_families = $parent_theme_json_data['settings']['typography']['fontFamilies'];
+
+				foreach ( $font_families as $font ) {
+					// Only pick it up if we're claiming it as ours to manage
+					if ( array_key_exists( 'provider', $font ) && 'blockbase-fonts' === $font['provider'] ) {
+						$fonts[] = $font;
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue where the theme.json file isn't found.
This means the `file_content_contents` on that theme.json returns false which causes the `json_decode` to fatal.

This is an example of the fatal error I found;

```
PHP Fatal error:  Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, bool given in /home/wpcom/public_html/wp-content/themes/pub/blockbase/inc/fonts/custom-fonts.php:123
Stack trace:
#0 /home/wpcom/public_html/wp-content/themes/pub/blockbase/inc/fonts/custom-fonts.php(123): json_decode(false, true)
#1 /home/wpcom/public_html/wp-content/themes/pub/blockbase/inc/fonts/custom-fonts.php(214): collect_fonts_from_blockbase()
#2 /home/wpcom/public_html/wp-includes/class-wp-hook.php(324): blockbase_filter_jetpack_google_fonts_list(Array)
#3 /home/wpcom/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#4 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/modules/google-fonts/current/load-google-fonts.php(110): apply_filters('jetpack_google_...', Array)
#5 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/modules/google-fonts/current/load-google-fonts.php(132): jetpack_get_available_google_fonts_map(Array)
#6 /home/wpcom/public_html/wp-includes/class-wp-hook.php(324): jetpack_register_google_fonts_to_theme_json(Object(WP_Theme_JSON_Data))
#7 /home/wpcom/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters(Object(WP_Theme_JSON_Data), Array)
#8 /home/wpcom/public_html/wp-includes/class-wp-theme-json-resolver.php(175): apply_filters('wp_theme_json_d...', Object(WP_Theme_JSON_Data))
#9 /home/wpcom/public_html/wp-includes/class-wp-theme-json-resolver.php(658): WP_Theme_JSON_Resolver::get_core_data()
#10 /home/wpcom/public_html/wp-includes/global-styles-and-settings.php(128): WP_Theme_JSON_Resolver::get_merged_data('custom')
#11 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/extensions/blocks/subscriptions/subscriptions.php(590): wp_get_global_styles(Array, Array)
#12 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/extensions/blocks/subscriptions/subscriptions.php(575): Automattic\Jetpack\Extensions\Subscriptions\get_global_style_color('buttonBackgroun...', '#113AF5')
#13 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/extensions/blocks/subscriptions/subscriptions.php(544): Automattic\Jetpack\Extensions\Subscriptions\get_attribute_color('buttonBackgroun...', Array, '#113AF5')
#14 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/extensions/blocks/subscriptions/subscriptions.php(667): Automattic\Jetpack\Extensions\Subscriptions\get_element_styles_from_attributes(Array)
#15 /home/wpcom/public_html/wp-includes/class-wp-block.php(538): Automattic\Jetpack\Extensions\Subscriptions\render_block(Array, '', Object(WP_Block))
#16 /home/wpcom/public_html/wp-includes/blocks.php(2160): WP_Block->render()
#17 /home/wpcom/public_html/wp-includes/blocks.php(2212): render_block(Array)
#18 /home/wpcom/public_html/wp-includes/class-wp-hook.php(324): do_blocks('<!-- wp:paragra...')
#19 /home/wpcom/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters('<!-- wp:paragra...', Array)
#20 /home/wpcom/public_html/wp-includes/feed.php(196): apply_filters('the_content', '<!-- wp:paragra...')
#21 /home/wpcom/public_html/wp-includes/feed-rss2.php(104): get_the_content_feed('rss2')
#22 /home/wpcom/public_html/bin/blog-rss.php(114): require('/home/wpcom/pub...')
#23 {main}
  thrown in /home/wpcom/public_html/wp-content/themes/pub/blockbase/inc/fonts/custom-fonts.php on line 123
```

When processing the feed via `feedbag_async_process_feed` on WPCOM, the issue with accessing the themes.json file appears.

You can see this by running the `php feedbag-update-feed.php 107299487` from the bin directory (this manually uses `feedbag_async_process_feed` to add posts to feeds table);

<img width="664" alt="Screenshot 2024-10-23 at 13 29 53" src="https://github.com/user-attachments/assets/a92b6028-83af-4dfd-a418-f3a6fec04113">

If you watch the php error log when running this, you will see the fatal error highlighted above.

When this PR is pushed to sandbox, the issue is resolved;

<img width="866" alt="Screenshot 2024-10-23 at 13 34 49" src="https://github.com/user-attachments/assets/001ae347-07cb-4158-827a-3bd6fb610982">


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Adds checks around the theme.json file to make sure it exists, is readable and contains a string before trying to call `json_decode`.

#### Related issue(s):
