### PR TITLE
Blockbase: Fix previewing post editor colors from style variations in child themes

### DIFF
--- a/blockbase/assets/ponyfill.css
+++ b/blockbase/assets/ponyfill.css
@@ -123,43 +123,43 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 }
 
 .has-primary-background-color {
-  background-color: var(--wp--custom--color--primary) !important;
+  background-color: var(--wp--custom--color--primary);
 }
 
 .has-secondary-background-color {
-  background-color: var(--wp--custom--color--secondary) !important;
+  background-color: var(--wp--custom--color--secondary);
 }
 
 .has-foreground-background-color {
-  background-color: var(--wp--custom--color--foreground) !important;
+  background-color: var(--wp--custom--color--foreground);
 }
 
 .has-background-background-color {
-  background-color: var(--wp--custom--color--background) !important;
+  background-color: var(--wp--custom--color--background);
 }
 
 .has-tertiary-background-color {
-  background-color: var(--wp--custom--color--tertiary) !important;
+  background-color: var(--wp--custom--color--tertiary);
 }
 
 .has-primary-color {
-  color: var(--wp--custom--color--primary) !important;
+  color: var(--wp--custom--color--primary);
 }
 
 .has-secondary-color {
-  color: var(--wp--custom--color--secondary) !important;
+  color: var(--wp--custom--color--secondary);
 }
 
 .has-foreground-color {
-  color: var(--wp--custom--color--foreground) !important;
+  color: var(--wp--custom--color--foreground);
 }
 
 .has-background-color {
-  color: var(--wp--custom--color--background) !important;
+  color: var(--wp--custom--color--background);
 }
 
 .has-tertiary-color {
-  color: var(--wp--custom--color--tertiary) !important;
+  color: var(--wp--custom--color--tertiary);
 }
 
 @media (max-width: 599px) {

--- a/blockbase/sass/base/_colors.scss
+++ b/blockbase/sass/base/_colors.scss
@@ -6,33 +6,41 @@
 // This means that undefined colors are mapped to defined ones.
 
 .has-primary-background-color {
-	background-color: var(--wp--custom--color--primary) !important
+	background-color: var(--wp--custom--color--primary);
 }
+
 .has-secondary-background-color {
-	background-color: var(--wp--custom--color--secondary) !important
+	background-color: var(--wp--custom--color--secondary);
 }
+
 .has-foreground-background-color {
-	background-color: var(--wp--custom--color--foreground) !important
+	background-color: var(--wp--custom--color--foreground);
 }
+
 .has-background-background-color {
-	background-color: var(--wp--custom--color--background) !important
+	background-color: var(--wp--custom--color--background);
 }
+
 .has-tertiary-background-color {
-	background-color: var(--wp--custom--color--tertiary) !important
+	background-color: var(--wp--custom--color--tertiary);
 }
 
 .has-primary-color {
-	color: var(--wp--custom--color--primary) !important;
+	color: var(--wp--custom--color--primary);
 }
+
 .has-secondary-color {
-	color: var(--wp--custom--color--secondary) !important;
+	color: var(--wp--custom--color--secondary);
 }
+
 .has-foreground-color {
-	color: var(--wp--custom--color--foreground) !important;
+	color: var(--wp--custom--color--foreground);
 }
+
 .has-background-color {
-	color: var(--wp--custom--color--background) !important;
+	color: var(--wp--custom--color--background);
 }
+
 .has-tertiary-color {
-	color: var(--wp--custom--color--tertiary) !important;
+	color: var(--wp--custom--color--tertiary);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/6963

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

This PR removes the `!important` from the fallback color rules in the Blockbase stylesheet. The actual colors are defined in theme.json and generated in global styles, and these `!important` fallbacks cause problems in child themes with style variations loaded, when previewing colors in the post editor. The issue was raised referencing the Attar theme, but it is reproducible with other Blockbase child themes, like Ames.

**Please note that these rules do not cause the same issues when the Blockbase theme itself is activated, or in the site editor, or on the frontend.**

With a child theme like Attar activated and a style variation selected, the Blockbase theme styles are inlined in the post editor document after the style variation styles, overriding them and causing the color to be set to the Blockbase theme default custom colors:

![Screenshot 2025-01-14 at 7 03 15 PM](https://github.com/user-attachments/assets/6e9a8732-f04f-4c6c-ba89-085888fa5365)

Lowering the specificity of these rules allows the correct color presets generated from the style variation to be used, as expected.

An alternative fix could be to adjust the loading order, so that the Blockbase stylesheet is inlined before the global styles. I'm not aware of this happening with other non Blockbase themes however.

### Screenshots (Theme: Attar, Style variation: Charcoal)

| | Before | After |
|-|-|-|
| Text | ![Screenshot 2025-01-14 at 6 46 08 PM](https://github.com/user-attachments/assets/8576db45-e7fa-4af7-9507-9d8b0a3da6db) | ![Screenshot 2025-01-15 at 2 50 03 PM](https://github.com/user-attachments/assets/7211834c-028f-49df-8ed4-25cd712c78c4) |
| Button | ![Screenshot 2025-01-14 at 6 45 52 PM](https://github.com/user-attachments/assets/f17df434-1eca-4641-af56-b401ddb4a68c) | ![Screenshot 2025-01-15 at 2 47 57 PM](https://github.com/user-attachments/assets/9e71d90d-fcf7-42aa-9b08-f25cf1c4e043) |

## Testing

We need to test both the Blockbase theme and child themes.

1. Activate the Attar theme
2. Under Appearance -> Editor -> Styles, select a style variation and save
3. Edit a post, changing the color of elements using colors from the color palette (should be the colors from the style variation)
4. Observe that the colors are applied in the post editor preview
5. Save and check that the post on the frontend matches the post editor preview
6. Return to the admin and use the site editor to edit a page or template, changing colors
7. Observe that the colors are applied in the site editor preview
8. Save and check that the page on the frontend matches the site editor preview
9. Activate the Blockbase theme and repeat steps 2 - 8

Further regression testing:
- Activate other child themes and repeat steps 2 - 8
- Repeat steps 3 - 8 with Blockbase or a child theme, and **no** style variation selected