### PR TITLE
Quadrat, Zoologist, Geologist: Fix post nav block arrows

### DIFF
--- a/geologist/assets/theme.css
+++ b/geologist/assets/theme.css
@@ -8,13 +8,13 @@
 * @return {string} comma separated rgb values
 */
 /**
- * Breakpoint mixins
- */
-/**
  * Long content fade mixin
  *
  * Creates a fading overlay to signify that the content is longer
  * than the space allows.
+ */
+/**
+ * Breakpoint mixins
  */
 /**
  * Focus styles.
@@ -37,7 +37,7 @@
  */
 .wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -50,7 +50,7 @@
 .wp-block-search .wp-block-search__button:focus,
 .wp-block-search .wp-block-search__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -84,7 +84,6 @@ ul ul {
 
 .wp-block-post-navigation-link {
   border-top: 1px solid;
-  display: flex;
   padding-top: 1em;
 }
 
@@ -159,8 +158,7 @@ ul ul {
 }
 
 .wp-block-post-content a:not(.wp-block-button__link) {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
+  text-decoration-line: underline;
 }
 .wp-block-post-content a:not(.wp-block-button__link):hover {
   text-decoration: none;

--- a/geologist/block-templates/single.html
+++ b/geologist/block-templates/single.html
@@ -24,12 +24,12 @@
 		<div class="wp-block-columns alignwide next-prev-links">
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"type":"previous","label":"←","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"textAlign":"right","label":"→","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"textAlign":"right","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 		</div>

--- a/geologist/sass/blocks/_post-navigation-link.scss
+++ b/geologist/sass/blocks/_post-navigation-link.scss
@@ -1,21 +1,25 @@
 .wp-block-post-navigation-link {
 	border-top: 1px solid;
-	display: flex;
 	padding-top: 1em;
 }
+
 .post-navigation-link-next {
 	flex-direction: row-reverse;
+
 	a {
 		margin-right: 0.5em;
 	}
 }
+
 .post-navigation-link-previous {
+
 	a {
 		margin-left: 0.5em;
 	}
 }
 
 .next-prev-links {
+
 	.wp-block-column,
 	.wp-block-column:not(:only-child) {
 		flex-basis: 40% !important; // This is needed to override the collapsing columns in Gutenberg

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -251,7 +251,6 @@ ul ul {
 
 .wp-block-post-navigation-link {
   border-top: 1px solid;
-  display: flex;
   padding-top: 1em;
 }
 
@@ -372,7 +371,7 @@ input[type=datetime-local]:focus,
 input[type=color]:focus,
 input[type=checkbox]:focus,
 textarea:focus {
-  outline: 1px dotted currentColor;
+  outline: 1px dotted currentcolor;
 }
 
 .home .site-footer-container .wp-block-group:before {

--- a/quadrat/assets/theme.css
+++ b/quadrat/assets/theme.css
@@ -9,13 +9,13 @@
 * @return {string} comma separated rgb values
 */
 /**
- * Breakpoint mixins
- */
-/**
  * Long content fade mixin
  *
  * Creates a fading overlay to signify that the content is longer
  * than the space allows.
+ */
+/**
+ * Breakpoint mixins
  */
 /**
  * Focus styles.
@@ -204,7 +204,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
 
 .wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -217,7 +217,7 @@ div.horizontal-query-pattern figure.wp-block-post-featured-image img {
 .wp-block-search .wp-block-search__button:focus,
 .wp-block-search .wp-block-search__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -323,8 +323,7 @@ ul ul {
 }
 
 .wp-block-post-content a:not(.wp-block-button__link) {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
+  text-decoration-line: underline;
 }
 .wp-block-post-content a:not(.wp-block-button__link):hover {
   text-decoration: none;
@@ -379,8 +378,7 @@ textarea:focus {
 .home .site-footer-container .wp-block-group:before {
   content: "";
   background-color: var(--wp--custom--color--tertiary);
-  -webkit-clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
-          clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
+  clip-path: polygon(41vw 49vw, 100vw 68vw, 100vw 100vw, 18vw 100vw);
   position: absolute;
   height: 100vw;
   bottom: 0;
@@ -404,20 +402,17 @@ textarea:focus {
 }
 @media (max-width: 599px) {
   .wp-site-blocks .site-header:before {
-    -webkit-clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
-            clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
+    clip-path: polygon(0 0, 100vw 0, 100vw 50vw, 52vw 83vw, 0 20vw);
   }
 }
 @media (min-width: 600px) {
   .wp-site-blocks .site-header:before {
-    -webkit-clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
-            clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
+    clip-path: polygon(0 0, 100vw 0, 100vw 37vw, 52vw 70vw, 0 5vw);
   }
 }
 @media (min-width: 960px) {
   .wp-site-blocks .site-header:before {
-    -webkit-clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
-            clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
+    clip-path: polygon(13vw 0, 100vw 0, 100vw 16vw, 50vw 51vw);
   }
 }
 

--- a/quadrat/block-templates/single.html
+++ b/quadrat/block-templates/single.html
@@ -30,12 +30,12 @@
 		<div class="wp-block-columns alignwide next-prev-links">
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"type":"previous","label":"←","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"textAlign":"right","label":"→","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"textAlign":"right","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 		</div>

--- a/quadrat/sass/blocks/_post-navigation-link.scss
+++ b/quadrat/sass/blocks/_post-navigation-link.scss
@@ -1,21 +1,25 @@
 .wp-block-post-navigation-link {
 	border-top: 1px solid;
-	display: flex;
 	padding-top: 1em;
 }
+
 .post-navigation-link-next {
 	flex-direction: row-reverse;
+
 	a {
 		margin-right: 0.5em;
 	}
 }
+
 .post-navigation-link-previous {
+
 	a {
 		margin-left: 0.5em;
 	}
 }
 
 .next-prev-links {
+
 	.wp-block-column,
 	.wp-block-column:not(:only-child) {
 		flex-basis: 40% !important; // This is needed to override the collapsing columns in Gutenberg

--- a/quadrat/sass/elements/_forms.scss
+++ b/quadrat/sass/elements/_forms.scss
@@ -16,8 +16,9 @@ input[type="datetime-local"],
 input[type="color"],
 input[type="checkbox"],
 textarea {
-	&:focus {
-		outline: 1px dotted currentColor;
-	}
 	font-size: var(--wp--custom--font-size--normal);
+
+	&:focus {
+		outline: 1px dotted currentcolor;
+	}
 }

--- a/quadrat/sass/templates/_meta.scss
+++ b/quadrat/sass/templates/_meta.scss
@@ -1,8 +1,8 @@
 .post-meta {
-	@include post-meta-with-separator('·');
-
 	align-items: center;
 	justify-content: center;
+
+	@include post-meta-with-separator("·");
 
 	@include break-small-only() {
 		padding-top: 0 !important;

--- a/zoologist/assets/theme.css
+++ b/zoologist/assets/theme.css
@@ -8,13 +8,13 @@
 * @return {string} comma separated rgb values
 */
 /**
- * Breakpoint mixins
- */
-/**
  * Long content fade mixin
  *
  * Creates a fading overlay to signify that the content is longer
  * than the space allows.
+ */
+/**
+ * Breakpoint mixins
  */
 /**
  * Focus styles.
@@ -37,7 +37,7 @@
  */
 .wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -50,7 +50,7 @@
 .wp-block-search .wp-block-search__button:focus,
 .wp-block-search .wp-block-search__button.has-focus {
   border-style: var(--wp--custom--button--border--style);
-  border-color: currentColor;
+  border-color: currentcolor;
   border-width: var(--wp--custom--button--border--width);
   padding-top: var(--wp--custom--button--spacing--padding--top);
   padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
@@ -84,7 +84,6 @@ ul ul {
 
 .wp-block-post-navigation-link {
   border-top: 1px solid;
-  display: flex;
   padding-top: 1em;
 }
 
@@ -159,8 +158,7 @@ ul ul {
 }
 
 .wp-block-post-content a:not(.wp-block-button__link) {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
+  text-decoration-line: underline;
 }
 .wp-block-post-content a:not(.wp-block-button__link):hover {
   text-decoration: none;

--- a/zoologist/block-templates/single.html
+++ b/zoologist/block-templates/single.html
@@ -24,12 +24,12 @@
 		<div class="wp-block-columns alignwide next-prev-links">
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"type":"previous","label":"←","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"type":"previous","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 			<!-- wp:column -->
 			<div class="wp-block-column">
-				<!-- wp:post-navigation-link {"textAlign":"right","label":"→","showTitle":true} /-->
+				<!-- wp:post-navigation-link {"textAlign":"right","arrow":"arrow","showTitle":true} /-->
 			</div>
 			<!-- /wp:column -->
 		</div>

--- a/zoologist/sass/blocks/_post-navigation-link.scss
+++ b/zoologist/sass/blocks/_post-navigation-link.scss
@@ -1,21 +1,25 @@
 .wp-block-post-navigation-link {
 	border-top: 1px solid;
-	display: flex;
 	padding-top: 1em;
 }
+
 .post-navigation-link-next {
 	flex-direction: row-reverse;
+
 	a {
 		margin-right: 0.5em;
 	}
 }
+
 .post-navigation-link-previous {
+
 	a {
 		margin-left: 0.5em;
 	}
 }
 
 .next-prev-links {
+
 	.wp-block-column,
 	.wp-block-column:not(:only-child) {
 		flex-basis: 40% !important; // This is needed to override the collapsing columns in Gutenberg


### PR DESCRIPTION

#### Changes proposed in this Pull Request:



This PR implements the native arrow (that didn't exist when these themes were developed) and removes some CSS that was breaking the block on Quadrat, Zoologist and Geologist. I checked Blockbase and the rest of the children and none of them implement the post-nav block this way so they are unaffected.

Quadrat:

<img width="1368" alt="Screenshot 2025-01-13 at 12 37 41" src="https://github.com/user-attachments/assets/1ec91743-8f14-49fd-b839-5d762a3c2c7b" />

Zoologist:

<img width="1375" alt="Screenshot 2025-01-13 at 12 38 17" src="https://github.com/user-attachments/assets/f759ee62-3ed0-4bd3-a43e-65ae8623eff1" />

Geologist:

<img width="1355" alt="Screenshot 2025-01-13 at 12 38 40" src="https://github.com/user-attachments/assets/a1b24745-89c4-4316-ae0d-dfdbe956e3db" />


#### Related issue(s):

Closes https://github.com/Automattic/wp-calypso/issues/76558
