### PR TITLE
Rockfield: Fix cart button styles

### DIFF
--- a/rockfield/sass/style-child-theme-woocommerce.scss
+++ b/rockfield/sass/style-child-theme-woocommerce.scss
@@ -89,6 +89,8 @@ body[class*="woocommerce"] #page {
 	.wp-block-button__link {
 		background-color: var(--wp--preset--color--primary);
 		color: var(--wp--preset--color--background);
+		outline: 2px solid;
+		outline-offset: -5px;
 	}
 
 	.wc-block-cart-item__remove-link {

--- a/rockfield/sass/style-child-theme-woocommerce.scss
+++ b/rockfield/sass/style-child-theme-woocommerce.scss
@@ -44,6 +44,7 @@
  * Remove grid-products flexbox layout
  */
 @include media(mobile) {
+
 	body[class*="woocommerce"] #page .widget.woocommerce ul.product_list_widget:not(.woocommerce-mini-cart) {
 
 		display: inherit;
@@ -81,6 +82,18 @@ body[class*="woocommerce"] #page {
 		@include media(mobile) {
 			display: none;
 		}
+	}
+
+	// Cart
+	.wp-block-woocommerce-cart-totals-block .wp-element-button,
+	.wp-block-button__link {
+		background-color: var(--wp--preset--color--primary);
+		color: var(--wp--preset--color--background);
+	}
+
+	.wc-block-cart-item__remove-link {
+		outline: none;
+		outline-offset: unset;
 	}
 
 	// Clean up mini-cart styles for mobile
@@ -160,21 +173,21 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a {
 }
 
 /* Remove weird square artifact in WC buttons */
-body[class*="woocommerce"] #page #respond input#submit:before,
-body[class*="woocommerce"] #page #respond input#submit.alt:before,
-body[class*="woocommerce"] #page a.button:before,
-body[class*="woocommerce"] #page a.button.alt:before,
-body[class*="woocommerce"] #page button.button:before,
-body[class*="woocommerce"] #page button.button.alt:before,
-body[class*="woocommerce"] #page input.button:before,
-body[class*="woocommerce"] #page input.button.alt:before,
-body[class*="woocommerce"] #page .cart .button:before,
-body[class*="woocommerce"] #page a.added_to_cart:before,
-body[class*="woocommerce"] #page .woocommerce #respond input#submit:before,
-body[class*="woocommerce"] #page .woocommerce a.button:before,
-body[class*="woocommerce"] #page .woocommerce button.button:before,
-body[class*="woocommerce"] #page .woocommerce input.button:before,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:before,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:before {
+body[class*="woocommerce"] #page #respond input#submit::before,
+body[class*="woocommerce"] #page #respond input#submit.alt::before,
+body[class*="woocommerce"] #page a.button::before,
+body[class*="woocommerce"] #page a.button.alt::before,
+body[class*="woocommerce"] #page button.button::before,
+body[class*="woocommerce"] #page button.button.alt::before,
+body[class*="woocommerce"] #page input.button::before,
+body[class*="woocommerce"] #page input.button.alt::before,
+body[class*="woocommerce"] #page .cart .button::before,
+body[class*="woocommerce"] #page a.added_to_cart::before,
+body[class*="woocommerce"] #page .woocommerce #respond input#submit::before,
+body[class*="woocommerce"] #page .woocommerce a.button::before,
+body[class*="woocommerce"] #page .woocommerce button.button::before,
+body[class*="woocommerce"] #page .woocommerce input.button::before,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a::before,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a::before {
 	display: none;
 }

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2850,7 +2850,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2867,7 +2867,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/rockfield/style-woocommerce-rtl.css
+++ b/rockfield/style-woocommerce-rtl.css
@@ -2168,6 +2168,16 @@ body[class*="woocommerce"] #page #site-navigation #toggle-cart {
 	}
 }
 
+body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button, body[class*="woocommerce"] #page .wp-block-button__link {
+	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
+}
+
+body[class*="woocommerce"] #page .wc-block-cart-item__remove-link {
+	outline: none;
+	outline-offset: unset;
+}
+
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page #masthead {
 		position: relative;

--- a/rockfield/style-woocommerce-rtl.css
+++ b/rockfield/style-woocommerce-rtl.css
@@ -2168,9 +2168,12 @@ body[class*="woocommerce"] #page #site-navigation #toggle-cart {
 	}
 }
 
-body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button, body[class*="woocommerce"] #page .wp-block-button__link {
+body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button,
+body[class*="woocommerce"] #page .wp-block-button__link {
 	background-color: var(--wp--preset--color--primary);
 	color: var(--wp--preset--color--background);
+	outline: 2px solid;
+	outline-offset: -5px;
 }
 
 body[class*="woocommerce"] #page .wc-block-cart-item__remove-link {
@@ -2239,21 +2242,21 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a {
 }
 
 /* Remove weird square artifact in WC buttons */
-body[class*="woocommerce"] #page #respond input#submit:before,
-body[class*="woocommerce"] #page #respond input#submit.alt:before,
-body[class*="woocommerce"] #page a.button:before,
-body[class*="woocommerce"] #page a.button.alt:before,
-body[class*="woocommerce"] #page button.button:before,
-body[class*="woocommerce"] #page button.button.alt:before,
-body[class*="woocommerce"] #page input.button:before,
-body[class*="woocommerce"] #page input.button.alt:before,
-body[class*="woocommerce"] #page .cart .button:before,
-body[class*="woocommerce"] #page a.added_to_cart:before,
-body[class*="woocommerce"] #page .woocommerce #respond input#submit:before,
-body[class*="woocommerce"] #page .woocommerce a.button:before,
-body[class*="woocommerce"] #page .woocommerce button.button:before,
-body[class*="woocommerce"] #page .woocommerce input.button:before,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:before,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:before {
+body[class*="woocommerce"] #page #respond input#submit::before,
+body[class*="woocommerce"] #page #respond input#submit.alt::before,
+body[class*="woocommerce"] #page a.button::before,
+body[class*="woocommerce"] #page a.button.alt::before,
+body[class*="woocommerce"] #page button.button::before,
+body[class*="woocommerce"] #page button.button.alt::before,
+body[class*="woocommerce"] #page input.button::before,
+body[class*="woocommerce"] #page input.button.alt::before,
+body[class*="woocommerce"] #page .cart .button::before,
+body[class*="woocommerce"] #page a.added_to_cart::before,
+body[class*="woocommerce"] #page .woocommerce #respond input#submit::before,
+body[class*="woocommerce"] #page .woocommerce a.button::before,
+body[class*="woocommerce"] #page .woocommerce button.button::before,
+body[class*="woocommerce"] #page .woocommerce input.button::before,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a::before,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a::before {
 	display: none;
 }

--- a/rockfield/style-woocommerce.css
+++ b/rockfield/style-woocommerce.css
@@ -2168,6 +2168,16 @@ body[class*="woocommerce"] #page #site-navigation #toggle-cart {
 	}
 }
 
+body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button, body[class*="woocommerce"] #page .wp-block-button__link {
+	background-color: var(--wp--preset--color--primary);
+	color: var(--wp--preset--color--background);
+}
+
+body[class*="woocommerce"] #page .wc-block-cart-item__remove-link {
+	outline: none;
+	outline-offset: unset;
+}
+
 @media only screen and (max-width: 559px) {
 	body[class*="woocommerce"] #page #masthead {
 		position: relative;

--- a/rockfield/style-woocommerce.css
+++ b/rockfield/style-woocommerce.css
@@ -2168,9 +2168,12 @@ body[class*="woocommerce"] #page #site-navigation #toggle-cart {
 	}
 }
 
-body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button, body[class*="woocommerce"] #page .wp-block-button__link {
+body[class*="woocommerce"] #page .wp-block-woocommerce-cart-totals-block .wp-element-button,
+body[class*="woocommerce"] #page .wp-block-button__link {
 	background-color: var(--wp--preset--color--primary);
 	color: var(--wp--preset--color--background);
+	outline: 2px solid;
+	outline-offset: -5px;
 }
 
 body[class*="woocommerce"] #page .wc-block-cart-item__remove-link {
@@ -2239,21 +2242,21 @@ body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a {
 }
 
 /* Remove weird square artifact in WC buttons */
-body[class*="woocommerce"] #page #respond input#submit:before,
-body[class*="woocommerce"] #page #respond input#submit.alt:before,
-body[class*="woocommerce"] #page a.button:before,
-body[class*="woocommerce"] #page a.button.alt:before,
-body[class*="woocommerce"] #page button.button:before,
-body[class*="woocommerce"] #page button.button.alt:before,
-body[class*="woocommerce"] #page input.button:before,
-body[class*="woocommerce"] #page input.button.alt:before,
-body[class*="woocommerce"] #page .cart .button:before,
-body[class*="woocommerce"] #page a.added_to_cart:before,
-body[class*="woocommerce"] #page .woocommerce #respond input#submit:before,
-body[class*="woocommerce"] #page .woocommerce a.button:before,
-body[class*="woocommerce"] #page .woocommerce button.button:before,
-body[class*="woocommerce"] #page .woocommerce input.button:before,
-body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a:before,
-body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a:before {
+body[class*="woocommerce"] #page #respond input#submit::before,
+body[class*="woocommerce"] #page #respond input#submit.alt::before,
+body[class*="woocommerce"] #page a.button::before,
+body[class*="woocommerce"] #page a.button.alt::before,
+body[class*="woocommerce"] #page button.button::before,
+body[class*="woocommerce"] #page button.button.alt::before,
+body[class*="woocommerce"] #page input.button::before,
+body[class*="woocommerce"] #page input.button.alt::before,
+body[class*="woocommerce"] #page .cart .button::before,
+body[class*="woocommerce"] #page a.added_to_cart::before,
+body[class*="woocommerce"] #page .woocommerce #respond input#submit::before,
+body[class*="woocommerce"] #page .woocommerce a.button::before,
+body[class*="woocommerce"] #page .woocommerce button.button::before,
+body[class*="woocommerce"] #page .woocommerce input.button::before,
+body[class*="woocommerce"] #page .woocommerce .widget_shopping_cart .buttons a::before,
+body[class*="woocommerce"] #page .woocommerce.widget_shopping_cart .buttons a::before {
 	display: none;
 }

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2869,7 +2869,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2886,7 +2886,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR fixes the button styles in the Cart page for Proceed to checkout button and also remove the outline from the remove item link.

Before:

![Screenshot 2024-11-28 at 6 21 47 PM](https://github.com/user-attachments/assets/7b80f4d7-fb2d-4812-861f-1eb9c4961f48)

After:

<img width="1150" alt="Screenshot 2024-12-06 at 2 33 23 PM" src="https://github.com/user-attachments/assets/381faea0-a022-43de-a96b-f664943995ef">


#### Related issue(s):
#8467