### PR TITLE
Kiosko: Add changelog.txt for woocommerce.com

### DIFF
--- a/kiosko/changelog.txt
+++ b/kiosko/changelog.txt
@@ -1,0 +1,4 @@
+== Changelog ==
+
+= 1.0.0 =
+* Initial release


### PR DESCRIPTION
Context: p9h1Lv-feI-p2

@mikachan @dsas Do you think adding a `changelog.txt` to this theme will cause any issues in Dotcom? I don't think we should add it to all the themes as it's redundant because a change log lives in the `readme.txt`, but currently, this is the only theme that needs the file.

We might need to update the scripts/workflow that updates the readme.txt so that it updates `changelog.txt` too if it exists.