### PR TITLE
Geologist and Zoologist: Revert color classes changes.

### DIFF
--- a/geologist/theme.json
+++ b/geologist/theme.json
@@ -78,7 +78,7 @@
 				}
 			},
 			"color": {
-				"foreground": "var(--wp--preset--color--foreground)",
+				"foreground": "var(--wp--preset--color--primary)",
 				"background": "var(--wp--preset--color--background)",
 				"primary": "var(--wp--preset--color--primary)",
 				"secondary": "var(--wp--preset--color--secondary)",

--- a/zoologist/theme.json
+++ b/zoologist/theme.json
@@ -78,10 +78,10 @@
 				}
 			},
 			"color": {
-				"foreground": "var(--wp--preset--color--foreground)",
+				"foreground": "var(--wp--preset--color--primary)",
 				"background": "var(--wp--preset--color--background)",
 				"primary": "var(--wp--preset--color--primary)",
-				"secondary": "var(--wp--preset--color--secondary)",
+				"secondary": "var(--wp--preset--color--primary)",
 				"tertiary": "var(--wp--preset--color--tertiary)"
 			},
 			"form": {


### PR DESCRIPTION
<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

https://github.com/Automattic/themes/pull/8616 and https://github.com/Automattic/themes/pull/8595 caused an issue where if the user chooses a certain style variation, the background is the same color as the font color.

The problem is due to `--wp--preset--color--foreground` not being found, so, until we find a solution to that, we need to revert these changes.

![Screenshot 2025-01-24 at 21 34 18](https://github.com/user-attachments/assets/fa5708b4-97c2-44d6-b690-ceaa03a5bfa9)

#### Related issue(s):
See https://github.com/Automattic/themes/pull/8595#discussion_r1924069229