### PR TITLE
Varia: Fix Jetpack subscription button

### DIFF
--- a/alves/style-rtl.css
+++ b/alves/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/alves/style.css
+++ b/alves/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/balasana/style-rtl.css
+++ b/balasana/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/balasana/style.css
+++ b/balasana/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/barnsbury/style-rtl.css
+++ b/barnsbury/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/barnsbury/style.css
+++ b/barnsbury/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/brompton/style-rtl.css
+++ b/brompton/style-rtl.css
@@ -2300,6 +2300,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/brompton/style.css
+++ b/brompton/style.css
@@ -2300,6 +2300,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/coutoire/style-rtl.css
+++ b/coutoire/style-rtl.css
@@ -2297,6 +2297,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/coutoire/style.css
+++ b/coutoire/style.css
@@ -2297,6 +2297,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/dalston/style-rtl.css
+++ b/dalston/style-rtl.css
@@ -2298,6 +2298,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/dalston/style.css
+++ b/dalston/style.css
@@ -2298,6 +2298,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/exford/style-rtl.css
+++ b/exford/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/exford/style.css
+++ b/exford/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/hever/style-rtl.css
+++ b/hever/style-rtl.css
@@ -2327,6 +2327,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/hever/style.css
+++ b/hever/style.css
@@ -2327,6 +2327,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/leven/style-rtl.css
+++ b/leven/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/leven/style.css
+++ b/leven/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/mayland/style-rtl.css
+++ b/mayland/style-rtl.css
@@ -2298,6 +2298,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/mayland/style.css
+++ b/mayland/style.css
@@ -2298,6 +2298,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/maywood/style-rtl.css
+++ b/maywood/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/maywood/style.css
+++ b/maywood/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/morden/style-rtl.css
+++ b/morden/style-rtl.css
@@ -2326,6 +2326,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/morden/style.css
+++ b/morden/style.css
@@ -2326,6 +2326,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/redhill/style-rtl.css
+++ b/redhill/style-rtl.css
@@ -2300,6 +2300,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/redhill/style.css
+++ b/redhill/style.css
@@ -2300,6 +2300,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/rivington/style-rtl.css
+++ b/rivington/style-rtl.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/rivington/style.css
+++ b/rivington/style.css
@@ -2299,6 +2299,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/rockfield/style-rtl.css
+++ b/rockfield/style-rtl.css
@@ -2323,6 +2323,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/rockfield/style.css
+++ b/rockfield/style.css
@@ -2323,6 +2323,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/shawburn/style-rtl.css
+++ b/shawburn/style-rtl.css
@@ -2327,6 +2327,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/shawburn/style.css
+++ b/shawburn/style.css
@@ -2327,6 +2327,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/stow/style.css
+++ b/stow/style.css
@@ -2327,6 +2327,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/stratford/style-rtl.css
+++ b/stratford/style-rtl.css
@@ -2326,6 +2326,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/stratford/style.css
+++ b/stratford/style.css
@@ -2326,6 +2326,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/varia/sass/blocks/subscription/style.scss
+++ b/varia/sass/blocks/subscription/style.scss
@@ -1,6 +1,12 @@
 .jetpack_subscription_widget {
-  input[type="text"] {
-    padding: #{map-deep-get($config-elements, "form", "padding")} !important;
-    width: 100% !important;
-  }
+
+	input[type="text"] {
+		padding: #{map-deep-get($config-elements, "form", "padding")} !important;
+		width: 100% !important;
+	}
+}
+
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
 }

--- a/varia/style-rtl.css
+++ b/varia/style-rtl.css
@@ -2258,6 +2258,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;

--- a/varia/style.css
+++ b/varia/style.css
@@ -2258,6 +2258,11 @@ hr.wp-block-separator.is-style-dots:before {
 	width: 100% !important;
 }
 
+.wp-block-jetpack-subscriptions button::before,
+.wp-block-jetpack-subscriptions button::after {
+	display: none;
+}
+
 table,
 .wp-block-table {
 	width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Override the :: before and ::after selectors for the button in the Jetpack subscription block. This CSS is added to all buttons in Varia themes. I'm not sure why it's there, but removing it changes a lot of buttons. Instead this small change only targets buttons in the Jetpack subscription block, so its scope is much smaller.

Before - notice that the button isn't inline with the input
<img width="854" alt="Screenshot 2025-01-16 at 15 35 43" src="https://github.com/user-attachments/assets/83214eb3-3444-4119-8f35-4f26e94ec3ff" />

After: - notice that the button is now inline with the input
<img width="849" alt="Screenshot 2025-01-16 at 15 35 17" src="https://github.com/user-attachments/assets/d0d11912-8417-440a-b913-51eb70c97dcb" />


#### Related issue(s):
Fixes https://github.com/Automattic/themes/issues/6785