### PR TITLE
Loic: Add fix for SyntaxHighlighter max-width bug

### DIFF
--- a/loic/style.css
+++ b/loic/style.css
@@ -36,7 +36,7 @@ a {
 
 /*
  * SyntaxHighlighter styles
- * https: //github.com/Automattic/themes/issues/8387
+ * https://github.com/Automattic/themes/issues/8387
  */
 .entry-content:has(.syntaxhighlighter) {
 	max-width: 100%;

--- a/loic/style.css
+++ b/loic/style.css
@@ -33,3 +33,11 @@ a {
 	text-decoration-thickness: .0625em !important;
 	text-underline-offset: .15em;
 }
+
+/*
+ * SyntaxHighlighter styles
+ * https: //github.com/Automattic/themes/issues/8387
+ */
+.entry-content:has(.syntaxhighlighter) {
+	max-width: 100%;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Ensure the `.entry-content` containers with SyntaxHighlighter blocks have a max-width set so the SyntaxHighlighter doesn't overflow.

**Before**

<img width="1509" alt="Screenshot 2024-11-13 at 10 55 09 AM" src="https://github.com/user-attachments/assets/e635f67d-d5ee-405f-9fd4-3d53b68e462a">

**After**

<img width="1512" alt="Screenshot 2024-11-13 at 10 54 40 AM" src="https://github.com/user-attachments/assets/1dddf9fb-cf85-4395-8f85-ea1ab7fa0468">


#### Related issue(s):

Fixes https://github.com/Automattic/themes/issues/8387