### PR TITLE
Improve spacing within post content with content and patterns

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -14,22 +14,10 @@ Text Domain: assembler
 Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-colors, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, rtl-language-support, style-variations, template-editing, theme-options, threaded-comments, translation-ready
 */
 
-/* Remove auto-applied padding on headings when color is applied. */
-
-h1.has-background, h2.has-background, h3.has-background, h4.has-background, h5.has-background, h6.has-background {
-    padding: 0;
-}
-
 /* Set default line height for font size presets. */
 
 .has-xx-large-font-size {
 	line-height: 1;
-}
-
-/* Add space between the header and first element, if its a paragraph. */
-
-.entry-content > p:first-child {
-	margin-top: var(--wp--style--root--padding-left);
 }
 
 /* Add a transition state for buttons. */

--- a/assembler/theme.json
+++ b/assembler/theme.json
@@ -843,6 +843,15 @@
                     "fontSize": "var(--wp--preset--font-size--x-large)"
                 }
             },
+            "core/post-content": {
+                "css": "& > div:first-child.alignfull { margin-top: calc( -1 * var(--wp--preset--spacing--20)) !important; } & > div:last-child.alignfull { margin-bottom: calc( -1 * var(--wp--preset--spacing--60)) !important; } & > p + div.alignfull { margin-top: var(--wp--style--block-gap) !important; }",
+                "spacing": {
+                    "padding": {
+                        "top": "var(--wp--preset--spacing--20)",
+                        "bottom": "var(--wp--preset--spacing--60)"
+                    }
+                }
+            },
             "core/separator": {
                 "border": {
 					"top": {
@@ -941,6 +950,7 @@
                 }
             },
             "heading": {
+                "css": "&.has-background { padding: 0; }",
                 "typography": {
                     "fontWeight": "500"
                 }


### PR DESCRIPTION
Improves the spacing between content and header/footer areas, as well as fullwidth patterns within content areas. This way patterns can both be fullwidth, right against header and footer template parts, AND paragraph content (standard post and pages for example) can have proper spacing apart from the header and footer. 

#### Changes proposed in this Pull Request:

### Before
If post content contains a paragraph last, rests against the footer: 

![CleanShot 2024-11-15 at 16 43 32](https://github.com/user-attachments/assets/3e4e5ac6-be53-4c3c-a9ca-84cfa45d67fe)

### After 
Paragraphs always have proper spacing:  

![LOCATION](https://github.com/user-attachments/assets/e119020d-7ae1-4095-bf6f-d1cd996303d3)


### Before
Fullwidth patterns with zero-ed out margin rest right against paragraph content:

![SERVICES](https://github.com/user-attachments/assets/bcbfbdf7-e310-4150-8f70-faa7ccb5c556)

### After
Better spacing: 

![SERVICES](https://github.com/user-attachments/assets/2a7b0eac-31cd-4589-9c86-0d698a8984ca)


