### PR TITLE
Storia: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/storia/theme.json
+++ b/storia/theme.json
@@ -630,10 +630,10 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var(--wp--style--block-gap)",
 				"right": "var(--wp--style--block-gap)",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590