### PR TITLE
WP-DOS: Removed negative top margin from post content block in blog home template

### DIFF
--- a/wp-dos/patterns/home.php
+++ b/wp-dos/patterns/home.php
@@ -53,7 +53,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"55%"} -->
-<div class="wp-block-column" style="flex-basis:55%"><!-- wp:post-content {"style":{"spacing":{"margin":{"top":"-1.7rem"}}},"layout":{"type":"constrained","justifyContent":"left"}} /--></div>
+<div class="wp-block-column" style="flex-basis:55%"><!-- wp:post-content {"layout":{"type":"constrained","justifyContent":"left"}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"20%"} -->


### PR DESCRIPTION
The negative margin was placed to combat a bug with the post content block in a query loop block in the site editor, but that negatively affects it on the front of the site, so this PR removes it.

EDITOR
![CleanShot 2025-01-24 at 19 50 56@2x](https://github.com/user-attachments/assets/78575dc6-d973-49fa-92b5-fc544cdabc28)

FRONT OF THE SITE
![CleanShot 2025-01-24 at 19 52 32@2x](https://github.com/user-attachments/assets/6ebc6d89-f8ec-49e9-b00a-fad4cddd1a41)


