### PR TITLE
Fix: Contact form block dropdown arrow wrapping under field in Assembler theme 

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -72,8 +72,15 @@ input:not([type=submit]):not([type=checkbox]),
     font-weight: inherit;
     line-height: 1.5;
     min-height: 42px;
-    padding: 0.8rem 1rem;
     width: 100%;
+}
+
+textarea,
+.wp-block-post-comments-form textarea,
+.wp-block-post-comments-form input:not([type=submit]):not([type=checkbox]),
+.jetpack-contact-form .jetpack-field .jetpack-field__input,
+.jetpack-contact-form .jetpack-field .jetpack-field__textarea {
+    padding: 0.8rem 1rem;  
 }
 
 textarea:focus,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

It looks like grunion (I thought that was deprecated, but some of the code lives in jetpack apparently) is doing some weird class swapping around, and if we modify the padding of the input element it preaks the arrow for the select. It's really hard to debug because the plugin is doing something with class swapping and rewriting the CSS, so it's not as simple as overriding the class. It was a matter of trial and error to actually verify that the selector apparently causing this problem is in fact `input:not([type="submit"]):not([type="checkbox"])` when the element we are targeting is a select!!!

This PR removes the padding altogether from the general input element to avoid this.

Before | After
--- | ---
<img width="297" alt="Screenshot 2024-11-14 at 11 34 22" src="https://github.com/user-attachments/assets/7f31ade8-eee7-4fc2-970e-c6086302fb28"> | <img width="325" alt="Screenshot 2024-11-14 at 11 34 28" src="https://github.com/user-attachments/assets/949239fb-2e6e-4d44-ac0c-95b928c6c87a">


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/8035