### PR TITLE
Outnow: Add Inter Tight font

### DIFF
--- a/outnow/templates/page.html
+++ b/outnow/templates/page.html
@@ -5,7 +5,7 @@
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"top","width":"33.3%"} -->
 <div class="wp-block-column is-vertically-aligned-top" style="flex-basis:33.3%"><!-- wp:group {"metadata":{"name":"Title and excerpt"},"align":"wide","layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group alignwide"><!-- wp:post-title {"level":1} /--></div>
+<div class="wp-block-group alignwide"><!-- wp:post-title {"level":1,"style":{"typography":{"letterSpacing":"-0.01rem"}},"fontSize":"large"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
 

--- a/outnow/templates/single.html
+++ b/outnow/templates/single.html
@@ -5,7 +5,7 @@
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"top","width":"33.3%"} -->
 <div class="wp-block-column is-vertically-aligned-top" style="flex-basis:33.3%"><!-- wp:group {"metadata":{"name":"Title and excerpt"},"align":"wide","layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group alignwide"><!-- wp:post-title {"level":1} /-->
+<div class="wp-block-group alignwide"><!-- wp:post-title {"level":1,"style":{"typography":{"letterSpacing":"-0.01rem"}},"fontSize":"large"} /-->
 
 <!-- wp:post-excerpt /--></div>
 <!-- /wp:group -->

--- a/outnow/theme.json
+++ b/outnow/theme.json
@@ -366,11 +366,11 @@
 				},
 				{
 					"fluid": {
-						"max": "4.8rem",
+						"max": "4.5rem",
 						"min": "2.5rem"
 					},
 					"name": "Extra Large",
-					"size": "4.8rem",
+					"size": "4.5rem",
 					"slug": "x-large"
 				}
 			],
@@ -655,7 +655,7 @@
 			"core/query-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--large)",
-					"letterSpacing": "-0.025rem"
+					"letterSpacing": "-0.01rem"
 				}
 			},
 			"core/quote": {
@@ -707,7 +707,6 @@
 					"text": "var(--wp--preset--color--custom-var-2-color-1)"
 				},
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--urbanist)",
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"letterSpacing": "0px",
 					"lineHeight": "1"
@@ -839,9 +838,9 @@
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--urbanist)",
+					"fontFamily": "var(--wp--preset--font-family--inter-tight)",
 					"fontStyle": "normal",
-					"fontWeight": "100",
+					"fontWeight": "300",
 					"lineHeight": "1"
 				}
 			},


### PR DESCRIPTION
This PR removes Urbanist from Heading and adds Inter Tight as intended. 
The Homepage QL were set to display default posts, with offset settings only.