### PR TITLE
Bitacora: Update Custom CSS for Subscription Block

### DIFF
--- a/bitacora/readme.txt
+++ b/bitacora/readme.txt
@@ -1,8 +1,8 @@
 === Bitácora ===
 Contributors: Automattic
 Requires at least: 6.0
-Tested up to: 6.1.1
-Requires PHP: 5.7
+Tested up to: 6.7
+Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/bitacora/style.css
+++ b/bitacora/style.css
@@ -113,32 +113,3 @@ a {
 	line-height: inherit;
 	padding: 10px 15px;
 }
-
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	.wp-block-jetpack-subscriptions__form
-	.wp-block-jetpack-subscriptions__button,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	.wp-block-jetpack-subscriptions__form
-	.wp-block-jetpack-subscriptions__textfield
-	.components-text-control__input,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	.wp-block-jetpack-subscriptions__form
-	button,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	.wp-block-jetpack-subscriptions__form
-	input[type="email"],
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	form
-	.wp-block-jetpack-subscriptions__button,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	form
-	.wp-block-jetpack-subscriptions__textfield
-	.components-text-control__input,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	form
-	button,
-.wp-block-jetpack-subscriptions.wp-block-jetpack-subscriptions__supports-newline
-	form
-	input[type="email"] {
-	line-height: inherit;
-}

--- a/bitacora/style.css
+++ b/bitacora/style.css
@@ -5,8 +5,8 @@ Author: Automattic
 Author URI: https://automattic.com/
 Description: Bitácora is a simple old-school blog theme.
 Requires at least: 6.0
-Tested up to: 6.1.1
-Requires PHP: 5.7
+Tested up to: 6.7
+Requires PHP: 7.0
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
The theme no longer needs the custom CSS for the block, which was necessary to make the button the same height as the input field next to it. And the rule is currently breaking the height.

I noticed this while I was taking the dotcom support rotation.

| Before | After |
| ----------- | ----------- |
| ![CleanShot 2025-01-08 at 18 23 52@2x](https://github.com/user-attachments/assets/afc33fc2-591f-4306-b310-e3ce344f074d) | ![CleanShot 2025-01-08 at 18 21 58@2x](https://github.com/user-attachments/assets/7445f9f4-0422-4c3a-8326-e6a0cb97a0d1) | 