### PR TITLE
Luce: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/luce/theme.json
+++ b/luce/theme.json
@@ -609,10 +609,10 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var(--wp--preset--spacing--50)",
 				"right": "var(--wp--preset--spacing--50)",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590