### PR TITLE
Varia: check for `$post` on widgets screen before adding admin body classes

### DIFF
--- a/varia/inc/wpcom.php
+++ b/varia/inc/wpcom.php
@@ -147,7 +147,7 @@ function varia_wpcom_admin_body_classes( $classes ) {
 	$hide                   = get_theme_mod( 'hide_front_page_title', false );
 	$front_page             = (int) get_option( 'page_on_front' );
 
-	if ( $is_block_editor_screen && $front_page === $post->ID && true === $hide ) {
+	if ( $is_block_editor_screen && ! empty( $post ) && $front_page === $post->ID && true === $hide ) {
 		$classes .= ' hide-homepage-title';
 	}
 


### PR DESCRIPTION


## Changes proposed in this Pull Request:

Check for `$post` before adding admin body classes. This prevents a PHP warning on the widgets screen where there is no post.


```html
<b>Warning</b>: Attempt to read property "ID" on null in <b>[...]wp-content/themes/pub/varia/inc/wpcom.php</b> on line <b>150</b><br>
```

The error also causes a UI anomaly in the admin sidebar:

<img width="442" alt="Screenshot 2024-12-31 at 1 51 59 pm" src="https://github.com/user-attachments/assets/36bf1ba6-f521-4dd1-a672-562ed5ebc2e9" />


### Testing:

Note, the PHP warning does not appear in production, probably because these warnings are suppressed.

Activate Varia or a Varia child theme like Rockfield.

Sandbox a test site and navigate to /wp-admin/widgets.php

The above error should not show and the nav should appear normal.


## Related issue(s):
