### PR TITLE
Fix cover hover reveal style on touch devices

### DIFF
--- a/dalston/block-extends/extend-cover-block-script.js
+++ b/dalston/block-extends/extend-cover-block-script.js
@@ -1,0 +1,22 @@
+document.addEventListener( 'DOMContentLoaded', function () {
+	// Check if the device supports hover.
+	// In this case, the effect is through CSS `:hover` selectors.
+	if ( window.matchMedia( '(hover: hover)' ).matches ) {
+		return;
+	}
+
+	const observer = new IntersectionObserver( ( entries ) => {
+		entries.forEach( entry => {
+			if ( entry.isIntersecting ) {
+				entry.target.classList.add( 'dalston-in-viewport' );
+			} else {
+				entry.target.classList.remove( 'dalston-in-viewport' );
+			}
+		});
+	}, { threshold: 0.6 } ); // Trigger when 60% of the element is visible
+
+	// Observe the elements with the hover reveal style.
+	document.querySelectorAll( '.is-style-hover-reveal' ).forEach( element => {
+		observer.observe( element );
+	} );
+} );

--- a/dalston/block-extends/extend-cover-block.css
+++ b/dalston/block-extends/extend-cover-block.css
@@ -9,6 +9,10 @@
 	opacity: 0;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-10 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-10:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-10 .wp-block-cover__gradient-background:hover,
@@ -16,6 +20,10 @@
 	opacity: .1;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-20 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-20:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-20 .wp-block-cover__gradient-background:hover,
@@ -23,6 +31,10 @@
 	opacity: .2;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-30 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-30:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-30 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-30:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-30 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-30:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-30 .wp-block-cover__gradient-background:hover,
@@ -30,6 +42,10 @@
 	opacity: .3;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-40 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-40:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-40 .wp-block-cover__gradient-background:hover,
@@ -37,6 +53,14 @@
 	opacity: .4;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim:not(.has-background-gradient):before,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim .wp-block-cover__gradient-background:hover,
@@ -48,6 +72,10 @@
 	opacity: .5;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-60 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-60:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-60 .wp-block-cover__gradient-background:hover,
@@ -55,6 +83,10 @@
 	opacity: .6;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-70 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-70:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-70 .wp-block-cover__gradient-background:hover,
@@ -62,6 +94,10 @@
 	opacity: .7;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-80 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-80:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-80 .wp-block-cover__gradient-background:hover,
@@ -69,6 +105,10 @@
 	opacity: .8;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-90 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-90:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-90 .wp-block-cover__gradient-background:hover,
@@ -76,6 +116,10 @@
 	opacity: .9;
 }
 
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100 .wp-block-cover__gradient-background,
+#editor .wp-block-cover-image.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100:not(.has-background-gradient):before,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100 .wp-block-cover__gradient-background,
+#editor .wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100:not(.has-background-gradient):before,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-100 .wp-block-cover__gradient-background:hover,
 #editor .wp-block-cover-image.is-style-hover-reveal.has-background-dim.has-background-dim-100:not(.has-background-gradient):hover:before,
 #editor .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-100 .wp-block-cover__gradient-background:hover,
@@ -107,6 +151,7 @@
 	transition: opacity 0.2s ease-in-out;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport .wp-block-cover__inner-container,
 .wp-block-cover.is-style-hover-reveal:hover .wp-block-cover__inner-container {
 	opacity: 1;
 }
@@ -122,31 +167,45 @@
 	transition: opacity 0.2s ease-in-out;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-0:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-0.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-0:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-0.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: 0;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-10.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-10:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-10.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .1;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-20.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-20:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-20.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .2;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-30:before,
+.wp-block-cover.is-style-hover-revea.dalston-in-viewport.has-background-dim.has-background-dim-30.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-30:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-30.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .3;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-40.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-40:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-40.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .4;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-gradient .wp-block-cover__gradient-background,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-50.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-50:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-gradient:hover .wp-block-cover__gradient-background,
@@ -154,26 +213,36 @@
 	opacity: .5;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-60.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-60:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-60.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .6;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-70.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-70:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-70.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .7;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-80.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-80:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-80.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .8;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-90.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-90:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-90.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: .9;
 }
 
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100:before,
+.wp-block-cover.is-style-hover-reveal.dalston-in-viewport.has-background-dim.has-background-dim-100.has-background-gradient .wp-block-cover__gradient-background,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-100:hover:before,
 .wp-block-cover.is-style-hover-reveal.has-background-dim.has-background-dim-100.has-background-gradient:hover .wp-block-cover__gradient-background {
 	opacity: 1;

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -272,6 +272,18 @@ function dalston_block_extends_styles() {
 add_action( 'enqueue_block_assets', 'dalston_block_extends_styles' );
 
 /**
+ * Enqueue Custom Cover Block Scripts
+ */
+function dalston_block_extends_scripts() {
+
+	wp_enqueue_script(
+		'dalston-extend-cover-block-script',
+		get_stylesheet_directory_uri() . '/block-extends/extend-cover-block-script.js'
+	);
+}
+add_action( 'enqueue_block_assets', 'dalston_block_extends_scripts' );
+
+/**
  * Whether this is an AMP endpoint.
  *
  * @see https://github.com/Automattic/amp-wp/blob/e4472bfa5c304b6c1b968e533819e3fa96579ad4/includes/amp-helper-functions.php#L248

--- a/dalston/functions.php
+++ b/dalston/functions.php
@@ -206,7 +206,7 @@ function dalston_editor_styles() {
 
 	// Hide duplicate palette colors
 	$colors_array = get_theme_mod( 'colors_manager', array( 'colors' => true ) ); // color annotations array()
-	if ( ! empty( $colors_array ) && $colors_array['colors']['txt'] != '#1E1E1E' ) { // $config-global--color-foreground-light-default;
+	if ( ! empty( $colors_array ) && ! empty( $colors_array['colors'] ) && ! empty( $colors_array['colors']['txt'] ) && $colors_array['colors']['txt'] != '#1E1E1E' ) { // $config-global--color-foreground-light-default;
 		$inline_palette_css = '.components-circular-option-picker__option-wrapper:nth-child(5),
 			.components-circular-option-picker__option-wrapper:nth-child(6) {
 				display: none;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

When using the hover reveal style in the Cover block, and the `hover` is not available in the browser, like in touch devices, it reveals the content when it's visible in the viewport while scrolling.

#### Known issues:

Effect in the layer is not working: https://github.com/Automattic/themes/issues/8377

#### Test Instructions:

1. Add multiple cover blocks with content to a page.
2. Select the style "Hover Reveal" for the Cover blocks (under styles in the editor sidebar).
3. Navigate through it in a normal browser, and make sure it continues working as previously (revealing the content on hover).
4. Navigate through it in a touch browser (works on mobile simulator in dev tools), and make sure the content is revealed as you scroll through it.

See a video of the result in the editor and in the frontend using the 2 types of scenarios (touch and mouse).

https://github.com/user-attachments/assets/8908c0a5-93fe-4684-8e8d-e456202069b2

#### Related issue(s):
https://github.com/Automattic/wp-calypso/issues/96070