### PR TITLE
Fix Lucette typography style JSON validation

### DIFF
--- a/assembler/styles/typography/09-lucette.json
+++ b/assembler/styles/typography/09-lucette.json
@@ -14,7 +14,7 @@
 		"versatile",
 		"quirky",
 		"contrasting",
-		"dynamic"
+		"dynamic",
 		"modern"
 	],
 	"settings": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

Follows #8358 

This PR fixes a JSON validation issue in the Lucette typography style variation.

#### Changes proposed in this Pull Request:

* Add a comma so that the file is valid JSON

Without this change, this particular style variation doesn't display:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/35702e11-8077-43a1-bbed-244d4a025824) | ![image](https://github.com/user-attachments/assets/1f96e82d-2ce9-426c-aacd-5db8b0c34fba) |