### PR TITLE
Global styles: allow override to work when Gutenberg plugin is active

### DIFF
--- a/blockbase/inc/rest-api.php
+++ b/blockbase/inc/rest-api.php
@@ -17,12 +17,15 @@ function blockbase_remove_style_variations_from_child_themes( $response, $handle
 	$handler_method = isset( $handler['callback'][1] ) ? $handler['callback'][1] : null;
 	$opt_out        = wp_get_global_settings( array( 'custom', 'optOutOfParentStyleVariations' ) );
 
+	// Global styles are overridden when Gutenberg plugin is used.
+	$check_class = class_exists( 'WP_REST_Global_Styles_Controller_Gutenberg' ) ? 'WP_REST_Global_Styles_Controller_Gutenberg' : 'WP_REST_Global_Styles_Controller';
+
 	/*
 	 * Prevents Blockbase child themes from being considered child themes in the
 	 * `wp/v2/global-styles/themes/:theme/variations` API endpoint, so they don't
 	 * inherit the style variations from the parent theme.
 	 */
-	if ( $opt_out && is_a( $handler_class, 'WP_REST_Global_Styles_Controller' ) && 'get_theme_items' === $handler_method ) {
+	if ( $opt_out && is_a( $handler_class, $check_class ) && 'get_theme_items' === $handler_method ) {
 		add_filter( 'template_directory', 'get_stylesheet_directory' );
 	}
 


### PR DESCRIPTION
Fixes #8636 