### PR TITLE
Bibimbap: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/bibimbap/theme.json
+++ b/bibimbap/theme.json
@@ -534,10 +534,10 @@
 		"spacing": {
 			"blockGap": "var:preset|spacing|50",
 			"padding": {
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var:preset|spacing|50",
 				"right": "var:preset|spacing|50",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590
