### PR TITLE
Fix: Independent Publisher 2: Theme adds unwanted image cropping to RSS.

### DIFF
--- a/independent-publisher-2/functions.php
+++ b/independent-publisher-2/functions.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'independent_publisher_2_setup' ) ) :
 		 * @link http://codex.wordpress.org/Function_Reference/add_theme_support#Post_Thumbnails
 		 */
 		add_theme_support( 'post-thumbnails' );
-		set_post_thumbnail_size( 740, 430, true );
+		set_post_thumbnail_size( 740, 9999, true );
 		add_image_size( 'independent-publisher-2-banner', 1440, 600, true );
 		add_image_size( 'independent-publisher-2-full-width', 1100, 9999 );
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/themes/issues/2754

A sizing parameter is added to the image URL: ?w=740&#038;h=430&#038;crop=1 on the podcast feeds.

This causes the image in the feed to be cropped, and for distributors like Spotify and Apple Podcasts to use the cropped image instead.

This happens because we were setting a fixed post thumbal size, which made a crop happened to force the images to be in that size.

#### Changes proposed in this Pull Request:
These PR changes `set_post_thumbnail_size( 740, 430, true );` to `set_post_thumbnail_size( 740, 9999, true );` making the post thumbnails/feature image still have a width of 740 but having a dynamic height proportional to the width avoid the crop.

This makes the theme follow a similar pattern used on core themes e.g:
https://github.com/WordPress/wordpress-develop/blob/f2f13cbff083e2dd7973565bdb9523f10746085e/src/wp-content/themes/twentytwenty/functions.php#L63
https://github.com/WordPress/wordpress-develop/blob/f2f13cbff083e2dd7973565bdb9523f10746085e/src/wp-content/themes/twentynineteen/functions.php#L47
https://github.com/WordPress/wordpress-develop/blob/f2f13cbff083e2dd7973565bdb9523f10746085e/src/wp-content/themes/twentytwentyone/functions.php#L65


## Testing

- Enable the Independent Publisher 2 theme.
- Configure a site for podcasting
- Publish a podcast post. Add a featured image that has equal width and height.
- View the site's podcast feed and look for the itunes:image line for the post in the feed.
- Verify the sizing parameters of the image still keep it square and not `?w=740&#038;h=430&#038;crop=1`as in trunk.
