### PR TITLE
Kigen: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/kigen/theme.json
+++ b/kigen/theme.json
@@ -970,7 +970,7 @@
 		"spacing": {
 			"blockGap": "var(--wp--preset--spacing--50)",
 			"padding": {
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var(--wp--preset--spacing--50)",
 				"right": "var(--wp--preset--spacing--50)",
 				"top": "var(--wp--preset--spacing--70)"


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590