### PR TITLE
Streamer: fixes Plunge style variation

### DIFF
--- a/streamer/styles/plunge.json
+++ b/streamer/styles/plunge.json
@@ -79,11 +79,11 @@
 				},
 				{
 					"fluid": {
-						"max": "6vh",
-						"min": "3vh"
+						"max": "4.25rem",
+						"min": "3rem"
 					},
 					"name": "Extra Large",
-					"size": "6vh",
+					"size": "4.25rem",
 					"slug": "x-large"
 				}
 			]


### PR DESCRIPTION
This PR fixes the units used on the H1s of a style variation. The (Virtual Height) `VH` values were causing the theme preview to break, but they are now fixed.