### PR TITLE
Remove forced post title font size for Assembler

### DIFF
--- a/assembler/templates/template-page-w-title.html
+++ b/assembler/templates/template-page-w-title.html
@@ -5,7 +5,7 @@
 <main class="wp-block-group" style="margin-top:0">
     
    <!-- wp:group {"metadata":{"name":"Page Title"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"24px"}}},"layout":{"type":"constrained"}} -->
-        <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:24px"><!-- wp:post-title {"textAlign":"center"} /--></div>
+        <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:24px"><!-- wp:post-title {"textAlign":"center","fontSize":"large"} /--></div>
     <!-- /wp:group -->
 
     <!-- wp:post-content {"layout":{"type":"constrained"}} /-->

--- a/assembler/theme.json
+++ b/assembler/theme.json
@@ -224,11 +224,6 @@
                     "fontSize": "var(--wp--preset--font-size--small)"
                 }
             },
-            "core/post-title": {
-                "typography": {
-                    "fontSize": "var(--wp--preset--font-size--x-large)"
-                }
-            },
             "core/post-content": {
                 "css": "& > div:first-child.alignfull { margin-top: calc( -1 * var(--wp--preset--spacing--20)) !important; } & > div:last-child.alignfull { margin-bottom: calc( -1 * var(--wp--preset--spacing--60)) !important; } & > p + div.alignfull { margin-top: var(--wp--style--block-gap) !important; }",
                 "spacing": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

If a post title does not have a post title, it renders quite large. This is fine for single post templates etc, but not for patterns. This removes the forced post title font size. 

#### Before 
![CleanShot 2024-12-04 at 18 17 01](https://github.com/user-attachments/assets/a24e0c7f-9863-434f-981b-cf86f5a528dd)

#### After 
![CleanShot 2024-12-04 at 18 17 36](https://github.com/user-attachments/assets/b47196ae-bff7-49c9-8f23-f3934cc67d10)
