### PR TITLE
Bump required PHP versions to 7.2

### DIFF
--- a/adonay/style.css
+++ b/adonay/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Adonay is crafted for single page websites that want to leave a stunning and memorable first impression. Nonetheless, the theme provides post and page templates for those looking to customize and broaden their website's functionality. Adonay comes with 3 distinctive style variations and an array of 12 vibrant color options.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/adventurer/style.css
+++ b/adventurer/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A theme for travelers, writers and photographers.
 Requires at least: 6.1
 Tested up to: 6.1.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/aether/style.css
+++ b/aether/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Aether is a store theme designed for small jewelry and accessories brands. Perfect for creators looking to highlight the unique beauty and craftsmanship of their handmade items.
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/aigoo/style.css
+++ b/aigoo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Aigoo is a theme for K-Pop enthusiasts.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/aldente/style.css
+++ b/aldente/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Al Dente is a blog theme perfect for blogs whose posts are categorised, for example food recipe blogs.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/alleyoop/style.css
+++ b/alleyoop/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: AlleyOop is a theme site created for fans (and practitioners) who want to blog about their sport.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/allez/style.css
+++ b/allez/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Allez is the perfect theme site for sports practitioners or fans who want to blog about their sport.
 Requires at least: 6.0
 Tested up to: 6.4.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/alter/style.css
+++ b/alter/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/alter
 Description: Alter is a lean theme for bloggers that goes directly to the point, showing text-only posts right above the fold ornamented by a single image to compound the style.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ames/style.css
+++ b/ames/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Ames is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/antonia/style.css
+++ b/antonia/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Antonia is a theme for selling products with the help of payments block.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/appleton/style.css
+++ b/appleton/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Appleton is a theme for creative professionals, such as photographers, designers and artists.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.10
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/arbutus/style.css
+++ b/arbutus/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Arbutus is a simple blogging theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/archeo/style.css
+++ b/archeo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme inspired by Mayan history and culture
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.21
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/archivo/style.css
+++ b/archivo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Archivo is a blog and portfolio theme that shows your featured image large.
 Requires at least: 6.3
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/artly/style.css
+++ b/artly/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Artly is a WordPress theme designed for blogs and magazines. Its modern, offset layout for posts and pages comes in three style variations, allowing you to showcase your content in a visually stunning and functional way. With Artly, you can display your content beautifully and efficiently, all in a package that is easy to use and customize.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/assembler/style.css
+++ b/assembler/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Assemble something beautiful.
 Requires at least: 6.4
 Tested up to: 6.4
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 0.0.29
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/attar/style.css
+++ b/attar/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Attar is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/awburn/style.css
+++ b/awburn/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Awburn is the ideal choice for creating an online presence for your business. As a block theme, Awburn allows you to choose any of the available blocks to create a wide range of content for your site. It comes with a set of color and style variations and templates to choose from.
 Requires at least: 5.8
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/azur/style.css
+++ b/azur/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Azur draws its inspiration from the mesmerizing hues of the Azure coast, where the Èze village is located.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bain-marie/style.css
+++ b/bain-marie/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Bain Marie is the perfect blogging theme for food bloggers. Featuring elegant, modern styles and specialized recipe cards, it offers a reliable and attractive choice for your blog. The theme includes two color palettes, providing you with more customization options.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 0.0.34
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bark/style.css
+++ b/bark/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A playful and energetic theme designed specifically for local dog walking and pet care businesses.
 Requires at least: 6.4
 Tested up to: 6.4
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 0.0.18
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/barnett/style.css
+++ b/barnett/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Barnett is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/barnsbury23/style.css
+++ b/barnsbury23/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: The recently updated Barnsbury is an earthy, friendly theme made with farming and agriculture businesses in mind — but versatile enough for a personal site, too.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/batch/style.css
+++ b/batch/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Batch is a store theme designed for small food-related businesses.
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bedrock/style.css
+++ b/bedrock/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Inspired by the iconic worlds of Minecraft and Minetest, Bedrock is a blog theme that reminds the immersive experience of these games.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/beep/style.css
+++ b/beep/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Inspired by the phrase “code is poetry”, this is a geeky theme designed for those who appreciate the beauty of code. It is a text-heavy theme with a dark palette that plays with the idea of emulating a terminal prompt or code editor.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bennett/style.css
+++ b/bennett/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Bennet is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bibimbap/style.css
+++ b/bibimbap/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A simple and fun restaurant theme.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/bibliophile/style.css
+++ b/bibliophile/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Bibliophile was designed to provide an impeccable reading experience. Its header on the left sidebar adds context, while its posts and content are elegantly displayed on the right. Inspired by printed books and with carefully chosen font sizes, Bibliophile offers a great solution for websites across devices. The layout is user-friendly and allows for seamless navigation, making it an ideal choice for those who enjoy reading on-the-go.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bitacora/style.css
+++ b/bitacora/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Bitácora is a simple old-school blog theme.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.10
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blank-canvas-3/style.css
+++ b/blank-canvas-3/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description:Blank Canvas is a barebones starter theme, stripped off of content templates but only a footer and a header. With its minimal styling, Blank Canvas is a great theme starting fresh with your website.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.11
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blank-canvas-blocks/style.css
+++ b/blank-canvas-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets by default, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 0.0.10
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blank-canvas/style.css
+++ b/blank-canvas/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Blank Canvas is a minimalist theme, designed for single-page websites. Its single post and page layouts have no header, navigation menus, or widgets by default, so the page you design in the WordPress editor is the same page you’ll see on the front end. The theme’s default styles are conservative, relying on simple sans-serif fonts and a subtle blue highlight color. Blank Canvas is ready for your customizations.
 Requires at least: 4.9.6
 Tested up to: 5.6
-Requires PHP: 5.6.2
+Requires PHP: 7.2
 Version: 1.2.12-wpcom
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blissed/style.css
+++ b/blissed/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Blissed is a theme created to serve as a comprehensive hub for all your wedding-related links. Designed with joy, the theme offers a sleek and intuitive interface that functions like a link tree for engaged couples to organize their event and share their thoughts with their guests.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/block-canvas/style.css
+++ b/block-canvas/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Block Canvas is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.0
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 0.0.32
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blockbase/style.css
+++ b/blockbase/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Blockbase is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 3.1.23
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blogorama/style.css
+++ b/blogorama/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: A beautifully designed blog theme displaying large typography and customizable color palettes. With a clean and modern design, Blogorama offers a unique and engaging way to showcase your blog content.
 Requires at least: 5.8
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/boxedbio/style.css
+++ b/boxedbio/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Your new Link-in-Bio site, BoxedBio, offers a simple organization of blocks to display contact information and links on an exciting landing page.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/brightblog/style.css
+++ b/brightblog/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Brightblog is a blog theme displaying large typography and vibrant color palettes. With its clean and modern design, the theme offers a unique and engaging way to showcase your blog content.
 Requires at least: 5.8
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/brute/style.css
+++ b/brute/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Brute is a theme design inspired by the Brutalist concepts of the homonymous Architectural movement. It aims to be harsh, honest, utilitarian, and useful. It is a good portfolio pick for architects, design studios, and creative organizations.
 Requires at least: 5.8
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bsoj/style.css
+++ b/bsoj/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: BSoJ (Blue Screen of Joy) is a blog theme inspired by the infamous Blue Screen of Death.
 Requires at least: 6.1
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bute/style.css
+++ b/bute/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Bute is a blog theme that has a full-screen front page
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/bysshe/style.css
+++ b/bysshe/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Bysshe is crafted light and elegantly for poetry. It explores using blocks of text as the primary design element.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/cakely/style.css
+++ b/cakely/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Cakely is a business theme with a vibrant colour. It's perfect for bakers or cake makers who would like to turn their passion into a side hustle.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/calvin/style.css
+++ b/calvin/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Calvin is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/calyx/style.css
+++ b/calyx/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Calyx is a simple theme that supports full-site editing. 
 Requires at least: 5.7
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.14
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/castcore/style.css
+++ b/castcore/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Welcome podcast producers about to onboard this journey — CastCore is designed to be your first podcast site.
 Requires at least: 6.1
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/casthub/style.css
+++ b/casthub/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme specially crafted for users who want to publish their show episodes on a professional hub site.
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/chanson/style.css
+++ b/chanson/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Chanson is an homage to Édith Piaf. It is direct and undisguised, echoing a somewhat simpler time when webpages were just hypertext documents—without ornament nor unnecessary adorn, straightforward and classic.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/coachava/style.css
+++ b/coachava/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Coach Ava is a theme designed for coaching professionals. It is tailored to showcase services, blog posts, and podcasts. It is the ideal platform to establish a solid online presence and connect coaches with their audience.
 Requires at least: 6.1
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/coachben/style.css
+++ b/coachben/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Coach Ben is a theme designed for coaching professionals. It is tailored for showcasing services, blog posts, and podcasts — the ideal platform to establish a solid online presence and connect coaches with their audience.
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/colorloops/style.css
+++ b/colorloops/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Colorloops is a minimalistic theme designed to bring some color to your blogging. With a thoughtful, neutral frame, this theme will make your blog posts shine with a colorful effect.
 Requires at least: 6.1
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/colorstream/style.css
+++ b/colorstream/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Colorstream is a slick and minimalistic theme design crafted especially for WordPress blogs.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/common/style.css
+++ b/common/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Common\'s style is anything but ordinary and it speaks for itself. The unique combination of an uppercase monospaced font and aesthetically pleasing demo content creates an excellent foundation for any website. Common is perfect for showcasing photos, articles, or collections of content. With its ever-present sidebar menu, browsing through content is both effortless and enjoyable.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/conference/style.css
+++ b/conference/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme designed for meetups and conferences. Use Conference to create captivating event websites with user-friendly customization options to ensure your gatherings leave a lasting impression.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/cookbook/style.css
+++ b/cookbook/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Cookbook is a versatile theme designed to cater to various content creators. It explores the Query Loop element in a very particular way, with zero spacings and block strokes.
 Requires at least: 6.0
 Tested up to: 6.4.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/cortado/style.css
+++ b/cortado/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Cortado is a simple and elegant theme. Its colors and typography work together perfectly to deliver a subtle style, perfect for restaurants and coffee shops.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/cottage/style.css
+++ b/cottage/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Cottage is a cottagecore blogging theme based on Tronar theme.
 Requires at least: 6.0
 Tested up to: 6.4.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/course/style.css
+++ b/course/style.css
@@ -6,7 +6,7 @@ Description: Course is a flexible and modern education theme for anyone wanting 
 Version: 1.3.9
 Requires at least: 6.3
 Tested up to: 6.6
-Requires PHP: 7.4
+Requires PHP: 7.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: course

--- a/covr/style.css
+++ b/covr/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Covr is a simple and straightforward theme designed for a sleek presentation of images. With its full width images home template, Covr makes any photography blog, portfolio or blog beautiful and enjoyable to browse through. Contrasting with the immersiveness is its highly functional single post template. Use Covr to present your work, display your photos or tell your stories.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/craftfully/style.css
+++ b/craftfully/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A cheerful WordPress blogging theme dedicated to all things homemade and delightful.
 Requires at least: 6.0
 Tested up to: 6.4.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/creatio-2/style.css
+++ b/creatio-2/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Creatio 2 is a simple, minimal theme that supports full-site editing and global styles. Use it to create something beautiful.
 Requires at least: 6.0
 Tested up to: 6.3.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/creatio/style.css
+++ b/creatio/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Creatio is a simple, minimal theme that supports full-site editing and global styles. Use it to build something beautiful.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ctlg/style.css
+++ b/ctlg/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: CTLG is a free WordPress block theme that is specifically designed for creating lists, directories, and catalogs. It comes with a variety of pre-designed block templates and style variations.
 Requires at least: 6.0
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/cubico/style.css
+++ b/cubico/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Cubico is a block version of the classic Cubic, a grid-based theme with large featured images, perfect for photoblogging.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/curriculum/style.css
+++ b/curriculum/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/curriculum
 Description: Curriculum is a blog theme that echoes the structure of a professional profile with original visuals and interesting navigation. It\\\'s suitable for the general public displaying information, experiences, and education. And it\\\'s super easy to be customized.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dadaist/style.css
+++ b/dadaist/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Dadaist is a theme designed to celebrate Dadaism and its great artists. A theme design full of diverse typefaces and background images to wrap a unique blog design.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dark-academia/style.css
+++ b/dark-academia/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Dark Academia is a blog theme with Dark Academia aesthetics. The unique 50:50 split layout reminds you of the books.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dawson/style.css
+++ b/dawson/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Dawson is a WordPress portfolio theme specifically tailored for photography. With a two column layout, the theme is ideal for those looking to build a portfolio website. Additionally, Dawson offers five distinct style variations, providing a wide range of aesthetic options to choose from.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/didone/style.css
+++ b/didone/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Didone draws inspiration from a genre of serif typeface that originated in the 18th century and became the standard style for general-purpose printing. It is bold, straightforward and timeless, designed to bring attention to the content and ideal to those looking to showcase written content elegantly.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/disco/style.css
+++ b/disco/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Disco is a funky, vibrant, opinionated theme with a monospaced font. Both its styles and spacing form an edgy aesthetic perfect for those looking to build a quirky website.
 Requires at least: 5.8
 Tested up to: 6.0.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dorna/style.css
+++ b/dorna/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Dorna is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dos/style.css
+++ b/dos/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: DOS is a blog theme designed for the nostalgic ones, a tribute to the folks that invented computing as we know it today. Let us blog as if we were back to green (or amber) phosphor back again.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dossier/style.css
+++ b/dossier/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A smooth portfolio theme, ready to display your projects in a refined, effective site.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/downtown/style.css
+++ b/downtown/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Downtown was designed as a spin-off of Vetro, a theme composed of wide-width layouts with generous space for images and bold type sizes. Its pages are composed of wide content blocks to grant viewers focus on visuals and short paragraphs.
 Requires at least: 6.5
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/dropp/style.css
+++ b/dropp/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Dropp is a blogging theme that appeals to the sneakerhead. Its urban styles with bold typography and vibrant accent color make it ideal to the streetwear enthusiasts looking to express themselves.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/entry/style.css
+++ b/entry/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Entry is a uniquely styled WordPress block theme designed for journaling. It features a grid layout and blocky layout for posts, with every element contained in squared or rectangular shapes. Its impactful design is sure to make a statement, while its customizable templates offer a range of options for creating a truly unique journaling experience.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/epi/style.css
+++ b/epi/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Epi is a simple blog theme with a sticky left sidebar.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/erma/style.css
+++ b/erma/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Erma is a WordPress portfolio block theme that features gorgeous imagery and modern layouts. With three unique style variations and elegant templates, Erma is the perfect choice for artists, designers, and other creative professionals looking to showcase their work in an eye-catching way. The theme's design is clean and sophisticated, allowing your portfolio pieces to take center stage.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.11
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/eventual/style.css
+++ b/eventual/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: As its name states Eventual is a theme designed for events and ceremonies. It is simple, and direct allowing users to display the essence of their subject with a large artwork on the Homepage.
 Requires at least: 6.1
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/exmoor/style.css
+++ b/exmoor/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Exmoor is a business theme
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/farrow/style.css
+++ b/farrow/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Farrow is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/feature/style.css
+++ b/feature/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Feature is a magazine theme focused on sizable typography and imagery to grow your blog posts, reviews, artwork, and news.
 Requires at least: 6.0 
 Tested up to: 6.6
-Requires PHP: 5.7 
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/feelingood/style.css
+++ b/feelingood/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A blog theme with a bold vaporwave aesthetic. Its nostalgic atmosphere pays homage to the 80s and early 90s.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/fewer/style.css
+++ b/fewer/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Fewer is perfect for showcasing portfolios and blogs. With a clean and opinionated design, it offers excellent typography and style variations that make it easy to present your work or business. The theme is highly versatile, making it ideal for bloggers and businesses alike, and it offers a range of customizable options that allow you to tailor your site to your specific needs.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/fictionary/style.css
+++ b/fictionary/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Fictionary is a typography based, opinionated blogging theme.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/fixmate/style.css
+++ b/fixmate/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Fixmate is a blog theme designed for individuals focusing on users who are into a side hustle on home improvement and handyperson services.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/foam/style.css
+++ b/foam/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Foam is a WordPress event theme with a vibrant, straightforward style. Entirely customisable, Foam allows you to present an event in a visually appealing way.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/fontaine/style.css
+++ b/fontaine/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Fontaine is a portfolio/profile theme designed for visual designers who appreciate the bold simplicity of Brutalist aesthetics. The goal was to create a theme that gracefully steps back, allowing your content to shine and capture the spotlight.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/fotograma/style.css
+++ b/fotograma/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Fotograma is a portfolio theme for photographers seeking to showcase powerful photography in large sizes.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/freddie/style.css
+++ b/freddie/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Freddie is a theme using a full-screen background image to captivate the viewer with a brief, immersive moment.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/geologist/style.css
+++ b/geologist/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Geologist is a streamlined theme for modern bloggers. It consists of a simple single column of posts, paired with a sophisticated color palette and beautiful sans-serif typography.
 Requires at least: 5.7
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.46
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/goodskin/style.css
+++ b/goodskin/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Goodskin is a blogging theme designed for skincare blogs.
 Requires at least: 6.0
 Tested up to: 6.6-RC4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/grammerone/style.css
+++ b/grammerone/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Bring the Social Media experience to your site and transform it into a repository for your photos and videos. Get Gramming now.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/greenseed/style.css
+++ b/greenseed/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Greenseed is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/happening/style.css
+++ b/happening/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: As its name states Happening is a theme designed for events and ceremonies. It is simple, and direct allowing users to display the essence of their subject with a large artwork on the Homepage.
 Requires at least: 6.1
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/hari/style.css
+++ b/hari/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Hari is a minimalist, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/heiwa/style.css
+++ b/heiwa/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Heiwa is a clean and elegant theme. Its sophisticated typography and clean look make it a perfect match for a business producing visual products.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/hey/style.css
+++ b/hey/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Hey is a simple personal blog theme.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/hola/style.css
+++ b/hola/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Hola is a text-only blog design, a new interpretation of the theme ‘Hey’ with diverse style variations.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ici/style.css
+++ b/ici/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: The design goal of Ici was to craft a mobile-first layout with high visual density on a narrow space. This theme could be a good choice for users that want to write a newsletter or a personal journal.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/impressionist/style.css
+++ b/impressionist/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Impressionist is a block theme about the impressionist art movement.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/indice/style.css
+++ b/indice/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Indice is a tribute to the iconic indicehibit, an archetypal open source CMS that was heavily used by a generation of designers in the early web due to its simplicity and charm.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/infield/style.css
+++ b/infield/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A passionate sports fan blog celebrating your favorite game.
 Requires at least: 6.0
 Tested up to: 6.4.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/inversum/style.css
+++ b/inversum/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A blog theme entirely designed in the Editor, Inversum offers a direct experience of post-reading with its noticeable post titles listed on a text-only page and an original swap of header and footer blocks.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.2.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/iotix/style.css
+++ b/iotix/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Iotix provides a great starting point for creating a business or startup website.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.11
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/issue/style.css
+++ b/issue/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Issue is a magazine theme focused on sizable typography and imagery to grow your blog posts, reviews, artwork, and news.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/jackson/style.css
+++ b/jackson/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Jackson is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/jaida/style.css
+++ b/jaida/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A WordPress block theme made for blogging.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/jazzygrid/style.css
+++ b/jazzygrid/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Your new link-in-bio site, JazzyGrid, organizes blocks to display contact information and links on an exciting landing page.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/jenn/style.css
+++ b/jenn/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Jenn is a block theme ideal for yoga bloggers wanting to turn their hobby into a business.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/jinjang/style.css
+++ b/jinjang/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: JinJang is a blog theme with a split, 50:50 layout like Yan Yang.
 Requires at least: 5.8
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kamala/style.css
+++ b/kamala/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Kamala is ideal for small businesses looking to present their services in a visually captivating way. Kamala uses Twenty Twenty-Four as a base theme, providing delicate yet functional styles for a pleasurable online experience.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kansei/style.css
+++ b/kansei/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kansei is a theme reminiscing of the Japanese book design tradition and graphic aesthetics. It aims to evoke a sense of harmony and balance.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kawaii-chan/style.css
+++ b/kawaii-chan/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kawaii-Chan is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.1
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kaze/style.css
+++ b/kaze/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kaze is a simple 3-column dark-colored theme with small font sizes.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kentwood/style.css
+++ b/kentwood/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kentwood is perfect for learning institutions.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kigen/style.css
+++ b/kigen/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kigen is a simple one page portfolio theme.
 Requires at least: 5.8
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kingsley/style.css
+++ b/kingsley/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kingsley is a minimalist theme, designed for single-page websites.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/kiosko/style.css
+++ b/kiosko/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Kiosko is a store theme for WooCommerce.
 Requires at least: 5.8
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/koinonia/style.css
+++ b/koinonia/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Koinonia is a WordPress theme designed for non-profit organizations and community-driven projects. Perfect for showcasing services and initiatives that bring people and pets together, it’s an ideal choice for those who share a passion for caring, connection, and our furry companions.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lativ/style.css
+++ b/lativ/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Lativ is a WordPress block theme specifically designed for businesses and startups. It offers fresh, vibrant color palettes and sleek, modern templates that are perfect for companies looking to establish a bold and innovative online presence.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/leancv/style.css
+++ b/leancv/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: LeanCV is a blog theme that echoes the structure of a professional curriculum. It's suitable for the general public to display information, experiences, and education. And it's super easy to customize.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.1.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lettre/style.css
+++ b/lettre/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A theme for writers that want to publish a newsletter using Jetpack.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.1.14
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lineup/style.css
+++ b/lineup/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Lineup is a fanzine inspired theme lists entries with a bold typography and colour.
 Requires at least: 5.8
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/livro/style.css
+++ b/livro/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Livro is a simple theme designed to evoke the calm feeling you get when you settle in with a classic book.
 Requires at least: 5.8
 Tested up to: 5.8.3
-Requires PHP: 5.6
+Requires PHP: 7.2
 Requires Gutenberg: 12.8
 Version: 1.0.25
 License: GNU General Public License v2 or later

--- a/loic/style.css
+++ b/loic/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A simple blogging theme ideal for writers.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lois/style.css
+++ b/lois/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: A theme in homage to George Lois, visionary American Art Director, and author. We will all miss your big ideas. Rest in Peace, George. From the Creative People of Automattic.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/loudness/style.css
+++ b/loudness/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A bold opinionated theme for music and learning 
 Requires at least: 6.0
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.10
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lowfi/style.css
+++ b/lowfi/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: LowFi is a simple blog theme with Lo-fi aesthetics.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/luce/style.css
+++ b/luce/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Simple resume and blog theme with bright personality.
 Requires at least: 6.1
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/luminance/style.css
+++ b/luminance/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Luminance is a bold blogging theme with opinionated typography and unique aesthetics that sets your blog apart from the crowd.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/luxus/style.css
+++ b/luxus/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A WordPress theme for nail and beauty salons.
 Requires at least: 6.1
 Tested up to: 6.6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/lynx/style.css
+++ b/lynx/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A theme for anyone who wants to create a collection of links to their online profiles. It comes with a selection of patterns ready for customization.
 Requires at least: 5.7
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.28
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/mann/style.css
+++ b/mann/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Heidi is a simple theme for music teachers or those who want to present their music teaching business in a clear and compelling way.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/margarethe/style.css
+++ b/margarethe/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Margarethe is based on Annalee and it is tailored for site owners who would like to take the step offering interior design services.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/marl/style.css
+++ b/marl/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Marl is a minimal, product-oriented theme.
 Requires at least: 5.9
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/massimo/style.css
+++ b/massimo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Massimo is a blog theme that reverences the legendary designer Massimo Vignelli and his playbills for the Piccolo Teatro in Milan. This design is suitable for programs, calendars, and announcements.
 Requires at least: 5.8
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/masu/style.css
+++ b/masu/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Masu is a blog theme inspired by a traditional square wooden box used to measure rice in Japan.
 Requires at least: 5.8
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/matrioska/style.css
+++ b/matrioska/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Matrioska is a blog design that displays posts overlapping featured images as a Matryoshka effect.
 Requires at least: 6.1
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/maverick/style.css
+++ b/maverick/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme in homage to George Lois, visionary American Art Director, and author. We will all miss your big ideas. Rest in Peace, George. From the Creative People of Automattic.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/mayland-blocks/style.css
+++ b/mayland-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Make your online portfolio wonderfully uncluttered with Mayland. Gracefully highlight your photography and other projects. Mayland is versatile enough to be your personal site too.
 Requires at least: 5.7
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 2.1.36
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/meraki/style.css
+++ b/meraki/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Meraki is a blogging theme that supports full-site editing.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.15
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/message/style.css
+++ b/message/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Message is a theme that brings the mobile messaging experience to your WordPress site.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/messagerie/style.css
+++ b/messagerie/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Messagerie is a theme that brings the mobile messaging experience to your WordPress site.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/miko/style.css
+++ b/miko/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Miko is a personal theme designed to showcase your resume and writing.
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/montagna/style.css
+++ b/montagna/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A WordPress theme for travel-related websites and blogs designed to showcase stunning destinations around the world.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/mpho/style.css
+++ b/mpho/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Mpho is a minimalist single column theme that draws inspiration from short-sized posts and social networks. It prioritizes the post content and author, featuring a header with the author's bio and profile picture. With its simplicity, Mpho offers four style variations to suit different preferences.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/muscat/style.css
+++ b/muscat/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Muscat is a simple blogging WordPress theme with grid post templates and a centered post layout. Its geometric sans-serif typography contributes to a delightful, comfortable and modern reading experience. With a light style variation, Muscat lets your content shine, whether it is text or media.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/musee/style.css
+++ b/musee/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Musee is a blog theme that presents posts in different Query Loops using tags. It is the perfect pick for museums or galleries.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/mysa/style.css
+++ b/mysa/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Mysa is a simple 3-column blog theme. This theme works best with featured images that appear the right column.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/negai/style.css
+++ b/negai/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Negai is a bold blogging theme with large post titles and interesting colour schemes
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/nested/style.css
+++ b/nested/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Nested is a blog design that displays posts overlapping featured images as a Matryoshka effect.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/nook/style.css
+++ b/nook/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Nook is a classic blogging theme offering a delightful canvas for your DIY projects, delicious recipes, and creative inspirations.
 Requires at least: 6.0
 Tested up to: 6.4.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/olympique/style.css
+++ b/olympique/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme to celebrate the history of the games and the milestones that have shaped their legacy.
 Requires at least: 6.4
 Tested up to: 6.6
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/onyxpulse/style.css
+++ b/onyxpulse/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: OnyxPulse is a blog theme with Health Goth aesthetics. The theme emphasises the monochrome palette with a clean, futuristic vibe that could resonate with the fan.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/optimismo/style.css
+++ b/optimismo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Optimismo is a blog theme with a big bold message at the front.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/organizer/style.css
+++ b/organizer/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Organizer has a simple structure and displays only the necessary information a real portfolio can benefit from. It's ready to be used by designers, artists, architects, and creators.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/otis/style.css
+++ b/otis/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Otis is a WordPress block theme that is well-suited for personal blogging. It is designed to provide a polished, modern user experience. Its default templates include an opinionated header template with large type, and straightforward single and page templates, which are particularly useful for users who do not want to include images on their site. Otis\' strong design point of view encourages users to follow its design principles. It is focused on simplicity and readability, with a clean and uncluttered layout that allows readers to easily navigate content.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/outnow/style.css
+++ b/outnow/style.css
@@ -6,7 +6,7 @@ Author URI: https://automatic.com
 Description: OutNow is the perfect theme for people who are engaged in artistic activities. Its concise and straightforward introduction enables users to promptly select topics for their blog posts or content pages.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.3.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/overlaid/style.css
+++ b/overlaid/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Overlaid displays large titles and excerpts that scroll over an image on the Homepage and neat single pages for the users that want their blogging to be simple.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/paimio/style.css
+++ b/paimio/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Paimio is a minimal blogging theme inspired by architects and designers Alvar, Aino and Elissa Aalto.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/partygurl/style.css
+++ b/partygurl/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Partygurl embodies a bold and rebellious aesthetic, inspired by edgy, chaotic fun and the unapologetic “brat” energy popularized by cultural trends.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/pendant/style.css
+++ b/pendant/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: An elegant product-focused theme.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Requires Gutenberg: 13.1
 Version: 1.0.19
 License: GNU General Public License v2 or later

--- a/perenne/style.css
+++ b/perenne/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Exegi monumentum aere perennius.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/pieria/style.css
+++ b/pieria/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Pieria is a theme focused on typography — essentially following a low-level styling approach. Its headings, paragraphs, links, and navigation have the same appearance, with everything sitting quietly into simple columns that split navigation, blog posts, and a content block. A soft design to make your content sparkle.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/pixl/style.css
+++ b/pixl/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Pixl is a simple yet opinionated blogging theme inspired by websites of the nineties.
 Requires at least: 6.0
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/podbase/style.css
+++ b/podbase/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Sometimes, your podcast episode cover arts deserve more attention than regular thumbnails offer. If you think so, PodBase is the design for your podcast site.
 Requires at least: 6.1
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/poema/style.css
+++ b/poema/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Poema pays tribute to the revered Portuguese writer and poet Fernando Pessoa, and his various pseudonyms. Its minimalist design features a black and white color scheme, complemented by an elegant serif font. Poema's carefully crafted templates boast a comfortable content width and meticulously considered white space that create a calming and immersive reading experience, ideal for the appreciation of poetry.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html 

--- a/poesis/style.css
+++ b/poesis/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Poesis pays homage to the literary figures represented in the painting “Six Tuscan Poets” by the Italian Renaissance painter, architect, and art historian Giorgio Vasari and is ideal for poetry or short stories. The theme\'s main feature is its split layout, with a full height column containing a sticky header and footer and scrollable content on the other column.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/pomme/style.css
+++ b/pomme/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Pomme is a simple portfolio theme for painters.
 Requires at least: 6.3
 Tested up to: 6.4
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/portia/style.css
+++ b/portia/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Portia is a simple business theme for a legal service.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/professio/style.css
+++ b/professio/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Professio is created for individual teachers based on Annalee, a theme designed for personal coaches.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/programme/style.css
+++ b/programme/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Programme is a blog theme that reverences the legendary designer Massimo Vignelli and his playbills for the Piccolo Teatro in Milan. This design is suitable for programs, calendars, and announcements.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/promoter/style.css
+++ b/promoter/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Promoter has a simple structure and displays only the necessary information for a real portfolio. It's ready for designers, artists, architects, and creators to use.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/psychedeli/style.css
+++ b/psychedeli/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Psychedeli is the ultimate WordPress theme for bloggers and artists seeking to showcase their vibrant journeys through the captivating visuals of the '60s. Designed with passion and creativity in mind, Psychedeli is your gateway to effortlessly share your psychedelic adventures and thought-provoking creations with the world. Get ready to ignite imaginations and captivate audiences like never before with Psychedeli.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/quadrat/style.css
+++ b/quadrat/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Quadrat is a simple, versatile WordPress theme, designed for blogs and podcasts. Inspired by squared shapes and colourful, minimalist flat illustrations, Quadrat bundles a set of images you can use on your site with the theme’s default color palette. Quadrat’s default styles are bold and playful, relying on a simple sans-serif font and a strong color scheme that you can customize.
 Requires at least: 5.7
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.1.59
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/raconteur/style.css
+++ b/raconteur/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme to promote marvelous stories, Raconteur displays enlarged imagery and typography on a practical layout to attract readers to your narrative.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/rainfall/style.css
+++ b/rainfall/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Rainfall is a clean, objective blogging theme strongly inspired by Swiss Design. Its minimalist functionality is balanced by a strong accent color, beautiful photography and post templates with sidebars.
 Requires at least: 6.0
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.11
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/raw/style.css
+++ b/raw/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: RAW is a theme design inspired by the Brutalist concepts from the homonymous Architectural movement. It aims to be harsh, honest, utilitarian, and useful. And it is a good portfolio pick for architects, design studios, and creative organizations.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/recipebook/style.css
+++ b/recipebook/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: RecipeBook is a versatile theme designed to cater to various content creators. It explores the Query Loop element in a very particular way, with zero spacings and block strokes.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/remote/style.css
+++ b/remote/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Remote is a dark, minimal block theme ideal for bloggers. Its default styles - a sans-serif font and dark background - contribute for a comfortable, immersive reading experience. It features a set of bold block patterns such as a large posts list and bordered categories and tags.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.1.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/reverie/style.css
+++ b/reverie/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Reverie is a blogging theme inspired by the work of Mark Rothko.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ritratto/style.css
+++ b/ritratto/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Besides an appreciable headshot, the theme offers large titles, descriptions, and links right away. There is also a grid of posts, and no Post Feature Images are used anytime.
 Requires at least: 6.0
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ron/style.css
+++ b/ron/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Ron is a minimalist blogging theme designed with a focus on delivering an exceptional reading experience. Its unique offset post layout and sticky post navigation make it stand out. By intentionally omitting a header, it includes only a footer, Ron allows readers to dive straight into the content without distractions.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/russell/style.css
+++ b/russell/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Russell is a simple blogging theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles.
 Requires at least: 5.7
 Tested up to: 5.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.32
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/saison/style.css
+++ b/saison/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Saison is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.0
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/screenplay/style.css
+++ b/screenplay/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Screenplay is a simple blog theme that suits perfectly writers or the general public that would like to have their sites formatted as movie scripts.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/seedlet-blocks/style.css
+++ b/seedlet-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A simple, text-driven, single-column block-based theme.
 Requires at least: 5.7
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 2.1.34
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/seedlet/style.css
+++ b/seedlet/style.css
@@ -7,7 +7,7 @@ Author URI: https://automattic.com/
 Description: Seedlet is a free WordPress theme. A two-column layout and classically elegant typography creates a refined site that gives your works and images space to breathe - and shine. Seedlet was built to be the perfect partner to the block editor, and supports all the latest blocks. Writing, audio, illustrations, photography, video - use Seedlet to engage and direct visitors' eyes, without your theme getting in the way. And the responsive design shifts naturally between desktop and mobile devices. Seedlet is a great option for professionals and creatives looking for a sophisticated vibe. Whether you're looking to create a blog or a robust site promoting your business, do with simplicity, style, and Seedlet.
 Requires at least: 5.5
 Tested up to: 5.5
-Requires PHP: 5.6.2
+Requires PHP: 7.2
 Version: 1.1.35-wpcom
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/shhh/style.css
+++ b/shhh/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Silence.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/skatepark/style.css
+++ b/skatepark/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Skatepark is a bold and exciting WordPress theme designed for modern events and organizations. With its simple but vivid color default scheme, duotone support, and playful grid, Skatepark is a theme designed for work and play. Customize its colors or try out different font pairings to create your own unique look and feel.
 Requires at least: 5.7.2
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.53
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/snd/style.css
+++ b/snd/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A minimal newsletter theme.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/spearhead-blocks/style.css
+++ b/spearhead-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Spearhead Blocks is the block based version of the original Spearhead theme.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/spearhead/style.css
+++ b/spearhead/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Share your podcast with the world using Spearhead.
 Requires at least: 5.5
 Tested up to: 5.5
-Requires PHP: 5.6.2
+Requires PHP: 7.2
 Version: 1.3.20
 License: GNU General Public License v2 or later
 License URI: LICENSE

--- a/specials/style.css
+++ b/specials/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A clean, beautiful, and customizable theme for restaurant menu websites.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/spiel/style.css
+++ b/spiel/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Spiel is a game magazine theme. The rich and dense old-school homepage layout could still work well for pro-bloggers.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/sprinkler/style.css
+++ b/sprinkler/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Sprinkler is ideal for gardening enthusiasts who would like to turn their hobby into a side hustle. Sprinkler is based on Artly.
 Requires at least: 6.0
 Tested up to: 6.4.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/stage/style.css
+++ b/stage/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: Stage is the perfect theme for our users engaged in artistic activities. Its concise and straightforward introduction enables users to select topics for their blog posts or content pages promptly.
 Requires at least: 6.0
 Tested up to: 6.2.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/stageplay/style.css
+++ b/stageplay/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Stageplay is a blog theme that ideally suits writers and the general public who want their sites formatted as scripts — following the concept present in another theme called Screenplay.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/startfit/style.css
+++ b/startfit/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: StartFit is a business theme perfect for a personal fitness training service.
 Requires at least: 6.0
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/startorg/style.css
+++ b/startorg/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Startorg is a community/non profit theme perfect for organizations.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/sten/style.css
+++ b/sten/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Sten is a simple blogging theme with a functional design. It is ideal for taking notes, writing short or long text, and includes a post sidebar and comment section.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/stewart/style.css
+++ b/stewart/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Stewart is a modern blogging theme with a left sidebar. Its default color scheme is a striking combination of orange and light gray, to give your blog a sophisticated appearance from day one.
 Requires at least: 6.1
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.20
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/storia/style.css
+++ b/storia/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: A visual story theme.
 Requires at least: 6.0
 Tested up to: 6.1.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/strand/style.css
+++ b/strand/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Strand is a simple blogging and newsletter theme. The main feature is its split layout, with a full height column containing a sticky header and subscription form and scrollable content on the other column.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/streamer/style.css
+++ b/streamer/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Elevate your esports squad's online presence and connect with fans like never before using this theme design.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/sunderland/style.css
+++ b/sunderland/style.css
@@ -6,8 +6,8 @@ Author URI: https://automattic.com/
 Description: Sunderland is a simple theme that supports full-site editing. It comes with a set of minimal templates and design settings that can be manipulated through Global Styles. Use it to build something beautiful.
 Requires at least: 6.0
 Tested up to: 6.2
-Requires PHP: 5.7
-Version: 1.0.6 
+Requires PHP: 7.2
+Version: 1.0.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: sunderland

--- a/surrealist/style.css
+++ b/surrealist/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Surrealist is a block theme about the Surrealism art movement.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tenaz/style.css
+++ b/tenaz/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Tenaz is a classic "magazine" theme with a rich, dense homepage perfect for pro-bloggers.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/texty/style.css
+++ b/texty/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Texty is a text-only blog theme that trusts Post excerpts rather than Post titles and Post Feature Images. It is a remix of another theme called 'Issue' and has got a lot of variations.
 Requires at least: 6.1
 Tested up to: 6.3
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/the-jazzers/style.css
+++ b/the-jazzers/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: A theme inspired by jazz album covers, with big covers and playful titles to display your posts.
 Requires at least: 5.8
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/the-menu/style.css
+++ b/the-menu/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/
 Description: A simple theme designed to facilitate restaurant owners' experience when building their sites. Is clean, direct, and customizable.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/the-shore/style.css
+++ b/the-shore/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: The Shore is a sleek and elegant WordPress theme designed specifically for hotels and resorts. It offers three distinct color variations, allowing you to customize the look and feel to match your brand perfectly. With its clean and modern design, The Shore provides a seamless and user-friendly experience for visitors. Its layout is thoughtfully crafted to showcase your property’s features, amenities, and services, making it easy to attract and engage potential guests. Ideal for creating a professional online presence, The Shore combines aesthetics with functionality, ensuring your hotel or resort stands out in the competitive hospitality industry.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tiebreak/style.css
+++ b/tiebreak/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: TieBreak is a theme for tennis enthusiasts. This WordPress magazine block theme features a variety of query loop patterns and a sidebar making it perfect for any other topic.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tomoni/style.css
+++ b/tomoni/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Tomoni is a theme that displays a use case of multilingual content with Japanese.
 Requires at least: 6.3
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/trellick/style.css
+++ b/trellick/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Trellick is a raw, brutalist blog theme that strips away the polished veneer of the samey web design to show the untamed essence of the digital realm.
 Requires at least: 6.0
 Tested up to: 6.4
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tronar/style.css
+++ b/tronar/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Tronar is a simple blog theme. It works best with featured images. The latest sticky post appears at the top with a large featured image.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tu/style.css
+++ b/tu/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Tú is a theme about you.
 Requires at least: 6.0
 Tested up to: 6.1.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/twentytwentytwo-blue/style.css
+++ b/twentytwentytwo-blue/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.8.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/twentytwentytwo-mint/style.css
+++ b/twentytwentytwo-mint/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.8.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/twentytwentytwo-pink/style.css
+++ b/twentytwentytwo-pink/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.8.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/twentytwentytwo-red/style.css
+++ b/twentytwentytwo-red/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.8.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/twentytwentytwo-swiss/style.css
+++ b/twentytwentytwo-swiss/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The WordPress default theme for 2022.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.8.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/ueno/style.css
+++ b/ueno/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Ueno is a mobile-first theme suitable for any kind of blog or website. It has an opinionated default style and two alternative style variations.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/upsidedown/style.css
+++ b/upsidedown/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Upsidedown is a blog theme designed in the WordPress Site Editor. With its neat visuals, it introduces a direct experience on post reading: noticeable post titles listed on a text-only page, with an original swap of header and footer blocks.
 Requires at least: 6.0
 Tested up to: 6.1
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/urbem/style.css
+++ b/urbem/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Urbem is a spin-off of Vitrum, a theme composed of wide-width layouts with generous space for images and bold type sizes.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/verso/style.css
+++ b/verso/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Verso pays tribute to the revered Portuguese writer and poet Fernando Pessoa, and his various pseudonyms. Its minimalist design features a black and white color scheme, complemented by an elegant serif font. Verso's carefully crafted templates boast a comfortable content width and meticulously considered white space that create a calming and immersive reading experience, ideal for the appreciation of poetry.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vetro/style.css
+++ b/vetro/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Vetro was designed to be a portfolio theme, and is composed by wide width layouts with the impact of generous imagery and typography. Its simple pages are aligned left with fair right paddings and large content blocks to grant viewers focus on visuals and short paragraphs.
 Requires at least: 5.8
 Tested up to: 6.2
-Requires PHP: 5.6
+Requires PHP: 7.2
 Version: 1.0.11
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vibrrrant/style.css
+++ b/vibrrrant/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Vibrrrant is a theme tailored to short-term rental businesses with a colourful, funky aesthetic.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vitrum/style.css
+++ b/vitrum/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Vitrum was designed to be a portfolio theme and is composed of wide-width layouts with the impact of generous imagery and typography. Its simple pages are aligned left with fair right paddings and large content blocks to grant viewers focus on visuals and short paragraphs.
 Requires at least: 6.0
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.2
 Version: 1.4.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vivre/style.css
+++ b/vivre/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Vivre is a bold, opinionated blogging theme, heavily inspired by fashion and lifestyle magazines and websites.
 Requires at least: 5.8
 Tested up to: 6.0
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.9
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vueo/style.css
+++ b/vueo/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com
 Description: Vueo presents a portfolio theme that offers a distinctive perspective on your gallery entrances. Alternating the aspect ratio of the query loops crafts a visually stunning pattern for an enhanced viewing experience.
 Requires at least: 6.6
 Tested up to: 6.7
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/winkel/style.css
+++ b/winkel/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Winkel is a minimal, product-oriented theme.
 Requires at least: 5.8
 Tested up to: 5.9
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-dos/style.css
+++ b/wp-dos/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org
 Description: WP-DOS is a blog theme designed for nostalgic ones. It is a tribute to the folks who invented computing as we know it today. It is an exciting opportunity to test blogging as if we were back again to the green (or amber) phosphor.
 Requires at least: 6.0
 Tested up to: 6.5
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/xanadu/style.css
+++ b/xanadu/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: This theme is named after the city in Samuel Taylor Coleridge’s poem Kubla Khan. Literary legend says the poem came to Coleridge in a dream, which he rushed to write down without preamble. Likewise, this design begins in earnest.
 Requires at least: 6.0
 Tested up to: 6.6
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/zoologist/style.css
+++ b/zoologist/style.css
@@ -6,7 +6,7 @@ Author URI: https://automattic.com/
 Description: Zoologist is a simple blogging theme that supports full-site editing.
 Requires at least: 5.8
 Tested up to: 5.8
-Requires PHP: 5.7
+Requires PHP: 7.2
 Version: 1.0.46
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Part of https://github.com/Automattic/themes/issues/7785.

`5.x`, `7.0`, and `7.1` are all bumped to `7.2`

WordPress requires at least PHP 7.2 since WordPress version 6.6.

These files are not touched and do not appear to have any required PHP version _and_ have no inactive status annotation:

```
altofocus
alves
apostrophe-2
balasana
barnsbury
button-2
canard
coutoire
dalston
dara
dyad-2
exford
gazette
hever
ibis
illustratr
independent-publisher-2
intergalactic-2
ixion
karuna
leven
libre-2
libretto
lodestar
mayland
maywood
morden
penscratch-2
photos
pique
publication
radcliffe-2
rebalance
rivington
rockfield
scratchpad
shawburn
shoreditch
sketch
stow
stratford
textbook
toujours
varia
```