### PR TITLE
Handle specific themes in versionBumpThemes

### DIFF
--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -77,7 +77,7 @@ const commands = {
 	'version-bump-themes': {
 		helpText:
 			'Bump the version of any theme that has had changes since the last deployment. This includes bumping the version of any parent themes and updating the changelog for the theme. Optionally specify a single theme to version bump.',
-		run: ( args ) => versionBumpThemes(	args?.[ 1 ].split( /[ ,]+/ ) ),
+		run: ( args ) => versionBumpThemes(	args?.[ 1 ]?.split( /[ ,]+/ ) ),
 	},
 	'land-diff': {
 		helpText: 'Run gh pr merge to merge in the specified pull request id.',

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -76,8 +76,8 @@ const commands = {
 	},
 	'version-bump-themes': {
 		helpText:
-			'Bump the version of any theme that has had changes since the last deployment. This includes bumping the version of any parent themes and updating the changelog for the theme.',
-		run: versionBumpThemes,
+			'Bump the version of any theme that has had changes since the last deployment. This includes bumping the version of any parent themes and updating the changelog for the theme. Optionally specify a single theme to version bump.',
+		run: ( args ) => versionBumpThemes(	args?.[ 1 ].split( /[ ,]+/ ) ),
 	},
 	'land-diff': {
 		helpText: 'Run gh pr merge to merge in the specified pull request id.',
@@ -810,10 +810,10 @@ async function updateLastDeployedHash() {
  If a theme has changes also update its changelog.
  Commit the change.
 */
-async function versionBumpThemes() {
+async function versionBumpThemes( themeSlugs ) {
 	console.log( 'Version Bumping' );
 
-	const themes = await getActionableThemes();
+	const themes = themeSlugs ? themeSlugs : await getActionableThemes();
 	const latestTag = execSync( 'git describe --tags --abbrev=0' )
 		.toString()
 		.trim();


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds the ability to handle specific themes in `versionBumpThemes`, so that we can pass specific theme slugs to the `version-bump` GH action.

To test locally, try running `node ./theme-utils.mjs version-bump-themes` with specific theme slugs, e.g.

```
node ./theme-utils.mjs version-bump-themes beep
node ./theme-utils.mjs version-bump-themes beep,greenseed
```

The specific themes should be version-bumped successfully (if they have changes).

#### Related issue(s):
