### PR TITLE
Assembler: fix woo commerce input range

### DIFF
--- a/assembler/style.css
+++ b/assembler/style.css
@@ -43,7 +43,7 @@ label,
 }
 
 textarea,
-input:not([type=submit]):not([type=checkbox]):not([type=radio]),
+input:not([type=submit]):not([type=checkbox]):not([type=radio]):not([type=range]),
 .wp-block-post-comments-form textarea,
 .wp-block-post-comments-form input:not([type=submit]):not([type=checkbox]):not([type=radio]),
 .jetpack-contact-form .jetpack-field .jetpack-field__input,


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR introduces an exception to not style inputs of type `range` to fix the related woo commerce issue

Before | Now
--- | ---
<img width="786" alt="Screenshot 2024-12-19 at 16 32 58" src="https://github.com/user-attachments/assets/f5dfc603-1bf6-4c59-b2bc-a961ab5d0dd4" /> | <img width="778" alt="Screenshot 2024-12-19 at 16 32 47" src="https://github.com/user-attachments/assets/62266094-c090-4da5-b525-8b7f1a47aab7" />


#### Related issue(s):

Closes https://github.com/Automattic/themes/issues/8033