### PR TITLE
Install SVN before running dotorg deploy script

### DIFF
--- a/.github/workflows/dotorg-deploy.yml
+++ b/.github/workflows/dotorg-deploy.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install SVN
+        run: |
+          sudo apt update
+          sudo apt install -y subversion
       - run: ./deploy-dotorg.sh
         env: 
          SVN_USERNAME: ${{ secrets.SVN_USERNAME }} 


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This change ensures SVN is installed before running dotorg deploy script, as we're seeing the error `svn: command not found` when running that script.

#### Related issue(s):
