### PR TITLE
Message: Fix for SyntaxHighlighter overflow and editor contrast

### DIFF
--- a/message/style.css
+++ b/message/style.css
@@ -46,3 +46,8 @@ a {
 .entry-content:has(.syntaxhighlighter) {
 	max-width: 100%;
 }
+
+.wp-block-syntaxhighlighter-code textarea {
+	color: black;
+	padding: .5em 1em;
+}

--- a/message/style.css
+++ b/message/style.css
@@ -38,3 +38,11 @@ a {
 	text-decoration-thickness: .0625em !important;
 	text-underline-offset: .15em;
 }
+
+/*
+ * SyntaxHighlighter styles
+ * https://github.com/Automattic/themes/issues/8247
+ */
+.entry-content:has(.syntaxhighlighter) {
+	max-width: 100%;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Ensure the `.entry-content` containers with SyntaxHighlighter blocks have a max-width set so the SyntaxHighlighter doesn't overflow.
* Specify contrasting color and padding on the textarea for SyntaxHighlighter blocks.
* Note the slight overflow due to padding should be fixed at the plugin level by https://github.com/Automattic/syntaxhighlighter/pull/278

**Before**

<img width="1122" alt="Screenshot 2024-11-13 at 11 17 37 AM" src="https://github.com/user-attachments/assets/9b6f232d-102c-4124-b7a5-409a45af94b1">

<img width="880" alt="Screenshot 2024-11-13 at 3 15 24 PM" src="https://github.com/user-attachments/assets/7a119046-9450-47e3-a4c7-ca297f06bdad">

**After**

<img width="806" alt="Screenshot 2024-11-13 at 11 17 47 AM" src="https://github.com/user-attachments/assets/d75f0b7a-54ab-4410-98d9-caf75f0a57b2">

<img width="889" alt="Screenshot 2024-11-13 at 3 11 55 PM" src="https://github.com/user-attachments/assets/ecb29547-43ae-4bd3-a3a1-1a96d3002927">


#### Related issue(s):

* https://github.com/Automattic/themes/issues/8247
* https://github.com/Automattic/themes/issues/8239