### PR TITLE
Tú: Add css unit to styles.spacing.padding value to regain default paddings on menu overlay

### DIFF
--- a/tu/theme.json
+++ b/tu/theme.json
@@ -640,9 +640,9 @@
 		"spacing": {
 			"blockGap": "1.5rem",
 			"padding": {
-				"top": "0",
+				"top": "0px",
 				"right": "var(--wp--style--block-gap)",
-				"bottom": "0",
+				"bottom": "0px",
 				"left": "var(--wp--style--block-gap)"
 			}
 		},


### PR DESCRIPTION
Add CSS unit to `styles.spacing.padding value` to regain the default padding on the menu overlay. See #7590