### PR TITLE
Allow overriding button styles in child themes

### DIFF
--- a/blockbase/theme.json
+++ b/blockbase/theme.json
@@ -571,31 +571,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"radius": "var(--wp--custom--button--border--radius)",
-					"color": "var(--wp--custom--button--border--color)",
-					"style": "var(--wp--custom--button--border--style)",
-					"width": "var(--wp--custom--button--border--width)"
-				},
-				"color": {
-					"background": "var(--wp--custom--button--color--background)",
-					"text": "var(--wp--custom--button--color--text)"
-				},
-				"typography": {
-					"fontSize": "var(--wp--custom--button--typography--font-size)",
-					"fontWeight": "var(--wp--custom--button--typography--font-weight)",
-					"lineHeight": "var(--wp--custom--button--typography--line-height)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--button--spacing--padding--top)",
-						"bottom": "var(--wp--custom--button--spacing--padding--bottom)",
-						"left": "var(--wp--custom--button--spacing--padding--left)",
-						"right": "var(--wp--custom--button--spacing--padding--right)"
-					}
-				}
-			},
 			"core/code": {
 				"border": {
 					"color": "#CCCCCC",
@@ -775,7 +750,10 @@
 		"elements": {
 			"button": {
 				"border": {
-					"radius": "var(--wp--custom--button--border--radius)"
+					"radius": "var(--wp--custom--button--border--radius)",
+					"color": "var(--wp--custom--button--border--color)",
+					"style": "var(--wp--custom--button--border--style)",
+					"width": "var(--wp--custom--button--border--width)"
 				},
 				"color": {
 					"background": "var(--wp--custom--button--color--background)",

--- a/marl/theme.json
+++ b/marl/theme.json
@@ -31,6 +31,15 @@
                 "secondary": "var(--wp--preset--color--foreground)",
                 "tertiary": "var(--wp--preset--color--tertiary)"
             },
+            "button": {
+                "color": {
+                    "background": "var(--wp--custom--color--background)",
+                    "text": "var(--wp--custom--color--foreground)"
+                },
+                "border": {
+                    "radius": "9999px"
+                }
+            },
             "excludedParentStyleVariations": [
                 "Ruby Wine"
             ]

--- a/marl/theme.json
+++ b/marl/theme.json
@@ -33,8 +33,8 @@
             },
             "button": {
                 "color": {
-                    "background": "var(--wp--custom--color--background)",
-                    "text": "var(--wp--custom--color--foreground)"
+                    "background": "var(--wp--custom--color--foreground)",
+                    "text": "var(--wp--custom--color--background)"
                 },
                 "border": {
                     "radius": "9999px"


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/8628

> When applying global styles on top of block styles, the fundamental problem is that block styles take precedence, and so global styles aren’t applied.

A better explanation of the issue and exploration on ways to fix it: p6rkRX-6hi-p2

#### Changes proposed in this Pull Request:
Remove styling for the block as it has higher priority to Global Styles.

#### Testing:
- Test the Blockbase theme before/after.
- Test a child theme, Marl, for example, adding Global Styles for buttons.

#### Screenshots
Blockbase before:
![blockbase - before](https://github.com/user-attachments/assets/432fe410-4c58-40ac-9839-9561217b74c2)

Blockbase after:
![blockbase - after](https://github.com/user-attachments/assets/39d0ae91-9ec0-41b5-bcc8-abc0587683c4)

Marl before:
![marl - before](https://github.com/user-attachments/assets/eedd458a-d1b2-4e25-af05-5a189cccce03)

Marl after:
![marl - after](https://github.com/user-attachments/assets/2b0a57e0-3238-4d64-b684-cca91ab8b428)

#### Related issue(s):