### PR TITLE
Varia: Fix nested bullets in menus

### DIFF
--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1542,6 +1542,12 @@ p:not(.site-title) a:hover {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: #394d55;
 }
@@ -1731,7 +1737,7 @@ p:not(.site-title) a:hover {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1542,14 +1542,14 @@ p:not(.site-title) a:hover {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: #394d55;
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/alves/style-editor.css
+++ b/alves/style-editor.css
@@ -1546,12 +1546,6 @@ p:not(.site-title) a:hover {
 	color: #394d55;
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #394d55;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.04167rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #394d55;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.04167rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #394d55;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/alves/style.css
+++ b/alves/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.04167rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #394d55;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/alves/style.css
+++ b/alves/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #394d55;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/alves/style.css
+++ b/alves/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.04167rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #394d55;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #303030;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #303030;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #303030;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #303030;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #303030;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #303030;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.71818rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #3C2323;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #3C2323;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.71818rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #3C2323;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #3C2323;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.71818rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #3C2323;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.71818rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #3C2323;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -1012,6 +1012,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2746,12 +2750,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #FFFFFF;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2744,6 +2744,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #FFFFFF;
 }
@@ -2933,7 +2937,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2744,12 +2744,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #FFFFFF;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -1012,6 +1012,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2765,12 +2769,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #FFFFFF;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2763,12 +2763,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #FFFFFF;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2763,6 +2763,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #FFFFFF;
 }
@@ -2952,7 +2956,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2741,6 +2741,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 2.48832rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #444444;
 }
@@ -2930,7 +2934,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2741,12 +2741,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 2.48832rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #444444;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -1009,6 +1009,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2743,12 +2747,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #444444;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2760,12 +2760,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 2.48832rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #444444;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2760,6 +2760,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 2.48832rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #444444;
 }
@@ -2949,7 +2953,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -1009,6 +1009,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2762,12 +2766,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #444444;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -1010,6 +1010,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2744,12 +2748,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #1e1e1e;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2742,6 +2742,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.74901rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #1e1e1e;
 }
@@ -2931,7 +2935,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2742,12 +2742,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.74901rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #1e1e1e;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2761,12 +2761,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.74901rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #1e1e1e;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -1010,6 +1010,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2763,12 +2767,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #1e1e1e;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2761,6 +2761,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 1.74901rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #1e1e1e;
 }
@@ -2950,7 +2954,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1543,14 +1543,14 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: #111111;
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1547,12 +1547,6 @@ pre.wp-block-verse {
 	color: #111111;
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/exford/style-editor.css
+++ b/exford/style-editor.css
@@ -1543,6 +1543,12 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: #111111;
 }
@@ -1732,7 +1738,7 @@ pre.wp-block-verse {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #111111;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #111111;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #111111;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/exford/style.css
+++ b/exford/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #111111;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/exford/style.css
+++ b/exford/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #111111;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/exford/style.css
+++ b/exford/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #111111;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1546,14 +1546,14 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1550,12 +1550,6 @@ pre.wp-block-verse {
 	color: var(--wp--preset--color--foreground);
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/hever/style-editor.css
+++ b/hever/style-editor.css
@@ -1546,6 +1546,12 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -1735,7 +1741,7 @@ pre.wp-block-verse {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2785,12 +2785,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2785,6 +2785,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -2974,7 +2978,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -1039,6 +1039,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2787,12 +2791,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/hever/style.css
+++ b/hever/style.css
@@ -2804,12 +2804,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/hever/style.css
+++ b/hever/style.css
@@ -1039,6 +1039,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2806,12 +2810,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/hever/style.css
+++ b/hever/style.css
@@ -2804,6 +2804,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -2993,7 +2997,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.82474rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #444444;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #444444;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.82474rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #444444;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/leven/style.css
+++ b/leven/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.82474rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #444444;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/leven/style.css
+++ b/leven/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #444444;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/leven/style.css
+++ b/leven/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.82474rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #444444;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2744,12 +2748,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #010101;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2742,6 +2742,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #010101;
 }
@@ -2931,7 +2935,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2742,12 +2742,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #010101;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2763,12 +2767,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #010101;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2761,12 +2761,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #010101;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2761,6 +2761,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #010101;
 }
@@ -2950,7 +2954,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1597,12 +1597,6 @@ b, strong {
 	color: #181818;
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1593,14 +1593,14 @@ b, strong {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: #181818;
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/maywood/style-editor.css
+++ b/maywood/style-editor.css
@@ -1593,6 +1593,12 @@ b, strong {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: #181818;
 }
@@ -1782,7 +1788,7 @@ b, strong {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #181818;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #181818;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #181818;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #181818;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #181818;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #181818;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1533,14 +1533,14 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--background);
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1537,12 +1537,6 @@ pre.wp-block-verse {
 	color: var(--wp--preset--color--background);
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/morden/style-editor.css
+++ b/morden/style-editor.css
@@ -1533,6 +1533,12 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--background);
 }
@@ -1722,7 +1728,7 @@ pre.wp-block-verse {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2770,6 +2770,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--background);
 }
@@ -2959,7 +2963,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -1038,6 +1038,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2772,12 +2776,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--background);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2770,12 +2770,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--background);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/morden/style.css
+++ b/morden/style.css
@@ -1038,6 +1038,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2791,12 +2795,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--background);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/morden/style.css
+++ b/morden/style.css
@@ -2789,12 +2789,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--background);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/morden/style.css
+++ b/morden/style.css
@@ -2789,6 +2789,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.75614rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--background);
 }
@@ -2978,7 +2982,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2744,6 +2744,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #222222;
 }
@@ -2933,7 +2937,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2744,12 +2744,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #222222;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -1012,6 +1012,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2746,12 +2750,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #222222;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2763,6 +2763,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #222222;
 }
@@ -2952,7 +2956,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2763,12 +2763,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #222222;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -1012,6 +1012,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2765,12 +2769,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #222222;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2743,12 +2743,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.8rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #f2f2f2;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2743,6 +2743,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.8rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #f2f2f2;
 }
@@ -2932,7 +2936,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2745,12 +2749,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #f2f2f2;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2762,6 +2762,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.8rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: #f2f2f2;
 }
@@ -2951,7 +2955,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2762,12 +2762,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.8rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: #f2f2f2;
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -1011,6 +1011,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2764,12 +2768,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: #f2f2f2;
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2781,6 +2781,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--background);
 }
@@ -2970,7 +2974,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -1035,6 +1035,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2783,12 +2787,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--background);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2781,12 +2781,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--background);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2800,6 +2800,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--background);
 }
@@ -2989,7 +2993,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2800,12 +2800,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--background);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -1035,6 +1035,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2802,12 +2806,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--background);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1533,6 +1533,12 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
+@counter-style empty {
+	.fse-template-part {
+		symbols: "– ";
+	}
+}
+
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--white);
 }
@@ -1602,7 +1608,7 @@ pre.wp-block-verse {
 	z-index: 1;
 }
 
-.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within], .js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -1619,7 +1625,8 @@ pre.wp-block-verse {
 		/* Submenu display */
 	}
 	.fse-template-part .main-navigation > div > ul li:hover > ul,
-	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] > ul,
 	.fse-template-part .main-navigation > div > ul li ul:hover,
 	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -1722,7 +1729,7 @@ pre.wp-block-verse {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1537,12 +1537,6 @@ pre.wp-block-verse {
 	color: var(--wp--preset--color--white);
 }
 
-@counter-style empty {
-	.fse-template-part .main-navigation {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation > div {
 	display: none;
 }

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1608,7 +1608,7 @@ pre.wp-block-verse {
 	z-index: 1;
 }
 
-.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within], .js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -1625,8 +1625,7 @@ pre.wp-block-verse {
 		/* Submenu display */
 	}
 	.fse-template-part .main-navigation > div > ul li:hover > ul,
-	.fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
-	.js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
 	.fse-template-part .main-navigation > div > ul li ul:hover,
 	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/shawburn/style-editor.css
+++ b/shawburn/style-editor.css
@@ -1533,14 +1533,14 @@ pre.wp-block-verse {
 	margin: 0 0 5px 0;
 }
 
-@counter-style empty {
-	.fse-template-part {
-		symbols: "– ";
-	}
-}
-
 .fse-template-part .main-navigation {
 	color: var(--wp--preset--color--white);
+}
+
+@counter-style empty {
+	.fse-template-part .main-navigation {
+		symbols: "– ";
+	}
 }
 
 .fse-template-part .main-navigation > div {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -1039,6 +1039,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2772,12 +2776,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--white);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2843,7 +2843,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2860,8 +2860,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2770,12 +2770,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--white);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2770,6 +2770,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--white);
 }
@@ -2839,7 +2843,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2856,7 +2860,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -2959,7 +2964,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2789,12 +2789,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--white);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2862,7 +2862,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2879,8 +2879,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2974,11 +2974,15 @@ body:not(.fse-enabled) .site-description {
 	padding-bottom: 8px;
 }
 
+@counter-style empty {
+	symbols: "";
+}
+
 .main-navigation .sub-menu .menu-item a::before {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2789,6 +2789,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--white);
 }
@@ -2858,7 +2862,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2875,7 +2879,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -2972,10 +2977,6 @@ body:not(.fse-enabled) .site-description {
 .main-navigation .sub-menu .menu-item a {
 	padding-top: 8px;
 	padding-bottom: 8px;
-}
-
-@counter-style empty {
-	symbols: "";
 }
 
 .main-navigation .sub-menu .menu-item a::before {

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -1039,6 +1039,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2791,12 +2795,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--white);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/stow/style.css
+++ b/stow/style.css
@@ -2804,12 +2804,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/stow/style.css
+++ b/stow/style.css
@@ -1039,6 +1039,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2806,12 +2810,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/stow/style.css
+++ b/stow/style.css
@@ -2804,6 +2804,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -2993,7 +2997,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -1038,6 +1038,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2786,12 +2790,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2784,6 +2784,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -2973,7 +2977,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2784,12 +2784,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2803,6 +2803,10 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
+@counter-style empty {
+	symbols: "– ";
+}
+
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
 }
@@ -2992,7 +2996,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2803,12 +2803,14 @@ body:not(.fse-enabled) .site-description {
 	font-size: 0.83333rem;
 }
 
-@counter-style empty {
-	symbols: "– ";
-}
-
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
+}
+
+@counter-style empty {
+	.main-navigation {
+		symbols: "– ";
+	}
 }
 
 .main-navigation > div {

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -1038,6 +1038,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2805,12 +2809,6 @@ body:not(.fse-enabled) .site-description {
 
 .main-navigation {
 	color: var(--wp--preset--color--foreground);
-}
-
-@counter-style empty {
-	.main-navigation {
-		symbols: "– ";
-	}
 }
 
 .main-navigation > div {

--- a/varia/postcss.config.js
+++ b/varia/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/varia/sass/components/header/_site-main-navigation.scss
+++ b/varia/sass/components/header/_site-main-navigation.scss
@@ -1,5 +1,8 @@
-// Navigation
+@counter-style empty {
+	symbols: "– ";
+}
 
+// Navigation
 .main-navigation {
 
 	color: #{map-deep-get($config-header, "main-nav", "color", "text")};
@@ -181,7 +184,7 @@
 				/* Increment the dashes */
 				counter-increment: nested-list;
 				/* Insert dashes with spaces in between */
-				content: "\2013\00a0" counters( nested-list, "\2013\00a0", none );
+				content: "– " counters(nested-list, "– ", empty);
 			}
 		}
 	}

--- a/varia/sass/components/header/_site-main-navigation.scss
+++ b/varia/sass/components/header/_site-main-navigation.scss
@@ -1,10 +1,6 @@
 // Navigation
 .main-navigation {
 
-	@counter-style empty {
-		symbols: "– ";
-	}
-
 	color: #{map-deep-get($config-header, "main-nav", "color", "text")};
 
 	// Menu wrapper

--- a/varia/sass/components/header/_site-main-navigation.scss
+++ b/varia/sass/components/header/_site-main-navigation.scss
@@ -1,9 +1,9 @@
-@counter-style empty {
-	symbols: "– ";
-}
-
 // Navigation
 .main-navigation {
+
+	@counter-style empty {
+		symbols: "– ";
+	}
 
 	color: #{map-deep-get($config-header, "main-nav", "color", "text")};
 
@@ -34,6 +34,7 @@
 	}
 
 	#toggle:checked + #toggle-menu {
+
 		.open {
 			display: none;
 		}
@@ -86,7 +87,7 @@
 			}
 
 			&:focus-within a {
-			//	outline: none;
+				//	outline: none;
 			}
 
 			@include media(mobile) {
@@ -108,7 +109,9 @@
 		& > li {
 
 			@include media(mobile) {
+
 				& > a {
+
 					@include crop-text(map-deep-get($config-header, "main-nav", "font", "line-height"));
 				}
 
@@ -149,6 +152,7 @@
 	a {
 		color: #{map-deep-get($config-header, "main-nav", "color", "link")};
 		display: block;
+
 		@include font-family( map-deep-get($config-header, "main-nav", "font", "family" ) );
 		font-weight: #{map-deep-get($config-header, "main-nav", "font", "weight")};
 		padding: #{0.5 * map-deep-get($config-header, "main-nav", "link-padding")} 0;
@@ -172,6 +176,7 @@
 
 		list-style: none;
 		margin-left: 0;
+
 		/* Reset the counter for each UL */
 		counter-reset: nested-list;
 
@@ -181,8 +186,10 @@
 			padding-bottom: #{0.5 * map-deep-get($config-header, "main-nav", "link-padding")};
 
 			&::before {
+
 				/* Increment the dashes */
 				counter-increment: nested-list;
+
 				/* Insert dashes with spaces in between */
 				content: "– " counters(nested-list, "– ", empty);
 			}
@@ -191,6 +198,7 @@
 
 	// Show top-level sub-menu indicators above mobile-breakpoint-only
 	@include media(mobile) {
+
 		& > div > ul > .menu-item-has-children > a {
 
 			&::after {
@@ -206,8 +214,8 @@
 	.hide-visually {
 		position: absolute !important;
 		clip: rect(1px, 1px, 1px, 1px);
-		padding:0 !important;
-		border:0 !important;
+		padding: 0 !important;
+		border: 0 !important;
 		height: 1px !important;
 		width: 1px !important;
 		overflow: hidden;
@@ -216,7 +224,8 @@
 
 // Prevent overruling the user defined font size value set inside Gutenberg
 // for Full Site Editing's Menu Navigation block.
-body:not( .fse-enabled ) {
+body:not(.fse-enabled) {
+
 	.main-navigation a {
 		font-size: #{map-deep-get($config-header, "main-nav", "font", "size")};
 	}

--- a/varia/sass/elements/_imports.scss
+++ b/varia/sass/elements/_imports.scss
@@ -2,6 +2,9 @@
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
 
 @import "blockquote";
 @import "forms";

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1528,7 +1528,7 @@ pre.wp-block-verse {
 	z-index: 1;
 }
 
-.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within], .js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -1545,8 +1545,7 @@ pre.wp-block-verse {
 		/* Submenu display */
 	}
 	.fse-template-part .main-navigation > div > ul li:hover > ul,
-	.fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
-	.js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
 	.fse-template-part .main-navigation > div > ul li ul:hover,
 	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/varia/style-editor.css
+++ b/varia/style-editor.css
@@ -1528,7 +1528,7 @@ pre.wp-block-verse {
 	z-index: 1;
 }
 
-.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part .main-navigation > div > ul li[focus-within] {
+.fse-template-part .main-navigation > div > ul li:hover, .fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within], .js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -1545,7 +1545,8 @@ pre.wp-block-verse {
 		/* Submenu display */
 	}
 	.fse-template-part .main-navigation > div > ul li:hover > ul,
-	.fse-template-part .main-navigation > div > ul li[focus-within] > ul,
+	.fse-template-part.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.js-focus-within .fse-template-part .main-navigation > div > ul li[focus-within] > ul,
 	.fse-template-part .main-navigation > div > ul li ul:hover,
 	.fse-template-part .main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -1648,7 +1649,7 @@ pre.wp-block-verse {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2775,7 +2775,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2792,8 +2792,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -970,6 +970,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-right: 16px;
 }
@@ -2771,7 +2775,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2788,7 +2792,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -2891,7 +2896,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {

--- a/varia/style.css
+++ b/varia/style.css
@@ -2794,7 +2794,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2811,8 +2811,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/varia/style.css
+++ b/varia/style.css
@@ -970,6 +970,10 @@ footer {
  * Elements
  * - Styles for basic HTML elemants
  */
+@counter-style empty {
+	symbols: "";
+}
+
 blockquote {
 	padding-left: 16px;
 }
@@ -2790,7 +2794,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2807,7 +2811,8 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
+	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;
@@ -2910,7 +2915,7 @@ body:not(.fse-enabled) .site-description {
 	/* Increment the dashes */
 	counter-increment: nested-list;
 	/* Insert dashes with spaces in between */
-	content: "– " counters(nested-list, "– ", none);
+	content: "– " counters(nested-list, "– ", empty);
 }
 
 @media only screen and (min-width: 560px) {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This is a fix for https://github.com/Automattic/themes/issues/7756

The previous code `content: "– " counters(nested-list, "– ", none);` isn't valid CSS. It works in some browsers but not all. 

(I found it didn't work in Firefox, which makes this a lot easier to test than iOS.)

The last parameter to the `counters` function is a `style`: https://developer.mozilla.org/en-US/docs/Web/CSS/counters. None doesn't seem to be a valid style, so intsead I have defined a style called `empty` which works the same as `none`.

## Testing instructions

1. Switch to a Varia based theme (e.g. Shawburn)
2. Add a menu, which has nested items
3. Open the front end your site in a mobile preview (small browser window should be fine)
4. Open the menu
5. Confirm that the nested items show `-`s before them like this
<img width="354" alt="Screenshot 2025-01-13 at 09 53 23" src="https://github.com/user-attachments/assets/5ed63635-203e-4567-a959-6b1caa160b37" />


#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/7756