### PR TITLE
Tomoni: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/tomoni/theme.json
+++ b/tomoni/theme.json
@@ -1038,10 +1038,10 @@
 		"spacing": {
 			"blockGap": "var(--wp--preset--spacing--50)",
 			"padding": {
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var(--wp--preset--spacing--50)",
 				"right": "var(--wp--preset--spacing--50)",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590