### PR TITLE
Fix Assembler outline variation size and style

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -26,6 +26,7 @@ Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-color
     transition: border, background-color, color, box-shadow, opacity, filter;
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    backdrop-filter: blur(30px);
 }
 
 /* Fields */

--- a/assembler/style.css
+++ b/assembler/style.css
@@ -26,7 +26,6 @@ Tags: blog, one-column, three-columns, wide-blocks, block-patterns, custom-color
     transition: border, background-color, color, box-shadow, opacity, filter;
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    backdrop-filter: blur(30px) brightness(120%);
 }
 
 /* Fields */

--- a/assembler/theme.json
+++ b/assembler/theme.json
@@ -194,10 +194,10 @@
                         },
                         "spacing": {
                             "padding": {
-                                "bottom": "13px",
-                                "left": "21px",
-                                "right": "21px",
-                                "top": "13px"
+                                "bottom": "15px",
+                                "left": "23px",
+                                "right": "23px",
+                                "top": "15px"
                             }
                         }
                     }


### PR DESCRIPTION
Making the outline button variation the same size as the default. Also removes the brightness effect on the button; was a bit finicky. 

### Visual 

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-12-04 at 18 13 11](https://github.com/user-attachments/assets/35b45d15-52b9-4340-92c5-2eaaebb249e1)|![CleanShot 2024-12-04 at 18 12 03](https://github.com/user-attachments/assets/4a6ccef2-d1c5-4575-8d13-e947ac9b95cf)|
