### PR TITLE
Varia: Fix Postcss Focus Within settings

### DIFF
--- a/alves/postcss.config.js
+++ b/alves/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -4395,7 +4395,7 @@ body:not(.fse-enabled) #masthead {
 
 .site-footer #footer-info-wrapper .footer-navigation .footer-menu {
 	display: block;
-	justify-content: left;
+	justify-content: right;
 	margin: 0;
 }
 

--- a/balasana/postcss.config.js
+++ b/balasana/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/barnsbury/postcss.config.js
+++ b/barnsbury/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/brompton/postcss.config.js
+++ b/brompton/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/coutoire/postcss.config.js
+++ b/coutoire/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/dalston/postcss.config.js
+++ b/dalston/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/exford/postcss.config.js
+++ b/exford/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/hever/postcss.config.js
+++ b/hever/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/leven/postcss.config.js
+++ b/leven/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/mayland/postcss.config.js
+++ b/mayland/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/maywood/postcss.config.js
+++ b/maywood/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/morden/postcss.config.js
+++ b/morden/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/redhill/postcss.config.js
+++ b/redhill/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/rivington/postcss.config.js
+++ b/rivington/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/rockfield/postcss.config.js
+++ b/rockfield/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2850,7 +2850,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2867,8 +2867,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2869,7 +2869,7 @@ body:not(.fse-enabled) .site-description {
 	z-index: 1;
 }
 
-.main-navigation > div > ul li:hover, .main-navigation.js-focus-within > div > ul li[focus-within], .js-focus-within .main-navigation > div > ul li[focus-within] {
+.main-navigation > div > ul li:hover, .main-navigation > div > ul li[focus-within] {
 	cursor: pointer;
 	z-index: 99999;
 }
@@ -2886,8 +2886,7 @@ body:not(.fse-enabled) .site-description {
 		/* Submenu display */
 	}
 	.main-navigation > div > ul li:hover > ul,
-	.main-navigation.js-focus-within > div > ul li[focus-within] > ul,
-	.js-focus-within .main-navigation > div > ul li[focus-within] > ul,
+	.main-navigation > div > ul li[focus-within] > ul,
 	.main-navigation > div > ul li ul:hover,
 	.main-navigation > div > ul li ul:focus {
 		visibility: visible;

--- a/shawburn/postcss.config.js
+++ b/shawburn/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/stow/postcss.config.js
+++ b/stow/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };

--- a/stratford/postcss.config.js
+++ b/stratford/postcss.config.js
@@ -1,13 +1,11 @@
-var postcssFocusWithin = require('postcss-focus-within');
+var postcssFocusWithin = require( 'postcss-focus-within' );
 
 module.exports = {
-    plugins: {
-        autoprefixer: {}
-    }
+	plugins: {
+		autoprefixer: {},
+	},
 };
 
 module.exports = {
-    plugins: [
-        postcssFocusWithin(/* pluginOptions */)
-    ]
+	plugins: [ postcssFocusWithin( { disablePolyfillReadyClass: true } ) ],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Since #7059, Varia and the child themes have been outputting extra selectors for focus within (you can see this for example in https://github.com/Automattic/themes/pull/8469/)

The PR updates the settings for `postcssFocusWithin` so that it outputs the same selectors as before  #7059.

To test, run `npm run children` from inside `varia` and confirm that the focus-within selectors don't change.

#### Related issue(s):
