### PR TITLE
Varia: Strengthen button CSS

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #ffffff;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #ffffff;
 	background-color: #2f5f74;

--- a/alves/style.css
+++ b/alves/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #ffffff;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #ffffff;
 	background-color: #2f5f74;

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #145f3e;

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #145f3e;

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFDF6;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
 	background-color: #133a24;

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFDF6;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: ("default": #FFFDF6, "light": #FDF9EC, "dark": #DDDDDD);
 	background-color: #133a24;

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -199,7 +199,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #E8E4DD;
@@ -218,11 +219,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -233,7 +236,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -241,7 +245,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -249,15 +254,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #E8E4DD;
 	background-color: #C04239;

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -199,7 +199,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #E8E4DD;
@@ -218,11 +219,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -233,7 +236,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -241,7 +245,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -249,15 +254,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #E8E4DD;
 	background-color: #C04239;

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -197,7 +197,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -215,11 +216,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -230,7 +233,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -238,7 +242,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -246,15 +251,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #FF7A5C;

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -197,7 +197,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -215,11 +216,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -230,7 +233,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -238,7 +242,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -246,15 +251,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #FF7A5C;

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -197,7 +197,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -216,11 +217,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -231,7 +234,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -239,7 +243,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -247,15 +252,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #005177;

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -197,7 +197,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -216,11 +217,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -231,7 +234,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -239,7 +243,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -247,15 +252,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #005177;

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #195f2b;

--- a/exford/style.css
+++ b/exford/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #195f2b;

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -226,7 +226,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -245,11 +246,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -260,7 +263,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -268,7 +272,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -276,15 +281,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/hever/style.css
+++ b/hever/style.css
@@ -226,7 +226,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -245,11 +246,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -260,7 +263,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -268,7 +272,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -276,15 +281,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #1285ce;

--- a/leven/style.css
+++ b/leven/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #1285ce;

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #666666;

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #666666;

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #685636;

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: #685636;

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -225,7 +225,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -244,11 +245,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -259,7 +262,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -267,7 +271,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -275,15 +280,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/morden/style.css
+++ b/morden/style.css
@@ -225,7 +225,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -244,11 +245,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -259,7 +262,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -267,7 +271,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -275,15 +280,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -199,7 +199,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -218,11 +219,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -233,7 +236,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -241,7 +245,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -249,15 +254,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #222222;

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -199,7 +199,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: #FFFFFF;
@@ -218,11 +219,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -233,7 +236,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -241,7 +245,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -249,15 +254,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #FFFFFF;
 	background-color: #222222;

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1.15;
 	color: #060f29;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.195em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.185em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #060f29;
 	background-color: #b59439;

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -198,7 +198,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1.15;
 	color: #060f29;
@@ -217,11 +218,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -232,7 +235,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.195em;
 }
@@ -240,7 +244,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.185em;
 }
@@ -248,15 +253,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: #060f29;
 	background-color: #b59439;

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -222,7 +222,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -241,11 +242,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -256,7 +259,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -264,7 +268,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -272,15 +277,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -222,7 +222,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -241,11 +242,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -256,7 +259,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -264,7 +268,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -272,15 +277,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -226,7 +226,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -245,11 +246,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -260,7 +263,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -268,7 +272,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -276,15 +281,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -226,7 +226,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -245,11 +246,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -260,7 +263,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -268,7 +272,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -276,15 +281,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary-hover);

--- a/stow/style.css
+++ b/stow/style.css
@@ -226,7 +226,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: var(--wp--preset--color--background);
@@ -245,11 +246,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -260,7 +263,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -268,7 +272,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -276,15 +281,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--secondary-hover);

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -225,7 +225,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1.44;
 	color: var(--wp--preset--color--background);
@@ -244,11 +245,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -259,7 +262,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.34em;
 }
@@ -267,7 +271,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.33em;
 }
@@ -275,15 +280,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary);

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -225,7 +225,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1.44;
 	color: var(--wp--preset--color--background);
@@ -244,11 +245,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -259,7 +262,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.34em;
 }
@@ -267,7 +271,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.33em;
 }
@@ -275,15 +280,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: var(--wp--preset--color--background);
 	background-color: var(--wp--preset--color--primary);

--- a/varia/sass/blocks/button/_style.scss
+++ b/varia/sass/blocks/button/_style.scss
@@ -4,7 +4,8 @@
 button,
 .button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button {
 	// Extend button style
 	@extend %button-style;
@@ -52,11 +53,13 @@ input[type="submit"],
 
 	// Set alignleft as default floating behavior
 	.entry-content > &:not(.alignleft):not(.alignright) {
+
 		@extend %responsive-alignleft;
 	}
 
 	// Set aligndefault as center floating behavior
 	.entry-content > &.aligncenter {
+
 		@extend %responsive-aligndefault;
 	}
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -157,7 +157,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -176,11 +177,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -191,7 +194,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -199,7 +203,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -207,15 +212,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: indigo;

--- a/varia/style.css
+++ b/varia/style.css
@@ -157,7 +157,8 @@ $grid-configuration: map-extend($grid-configuration-default, $grid-configuration
 button[data-load-more-btn],
 .button, button,
 input[type="submit"],
-.wp-block-button__link,
+a.wp-block-button__link,
+button.wp-block-button__link,
 .wp-block-file__button, .a8c-posts-list__view-all, .wp-block-search .wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept {
 	line-height: 1;
 	color: white;
@@ -176,11 +177,13 @@ input[type="submit"],
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before, button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	content: '';
 	display: block;
@@ -191,7 +194,8 @@ input[type="submit"]:after,
 button[data-load-more-btn]:before,
 .button:before, button:before,
 input[type="submit"]:before,
-.wp-block-button__link:before,
+a.wp-block-button__link:before,
+button.wp-block-button__link:before,
 .wp-block-file__button:before, .a8c-posts-list__view-all:before, .wp-block-search .wp-block-search__button:before, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:before {
 	margin-bottom: -0.12em;
 }
@@ -199,7 +203,8 @@ input[type="submit"]:before,
 button[data-load-more-btn]:after,
 .button:after, button:after,
 input[type="submit"]:after,
-.wp-block-button__link:after,
+a.wp-block-button__link:after,
+button.wp-block-button__link:after,
 .wp-block-file__button:after, .a8c-posts-list__view-all:after, .wp-block-search .wp-block-search__button:after, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:after {
 	margin-top: -0.11em;
 }
@@ -207,15 +212,15 @@ input[type="submit"]:after,
 
 .button:not(.has-background):hover, button:not(.has-background):hover,
 input:not(.has-background):hover[type="submit"],
-.wp-block-button__link:not(.has-background):hover,
+a.wp-block-button__link:not(.has-background):hover,
 .wp-block-file__button:not(.has-background):hover, .a8c-posts-list__view-all:not(.has-background):hover, .wp-block-search .wp-block-search__button:not(.has-background):hover, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:not(.has-background):hover,
 .button:focus, button:focus,
 input:focus[type="submit"],
-.wp-block-button__link:focus,
+a.wp-block-button__link:focus,
 .wp-block-file__button:focus, .a8c-posts-list__view-all:focus, .wp-block-search .wp-block-search__button:focus, body .widget_eu_cookie_law_widget #eu-cookie-law input.accept:focus,
 .has-focus.button, button.has-focus,
 input.has-focus[type="submit"],
-.has-focus.wp-block-button__link,
+a.has-focus.wp-block-button__link,
 .has-focus.wp-block-file__button, .has-focus.a8c-posts-list__view-all, .wp-block-search .has-focus.wp-block-search__button, body .widget_eu_cookie_law_widget #eu-cookie-law input.has-focus.accept {
 	color: white;
 	background-color: indigo;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This stengthens the button CSS in Varia based themes so that when the CSS is concatenated by the page-optimize plugin, the theme CSS still wins.

#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/7309
Fixes #2327

Before:
<img width="675" alt="Screenshot 2025-01-16 at 13 00 57" src="https://github.com/user-attachments/assets/1e7306ff-79f0-46b8-ba1c-d508582cfa64" />


After:
<img width="597" alt="Screenshot 2025-01-16 at 13 00 27" src="https://github.com/user-attachments/assets/959779c8-f6b9-4b94-8fd4-660cba87207d" />

To test:
1. Install the page optimize plugin - https://github.com/Automattic/page-optimize/
2. Activate the plugin and confirm that button styles are now grey
3. Checkout this PR and confirm that buttons appear as expected again