### PR TITLE
Independent Publisher 2: Add fixed styles to buttons in the block editor

### DIFF
--- a/independent-publisher-2/css/editor-blocks.css
+++ b/independent-publisher-2/css/editor-blocks.css
@@ -381,7 +381,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	background: #0087be;
 	border: solid 1px transparent;
 	border-radius: 3px;
-	box-sizing: content-box;
+	box-sizing: border-box;
 	color: #fff;
 	cursor: pointer;
 	-webkit-transition: background 120ms ease-in-out, box-shadow 120ms ease-in-out;
@@ -390,7 +390,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 16px;
 	font-weight: 400;
 	font-style: normal;
-	padding: .4375em .875em;
+	padding: .4375em 1.25em;
 	text-decoration: none;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -541,7 +541,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	box-sizing: content-box;
+	box-sizing: border-box;
 	cursor: pointer;
 	-webkit-transition: background 120ms ease-in-out, box-shadow 120ms ease-in-out;
 			transition: background 120ms ease-in-out, box-shadow 120ms ease-in-out;
@@ -549,7 +549,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	font-size: 16px;
 	font-weight: 400;
 	font-style: normal;
-	padding: .4375em .875em;
+	padding: .4375em 1.25em;
 	text-decoration: none;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

* Add the same fixes applied to buttons in https://github.com/Automattic/themes/pull/8516/ to the block editor styles to prevent buttons from overlapping.

**Before**

<img width="287" alt="Screenshot 2025-01-09 at 10 45 33 AM" src="https://github.com/user-attachments/assets/07842637-7b24-479c-932c-5116dc8b8e36" />

**After**

<img width="254" alt="Screenshot 2025-01-09 at 10 38 25 AM" src="https://github.com/user-attachments/assets/9d1ee413-396a-4477-83d7-7b535e56b3d2" />


#### Related issue(s):

https://github.com/Automattic/themes/issues/8511
