### PR TITLE
Remove some themes from dotorg ignore list

### DIFF
--- a/.dotorg-ignore
+++ b/.dotorg-ignore
@@ -5,7 +5,6 @@ artly
 assembler
 attar
 awburn
-azur
 barnett
 barnsbury23
 beep
@@ -16,7 +15,6 @@ blogorama
 boxedbio
 calvin
 calyx
-chanson
 cortado
 covr
 craftfully
@@ -36,8 +34,6 @@ grammerone
 hall
 hari
 heiwa
-ici
-indice
 infield
 iotix
 issue
@@ -64,7 +60,6 @@ nook
 organizer
 otis
 overlaid
-perenne
 pieria
 poesis
 pomme
@@ -74,7 +69,6 @@ reverie
 ritratto
 russell
 screenplay
-shhh
 snd
 spearhead-blocks
 spiel
@@ -96,7 +90,6 @@ twentytwentytwo-swiss
 verso
 vetro
 winkel
-xanadu
 
 # General paths to be ignored when deploying to the WordPress.org theme repository
 inc/headstart


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Removes xanadu, indice, perenne, shhh, ici, azur, and chanson from the dotorg ignore list, so they can be deployed automatically to the dotorg repo.

cc @iamtakashi 