### PR TITLE
Trellick: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/trellick/theme.json
+++ b/trellick/theme.json
@@ -745,7 +745,7 @@
 				"bottom": "var(--wp--preset--spacing--50)",
 				"left": "var(--wp--preset--spacing--50)",
 				"right": "var(--wp--preset--spacing--50)",
-				"top": "0"
+				"top": "0px"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590