### PR TITLE
Poesis: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/poesis/theme.json
+++ b/poesis/theme.json
@@ -519,10 +519,10 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"bottom": "0",
-				"left": "0",
-				"right": "0",
-				"top": "0"
+				"bottom": "0px",
+				"left": "0px",
+				"right": "0px",
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590