### PR TITLE
Multiple Themes: Corrected authors/contributors names

### DIFF
--- a/allez/readme.txt
+++ b/allez/readme.txt
@@ -1,5 +1,5 @@
 === Allez ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.4.1
 Requires PHP: 5.7

--- a/allez/style.css
+++ b/allez/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Allez
 Theme URI: https://github.com/wordpress/allez/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: Allez is the perfect theme site for sports practitioners or fans who want to blog about their sport.
 Requires at least: 6.0

--- a/alter/readme.txt
+++ b/alter/readme.txt
@@ -1,5 +1,5 @@
 === Alter ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.2.2
 Requires PHP: 5.7
@@ -23,7 +23,7 @@ Alter is a lean theme for bloggers that goes directly to the point, showing text
 
 == Copyright ==
 
-Alter WordPress Theme, (C) 2023 the WordPress team
+Alter WordPress Theme, (C) 2023 Automattic
 Alter is distributed under the terms of the GNU GPL.
 Alter is based on G01 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/alter/style.css
+++ b/alter/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Alter
 Theme URI: https://github.com/wordpress/alter/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/alter
 Description: Alter is a lean theme for bloggers that goes directly to the point, showing text-only posts right above the fold ornamented by a single image to compound the style.
 Requires at least: 6.0

--- a/blogorama/readme.txt
+++ b/blogorama/readme.txt
@@ -1,5 +1,5 @@
 === Blogorama ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 5.8
 Tested up to: 6.3
 Requires PHP: 5.7
@@ -26,9 +26,9 @@ A beautifully designed blog theme displaying large typography and customizable c
 
 == Copyright ==
 
-Blogorama WordPress Theme, (C) 2023 the WordPress team
+Blogorama WordPress Theme, (C) 2023 Automattic
 Blogorama is distributed under the terms of the GNU GPL.
-Blogorama is based on Blogorama (https://github.com/wordpress/blogorama/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Blogorama is based on Blogorama (https://github.com/wordpress/blogorama/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/boxedbio/readme.txt
+++ b/boxedbio/readme.txt
@@ -1,5 +1,5 @@
 === Boxed Bio ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.2.2
 Requires PHP: 5.7
@@ -23,11 +23,11 @@ Your new Link-in-Bio site, BoxedBio, offers a simple organization of blocks to d
 
 == Copyright ==
 
-Boxed Bio is based on BiB (https://github.com/wordpress/bib/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Boxed Bio is based on BiB (https://github.com/wordpress/bib/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
-BiB WordPress Theme, (C) 2023 the WordPress team
+BiB WordPress Theme, (C) 2023 Automattic
 BiB is distributed under the terms of the GNU GPL.
-BiB is based on BiB (https://github.com/wordpress/bib/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+BiB is based on BiB (https://github.com/wordpress/bib/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/curriculum/readme.txt
+++ b/curriculum/readme.txt
@@ -1,5 +1,5 @@
 === Curriculum ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 5.8
 Tested up to: 6.2
 Requires PHP: 5.7
@@ -29,9 +29,9 @@ Curriculum is a blog theme that echoes the structure of a professional profile w
 
 == Copyright ==
 
-Curriculum WordPress Theme, (C) 2023 the WordPress team
+Curriculum WordPress Theme, (C) 2023 Automattic
 Curriculum is distributed under the terms of the GNU GPL.
-Curriculum is based on Curriculum (https://github.com/wordpress/curriculum/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Curriculum is based on Curriculum (https://github.com/wordpress/curriculum/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/curriculum/style.css
+++ b/curriculum/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Curriculum
 Theme URI: https://github.com/wordpress/curriculum/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/curriculum
 Description: Curriculum is a blog theme that echoes the structure of a professional profile with original visuals and interesting navigation. It\\\'s suitable for the general public displaying information, experiences, and education. And it\\\'s super easy to be customized.
 Requires at least: 5.8

--- a/dos/readme.txt
+++ b/dos/readme.txt
@@ -26,7 +26,7 @@ DOS is a blog theme designed for the nostalgic ones, a tribute to the folks that
 
 == Copyright ==
 
-DOS WordPress Theme, (C) 2023 the WordPress team
+DOS WordPress Theme, (C) 2023 Automattic
 DOS is distributed under the terms of the GNU GPL.
 DOS is based on Block Canvas (https://github.com/Automattic/themes/tree/trunk/block-canvas), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/grammerone/readme.txt
+++ b/grammerone/readme.txt
@@ -1,5 +1,5 @@
 === Grammer One ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 5.7

--- a/inversum/readme.txt
+++ b/inversum/readme.txt
@@ -36,8 +36,7 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
-
-Inversum is based on Upsidedown (), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Inversum is based on Upsidedown (), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 
 == Fonts ==

--- a/issue/readme.txt
+++ b/issue/readme.txt
@@ -1,5 +1,5 @@
 === Issue ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 5.7
@@ -26,9 +26,9 @@ Issue is a magazine theme focused on sizable typography and imagery to grow your
 
 == Copyright ==
 
-Issue WordPress Theme, (C) 2023 the WordPress team
+Issue WordPress Theme, (C) 2023 Automattic
 Issue is distributed under the terms of the GNU GPL.
-Issue is based on Issue (https://github.com/wordpress/issue/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Issue is based on Issue (https://github.com/wordpress/issue/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/leven/languages/leven.pot
+++ b/leven/languages/leven.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 the WordPress team
+# Copyright (C) 2021 Automattic
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
@@ -27,7 +27,7 @@ msgid "A colorful, typography driven, Gutenberg-ready theme meant to grab the at
 msgstr ""
 
 #. Author of the theme
-msgid "the WordPress team"
+msgid "Automattic"
 msgstr ""
 
 #. Author URI of the theme

--- a/leven/sass/style-child-theme.scss
+++ b/leven/sass/style-child-theme.scss
@@ -1,7 +1,7 @@
 /*
 Theme Name: Leven
 Theme URI: https://wordpress.com/theme/leven
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Leven
 Theme URI: https://wordpress.com/theme/leven
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6

--- a/leven/style.css
+++ b/leven/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Leven
 Theme URI: https://wordpress.com/theme/leven
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A colorful, typography driven, Gutenberg-ready theme meant to grab the attention of potential customers and market or sell products to them.
 Requires at least: WordPress 4.9.6

--- a/massimo/readme.txt
+++ b/massimo/readme.txt
@@ -34,7 +34,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 
-Massimo is based on Programme (https://github.com/wordpress/programme/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Massimo is based on Programme (https://github.com/wordpress/programme/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 
 == Fonts ==

--- a/messagerie/readme.txt
+++ b/messagerie/readme.txt
@@ -1,5 +1,5 @@
 === Messagerie ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 5.7
@@ -30,7 +30,7 @@ Messagerie is a theme that brings the mobile messaging experience to your WordPr
 
 == Copyright ==
 
-Messagerie WordPress Theme, (C) 2023 the WordPress team
+Messagerie WordPress Theme, (C) 2023 Automattic
 Messagerie is distributed under the terms of the GNU GPL.
 Messagerie is based on M01 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/messagerie/style.css
+++ b/messagerie/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Messagerie
 Theme URI: https://github.com/wordpress/messagerie/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: Messagerie is a theme that brings the mobile messaging experience to your WordPress site.
 Requires at least: 6.0

--- a/modern-business/languages/modern-business.pot
+++ b/modern-business/languages/modern-business.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 the WordPress team
+# Copyright (C) 2021 Automattic
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
@@ -27,7 +27,7 @@ msgid "A minimalist theme for those with an eye for style. Modern Business is a 
 msgstr ""
 
 #. Author of the theme
-msgid "the WordPress team"
+msgid "Automattic"
 msgstr ""
 
 #. Author URI of the theme

--- a/modern-business/style-rtl.css
+++ b/modern-business/style-rtl.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Modern Business
 Theme URI: https://wordpress.com/theme/modern-business
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6

--- a/modern-business/style.css
+++ b/modern-business/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Modern Business
 Theme URI: https://wordpress.com/theme/modern-business
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6

--- a/modern-business/style.scss
+++ b/modern-business/style.scss
@@ -1,7 +1,7 @@
 /*
 Theme Name: Modern Business
 Theme URI: https://wordpress.com/theme/modern-business
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/
 Description: A minimalist theme for those with an eye for style. Modern Business is a perfect choice for stores offering high-end products and services, or the fashion and beauty industries -- any site where elegance and polish is key.
 Requires at least: WordPress 4.9.6

--- a/mymenu/readme.txt
+++ b/mymenu/readme.txt
@@ -41,7 +41,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 
-MyMenu is based on My Menu (), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+MyMenu is based on My Menu (), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 
 This theme bundles the following third-party resources:

--- a/organizer/readme.txt
+++ b/organizer/readme.txt
@@ -1,5 +1,5 @@
 === Organizer ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.2.2
 Requires PHP: 5.7
@@ -29,7 +29,7 @@ Organizer has a simple structure and displays only the necessary information a r
 
 == Copyright ==
 
-Organizer WordPress Theme, (C) 2023 the WordPress team
+Organizer WordPress Theme, (C) 2023 Automattic
 Organizer is distributed under the terms of the GNU GPL.
 Organizer is based on ORG04 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/overlaid/readme.txt
+++ b/overlaid/readme.txt
@@ -23,7 +23,7 @@ Overlaid displays large titles and excerpts that scroll over an image on the Hom
 
 == Copyright ==
 
-Overlaid WordPress Theme, (C) 2023 the WordPress team
+Overlaid WordPress Theme, (C) 2023 Automattic
 Overlaid is distributed under the terms of the GNU GPL.
 Overlaid is based on BT4 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/pieria/readme.txt
+++ b/pieria/readme.txt
@@ -29,7 +29,7 @@ Pieria is a theme focused on typography — essentially following a low-level st
 
 == Copyright ==
 
-Pieria WordPress Theme, (C) 2023 the WordPress team
+Pieria WordPress Theme, (C) 2023 Automattic
 Pieria is distributed under the terms of the GNU GPL.
 Pieria is based on Block Canvas (https://github.com/Automattic/themes/tree/trunk/block-canvas), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/professio/readme.txt
+++ b/professio/readme.txt
@@ -37,7 +37,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 
-Professio is based on Nausicaa (https://github.com/wordpress/nausicaa/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Professio is based on Nausicaa (https://github.com/wordpress/nausicaa/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 
 == Images ==

--- a/programme/readme.txt
+++ b/programme/readme.txt
@@ -1,5 +1,5 @@
 === Programme ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 5.8
 Tested up to: 6.2
 Requires PHP: 5.7
@@ -32,7 +32,7 @@ Programme is a blog theme that reverences the legendary designer Massimo Vignell
 
 == Copyright ==
 
-Programme WordPress Theme, (C) 2023 the WordPress team
+Programme WordPress Theme, (C) 2023 Automattic
 Programme is distributed under the terms of the GNU GPL.
 Programme is based on PV1 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/programme/style.css
+++ b/programme/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Programme
 Theme URI: https://github.com/wordpress/programme/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: Programme is a blog theme that reverences the legendary designer Massimo Vignelli and his playbills for the Piccolo Teatro in Milan. This design is suitable for programs, calendars, and announcements.
 Requires at least: 5.8

--- a/raw/readme.txt
+++ b/raw/readme.txt
@@ -1,5 +1,5 @@
 === RAW ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 5.8
 Tested up to: 6.2
 Requires PHP: 5.7
@@ -32,7 +32,7 @@ RAW is a theme design inspired by the Brutalist concepts from the homonymous Arc
 
 == Copyright ==
 
-RAW WordPress Theme, (C) 2023 the WordPress team
+RAW WordPress Theme, (C) 2023 Automattic
 RAW is distributed under the terms of the GNU GPL.
 RAW is based on Brut Second (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/raw/style.css
+++ b/raw/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: RAW
 Theme URI: https://github.com/wordpress/raw/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: RAW is a theme design inspired by the Brutalist concepts from the homonymous Architectural movement. It aims to be harsh, honest, utilitarian, and useful. And it is a good portfolio pick for architects, design studios, and creative organizations.
 Requires at least: 5.8

--- a/ritratto/readme.txt
+++ b/ritratto/readme.txt
@@ -1,5 +1,5 @@
 === Ritratto ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.3
 Requires PHP: 5.7
@@ -32,9 +32,9 @@ Besides an appreciable headshot, the theme offers large titles, descriptions, an
 
 == Copyright ==
 
-Ritratto is based on Headshot (https://github.com/wordpress/headshot/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Ritratto is based on Headshot (https://github.com/wordpress/headshot/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
-Headshot WordPress Theme, (C) 2023 the WordPress team
+Headshot WordPress Theme, (C) 2023 Automattic
 Headshot is distributed under the terms of the GNU GPL.
 Headshot is based on HDST (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/ritratto/style.css
+++ b/ritratto/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Ritratto
 Theme URI: https://wordpress.com/themes/ritratto/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: Besides an appreciable headshot, the theme offers large titles, descriptions, and links right away. There is also a grid of posts, and no Post Feature Images are used anytime.
 Requires at least: 6.0

--- a/screenplay/readme.txt
+++ b/screenplay/readme.txt
@@ -23,7 +23,7 @@ Screenplay is a simple blog theme that suits perfectly writers or the general pu
 
 == Copyright ==
 
-Screenplay WordPress Theme, (C) 2023 the WordPress team
+Screenplay WordPress Theme, (C) 2023 Automattic
 Screenplay is distributed under the terms of the GNU GPL.
 Screenplay is based on Casablanca (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/specials/readme.txt
+++ b/specials/readme.txt
@@ -17,7 +17,7 @@ A clean, beautiful, and customizable theme for restaurant menu websites.
 
 == Copyright ==
 
-Specials is based on MyMenu (https://github.com/wordpress/mymenu/), (C) the WordPress team, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
+Specials is based on MyMenu (https://github.com/wordpress/mymenu/), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/stage/readme.txt
+++ b/stage/readme.txt
@@ -1,5 +1,5 @@
 === Stage ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.0
 Tested up to: 6.2.2
 Requires PHP: 5.7
@@ -30,7 +30,7 @@ Stage is the perfect theme for our users engaged in artistic activities. Its con
 
 == Copyright ==
 
-Stage WordPress Theme, (C) 2023 the WordPress team
+Stage WordPress Theme, (C) 2023 Automattic
 Stage is distributed under the terms of the GNU GPL.
 Stage is based on SCFF1 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/stage/style.css
+++ b/stage/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Stage
 Theme URI: https://github.com/wordpress/stage/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: Stage is the perfect theme for our users engaged in artistic activities. Its concise and straightforward introduction enables users to select topics for their blog posts or content pages promptly.
 Requires at least: 6.0

--- a/texty/readme.txt
+++ b/texty/readme.txt
@@ -29,7 +29,7 @@ Texty is a text-only blog theme that trusts Post excerpts rather than Post title
 
 == Copyright ==
 
-Texty WordPress Theme, (C) 2023 the WordPress team
+Texty WordPress Theme, (C) 2023 Automattic
 Texty is distributed under the terms of the GNU GPL.
 Texty is based on TXT1 (), (C) , [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/the-menu/readme.txt
+++ b/the-menu/readme.txt
@@ -1,5 +1,5 @@
 === The MENU ===
-Contributors: the WordPress team
+Contributors: Automattic
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 5.7
@@ -26,7 +26,7 @@ A simple theme designed to facilitate restaurant owners' experience when buildin
 
 == Copyright ==
 
-The MENU WordPress Theme, (C) 2023 the WordPress team
+The MENU WordPress Theme, (C) 2023 Automattic
 The MENU is distributed under the terms of the GNU GPL.
 The MENU is based on Block Canvas (https://github.com/Automattic/themes/tree/trunk/block-canvas), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/the-menu/style.css
+++ b/the-menu/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: The MENU
 Theme URI: https://github.com/wordpress/the-menu/
-Author: the WordPress team
+Author: Automattic
 Author URI: https://wordpress.org/themes/
 Description: A simple theme designed to facilitate restaurant owners' experience when building their sites. Is clean, direct, and customizable.
 Requires at least: 6.1

--- a/varia/readme.txt
+++ b/varia/readme.txt
@@ -1,5 +1,5 @@
 === Varia ===
-Contributors: the WordPress team
+Contributors: Automattic
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, jetpack-global-styles
 Requires at least: 4.9.6
 Tested up to: WordPress 5.0


### PR DESCRIPTION
Fixes #7437 

This corrects the authors/contributors' names from `the WordPress team` to `Automattic` in multiple themes.