### PR TITLE
Artly: Add css unit to styles.spacing.padding value to regain default padding on menu overlay

### DIFF
--- a/artly/theme.json
+++ b/artly/theme.json
@@ -923,7 +923,7 @@
 				"bottom": "0px",
 				"left": "var:preset|spacing|50",
 				"right": "var:preset|spacing|50",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590