### PR TITLE
Tools: Add separate version bump script for GH actions

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ jobs:
         id: version-bump
         run: |
           if [ "${{ github.event.inputs.theme-slug }}" == 'all' ]; then
-            npm run deploy:version-bump
+            npm run deploy:version-bump-from-last-bump
           else
             # Check if theme exists
             theme_exists=false
@@ -59,7 +59,7 @@ jobs:
               exit 1
             fi
 
-            npm run deploy:version-bump -- ${{ github.event.inputs.theme-slug }}
+            npm run deploy:version-bump-from-last-bump -- ${{ github.event.inputs.theme-slug }}
           fi
 
       - name: Check if there are changes

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"batch:audit:fix": "./theme-batch-utils.sh audit-dependencies",
 		"batch:update": "./theme-batch-utils.sh update-dependencies",
 		"deploy:version-bump": "node ./theme-utils.mjs version-bump-themes",
+		"deploy:version-bump-from-last-bump": "node ./theme-utils.mjs version-bump-from-last-bump",
 		"deploy:push:all": "node ./theme-utils.mjs push-to-sandbox",
 		"deploy:push:changes": "node ./theme-utils.mjs push-changes-to-sandbox",
 		"deploy:push:theme": "node ./theme-utils.mjs push-theme-to-sandbox",

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -864,8 +864,8 @@ async function versionBumpThemes( themeSlugs ) {
 }
 
 /*
- Version bump (increment version patch) any theme project that has had changes since the last "Version Bump" commit (e.g. for running via the GH Action, as we do not want to use the last dotcom deployment as a reference.)
- If a theme's version has already been changed since that last deployment then do not version bump it.
+ Version bump (increment version patch) any theme project that has had changes since the last "Version Bump" commit (e.g. for running via the GH Action, as we do not want to use the last wpcom deployment as a reference.)
+ If a theme's version has already been changed since that last commit then do not version bump it.
  If a theme has changes also update its changelog.
  Does not update the root project version.
 */

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1082,7 +1082,6 @@ async function versionBumpTheme( theme, addChanges ) {
  Determine if a theme has had a version bump since a given hash.
  Used by versionBumpThemes
  Compares the value of 'version' in style.css between the hash and current value
- Returns true if the theme does not need a version bump
 */
 async function checkThemeForVersionBump( theme, hash ) {
 	return executeCommand( `
@@ -1102,7 +1101,7 @@ async function checkThemeForVersionBump( theme, hash ) {
 			);
 			let styleCss = fs.readFileSync( `${ theme }/style.css`, 'utf8' );
 			let currentVersion = getThemeMetadata( styleCss, 'Version' );
-			return previousVersion !== currentVersion;
+			return previousVersion != currentVersion;
 		} );
 }
 

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -79,6 +79,11 @@ const commands = {
 			'Bump the version of any theme that has had changes since the last deployment. This includes bumping the version of any parent themes and updating the changelog for the theme. Optionally specify a single theme to version bump.',
 		run: ( args ) => versionBumpThemes(	args?.[ 1 ]?.split( /[ ,]+/ ) ),
 	},
+	'version-bump-from-last-bump': {
+		helpText:
+			'Bump the version of any theme that has had changes since the last "Version Bump" commit. This includes updating the changelog for the theme. Optionally specify a single theme to version bump.',
+		run: ( args ) => versionBumpThemesFromLastBump( args?.[ 1 ]?.split( /[ ,]+/ ) ),
+	},
 	'land-diff': {
 		helpText: 'Run gh pr merge to merge in the specified pull request id.',
 		additionalArgs: '<gh pr id>',
@@ -858,6 +863,43 @@ async function versionBumpThemes( themeSlugs ) {
 	return changesWereMade;
 }
 
+/*
+ Version bump (increment version patch) any theme project that has had changes since the last "Version Bump" commit (e.g. for running via the GH Action, as we do not want to use the last dotcom deployment as a reference.)
+ If a theme's version has already been changed since that last deployment then do not version bump it.
+ If a theme has changes also update its changelog.
+ Does not update the root project version.
+*/
+async function versionBumpThemesFromLastBump( themeSlugs ) {
+	console.log( 'Version Bumping' );
+
+	const themes = themeSlugs ? themeSlugs : await getActionableThemes();
+	// Get the hash for the latest "Version Bump" commit.
+	const hash = execSync( `git log -1 --grep="Version Bump" --format=%H` ).toString().trim();
+	let changesWereMade = false;
+
+	for ( let theme of themes ) {
+		const hasChanges = await checkThemeForChanges( theme, hash );
+
+		if ( ! hasChanges ) {
+			continue;
+		}
+
+		const hasVersionBump = await checkThemeForVersionBump( theme, hash );
+
+		if ( hasVersionBump ) {
+			continue;
+		}
+
+		await versionBumpTheme( theme, true );
+		await updateThemeChangelog( theme, true );
+		changesWereMade = true;
+	}
+
+	console.log( `Version bumping complete:`, changesWereMade ? 'themes successfully version bumped' : 'no changes were made' );
+
+	return changesWereMade;
+}
+
 export function getThemeMetadata( styleCss, attribute, trimWPCom = true ) {
 	if ( ! styleCss || ! attribute ) {
 		return null;
@@ -1060,7 +1102,7 @@ async function checkThemeForVersionBump( theme, hash ) {
 			);
 			let styleCss = fs.readFileSync( `${ theme }/style.css`, 'utf8' );
 			let currentVersion = getThemeMetadata( styleCss, 'Version' );
-			return previousVersion === currentVersion;
+			return previousVersion !== currentVersion;
 		} );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This adds a separate version bump script, `versionBumpThemesFromLastBump`, intended for version bumping themes from GH actions. It uses the latest "Version Bump" commit rather than the last wpcom deployment to look for changes to themes, which is more appropriate for the version bumping GH action which is designed for bumping dotorg themes.

It also reverts the changes in https://github.com/Automattic/themes/pull/8540, as this wasn't needed.

#### Related issue(s):
