### PR TITLE
Publication: Fix patterns with Full Width and Wide Width

### DIFF
--- a/publication/blocks.css
+++ b/publication/blocks.css
@@ -21,8 +21,8 @@ Description: Used to style Gutenberg Blocks.
 /* Full Width */
 
 .no-sidebar .alignfull {
-	width: 100%;
-	max-width: 100%;
+	width: 100vw;
+	max-width: 100vw;
 	margin-left: 0;
 	margin-right: 0;
 	position: relative;
@@ -55,14 +55,10 @@ Description: Used to style Gutenberg Blocks.
 /* Wide Width */
 
 @media (min-width: 1100px) {
+
 	.no-sidebar .alignwide {
 		width: 1100px;
 		max-width: 1100px;
-		margin-left: 0;
-		margin-right: -0;
-		position: relative;
-		left: 50%;
-		transform: translateX( -50% );
 	}
 
 	.no-sidebar .wp-block-embed.is-type-video.alignwide iframe {

--- a/publication/blocks.css
+++ b/publication/blocks.css
@@ -58,9 +58,11 @@ Description: Used to style Gutenberg Blocks.
 	.no-sidebar .alignwide {
 		width: 1100px;
 		max-width: 1100px;
-		margin-left: -268px;
-		margin-right: -268px;
+		margin-left: 0;
+		margin-right: -0;
 		position: relative;
+		left: 50%;
+		transform: translateX( -50% );
 	}
 
 	.no-sidebar .wp-block-embed.is-type-video.alignwide iframe {

--- a/publication/blocks.css
+++ b/publication/blocks.css
@@ -21,8 +21,8 @@ Description: Used to style Gutenberg Blocks.
 /* Full Width */
 
 .no-sidebar .alignfull {
-	width: 100vw;
-	max-width: 100vw;
+	width: 100%;
+	max-width: 100%;
 	margin-left: 0;
 	margin-right: 0;
 	position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This changes the styles for `.no-sidebar .alignfull` and `.no-sidebar .alignwide` so that the container does not disappear off the side of the viewport. It also ensures the Full Width alignment makes the container the full width, and the Wide Width is the wide setting at 1100px.

Full Width:
| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/7d26b643-825a-4530-a985-1c33ee83ee49) | ![image](https://github.com/user-attachments/assets/f51b305f-cf83-4d75-8ad5-c29618a5b12d) |

Wide Width:
![image](https://github.com/user-attachments/assets/be197310-309b-4efc-9221-62ea5ad1ba17)

Testing instructions:

1. Activate Publication on a simple site
2. Add a new page
3. Insert an About pattern (I used the third in the list)

![Screenshot 2025-01-16 at 13 13 37](https://github.com/user-attachments/assets/c012477e-c084-44c9-8675-ed61e1afee53)

4. Make sure the pattern has Full Width or Wide Width alignment
5. Save and view the page on the front end
6. The pattern should be fully visible for both alignments

#### Related issue(s):
Closes https://github.com/Automattic/themes/issues/8078
