### PR TITLE
varia: check if get_the_tag_list() returned a string

### DIFF
--- a/varia/inc/template-tags.php
+++ b/varia/inc/template-tags.php
@@ -97,7 +97,7 @@ if ( ! function_exists( 'varia_entry_meta' ) ) :
 
 			/* translators: used between list items, there is a space after the comma. */
 			$tags_list = get_the_tag_list( '', __( ', ', 'varia' ) );
-			if ( $tags_list ) {
+			if ( is_string( $tags_list ) ) {
 				printf(
 					/* translators: 1: SVG icon. 2: posted in label, only visible to screen readers. 3: list of tags. */
 					'<span class="tags-links">%1$s<span class="screen-reader-text">%2$s</span>%3$s</span>',


### PR DESCRIPTION
Calls to `get_the_tag_list()` can return `string|false|WP_Error` - https://developer.wordpress.org/reference/functions/get_the_tag_list/
- but the return value not fully checked.  The only useful thing in the return value is when it is a string.  If it is a `WP_Error` object then it results in a fatal error.


<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
