### PR TITLE
Revert "Marl: Correct primary and secondary color classes"

### DIFF
--- a/marl/theme.json
+++ b/marl/theme.json
@@ -27,8 +27,8 @@
             "color": {
                 "foreground": "var(--wp--preset--color--foreground)",
                 "background": "var(--wp--preset--color--background)",
-                "primary": "var(--wp--preset--color--primary)",
-                "secondary": "var(--wp--preset--color--secondary)",
+                "primary": "var(--wp--preset--color--foreground)",
+                "secondary": "var(--wp--preset--color--foreground)",
                 "tertiary": "var(--wp--preset--color--tertiary)"
             },
             "excludedParentStyleVariations": [


### PR DESCRIPTION
Reverts Automattic/themes#8615

`Primary` and `Secondary` are not set within the theme palette (only available through parent theme).

We should also add restrictions around inheriting parent styles, since they don't work seamlessly.

